### PR TITLE
Fix for when landing page id is not set.

### DIFF
--- a/includes/class-convertkit.php
+++ b/includes/class-convertkit.php
@@ -244,7 +244,7 @@ class WP_ConvertKit {
 
 			$landing_page_id = self::_get_meta( $queried_object->ID, 'landing_page' );
 
-			if ( '0' === $landing_page_id ) {
+			if ( '0' === $landing_page_id || empty( $landing_page_id ) ) {
 				// Set to None
 				return;
 			}


### PR DESCRIPTION
Closes #116 
Closes #120 

## Summary

This PR handles the scenario where the WordPress meta `landing_page` is not set on a post. This would happen if a page was created in an old version of the plugin and has not been saved since.

When the page is loaded a "PHP Notice:  Undefined index" is added to the debug.log if WP_Debug is turned on.

## Pull request checklist

* [ ] Is the added/modified code sufficiently tested? Do all tests pass?
* [ ] Is the code easy to understand? Does it follow [the rules](https://robots.thoughtbot.com/sandi-metz-rules-for-developers)?
* [ ] Are the return values of public methods documented?
* [ ] Are any complicated parts explained / documented?
* [ ] Does this PR positively affect the code climate GPA score?
* [ ] Do you want feedback on anything in particular?
* [ ] Does this require QA? What should be tested? 

## Ready for review?
- [x] Add "ready for review" label
- [x] Assign a reviewer (or two)
- [ ] post RFR in #wordpress

**Handy links**
- [PR Checklist](https://github.com/ConvertKit/convertkit/wiki/Pull-Request-Checklist)
- [Code design](https://github.com/ConvertKit/convertkit/blob/master/README-coding-style.md)
