### PR TITLE
Fix CF7 integration for 5.0.5. Fix #137

### DIFF
--- a/admin/section/class-convertkit-settings-contactform7.php
+++ b/admin/section/class-convertkit-settings-contactform7.php
@@ -224,7 +224,7 @@ class ConvertKit_Settings_ContactForm7 extends ConvertKit_Settings_Base {
 		$cf7_form_id = $args['cf7_form_id'];
 		$forms  = $args['forms'];
 
-		$html = sprintf( '<select id="%1$s_%2$s" name="%1$s[%2$s]">', $this->settings_key, $cf7_form_id );
+		$html = sprintf( '<select id="%1$s_%2$s" class="widefat" name="%1$s[%2$s]">', $this->settings_key, $cf7_form_id );
 		$html .= '<option value="default">' . esc_html__( 'None', 'convertkit' ) . '</option>';
 		foreach ( $forms as $form ) {
 			$selected = '';
@@ -274,7 +274,7 @@ class ConvertKit_Settings_ContactForm7 extends ConvertKit_Settings_Base {
 		$output = $this->options;
 
 		foreach ( $input as $key => $value ) {
-			$output[ $key ] = stripslashes( $input[ $key ] );
+			$output[ $key ] = sanitize_text_field( $input[ $key ] );
 		}
 		$sanitize_hook = 'sanitize' . $this->settings_key;
 		return apply_filters( $sanitize_hook, $output, $input );


### PR DESCRIPTION
Closes #134 and #107 

## Summary

Fix CF7 version 5.0.2 and 5.05 issue where mappings were not being saved on the ConvertKit CF7 settings tab.

## Pull request checklist

* [ ] Is the added/modified code sufficiently tested? Do all tests pass?
* [ ] Is the code easy to understand? Does it follow [the rules](https://robots.thoughtbot.com/sandi-metz-rules-for-developers)?
* [ ] Are the return values of public methods documented?
* [ ] Are any complicated parts explained / documented?
* [ ] Does this PR positively affect the code climate GPA score?
* [ ] Do you want feedback on anything in particular?
* [ ] Does this require QA? What should be tested? 

## Ready for review?
- [ ] Add "ready for review" label
- [ ] Assign a reviewer (or two)
- [ ] post RFR in #wordpress

**Handy links**
- [PR Checklist](https://github.com/ConvertKit/convertkit/wiki/Pull-Request-Checklist)
- [Code design](https://github.com/ConvertKit/convertkit/blob/master/README-coding-style.md)
