### PR TITLE
Adding tools tab.

### DIFF
--- a/admin/class-convertkit-settings.php
+++ b/admin/class-convertkit-settings.php
@@ -44,6 +44,8 @@ class ConvertKit_Settings {
 		add_action( 'admin_menu', array( $this, 'add_settings_page' ) );
 		add_action( 'admin_init', array( $this, 'register_sections' ) );
 
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+
 		// AJAX callback for TinyMCE button to get list of tags
 		add_action( 'wp_ajax_convertkit_get_tags', array( $this, 'get_tags' ) );
 		// Function to output
@@ -56,6 +58,20 @@ class ConvertKit_Settings {
 		if ( WP_DEBUG ) {
 			add_action( 'show_user_profile', array( $this, 'add_customer_meta_fields' ) );
 			add_action( 'edit_user_profile', array( $this, 'add_customer_meta_fields' ) );
+		}
+	}
+
+	/**
+	 * Enqueue Scripts in Admin
+	 *
+	 * @param $hook
+	 */
+	public function enqueue_scripts( $hook ) {
+		if ( 'settings_page__wp_convertkit_settings' === $hook ) {
+			wp_enqueue_script( 'ck-admin-js', plugins_url( '../resources/backend/wp-convertkit.js', __FILE__ ), array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
+			wp_localize_script( 'ck-admin-js', 'ck_admin', array(
+				'option_none' => __( 'None', 'convertkit' ),
+			));
 		}
 	}
 

--- a/admin/class-convertkit-settings.php
+++ b/admin/class-convertkit-settings.php
@@ -44,8 +44,6 @@ class ConvertKit_Settings {
 		add_action( 'admin_menu', array( $this, 'add_settings_page' ) );
 		add_action( 'admin_init', array( $this, 'register_sections' ) );
 
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-
 		// AJAX callback for TinyMCE button to get list of tags
 		add_action( 'wp_ajax_convertkit_get_tags', array( $this, 'get_tags' ) );
 		// Function to output
@@ -58,21 +56,6 @@ class ConvertKit_Settings {
 		if ( WP_DEBUG ) {
 			add_action( 'show_user_profile', array( $this, 'add_customer_meta_fields' ) );
 			add_action( 'edit_user_profile', array( $this, 'add_customer_meta_fields' ) );
-		}
-	}
-
-	/**
-	 * Enqueue Scripts in Admin
-	 *
-	 * @param $hook
-	 */
-	public function enqueue_scripts( $hook ) {
-
-		if ( 'settings_page__wp_convertkit_settings' === $hook ) {
-			wp_enqueue_script( 'ck-admin-js', plugins_url( '../resources/backend/wp-convertkit.js', __FILE__ ), array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
-			wp_localize_script( 'ck-admin-js', 'ck_admin', array(
-				'option_none' => __( 'None', 'convertkit' ),
-			));
 		}
 	}
 
@@ -102,35 +85,35 @@ class ConvertKit_Settings {
 		}
 
 		?>
-        <div class="wrap convertkit-settings-wrap">
-			<?php
-			if ( count( $this->sections ) > 1 ) {
-				$this->display_section_nav( $active_section );
-			} else {
-				?>
-                <h2><?php esc_html_e( 'ConvertKit', 'convertkit' ); ?></h2>
-				<?php
-			}
+		<div class="wrap convertkit-settings-wrap">
+		<?php
+		if ( count( $this->sections ) > 1 ) {
+			$this->display_section_nav( $active_section );
+		} else {
 			?>
+			<h2><?php esc_html_e( 'ConvertKit', 'convertkit' ); ?></h2>
+			<?php
+		}
+		?>
 
-            <form method="post" action="options.php">
-				<?php
-				foreach ( $this->sections as $section ) :
-					if ( $active_section === $section->name ) :
-						$section->render();
-					endif;
-				endforeach;
+		<form method="post" action="options.php">
+		<?php
+		foreach ( $this->sections as $section ) :
+			if ( $active_section === $section->name ) :
+				$section->render();
+			endif;
+		endforeach;
 
-				// Check for Multibyte string PHP extension.
-				if ( ! extension_loaded( 'mbstring' ) ) {
-					?><p><strong><?php
-						echo  sprintf( __( 'Note: Your server does not support the %s functions - this is required for better character encoding. Please contact your webhost to have it installed.', 'woocommerce' ), '<a href="https://php.net/manual/en/mbstring.installation.php">mbstring</a>' ) . '</mark>';
-						?></strong></p><?php
-				}
-				?><p class="description"><?php
-					printf( 'If you need help setting up the plugin please refer to the %s plugin documentation.</a>', '<a href="http://help.convertkit.com/article/99-the-convertkit-wordpress-plugin" target="_blank">' ); ?></p>
-            </form>
-        </div>
+		// Check for Multibyte string PHP extension.
+		if ( ! extension_loaded( 'mbstring' ) ) {
+			?><p><strong><?php
+			echo  sprintf( __( 'Note: Your server does not support the %s functions - this is required for better character encoding. Please contact your webhost to have it installed.', 'woocommerce' ), '<a href="https://php.net/manual/en/mbstring.installation.php">mbstring</a>' ) . '</mark>';
+			?></strong></p><?php
+		}
+		?><p class="description"><?php
+				printf( 'If you need help setting up the plugin please refer to the %s plugin documentation.</a>', '<a href="http://help.convertkit.com/article/99-the-convertkit-wordpress-plugin" target="_blank">' ); ?></p>
+		</form>
+		</div>
 		<?php
 	}
 
@@ -148,20 +131,20 @@ class ConvertKit_Settings {
 	 */
 	public function display_section_nav( $active_section ) {
 		?>
-        <h1><?php esc_html_e( 'ConvertKit', 'convertkit' ); ?></h1>
-        <h2 class="nav-tab-wrapper">
-			<?php
-			foreach ( $this->sections as $section ) :
-				printf(
-					'<a href="?page=%s&tab=%s" class="nav-tab right %s">%s</a>',
-					esc_html( $this->settings_key ),
-					esc_html( $section->name ),
-					$active_section === $section->name ? 'nav-tab-active' : '',
-					esc_html( $section->tab_text )
-				);
-			endforeach;
-			?>
-        </h2>
+		<h1><?php esc_html_e( 'ConvertKit', 'convertkit' ); ?></h1>
+		<h2 class="nav-tab-wrapper">
+		<?php
+		foreach ( $this->sections as $section ) :
+			printf(
+				'<a href="?page=%s&tab=%s" class="nav-tab right %s">%s</a>',
+				esc_html( $this->settings_key ),
+				esc_html( $section->name ),
+				$active_section === $section->name ? 'nav-tab-active' : '',
+				esc_html( $section->tab_text )
+			);
+		endforeach;
+		?>
+		</h2>
 		<?php
 	}
 
@@ -184,6 +167,7 @@ class ConvertKit_Settings {
 	public function register_sections() {
 		wp_register_style( 'wp-convertkit-admin', plugins_url( '../resources/backend/wp-convertkit.css', __FILE__ ) );
 		$this->register_section( 'ConvertKit_Settings_General' );
+		$this->register_section( 'ConvertKit_Settings_Tools' );
 		$this->register_section( 'ConvertKit_Settings_Wishlist' );
 		$this->register_section( 'ConvertKit_Settings_ContactForm7' );
 	}
@@ -218,25 +202,25 @@ class ConvertKit_Settings {
 		if ( $pagenow !== 'admin.php' ) {
 			$nonce = wp_create_nonce( 'convertkit-tinymce' );
 			?><script type="text/javascript">
-                jQuery( document ).ready( function( $ ) {
-                    var data = {
-                        'action'	: 'convertkit_get_tags', // wp ajax action
-                        'security'	: '<?php echo $nonce; ?>' // nonce value created earlier
-                    };
-                    jQuery.post( ajaxurl, data, function( response ) {
-                        if( response === '-1' ){
-                            console.log( 'error convertkit_get_tags' );
-                        } else {
-                            if ( typeof( tinyMCE ) != 'undefined' ) {
-                                if (tinyMCE.activeEditor != null) {
-                                    tinyMCE.activeEditor.settings.ckTags = response;
-                                    console.log('added tags');
-                                }
-                            }
-                        }
-                    });
-                });
-            </script>
+				jQuery( document ).ready( function( $ ) {
+					var data = {
+						'action'	: 'convertkit_get_tags', // wp ajax action
+						'security'	: '<?php echo $nonce; ?>' // nonce value created earlier
+					};
+					jQuery.post( ajaxurl, data, function( response ) {
+						if( response === '-1' ){
+							console.log( 'error convertkit_get_tags' );
+						} else {
+							if ( typeof( tinyMCE ) != 'undefined' ) {
+								if (tinyMCE.activeEditor != null) {
+									tinyMCE.activeEditor.settings.ckTags = response;
+									console.log('added tags');
+								}
+							}
+						}
+					});
+				});
+			</script>
 			<?php
 		}
 	}
@@ -249,13 +233,13 @@ class ConvertKit_Settings {
 
 		$tags = get_user_meta( $user->ID, 'convertkit_tags', true );
 		?>
-        <h2><?php esc_attr_e( 'ConvertKit Tags', 'convertkit' ) ?></h2>
-        <table class="form-table" id="<?php echo esc_attr( 'fieldset-convertkit' ); ?>">
+		<h2><?php esc_attr_e( 'ConvertKit Tags', 'convertkit' ) ?></h2>
+		<table class="form-table" id="<?php echo esc_attr( 'fieldset-convertkit' ); ?>">
 			<?php
-			?>
-            <tr>
-                <th><label for="tags"><?php esc_attr_e( 'Tags', 'convertkit' ) ?></label></th>
-                <td><textarea id="tags" name="tags" disabled="disabled">
+				?>
+				<tr>
+					<th><label for="tags"><?php esc_attr_e( 'Tags', 'convertkit' ) ?></label></th>
+					<td><textarea id="tags" name="tags" disabled="disabled">
 					<?php
 					if ( empty( $tags ) ) {
 						esc_html_e( 'No ConvertKit Tags assigned to this user.' ,'convertkit' );
@@ -266,11 +250,11 @@ class ConvertKit_Settings {
 						}
 					}
 					?></textarea>
-                </td>
-            </tr>
-			<?php
+					</td>
+				</tr>
+				<?php
 			?>
-        </table>
+		</table>
 		<?php
 	}
 
@@ -285,7 +269,7 @@ class ConvertKit_Settings {
 		$forms = get_option( 'convertkit_forms' );
 		$default_form = get_term_meta( $tag->term_id, 'ck_default_form', true );
 
-		echo '<tr class="form-field ck-term-description-wrap"><th scope="row"><label for="description">ConvertKit Form</label></th><td>';
+		echo '<tr class="form-field term-description-wrap"><th scope="row"><label for="description">ConvertKit Form</label></th><td>';
 
 		// Check for error in response.
 		if ( isset( $forms[0]['id'] ) && '-2' === $forms[0]['id'] ) {

--- a/admin/section/class-convertkit-settings-base.php
+++ b/admin/section/class-convertkit-settings-base.php
@@ -61,6 +61,13 @@ abstract class ConvertKit_Settings_Base {
 	public $options;
 
 	/**
+	 * If false, we will hide the submit button.
+	 *
+	 * @var bool
+	 */
+	protected $show_submit = true;
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -105,7 +112,9 @@ abstract class ConvertKit_Settings_Base {
 	public function render() {
 		do_settings_sections( $this->settings_key );
 		settings_fields( $this->settings_key );
-		submit_button();
+		if ( $this->show_submit ) {
+			submit_button();
+		}
 	}
 
 	/**

--- a/admin/section/class-convertkit-settings-tools.php
+++ b/admin/section/class-convertkit-settings-tools.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * ConvertKit Tools Settings class
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Class ConvertKit_Settings_Tools
+ */
+class ConvertKit_Settings_Tools extends ConvertKit_Settings_Base {
+
+	/**
+     * We are hiding the submit button.
+     *
+	 * @var bool
+	 */
+    protected $show_submit = false;
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		$this->settings_key = '_wp_convertkit_integration_tools_settings';
+		$this->name         = 'tools';
+		$this->title        = __( 'Tools', 'convertkit' );
+		$this->tab_text     = __( 'Tools', 'convertkit' );
+
+		parent::__construct();
+	}
+
+	/**
+	 * Register and add settings
+	 */
+	public function register_fields() {
+		add_settings_field(
+			'log',
+			'Log',
+			array( $this, 'view_log' ),
+			$this->settings_key,
+			$this->name
+		);
+	}
+
+	/**
+	 * Prints help info for this section
+	 */
+	public function print_section_info() {
+		?>
+		<p><?php esc_html_e( 'Tools to help you manage ConvertKit on your site.', 'convertkit' ); ?></p>
+		<?php
+	}
+
+	/*
+	 * View the Log
+	 */
+	public function view_log() {
+	    $log_file = trailingslashit( CONVERTKIT_PLUGIN_PATH ) . 'log.txt';
+        $log = file_get_contents( $log_file );
+
+        if ( ! $log ) {
+            ?>
+            <p class="description"><?php esc_html_e( 'Log file is empty', 'convertkit' ); ?></p>
+            <?php
+            return;
+        }
+	    ?>
+        <button type="submit" class="button button-secondary" name="convertkit_clear_log"><?php esc_html_e( 'Clear the Log', 'converkit' ); ?></button>
+        <div class="convertkit-log-viewer">
+		    <pre><?php echo esc_html( file_get_contents( $log_file ) ); ?></pre>
+        </div>
+	    <?php
+    }
+
+	/**
+	 * Sanitizes the settings.
+     * We are also using this to clear the Log file.
+	 *
+	 * @param  array $settings The settings fields submitted.
+	 * @return array           Sanitized settings.
+	 */
+	public function sanitize_settings( $settings ) {
+
+		$log_file = trailingslashit( CONVERTKIT_PLUGIN_PATH ) . 'log.txt';
+		if ( isset( $_POST['convertkit_clear_log'] ) ) {
+			$handle = fopen( $log_file, 'w' );
+			fclose( $handle );
+		}
+		return $settings;
+	}
+}

--- a/admin/section/class-convertkit-settings-tools.php
+++ b/admin/section/class-convertkit-settings-tools.php
@@ -53,41 +53,377 @@ class ConvertKit_Settings_Tools extends ConvertKit_Settings_Base {
 		<?php
 	}
 
+	/**
+	 * Renders the section
+	 */
+	public function render() {
+		settings_fields( $this->settings_key );
+		$this->view_log();
+		$this->view_server_info();
+	}
+
 	/*
 	 * View the Log
 	 */
 	public function view_log() {
-	    $log_file = trailingslashit( CONVERTKIT_PLUGIN_PATH ) . 'log.txt';
-        $log = file_get_contents( $log_file );
+		$log_file = trailingslashit( CONVERTKIT_PLUGIN_PATH ) . 'log.txt';
+		$log      = file_get_contents( $log_file );
 
-        if ( ! $log ) {
-            ?>
-            <p class="description"><?php esc_html_e( 'Log file is empty', 'convertkit' ); ?></p>
-            <?php
-            return;
-        }
-	    ?>
-        <button type="submit" class="button button-secondary" name="convertkit_clear_log"><?php esc_html_e( 'Clear the Log', 'converkit' ); ?></button>
-        <div class="convertkit-log-viewer">
-		    <pre><?php echo esc_html( file_get_contents( $log_file ) ); ?></pre>
-        </div>
-	    <?php
-    }
+		?>
+        <div class="metabox-holder">
+            <div class="postbox ck-debug-log">
+                <h3><span><?php esc_html_e( 'Debug Log', 'convertkit' ); ?></span></h3>
+                <div class="inside">
+                    <p><?php _e( 'Use this tool to help debug ConvertKit plugin functionality.', 'convertkit' ); ?></p>
+                    <textarea readonly="readonly" class="large-text monospace" rows="15"
+                              name="convertkit-debug-log-contents"><?php echo esc_textarea( $log ); ?></textarea>
+                    <p class="submit">
+						<?php
+						submit_button(
+							__( 'Copy Log','convertkit' ),
+							'primary',
+							'convertkit-copy-debug-log',
+							false,
+							array(
+								'onclick' => "this.form['convertkit-debug-log-contents'].focus();this.form['convertkit-debug-log-contents'].select();document.execCommand('copy');return false;"
+							)
+						);
+						submit_button(
+							__( 'Clear Log', 'convertkit' ),
+							'secondary ck-inline-button',
+							'convertkit-clear-debug-log',
+							false
+						);
+						?>
+                    </p>
+                    <p><?php _e( 'Log file', 'convertkit' ); ?>: <code><?php echo $log_file; ?></code></p>
+                </div><!-- .inside -->
+            </div><!-- .postbox -->
+        </div><!-- .metabox-holder -->
+		<?php
+	}
+
+	public function view_server_info() {
+		?>
+        <div class="metabox-holder">
+            <div class="postbox ck-debug-log">
+                <h3><span><?php esc_html_e( 'System Info', 'convertkit' ); ?></span></h3>
+                <div class="inside">
+                    <p><?php _e( 'Use this tool to send system info to support when necessary.', 'convertkit' ); ?></p>
+                        <textarea readonly="readonly" onclick="this.focus(); this.select()" id="system-info-textarea" class="large-text monospace" rows="15" name="convertkit-sysinfo"><?php echo $this->get_system_info(); ?></textarea>
+                        <p class="submit">
+                            <input type="hidden" name="convertkit-action" value="download_sysinfo" />
+	                        <?php
+	                        submit_button(
+		                        __( 'Copy System Info', 'convertkit' ),
+		                        'primary',
+		                        'convertkit-copy-system-info',
+		                        false,
+		                        array(
+			                        'onclick' => "this.form['convertkit-sysinfo'].focus();this.form['convertkit-sysinfo'].select();document.execCommand('copy');return false;"
+		                        )
+	                        );
+	                        ?>
+                        </p>
+                </div><!-- .inside -->
+            </div><!-- .postbox -->
+        </div><!-- .metabox-holder -->
+		<?php
+	}
 
 	/**
 	 * Sanitizes the settings.
-     * We are also using this to clear the Log file.
+	 * We are also using this to clear the Log file.
 	 *
 	 * @param  array $settings The settings fields submitted.
+	 *
 	 * @return array           Sanitized settings.
 	 */
 	public function sanitize_settings( $settings ) {
 
 		$log_file = trailingslashit( CONVERTKIT_PLUGIN_PATH ) . 'log.txt';
-		if ( isset( $_POST['convertkit_clear_log'] ) ) {
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		if ( isset( $_REQUEST['convertkit-clear-debug-log'] ) ) {
+
 			$handle = fopen( $log_file, 'w' );
 			fclose( $handle );
+
+			wp_safe_redirect( admin_url( 'options-general.php?page=_wp_convertkit_settings&tab=tools' ) );
+			exit;
+
 		}
-		return $settings;
+	}
+
+	/**
+	 * Get system info
+     *
+     * Adapted from Easy Digital Downloads
+	 *
+	 * @since       2.0
+	 * @global      object $wpdb Used to query the database using the WordPress Database API
+	 * @return      string $return A string containing the info to output
+	 */
+	function get_system_info() {
+		global $wpdb;
+
+		if ( ! class_exists( 'Browser' ) ) {
+			require_once CONVERTKIT_PLUGIN_PATH . 'lib/browser.php';
+        }
+
+		$browser = new Browser();
+
+		// Get theme info
+		$theme_data   = wp_get_theme();
+		$theme        = $theme_data->Name . ' ' . $theme_data->Version;
+		$parent_theme = $theme_data->Template;
+		if ( ! empty( $parent_theme ) ) {
+			$parent_theme_data = wp_get_theme( $parent_theme );
+			$parent_theme      = $parent_theme_data->Name . ' ' . $parent_theme_data->Version;
+		}
+
+		// Try to identify the hosting provider
+		$host = $this->get_host();
+
+		$return  = '### Begin System Info ###' . "\n\n";
+
+		// Start with the basics...
+		$return .= '-- Site Info' . "\n\n";
+		$return .= 'Site URL:                 ' . site_url() . "\n";
+		$return .= 'Home URL:                 ' . home_url() . "\n";
+		$return .= 'Multisite:                ' . ( is_multisite() ? 'Yes' : 'No' ) . "\n";
+
+		$return  = apply_filters( 'convertkit_sysinfo_after_site_info', $return );
+
+		// Can we determine the site's host?
+		if( $host ) {
+			$return .= "\n" . '-- Hosting Provider' . "\n\n";
+			$return .= 'Host:                     ' . $host . "\n";
+
+			$return  = apply_filters( 'convertkit_sysinfo_after_host_info', $return );
+		}
+
+		// The local users' browser information, handled by the Browser class
+		$return .= "\n" . '-- User Browser' . "\n\n";
+		$return .= $browser;
+
+		$return  = apply_filters( 'convertkit_sysinfo_after_user_browser', $return );
+
+		$locale = get_locale();
+
+		// WordPress configuration
+		$return .= "\n" . '-- WordPress Configuration' . "\n\n";
+		$return .= 'Version:                  ' . get_bloginfo( 'version' ) . "\n";
+		$return .= 'Language:                 ' . ( !empty( $locale ) ? $locale : 'en_US' ) . "\n";
+		$return .= 'Permalink Structure:      ' . ( get_option( 'permalink_structure' ) ? get_option( 'permalink_structure' ) : 'Default' ) . "\n";
+		$return .= 'Active Theme:             ' . $theme . "\n";
+		if ( $parent_theme !== $theme ) {
+			$return .= 'Parent Theme:             ' . $parent_theme . "\n";
+		}
+		$return .= 'Show On Front:            ' . get_option( 'show_on_front' ) . "\n";
+
+		// Only show page specs if frontpage is set to 'page'
+		if( get_option( 'show_on_front' ) == 'page' ) {
+			$front_page_id = get_option( 'page_on_front' );
+			$blog_page_id = get_option( 'page_for_posts' );
+
+			$return .= 'Page On Front:            ' . ( $front_page_id != 0 ? get_the_title( $front_page_id ) . ' (#' . $front_page_id . ')' : 'Unset' ) . "\n";
+			$return .= 'Page For Posts:           ' . ( $blog_page_id != 0 ? get_the_title( $blog_page_id ) . ' (#' . $blog_page_id . ')' : 'Unset' ) . "\n";
+		}
+
+		$return .= 'ABSPATH:                  ' . ABSPATH . "\n";
+
+		// Make sure wp_remote_post() is working
+		$request['cmd'] = '_notify-validate';
+
+		$params = array(
+			'sslverify'     => false,
+			'timeout'       => 60,
+			'user-agent'    => 'ConvertKit/' . CONVERTKIT_PLUGIN_VERSION,
+			'body'          => $request
+		);
+
+		$response = wp_remote_post( 'https://www.paypal.com/cgi-bin/webscr', $params );
+
+		if( !is_wp_error( $response ) && $response['response']['code'] >= 200 && $response['response']['code'] < 300 ) {
+			$WP_REMOTE_POST = 'wp_remote_post() works';
+		} else {
+			$WP_REMOTE_POST = 'wp_remote_post() does not work';
+		}
+
+		$return .= 'Remote Post:              ' . $WP_REMOTE_POST . "\n";
+		$return .= 'Table Prefix:             ' . 'Length: ' . strlen( $wpdb->prefix ) . '   Status: ' . ( strlen( $wpdb->prefix ) > 16 ? 'ERROR: Too long' : 'Acceptable' ) . "\n";
+		$return .= 'WP_DEBUG:                 ' . ( defined( 'WP_DEBUG' ) ? WP_DEBUG ? 'Enabled' : 'Disabled' : 'Not set' ) . "\n";
+		$return .= 'Memory Limit:             ' . WP_MEMORY_LIMIT . "\n";
+		$return .= 'Registered Post Stati:    ' . implode( ', ', get_post_stati() ) . "\n";
+
+		$return  = apply_filters( 'convertkit_sysinfo_after_wordpress_config', $return );
+
+		// ConvertKit configuration
+		$return .= "\n" . '-- ConvertKit Configuration' . "\n\n";
+		$return .= 'Version:                  ' . CONVERTKIT_PLUGIN_VERSION . "\n";
+        // @TODO add info on form settings, incl. integrations, etc.
+
+		$return  = apply_filters( 'convertkit_sysinfo_after_convertkit_config', $return );
+
+		// Get plugins that have an update
+		$updates = get_plugin_updates();
+
+		// Must-use plugins
+		// NOTE: MU plugins can't show updates!
+		$muplugins = get_mu_plugins();
+		if( count( $muplugins ) > 0 ) {
+			$return .= "\n" . '-- Must-Use Plugins' . "\n\n";
+
+			foreach( $muplugins as $plugin => $plugin_data ) {
+				$return .= $plugin_data['Name'] . ': ' . $plugin_data['Version'] . "\n";
+			}
+
+			$return = apply_filters( 'convertkit_sysinfo_after_wordpress_mu_plugins', $return );
+		}
+
+		// WordPress active plugins
+		$return .= "\n" . '-- WordPress Active Plugins' . "\n\n";
+
+		$plugins = get_plugins();
+		$active_plugins = get_option( 'active_plugins', array() );
+
+		foreach( $plugins as $plugin_path => $plugin ) {
+			if( !in_array( $plugin_path, $active_plugins ) )
+				continue;
+
+			$update = ( array_key_exists( $plugin_path, $updates ) ) ? ' (needs update - ' . $updates[$plugin_path]->update->new_version . ')' : '';
+			$return .= $plugin['Name'] . ': ' . $plugin['Version'] . $update . "\n";
+		}
+
+		$return  = apply_filters( 'convertkit_sysinfo_after_wordpress_plugins', $return );
+
+		// WordPress inactive plugins
+		$return .= "\n" . '-- WordPress Inactive Plugins' . "\n\n";
+
+		foreach( $plugins as $plugin_path => $plugin ) {
+			if( in_array( $plugin_path, $active_plugins ) )
+				continue;
+
+			$update = ( array_key_exists( $plugin_path, $updates ) ) ? ' (needs update - ' . $updates[$plugin_path]->update->new_version . ')' : '';
+			$return .= $plugin['Name'] . ': ' . $plugin['Version'] . $update . "\n";
+		}
+
+		$return  = apply_filters( 'convertkit_sysinfo_after_wordpress_plugins_inactive', $return );
+
+		if( is_multisite() ) {
+			// WordPress Multisite active plugins
+			$return .= "\n" . '-- Network Active Plugins' . "\n\n";
+
+			$plugins = wp_get_active_network_plugins();
+			$active_plugins = get_site_option( 'active_sitewide_plugins', array() );
+
+			foreach( $plugins as $plugin_path ) {
+				$plugin_base = plugin_basename( $plugin_path );
+
+				if( !array_key_exists( $plugin_base, $active_plugins ) )
+					continue;
+
+				$update = ( array_key_exists( $plugin_path, $updates ) ) ? ' (needs update - ' . $updates[$plugin_path]->update->new_version . ')' : '';
+				$plugin  = get_plugin_data( $plugin_path );
+				$return .= $plugin['Name'] . ': ' . $plugin['Version'] . $update . "\n";
+			}
+
+			$return  = apply_filters( 'convertkit_sysinfo_after_wordpress_ms_plugins', $return );
+		}
+
+		// Server configuration (really just versioning)
+		$return .= "\n" . '-- Webserver Configuration' . "\n\n";
+		$return .= 'PHP Version:              ' . PHP_VERSION . "\n";
+		$return .= 'MySQL Version:            ' . $wpdb->db_version() . "\n";
+		$return .= 'Webserver Info:           ' . $_SERVER['SERVER_SOFTWARE'] . "\n";
+
+		$return  = apply_filters( 'convertkit_sysinfo_after_webserver_config', $return );
+
+		// PHP configs... now we're getting to the important stuff
+		$return .= "\n" . '-- PHP Configuration' . "\n\n";
+		$return .= 'Memory Limit:             ' . ini_get( 'memory_limit' ) . "\n";
+		$return .= 'Upload Max Size:          ' . ini_get( 'upload_max_filesize' ) . "\n";
+		$return .= 'Post Max Size:            ' . ini_get( 'post_max_size' ) . "\n";
+		$return .= 'Upload Max Filesize:      ' . ini_get( 'upload_max_filesize' ) . "\n";
+		$return .= 'Time Limit:               ' . ini_get( 'max_execution_time' ) . "\n";
+		$return .= 'Max Input Vars:           ' . ini_get( 'max_input_vars' ) . "\n";
+		$return .= 'Display Errors:           ' . ( ini_get( 'display_errors' ) ? 'On (' . ini_get( 'display_errors' ) . ')' : 'N/A' ) . "\n";
+		$return .= 'PHP Arg Separator:        ' . ini_get( 'arg_separator.output') . "\n";
+
+		$return  = apply_filters( 'convertkit_sysinfo_after_php_config', $return );
+
+		// PHP extensions and such
+		$return .= "\n" . '-- PHP Extensions' . "\n\n";
+		$return .= 'cURL:                     ' . ( function_exists( 'curl_init' ) ? 'Supported' : 'Not Supported' ) . "\n";
+		$return .= 'fsockopen:                ' . ( function_exists( 'fsockopen' ) ? 'Supported' : 'Not Supported' ) . "\n";
+		$return .= 'SOAP Client:              ' . ( class_exists( 'SoapClient' ) ? 'Installed' : 'Not Installed' ) . "\n";
+		$return .= 'Suhosin:                  ' . ( extension_loaded( 'suhosin' ) ? 'Installed' : 'Not Installed' ) . "\n";
+
+		$return  = apply_filters( 'convertkit_sysinfo_after_php_ext', $return );
+
+		// Session stuff
+		$return .= "\n" . '-- Session Configuration' . "\n\n";
+
+		// The rest of this is only relevant is session is enabled
+		if( isset( $_SESSION ) ) {
+			$return .= 'Session Name:             ' . esc_html( ini_get( 'session.name' ) ) . "\n";
+			$return .= 'Cookie Path:              ' . esc_html( ini_get( 'session.cookie_path' ) ) . "\n";
+			$return .= 'Save Path:                ' . esc_html( ini_get( 'session.save_path' ) ) . "\n";
+			$return .= 'Use Cookies:              ' . ( ini_get( 'session.use_cookies' ) ? 'On' : 'Off' ) . "\n";
+			$return .= 'Use Only Cookies:         ' . ( ini_get( 'session.use_only_cookies' ) ? 'On' : 'Off' ) . "\n";
+		}
+
+		$return  = apply_filters( 'convertkit_sysinfo_after_session_config', $return );
+
+		$return .= "\n" . '### End System Info ###';
+
+		return $return;
+	}
+
+	/**
+	 * Get user host
+     *
+     * Adapted from Easy Digital Downloads
+	 *
+	 * Returns the webhost this site is using if possible
+	 *
+	 * @since 1.6.4
+	 * @return mixed string $host if detected, false otherwise
+	 */
+	function get_host() {
+		$host = false;
+
+		if( defined( 'WPE_APIKEY' ) ) {
+			$host = 'WP Engine';
+		} elseif( defined( 'PAGELYBIN' ) ) {
+			$host = 'Pagely';
+		} elseif( DB_HOST == 'localhost:/tmp/mysql5.sock' ) {
+			$host = 'ICDSoft';
+		} elseif( DB_HOST == 'mysqlv5' ) {
+			$host = 'NetworkSolutions';
+		} elseif( strpos( DB_HOST, 'ipagemysql.com' ) !== false ) {
+			$host = 'iPage';
+		} elseif( strpos( DB_HOST, 'ipowermysql.com' ) !== false ) {
+			$host = 'IPower';
+		} elseif( strpos( DB_HOST, '.gridserver.com' ) !== false ) {
+			$host = 'MediaTemple Grid';
+		} elseif( strpos( DB_HOST, '.pair.com' ) !== false ) {
+			$host = 'pair Networks';
+		} elseif( strpos( DB_HOST, '.stabletransit.com' ) !== false ) {
+			$host = 'Rackspace Cloud';
+		} elseif( strpos( DB_HOST, '.sysfix.eu' ) !== false ) {
+			$host = 'SysFix.eu Power Hosting';
+		} elseif( strpos( $_SERVER['SERVER_NAME'], 'Flywheel' ) !== false ) {
+			$host = 'Flywheel';
+		} else {
+			// Adding a general fallback for data gathering
+			$host = 'DBH: ' . DB_HOST . ', SRV: ' . $_SERVER['SERVER_NAME'];
+		}
+
+		return $host;
 	}
 }

--- a/lib/browser.php
+++ b/lib/browser.php
@@ -1,0 +1,1106 @@
+<?php
+
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+/**
+ * Adapted for ConvertKit from Easy Digital Downloads
+ * https://github.com/easydigitaldownloads/easy-digital-downloads
+ *
+ * Modified to remove var
+ * Chris Christoff on 12/26/2012
+ * Changes: Changes vars to publics
+ *
+ * Modified to work for EDD by
+ * Chris Christoff on 12/23/2012
+ * Changes: Removed the browser string return and added spacing. Also removed return HTML formatting.
+ *
+ * Modified to add formatted User Agent string for EDD System Info by
+ * Chris Christoff on 12/23/2012
+ * Changes: Split user string and add formatting so we can print a nicely
+ * formatted user agent string on the EDD System Info
+ *
+ * File: Browser.php
+ * Author: Chris Schuld (http://chrisschuld.com/)
+ * Last Modified: August 20th, 2010
+ *
+ * @version 1.9
+ * @package PegasusPHP
+ *
+ * Copyright (C) 2008-2010 Chris Schuld  (chris@chrisschuld.com)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details at:
+ * http://www.gnu.org/copyleft/gpl.html
+ *
+ *
+ * Typical Usage:
+ *
+ *   $browser = new Browser();
+ *   if( $browser->getBrowser() == Browser::BROWSER_FIREFOX && $browser->getVersion() >= 2 ) {
+ *    echo 'You have FireFox version 2 or greater';
+ *   }
+ *
+ * User Agents Sampled from: http://www.useragentstring.com/
+ *
+ * This implementation is based on the original work from Gary White
+ * http://apptools.com/phptools/browser/
+ *
+ * UPDATES:
+ *
+ * 2010-08-20 (v1.9):
+ *  + Added MSN Explorer Browser (legacy)
+ *  + Added Bing/MSN Robot (Thanks Rob MacDonald)
+ *  + Added the Android Platform (PLATFORM_ANDROID)
+ *  + Fixed issue with Android 1.6/2.2 (Thanks Tom Hirashima)
+ *
+ * 2010-04-27 (v1.8):
+ *  + Added iPad Support
+ *
+ * 2010-03-07 (v1.7):
+ *  + *MAJOR* Rebuild (preg_match and other "slow" routine removal(s))
+ *  + Almost allof Gary's original code has been replaced
+ *  + Large PHPUNIT testing environment created to validate new releases and additions
+ *  + Added FreeBSD Platform
+ *  + Added OpenBSD Platform
+ *  + Added NetBSD Platform
+ *  + Added SunOS Platform
+ *  + Added OpenSolaris Platform
+ *  + Added support of the Iceweazel Browser
+ *  + Added isChromeFrame() call to check if chromeframe is in use
+ *  + Moved the Opera check in front of the Firefox check due to legacy Opera User Agents
+ *  + Added the __toString() method (Thanks Deano)
+ *
+ * 2009-11-15:
+ *  + Updated the checkes for Firefox
+ *  + Added the NOKIA platform
+ *  + Added Checks for the NOKIA brower(s)
+ *
+ * 2009-11-08:
+ *  + PHP 5.3 Support
+ *  + Added support for BlackBerry OS and BlackBerry browser
+ *  + Added support for the Opera Mini browser
+ *  + Added additional documenation
+ *  + Added support for isRobot() and isMobile()
+ *  + Added support for Opera version 10
+ *  + Added support for deprecated Netscape Navigator version 9
+ *  + Added support for IceCat
+ *  + Added support for Shiretoko
+ *
+ * 2010-04-27 (v1.8):
+ *  + Added iPad Support
+ *
+ * 2009-08-18:
+ *  + Updated to support PHP 5.3 - removed all deprecated function calls
+ *  + Updated to remove all double quotes (") -- converted to single quotes (')
+ *
+ * 2009-04-27:
+ *  + Updated the IE check to remove a typo and bug (thanks John)
+ *
+ * 2009-04-22:
+ *  + Added detection for GoogleBot
+ *  + Added detection for the W3C Validator.
+ *  + Added detection for Yahoo! Slurp
+ *
+ * 2009-03-14:
+ *  + Added detection for iPods.
+ *  + Added Platform detection for iPhones
+ *  + Added Platform detection for iPods
+ *
+ * 2009-02-16: (Rick Hale)
+ *  + Added version detection for Android phones.
+ *
+ * 2008-12-09:
+ *  + Removed unused constant
+ *
+ * 2008-11-07:
+ *  + Added Google's Chrome to the detection list
+ *  + Added isBrowser(string) to the list of functions special thanks to
+ *    Daniel 'mavrick' Lang for the function concept (http://mavrick.id.au)
+ *
+ *
+ * Gary White noted: "Since browser detection is so unreliable, I am
+ * no longer maintaining this script. You are free to use and or
+ * modify/update it as you want, however the author assumes no
+ * responsibility for the accuracy of the detected values."
+ *
+ * Anyone experienced with Gary's script might be interested in these notes:
+ *
+ *   Added class constants
+ *   Added detection and version detection for Google's Chrome
+ *   Updated the version detection for Amaya
+ *   Updated the version detection for Firefox
+ *   Updated the version detection for Lynx
+ *   Updated the version detection for WebTV
+ *   Updated the version detection for NetPositive
+ *   Updated the version detection for IE
+ *   Updated the version detection for OmniWeb
+ *   Updated the version detection for iCab
+ *   Updated the version detection for Safari
+ *   Updated Safari to remove mobile devices (iPhone)
+ *   Added detection for iPhone
+ *   Added detection for robots
+ *   Added detection for mobile devices
+ *   Added detection for BlackBerry
+ *   Removed Netscape checks (matches heavily with firefox & mozilla)
+ *
+ */
+
+class Browser {
+	public $_agent = '';
+	public $_browser_name = '';
+	public $_version = '';
+	public $_platform = '';
+	public $_os = '';
+	public $_is_aol = false;
+	public $_is_mobile = false;
+	public $_is_robot = false;
+	public $_aol_version = '';
+
+	public $BROWSER_UNKNOWN = 'unknown';
+	public $VERSION_UNKNOWN = 'unknown';
+
+	public $BROWSER_OPERA = 'Opera';                            // Http://www.opera.com/
+	public $BROWSER_OPERA_MINI = 'Opera Mini';                  // Http://www.opera.com/mini/
+	public $BROWSER_WEBTV = 'WebTV';                            // Http://www.webtv.net/pc/
+	public $BROWSER_IE = 'Internet Explorer';                   // Http://www.microsoft.com/ie/
+	public $BROWSER_POCKET_IE = 'Pocket Internet Explorer';     // Http://en.wikipedia.org/wiki/Internet_Explorer_Mobile
+	public $BROWSER_KONQUEROR = 'Konqueror';                    // Http://www.konqueror.org/
+	public $BROWSER_ICAB = 'iCab';                              // Http://www.icab.de/
+	public $BROWSER_OMNIWEB = 'OmniWeb';                        // Http://www.omnigroup.com/applications/omniweb/
+	public $BROWSER_FIREBIRD = 'Firebird';                      // Http://www.ibphoenix.com/
+	public $BROWSER_FIREFOX = 'Firefox';                        // Http://www.mozilla.com/en-US/firefox/firefox.html
+	public $BROWSER_ICEWEASEL = 'Iceweasel';                    // Http://www.geticeweasel.org/
+	public $BROWSER_SHIRETOKO = 'Shiretoko';                    // Http://wiki.mozilla.org/Projects/shiretoko
+	public $BROWSER_MOZILLA = 'Mozilla';                        // Http://www.mozilla.com/en-US/
+	public $BROWSER_AMAYA = 'Amaya';                            // Http://www.w3.org/Amaya/
+	public $BROWSER_LYNX = 'Lynx';                              // Http://en.wikipedia.org/wiki/Lynx
+	public $BROWSER_SAFARI = 'Safari';                          // Http://apple.com
+	public $BROWSER_IPHONE = 'iPhone';                          // Http://apple.com
+	public $BROWSER_IPOD = 'iPod';                              // Http://apple.com
+	public $BROWSER_IPAD = 'iPad';                              // Http://apple.com
+	public $BROWSER_CHROME = 'Chrome';                          // Http://www.google.com/chrome
+	public $BROWSER_ANDROID = 'Android';                        // Http://www.android.com/
+	public $BROWSER_GOOGLEBOT = 'GoogleBot';                    // Http://en.wikipedia.org/wiki/Googlebot
+	public $BROWSER_SLURP = 'Yahoo! Slurp';                     // Http://en.wikipedia.org/wiki/Yahoo!_Slurp
+	public $BROWSER_W3CVALIDATOR = 'W3C Validator';             // Http://validator.w3.org/
+	public $BROWSER_BLACKBERRY = 'BlackBerry';                  // Http://www.blackberry.com/
+	public $BROWSER_ICECAT = 'IceCat';                          // Http://en.wikipedia.org/wiki/GNU_IceCat
+	public $BROWSER_NOKIA_S60 = 'Nokia S60 OSS Browser';        // Http://en.wikipedia.org/wiki/Web_Browser_for_S60
+	public $BROWSER_NOKIA = 'Nokia Browser';                    // * all other WAP-based browsers on the Nokia Platform
+	public $BROWSER_MSN = 'MSN Browser';                        // Http://explorer.msn.com/
+	public $BROWSER_MSNBOT = 'MSN Bot';                         // Http://search.msn.com/msnbot.htm
+	// Http://en.wikipedia.org/wiki/Msnbot  (used for Bing as well)
+
+	public $BROWSER_NETSCAPE_NAVIGATOR = 'Netscape Navigator';  // Http://browser.netscape.com/ (DEPRECATED)
+	public $BROWSER_GALEON = 'Galeon';                          // Http://galeon.sourceforge.net/ (DEPRECATED)
+	public $BROWSER_NETPOSITIVE = 'NetPositive';                // Http://en.wikipedia.org/wiki/NetPositive (DEPRECATED)
+	public $BROWSER_PHOENIX = 'Phoenix';                        // Http://en.wikipedia.org/wiki/History_of_Mozilla_Firefox (DEPRECATED)
+
+	public $PLATFORM_UNKNOWN = 'unknown';
+	public $PLATFORM_WINDOWS = 'Windows';
+	public $PLATFORM_WINDOWS_CE = 'Windows CE';
+	public $PLATFORM_APPLE = 'Apple';
+	public $PLATFORM_LINUX = 'Linux';
+	public $PLATFORM_OS2 = 'OS/2';
+	public $PLATFORM_BEOS = 'BeOS';
+	public $PLATFORM_IPHONE = 'iPhone';
+	public $PLATFORM_IPOD = 'iPod';
+	public $PLATFORM_IPAD = 'iPad';
+	public $PLATFORM_BLACKBERRY = 'BlackBerry';
+	public $PLATFORM_NOKIA = 'Nokia';
+	public $PLATFORM_FREEBSD = 'FreeBSD';
+	public $PLATFORM_OPENBSD = 'OpenBSD';
+	public $PLATFORM_NETBSD = 'NetBSD';
+	public $PLATFORM_SUNOS = 'SunOS';
+	public $PLATFORM_OPENSOLARIS = 'OpenSolaris';
+	public $PLATFORM_ANDROID = 'Android';
+
+	public $OPERATING_SYSTEM_UNKNOWN = 'unknown';
+
+	function __construct( $useragent="" ) {
+		$this->reset();
+		if ( $useragent != "" ) {
+			$this->setUserAgent( $useragent );
+		} else {
+			$this->determine();
+		}
+	}
+
+	/**
+	 * Reset all properties
+	 */
+	function reset() {
+		$this->_agent = isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : "";
+		$this->_browser_name = $this->BROWSER_UNKNOWN;
+		$this->_version = $this->VERSION_UNKNOWN;
+		$this->_platform = $this->PLATFORM_UNKNOWN;
+		$this->_os = $this->OPERATING_SYSTEM_UNKNOWN;
+		$this->_is_aol = false;
+		$this->_is_mobile = false;
+		$this->_is_robot = false;
+		$this->_aol_version = $this->VERSION_UNKNOWN;
+	}
+
+	/**
+	 * Check to see if the specific browser is valid
+	 *
+	 * @param string  $browserName
+	 * @return True if the browser is the specified browser
+	 */
+	function isBrowser( $browserName ) { return 0 == strcasecmp( $this->_browser_name, trim( $browserName ) ); }
+
+	/**
+	 * The name of the browser.  All return types are from the class contants
+	 *
+	 * @return string Name of the browser
+	 */
+	function getBrowser() { return $this->_browser_name; }
+	/**
+	 * Set the name of the browser
+	 *
+	 * @param unknown $browser The name of the Browser
+	 */
+	function setBrowser( $browser ) { return $this->_browser_name = $browser; }
+	/**
+	 * The name of the platform.  All return types are from the class contants
+	 *
+	 * @return string Name of the browser
+	 */
+	function getPlatform() { return $this->_platform; }
+	/**
+	 * Set the name of the platform
+	 *
+	 * @param unknown $platform The name of the Platform
+	 */
+	function setPlatform( $platform ) { return $this->_platform = $platform; }
+	/**
+	 * The version of the browser.
+	 *
+	 * @return string Version of the browser (will only contain alpha-numeric characters and a period)
+	 */
+	function getVersion() { return $this->_version; }
+	/**
+	 * Set the version of the browser
+	 *
+	 * @param unknown $version The version of the Browser
+	 */
+	function setVersion( $version ) { $this->_version = preg_replace( '/[^0-9,.,a-z,A-Z-]/', '', $version ); }
+	/**
+	 * The version of AOL.
+	 *
+	 * @return string Version of AOL (will only contain alpha-numeric characters and a period)
+	 */
+	function getAolVersion() { return $this->_aol_version; }
+	/**
+	 * Set the version of AOL
+	 *
+	 * @param unknown $version The version of AOL
+	 */
+	function setAolVersion( $version ) { $this->_aol_version = preg_replace( '/[^0-9,.,a-z,A-Z]/', '', $version ); }
+	/**
+	 * Is the browser from AOL?
+	 *
+	 * @return boolean True if the browser is from AOL otherwise false
+	 */
+	function isAol() { return $this->_is_aol; }
+	/**
+	 * Is the browser from a mobile device?
+	 *
+	 * @return boolean True if the browser is from a mobile device otherwise false
+	 */
+	function isMobile() { return $this->_is_mobile; }
+	/**
+	 * Is the browser from a robot (ex Slurp,GoogleBot)?
+	 *
+	 * @return boolean True if the browser is from a robot otherwise false
+	 */
+	function isRobot() { return $this->_is_robot; }
+	/**
+	 * Set the browser to be from AOL
+	 *
+	 * @param unknown $isAol
+	 */
+	function setAol( $isAol ) { $this->_is_aol = $isAol; }
+	/**
+	 * Set the Browser to be mobile
+	 *
+	 * @param boolean $value is the browser a mobile brower or not
+	 */
+	function setMobile( $value=true ) { $this->_is_mobile = $value; }
+	/**
+	 * Set the Browser to be a robot
+	 *
+	 * @param boolean $value is the browser a robot or not
+	 */
+	function setRobot( $value=true ) { $this->_is_robot = $value; }
+	/**
+	 * Get the user agent value in use to determine the browser
+	 *
+	 * @return string The user agent from the HTTP header
+	 */
+	function getUserAgent() { return $this->_agent; }
+	/**
+	 * Set the user agent value (the construction will use the HTTP header value - this will overwrite it)
+	 *
+	 * @param unknown $agent_string The value for the User Agent
+	 */
+	function setUserAgent( $agent_string ) {
+		$this->reset();
+		$this->_agent = $agent_string;
+		$this->determine();
+	}
+	/**
+	 * Used to determine if the browser is actually "chromeframe"
+	 *
+	 * @since 1.7
+	 * @return boolean True if the browser is using chromeframe
+	 */
+	function isChromeFrame() {
+		return strpos( $this->_agent, "chromeframe" ) !== false;
+	}
+	/**
+	 * Returns a formatted string with a summary of the details of the browser.
+	 *
+	 * @return string formatted string with a summary of the browser
+	 */
+	function __toString() {
+		$text1   = $this->getUserAgent(); //grabs the UA (user agent) string
+		$UAline1 = substr( $text1, 0, 32 ); //the first line we print should only be the first 32 characters of the UA string
+		$text2       = $this->getUserAgent();//now we grab it again and save it to a string
+		$towrapUA    = str_replace( $UAline1, '', $text2 );//the rest of the printoff (other than first line) is equivolent
+		// To the whole string minus the part we printed off. IE
+		// User Agent:      thefirst32charactersfromUAline1
+		//                  the rest of it is now stored in
+		//                  $text2 to be printed off
+		// But we need to add spaces before each line that is split other than line 1
+		$space = '';
+		for ( $i = 0; $i < 25; $i++ ) {
+			$space .= ' ';
+		}
+		// Now we split the remaining string of UA ($text2) into lines that are prefixed by spaces for formatting
+		$wordwrapped = chunk_split( $towrapUA, 32, "\n $space" );
+		return "Platform:                 {$this->getPlatform()} \n".
+			"Browser Name:             {$this->getBrowser()}  \n" .
+			"Browser Version:          {$this->getVersion()} \n" .
+			"User Agent String:        $UAline1 \n\t\t\t  " .
+			"$wordwrapped";
+	}
+	/**
+	 * Protected routine to calculate and determine what the browser is in use (including platform)
+	 */
+	function determine() {
+		$this->checkPlatform();
+		$this->checkBrowsers();
+		$this->checkForAol();
+	}
+	/**
+	 * Protected routine to determine the browser type
+	 *
+	 * @return boolean True if the browser was detected otherwise false
+	 */
+	function checkBrowsers() {
+		return (
+			// Well-known, well-used
+			// Special Notes:
+			// (1) Opera must be checked before FireFox due to the odd
+			//     user agents used in some older versions of Opera
+			// (2) WebTV is strapped onto Internet Explorer so we must
+			//     check for WebTV before IE
+			// (3) (deprecated) Galeon is based on Firefox and needs to be
+			//     tested before Firefox is tested
+			// (4) OmniWeb is based on Safari so OmniWeb check must occur
+			//     before Safari
+			// (5) Netscape 9+ is based on Firefox so Netscape checks
+			//     before FireFox are necessary
+			$this->checkBrowserWebTv() ||
+			$this->checkBrowserInternetExplorer() ||
+			$this->checkBrowserOpera() ||
+			$this->checkBrowserGaleon() ||
+			$this->checkBrowserNetscapeNavigator9Plus() ||
+			$this->checkBrowserFirefox() ||
+			$this->checkBrowserChrome() ||
+			$this->checkBrowserOmniWeb() ||
+
+			// Common mobile
+			$this->checkBrowserAndroid() ||
+			$this->checkBrowseriPad() ||
+			$this->checkBrowseriPod() ||
+			$this->checkBrowseriPhone() ||
+			$this->checkBrowserBlackBerry() ||
+			$this->checkBrowserNokia() ||
+
+			// Common bots
+			$this->checkBrowserGoogleBot() ||
+			$this->checkBrowserMSNBot() ||
+			$this->checkBrowserSlurp() ||
+
+			// WebKit base check (post mobile and others)
+			$this->checkBrowserSafari() ||
+
+			// Everyone else
+			$this->checkBrowserNetPositive() ||
+			$this->checkBrowserFirebird() ||
+			$this->checkBrowserKonqueror() ||
+			$this->checkBrowserIcab() ||
+			$this->checkBrowserPhoenix() ||
+			$this->checkBrowserAmaya() ||
+			$this->checkBrowserLynx() ||
+
+			$this->checkBrowserShiretoko() ||
+			$this->checkBrowserIceCat() ||
+			$this->checkBrowserW3CValidator() ||
+			$this->checkBrowserMozilla() /* Mozilla is such an open standard that you must check it last */
+		);
+	}
+
+	/**
+	 * Determine if the user is using a BlackBerry (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is the BlackBerry browser otherwise false
+	 */
+	function checkBrowserBlackBerry() {
+		if ( stripos( $this->_agent, 'blackberry' ) !== false ) {
+			$aresult = explode( "/", stristr( $this->_agent, "BlackBerry" ) );
+			$aversion = explode( ' ', $aresult[1] );
+			$this->setVersion( $aversion[0] );
+			$this->_browser_name = $this->BROWSER_BLACKBERRY;
+			$this->setMobile( true );
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the user is using an AOL User Agent (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is from AOL otherwise false
+	 */
+	function checkForAol() {
+		$this->setAol( false );
+		$this->setAolVersion( $this->VERSION_UNKNOWN );
+
+		if ( stripos( $this->_agent, 'aol' ) !== false ) {
+			$aversion = explode( ' ', stristr( $this->_agent, 'AOL' ) );
+			$this->setAol( true );
+			$this->setAolVersion( preg_replace( '/[^0-9\.a-z]/i', '', $aversion[1] ) );
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the browser is the GoogleBot or not (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is the GoogletBot otherwise false
+	 */
+	function checkBrowserGoogleBot() {
+		if ( stripos( $this->_agent, 'googlebot' ) !== false ) {
+			$aresult = explode( '/', stristr( $this->_agent, 'googlebot' ) );
+			$aversion = explode( ' ', $aresult[1] );
+			$this->setVersion( str_replace( ';', '', $aversion[0] ) );
+			$this->_browser_name = $this->BROWSER_GOOGLEBOT;
+			$this->setRobot( true );
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the browser is the MSNBot or not (last updated 1.9)
+	 *
+	 * @return boolean True if the browser is the MSNBot otherwise false
+	 */
+	function checkBrowserMSNBot() {
+		if ( stripos( $this->_agent, "msnbot" ) !== false ) {
+			$aresult = explode( "/", stristr( $this->_agent, "msnbot" ) );
+			$aversion = explode( " ", $aresult[1] );
+			$this->setVersion( str_replace( ";", "", $aversion[0] ) );
+			$this->_browser_name = $this->BROWSER_MSNBOT;
+			$this->setRobot( true );
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the browser is the W3C Validator or not (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is the W3C Validator otherwise false
+	 */
+	function checkBrowserW3CValidator() {
+		if ( stripos( $this->_agent, 'W3C-checklink' ) !== false ) {
+			$aresult = explode( '/', stristr( $this->_agent, 'W3C-checklink' ) );
+			$aversion = explode( ' ', $aresult[1] );
+			$this->setVersion( $aversion[0] );
+			$this->_browser_name = $this->BROWSER_W3CVALIDATOR;
+			return true;
+		} else if ( stripos( $this->_agent, 'W3C_Validator' ) !== false ) {
+			// Some of the Validator versions do not delineate w/ a slash - add it back in
+			$ua = str_replace( "W3C_Validator ", "W3C_Validator/", $this->_agent );
+			$aresult = explode( '/', stristr( $ua, 'W3C_Validator' ) );
+			$aversion = explode( ' ', $aresult[1] );
+			$this->setVersion( $aversion[0] );
+			$this->_browser_name = $this->BROWSER_W3CVALIDATOR;
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the browser is the Yahoo! Slurp Robot or not (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is the Yahoo! Slurp Robot otherwise false
+	 */
+	function checkBrowserSlurp() {
+		if ( stripos( $this->_agent, 'slurp' ) !== false ) {
+			$aresult = explode( '/', stristr( $this->_agent, 'Slurp' ) );
+			$aversion = explode( ' ', $aresult[1] );
+			$this->setVersion( $aversion[0] );
+			$this->_browser_name = $this->BROWSER_SLURP;
+			$this->setRobot( true );
+			$this->setMobile( false );
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the browser is Internet Explorer or not (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is Internet Explorer otherwise false
+	 */
+	function checkBrowserInternetExplorer() {
+
+		// Test for v1 - v1.5 IE
+		if ( stripos( $this->_agent, 'microsoft internet explorer' ) !== false ) {
+			$this->setBrowser( $this->BROWSER_IE );
+			$this->setVersion( '1.0' );
+			$aresult = stristr( $this->_agent, '/' );
+			if ( preg_match( '/308|425|426|474|0b1/i', $aresult ) ) {
+				$this->setVersion( '1.5' );
+			}
+			return true;
+		}
+		// Test for versions > 1.5
+		else if ( stripos( $this->_agent, 'msie' ) !== false && stripos( $this->_agent, 'opera' ) === false ) {
+			// See if the browser is the odd MSN Explorer
+			if ( stripos( $this->_agent, 'msnb' ) !== false ) {
+				$aresult = explode( ' ', stristr( str_replace( ';', '; ', $this->_agent ), 'MSN' ) );
+				$this->setBrowser( $this->BROWSER_MSN );
+				$this->setVersion( str_replace( array( '(', ')', ';' ), '', $aresult[1] ) );
+				return true;
+			}
+			$aresult = explode( ' ', stristr( str_replace( ';', '; ', $this->_agent ), 'msie' ) );
+			$this->setBrowser( $this->BROWSER_IE );
+			$this->setVersion( str_replace( array( '(', ')', ';' ), '', $aresult[1] ) );
+			return true;
+		}
+		// Test for Pocket IE
+		else if ( stripos( $this->_agent, 'mspie' ) !== false || stripos( $this->_agent, 'pocket' ) !== false ) {
+			$aresult = explode( ' ', stristr( $this->_agent, 'mspie' ) );
+				$this->setPlatform( $this->PLATFORM_WINDOWS_CE );
+			$this->setBrowser( $this->BROWSER_POCKET_IE );
+			$this->setMobile( true );
+
+			if ( stripos( $this->_agent, 'mspie' ) !== false ) {
+				$this->setVersion( $aresult[1] );
+			} else {
+				$aversion = explode( '/', $this->_agent );
+				$this->setVersion( $aversion[1] );
+			}
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the browser is Opera or not (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is Opera otherwise false
+	 */
+	function checkBrowserOpera() {
+		if ( stripos( $this->_agent, 'opera mini' ) !== false ) {
+			$resultant = stristr( $this->_agent, 'opera mini' );
+			if ( preg_match( '/\//', $resultant ) ) {
+				$aresult = explode( '/', $resultant );
+				$aversion = explode( ' ', $aresult[1] );
+				$this->setVersion( $aversion[0] );
+			} else {
+				$aversion = explode( ' ', stristr( $resultant, 'opera mini' ) );
+				$this->setVersion( $aversion[1] );
+			}
+			$this->_browser_name = $this->BROWSER_OPERA_MINI;
+			$this->setMobile( true );
+			return true;
+		} else if ( stripos( $this->_agent, 'opera' ) !== false ) {
+			$resultant = stristr( $this->_agent, 'opera' );
+			if ( preg_match( '/Version\/(10.*)$/', $resultant, $matches ) ) {
+				$this->setVersion( $matches[1] );
+			} else if ( preg_match( '/\//', $resultant ) ) {
+				$aresult = explode( '/', str_replace( "(", " ", $resultant ) );
+				$aversion = explode( ' ', $aresult[1] );
+				$this->setVersion( $aversion[0] );
+			} else {
+				$aversion = explode( ' ', stristr( $resultant, 'opera' ) );
+				$this->setVersion( isset( $aversion[1] )?$aversion[1]:"" );
+			}
+			$this->_browser_name = $this->BROWSER_OPERA;
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the browser is Chrome or not (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is Chrome otherwise false
+	 */
+	function checkBrowserChrome() {
+		if ( stripos( $this->_agent, 'Chrome' ) !== false ) {
+			$aresult = explode( '/', stristr( $this->_agent, 'Chrome' ) );
+			$aversion = explode( ' ', $aresult[1] );
+			$this->setVersion( $aversion[0] );
+			$this->setBrowser( $this->BROWSER_CHROME );
+			return true;
+		}
+		return false;
+	}
+
+
+	/**
+	 * Determine if the browser is WebTv or not (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is WebTv otherwise false
+	 */
+	function checkBrowserWebTv() {
+		if ( stripos( $this->_agent, 'webtv' ) !== false ) {
+			$aresult = explode( '/', stristr( $this->_agent, 'webtv' ) );
+			$aversion = explode( ' ', $aresult[1] );
+			$this->setVersion( $aversion[0] );
+			$this->setBrowser( $this->BROWSER_WEBTV );
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the browser is NetPositive or not (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is NetPositive otherwise false
+	 */
+	function checkBrowserNetPositive() {
+		if ( stripos( $this->_agent, 'NetPositive' ) !== false ) {
+			$aresult = explode( '/', stristr( $this->_agent, 'NetPositive' ) );
+			$aversion = explode( ' ', $aresult[1] );
+			$this->setVersion( str_replace( array( '(', ')', ';' ), '', $aversion[0] ) );
+			$this->setBrowser( $this->BROWSER_NETPOSITIVE );
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the browser is Galeon or not (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is Galeon otherwise false
+	 */
+	function checkBrowserGaleon() {
+		if ( stripos( $this->_agent, 'galeon' ) !== false ) {
+			$aresult = explode( ' ', stristr( $this->_agent, 'galeon' ) );
+			$aversion = explode( '/', $aresult[0] );
+			$this->setVersion( $aversion[1] );
+			$this->setBrowser( $this->BROWSER_GALEON );
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the browser is Konqueror or not (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is Konqueror otherwise false
+	 */
+	function checkBrowserKonqueror() {
+		if ( stripos( $this->_agent, 'Konqueror' ) !== false ) {
+			$aresult = explode( ' ', stristr( $this->_agent, 'Konqueror' ) );
+			$aversion = explode( '/', $aresult[0] );
+			$this->setVersion( $aversion[1] );
+			$this->setBrowser( $this->BROWSER_KONQUEROR );
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the browser is iCab or not (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is iCab otherwise false
+	 */
+	function checkBrowserIcab() {
+		if ( stripos( $this->_agent, 'icab' ) !== false ) {
+			$aversion = explode( ' ', stristr( str_replace( '/', ' ', $this->_agent ), 'icab' ) );
+			$this->setVersion( $aversion[1] );
+			$this->setBrowser( $this->BROWSER_ICAB );
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the browser is OmniWeb or not (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is OmniWeb otherwise false
+	 */
+	function checkBrowserOmniWeb() {
+		if ( stripos( $this->_agent, 'omniweb' ) !== false ) {
+			$aresult = explode( '/', stristr( $this->_agent, 'omniweb' ) );
+			$aversion = explode( ' ', isset( $aresult[1] )?$aresult[1]:"" );
+			$this->setVersion( $aversion[0] );
+			$this->setBrowser( $this->BROWSER_OMNIWEB );
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the browser is Phoenix or not (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is Phoenix otherwise false
+	 */
+	function checkBrowserPhoenix() {
+		if ( stripos( $this->_agent, 'Phoenix' ) !== false ) {
+			$aversion = explode( '/', stristr( $this->_agent, 'Phoenix' ) );
+			$this->setVersion( $aversion[1] );
+			$this->setBrowser( $this->BROWSER_PHOENIX );
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the browser is Firebird or not (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is Firebird otherwise false
+	 */
+	function checkBrowserFirebird() {
+		if ( stripos( $this->_agent, 'Firebird' ) !== false ) {
+			$aversion = explode( '/', stristr( $this->_agent, 'Firebird' ) );
+			$this->setVersion( $aversion[1] );
+			$this->setBrowser( $this->BROWSER_FIREBIRD );
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the browser is Netscape Navigator 9+ or not (last updated 1.7)
+	 * NOTE: (http://browser.netscape.com/ - Official support ended on March 1st, 2008)
+	 *
+	 * @return boolean True if the browser is Netscape Navigator 9+ otherwise false
+	 */
+	function checkBrowserNetscapeNavigator9Plus() {
+		if ( stripos( $this->_agent, 'Firefox' ) !== false && preg_match( '/Navigator\/([^ ]*)/i', $this->_agent, $matches ) ) {
+			$this->setVersion( $matches[1] );
+			$this->setBrowser( $this->BROWSER_NETSCAPE_NAVIGATOR );
+			return true;
+		} else if ( stripos( $this->_agent, 'Firefox' ) === false && preg_match( '/Netscape6?\/([^ ]*)/i', $this->_agent, $matches ) ) {
+			$this->setVersion( $matches[1] );
+			$this->setBrowser( $this->BROWSER_NETSCAPE_NAVIGATOR );
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the browser is Shiretoko or not (https://wiki.mozilla.org/Projects/shiretoko) (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is Shiretoko otherwise false
+	 */
+	function checkBrowserShiretoko() {
+		if ( stripos( $this->_agent, 'Mozilla' ) !== false && preg_match( '/Shiretoko\/([^ ]*)/i', $this->_agent, $matches ) ) {
+			$this->setVersion( $matches[1] );
+			$this->setBrowser( $this->BROWSER_SHIRETOKO );
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the browser is Ice Cat or not (http://en.wikipedia.org/wiki/GNU_IceCat) (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is Ice Cat otherwise false
+	 */
+	function checkBrowserIceCat() {
+		if ( stripos( $this->_agent, 'Mozilla' ) !== false && preg_match( '/IceCat\/([^ ]*)/i', $this->_agent, $matches ) ) {
+			$this->setVersion( $matches[1] );
+			$this->setBrowser( $this->BROWSER_ICECAT );
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the browser is Nokia or not (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is Nokia otherwise false
+	 */
+	function checkBrowserNokia() {
+		if ( preg_match( "/Nokia([^\/]+)\/([^ SP]+)/i", $this->_agent, $matches ) ) {
+			$this->setVersion( $matches[2] );
+			if ( stripos( $this->_agent, 'Series60' ) !== false || strpos( $this->_agent, 'S60' ) !== false ) {
+				$this->setBrowser( $this->BROWSER_NOKIA_S60 );
+			} else {
+				$this->setBrowser( $this->BROWSER_NOKIA );
+			}
+			$this->setMobile( true );
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the browser is Firefox or not (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is Firefox otherwise false
+	 */
+	function checkBrowserFirefox() {
+		if ( stripos( $this->_agent, 'safari' ) === false ) {
+			if ( preg_match( "/Firefox[\/ \(]([^ ;\)]+)/i", $this->_agent, $matches ) ) {
+				$this->setVersion( $matches[1] );
+				$this->setBrowser( $this->BROWSER_FIREFOX );
+				return true;
+			} else if ( preg_match( "/Firefox$/i", $this->_agent, $matches ) ) {
+				$this->setVersion( "" );
+				$this->setBrowser( $this->BROWSER_FIREFOX );
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the browser is Firefox or not (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is Firefox otherwise false
+	 */
+	function checkBrowserIceweasel() {
+		if ( stripos( $this->_agent, 'Iceweasel' ) !== false ) {
+			$aresult = explode( '/', stristr( $this->_agent, 'Iceweasel' ) );
+			$aversion = explode( ' ', $aresult[1] );
+			$this->setVersion( $aversion[0] );
+			$this->setBrowser( $this->BROWSER_ICEWEASEL );
+			return true;
+		}
+		return false;
+	}
+	/**
+	 * Determine if the browser is Mozilla or not (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is Mozilla otherwise false
+	 */
+	function checkBrowserMozilla() {
+		if ( stripos( $this->_agent, 'mozilla' ) !== false  && preg_match( '/rv:[0-9].[0-9][a-b]?/i', $this->_agent ) && stripos( $this->_agent, 'netscape' ) === false ) {
+			$aversion = explode( ' ', stristr( $this->_agent, 'rv:' ) );
+			preg_match( '/rv:[0-9].[0-9][a-b]?/i', $this->_agent, $aversion );
+			$this->setVersion( str_replace( 'rv:', '', $aversion[0] ) );
+			$this->setBrowser( $this->BROWSER_MOZILLA );
+			return true;
+		} else if ( stripos( $this->_agent, 'mozilla' ) !== false && preg_match( '/rv:[0-9]\.[0-9]/i', $this->_agent ) && stripos( $this->_agent, 'netscape' ) === false ) {
+			$aversion = explode( '', stristr( $this->_agent, 'rv:' ) );
+			$this->setVersion( str_replace( 'rv:', '', $aversion[0] ) );
+			$this->setBrowser( $this->BROWSER_MOZILLA );
+			return true;
+		} else if ( stripos( $this->_agent, 'mozilla' ) !== false  && preg_match( '/mozilla\/([^ ]*)/i', $this->_agent, $matches ) && stripos( $this->_agent, 'netscape' ) === false ) {
+			$this->setVersion( $matches[1] );
+			$this->setBrowser( $this->BROWSER_MOZILLA );
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the browser is Lynx or not (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is Lynx otherwise false
+	 */
+	function checkBrowserLynx() {
+		if ( stripos( $this->_agent, 'lynx' ) !== false ) {
+			$aresult = explode( '/', stristr( $this->_agent, 'Lynx' ) );
+			$aversion = explode( ' ', ( isset( $aresult[1] )?$aresult[1]:"" ) );
+			$this->setVersion( $aversion[0] );
+			$this->setBrowser( $this->BROWSER_LYNX );
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the browser is Amaya or not (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is Amaya otherwise false
+	 */
+	function checkBrowserAmaya() {
+		if ( stripos( $this->_agent, 'amaya' ) !== false ) {
+			$aresult = explode( '/', stristr( $this->_agent, 'Amaya' ) );
+			$aversion = explode( ' ', $aresult[1] );
+			$this->setVersion( $aversion[0] );
+			$this->setBrowser( $this->BROWSER_AMAYA );
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the browser is Safari or not (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is Safari otherwise false
+	 */
+	function checkBrowserSafari() {
+		if ( stripos( $this->_agent, 'Safari' ) !== false && stripos( $this->_agent, 'iPhone' ) === false && stripos( $this->_agent, 'iPod' ) === false ) {
+			$aresult = explode( '/', stristr( $this->_agent, 'Version' ) );
+			if ( isset( $aresult[1] ) ) {
+				$aversion = explode( ' ', $aresult[1] );
+				$this->setVersion( $aversion[0] );
+			} else {
+				$this->setVersion( $this->VERSION_UNKNOWN );
+			}
+			$this->setBrowser( $this->BROWSER_SAFARI );
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the browser is iPhone or not (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is iPhone otherwise false
+	 */
+	function checkBrowseriPhone() {
+		if ( stripos( $this->_agent, 'iPhone' ) !== false ) {
+			$aresult = explode( '/', stristr( $this->_agent, 'Version' ) );
+			if ( isset( $aresult[1] ) ) {
+				$aversion = explode( ' ', $aresult[1] );
+				$this->setVersion( $aversion[0] );
+			} else {
+				$this->setVersion( $this->VERSION_UNKNOWN );
+			}
+			$this->setMobile( true );
+			$this->setBrowser( $this->BROWSER_IPHONE );
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the browser is iPod or not (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is iPod otherwise false
+	 */
+	function checkBrowseriPad() {
+		if ( stripos( $this->_agent, 'iPad' ) !== false ) {
+			$aresult = explode( '/', stristr( $this->_agent, 'Version' ) );
+			if ( isset( $aresult[1] ) ) {
+				$aversion = explode( ' ', $aresult[1] );
+				$this->setVersion( $aversion[0] );
+			} else {
+				$this->setVersion( $this->VERSION_UNKNOWN );
+			}
+			$this->setMobile( true );
+			$this->setBrowser( $this->BROWSER_IPAD );
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the browser is iPod or not (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is iPod otherwise false
+	 */
+	function checkBrowseriPod() {
+		if ( stripos( $this->_agent, 'iPod' ) !== false ) {
+			$aresult = explode( '/', stristr( $this->_agent, 'Version' ) );
+			if ( isset( $aresult[1] ) ) {
+				$aversion = explode( ' ', $aresult[1] );
+				$this->setVersion( $aversion[0] );
+			} else {
+				$this->setVersion( $this->VERSION_UNKNOWN );
+			}
+			$this->setMobile( true );
+			$this->setBrowser( $this->BROWSER_IPOD );
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine if the browser is Android or not (last updated 1.7)
+	 *
+	 * @return boolean True if the browser is Android otherwise false
+	 */
+	function checkBrowserAndroid() {
+		if ( stripos( $this->_agent, 'Android' ) !== false ) {
+			$aresult = explode( ' ', stristr( $this->_agent, 'Android' ) );
+			if ( isset( $aresult[1] ) ) {
+				$aversion = explode( ' ', $aresult[1] );
+				$this->setVersion( $aversion[0] );
+			} else {
+				$this->setVersion( $this->VERSION_UNKNOWN );
+			}
+			$this->setMobile( true );
+			$this->setBrowser( $this->BROWSER_ANDROID );
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Determine the user's platform (last updated 1.7)
+	 */
+	function checkPlatform() {
+		if ( stripos( $this->_agent, 'windows' ) !== false ) {
+			$this->_platform = $this->PLATFORM_WINDOWS;
+		} else if ( stripos( $this->_agent, 'iPad' ) !== false ) {
+			$this->_platform = $this->PLATFORM_IPAD;
+		} else if ( stripos( $this->_agent, 'iPod' ) !== false ) {
+			$this->_platform = $this->PLATFORM_IPOD;
+		} else if ( stripos( $this->_agent, 'iPhone' ) !== false ) {
+			$this->_platform = $this->PLATFORM_IPHONE;
+		} elseif ( stripos( $this->_agent, 'mac' ) !== false ) {
+			$this->_platform = $this->PLATFORM_APPLE;
+		} elseif ( stripos( $this->_agent, 'android' ) !== false ) {
+			$this->_platform = $this->PLATFORM_ANDROID;
+		} elseif ( stripos( $this->_agent, 'linux' ) !== false ) {
+			$this->_platform = $this->PLATFORM_LINUX;
+		} else if ( stripos( $this->_agent, 'Nokia' ) !== false ) {
+			$this->_platform = $this->PLATFORM_NOKIA;
+		} else if ( stripos( $this->_agent, 'BlackBerry' ) !== false ) {
+			$this->_platform = $this->PLATFORM_BLACKBERRY;
+		} elseif ( stripos( $this->_agent, 'FreeBSD' ) !== false ) {
+			$this->_platform = $this->PLATFORM_FREEBSD;
+		} elseif ( stripos( $this->_agent, 'OpenBSD' ) !== false ) {
+			$this->_platform = $this->PLATFORM_OPENBSD;
+		} elseif ( stripos( $this->_agent, 'NetBSD' ) !== false ) {
+			$this->_platform = $this->PLATFORM_NETBSD;
+		} elseif ( stripos( $this->_agent, 'OpenSolaris' ) !== false ) {
+			$this->_platform = $this->PLATFORM_OPENSOLARIS;
+		} elseif ( stripos( $this->_agent, 'SunOS' ) !== false ) {
+			$this->_platform = $this->PLATFORM_SUNOS;
+		} elseif ( stripos( $this->_agent, 'OS\/2' ) !== false ) {
+			$this->_platform = $this->PLATFORM_OS2;
+		} elseif ( stripos( $this->_agent, 'BeOS' ) !== false ) {
+			$this->_platform = $this->PLATFORM_BEOS;
+		} elseif ( stripos( $this->_agent, 'win' ) !== false ) {
+			$this->_platform = $this->PLATFORM_WINDOWS;
+		}
+
+	}
+}

--- a/resources/backend/wp-convertkit.css
+++ b/resources/backend/wp-convertkit.css
@@ -18,3 +18,12 @@
         background-size: 18px 17px !important;
     }
 }
+
+.convertkit-log-viewer {
+    background: #fff;
+    border: 1px solid #e5e5e5;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, .04);
+    padding: 5px 20px;
+    max-height: 500px;
+    overflow: scroll;
+}

--- a/resources/backend/wp-convertkit.css
+++ b/resources/backend/wp-convertkit.css
@@ -19,11 +19,11 @@
     }
 }
 
-.convertkit-log-viewer {
-    background: #fff;
-    border: 1px solid #e5e5e5;
-    box-shadow: 0 1px 1px rgba(0, 0, 0, .04);
-    padding: 5px 20px;
-    max-height: 500px;
-    overflow: scroll;
+.ck-debug-log .ck-inline-button {
+    margin-left: 5px;
+}
+
+textarea.monospace {
+    font-family: monospace;
+    padding: 20px;
 }

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -3,7 +3,7 @@
  * Plugin Name: ConvertKit
  * Plugin URI: https://convertkit.com/
  * Description: Quickly and easily integrate ConvertKit forms into your site.
- * Version: 1.6.3
+ * Version: 1.6.2
  * Author: ConvertKit
  * Author URI: https://convertkit.com/
  * Text Domain: convertkit
@@ -16,7 +16,7 @@ if ( class_exists( 'WP_ConvertKit' ) ) {
 define( 'CONVERTKIT_PLUGIN_FILE', plugin_basename( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
-define( 'CONVERTKIT_PLUGIN_VERSION', '1.6.3' );
+define( 'CONVERTKIT_PLUGIN_VERSION', '1.6.2' );
 
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-api.php';
@@ -31,6 +31,7 @@ if ( is_admin() ) {
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-tinymce.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-settings-base.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-settings-general.php';
+	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-settings-tools.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-settings-wishlist.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-settings-contactform7.php';
 

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -3,7 +3,7 @@
  * Plugin Name: ConvertKit
  * Plugin URI: https://convertkit.com/
  * Description: Quickly and easily integrate ConvertKit forms into your site.
- * Version: 1.6.2
+ * Version: 1.6.3
  * Author: ConvertKit
  * Author URI: https://convertkit.com/
  * Text Domain: convertkit
@@ -16,7 +16,7 @@ if ( class_exists( 'WP_ConvertKit' ) ) {
 define( 'CONVERTKIT_PLUGIN_FILE', plugin_basename( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
-define( 'CONVERTKIT_PLUGIN_VERSION', '1.6.2' );
+define( 'CONVERTKIT_PLUGIN_VERSION', '1.6.3' );
 
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-api.php';


### PR DESCRIPTION

## Summary

Adds a "Tools" tab to the ConvertKit settings page. The new tab includes a log viewer to show the CK log. This will help in troubleshooting issues with the plugin. Customer support can request the customer copy+paste this log into support requests or get admin credentials this log file instead.
This will remove the need to ask for SFTP credentials or going through the WP plugin editor (not active on all sites) to view the log file.
<img width="1000" alt="convertkit convertkit wordpress 2019-01-11 09-59-08" src="https://user-images.githubusercontent.com/290886/51044787-9371fc80-1587-11e9-9748-57f5682c0d83.png">

There is also a "clear the log" button to remove old or out of date entries from the log file.

## Pull request checklist

* [ ] Is the added/modified code sufficiently tested? Do all tests pass?
* [ ] Is the code easy to understand? Does it follow [the rules](https://robots.thoughtbot.com/sandi-metz-rules-for-developers)?
* [ ] Are the return values of public methods documented?
* [ ] Are any complicated parts explained / documented?
* [ ] Does this PR positively affect the code climate GPA score?
* [ ] Do you want feedback on anything in particular?
* [ ] Does this require QA? What should be tested? 

## Ready for review?
- [ ] Add "ready for review" label
- [ ] Assign a reviewer (or two)
- [ ] post RFR in #wordpress

