### PR TITLE
Make the custom content feature work properly

### DIFF
--- a/resources/frontend/wp-convertkit.js
+++ b/resources/frontend/wp-convertkit.js
@@ -75,7 +75,7 @@ jQuery(document).ready(function($) {
      * If found add cookie.
      *
      */
-    jQuery(".formkit-form").submit( function() {
+    jQuery(document).on('click', '.formkit-submit', function() {
         var email = jQuery("input[name=email_address]").val();
 
         sleep( 1000 );
@@ -101,8 +101,6 @@ jQuery(document).ready(function($) {
                 console.log( "AJAX ERROR" + response );
             }
         });
-
-
     });
 
     /**
@@ -119,3 +117,4 @@ jQuery(document).ready(function($) {
     }
 
 });
+

--- a/resources/frontend/wp-convertkit.js
+++ b/resources/frontend/wp-convertkit.js
@@ -75,9 +75,9 @@ jQuery(document).ready(function($) {
      * If found add cookie.
      *
      */
-    jQuery("#ck_subscribe_button").click( function() {
+    jQuery(".formkit-submit").click( function() {
 
-        var email = jQuery("#ck_emailField").val();
+        var email = jQuery("input[name=email_address]").val();
 
         sleep( 2000 );
 

--- a/resources/frontend/wp-convertkit.js
+++ b/resources/frontend/wp-convertkit.js
@@ -78,7 +78,7 @@ jQuery(document).ready(function($) {
     jQuery(".formkit-form").submit( function() {
         var email = jQuery("input[name=email_address]").val();
 
-        sleep( 2000 );
+        sleep( 1000 );
 
         $.ajax({
             type: "POST",

--- a/resources/frontend/wp-convertkit.js
+++ b/resources/frontend/wp-convertkit.js
@@ -75,8 +75,7 @@ jQuery(document).ready(function($) {
      * If found add cookie.
      *
      */
-    jQuery(".formkit-submit").click( function() {
-
+    jQuery(".formkit-form").submit( function() {
         var email = jQuery("input[name=email_address]").val();
 
         sleep( 2000 );


### PR DESCRIPTION
Closes #148 

## Summary
Dynamic content was only partially working within the plugin prior to this change. If a subscriber clicked on a link with `?ck_subscriber_id={id}` in the URL (which CK generates in emails if a setting is checked on the account), then dynamic content worked. However, if a CK form was submitted on a site using the plugin, then a cookie was not added with the subscriber ID, so the plugin could not look up the subscriber to fetch tags and show dynamic content.

This change corrects the form elements being targeted to fetch the new subscriber's ID, so a cookie can be added after form submission.

## QA
- On a page on the test site, add a form. Make sure the form will apply a tag to the subscriber. You can use the default form already on the account; it will add the tag `test-tag`.
- On this page, use the `[convertkit_content tag={tag_id}]content goes here[/convertkit_content]` shortcode. You can use the editor button to insert this, as per the "Custom Content" section in [this article](https://help.convertkit.com/article/99-the-convertkit-wordpress-plugin). Use the tag associated with the form from the previous step.
- Submit the form
- Ensure the custom content is shown when the page is reloaded.
- Please test in multiple browsers

## Ready for review?
- [x] Add "ready for review" label
- [x] Assign a reviewer (or two)
- [x] post RFR in #wordpress

**Handy links**
- [PR Checklist](https://github.com/ConvertKit/convertkit/wiki/Pull-Request-Checklist)
- [Code design](https://github.com/ConvertKit/convertkit/blob/master/README-coding-style.md)
