### PR TITLE
Only call ConvertKit_Custom_Content::maybe_tag_subscriber() on actual pages/posts

### DIFF
--- a/includes/class-convertkit-custom-content.php
+++ b/includes/class-convertkit-custom-content.php
@@ -76,15 +76,17 @@ class ConvertKit_Custom_Content {
 	public function maybe_tag_subscriber_ajax(){
 
 		// get post_id from url
-		$url            = isset( $_POST['url'] ) ? sanitize_text_field( $_POST['url'] ): '';
+		$url     = isset( $_POST['url'] ) ? sanitize_text_field( $_POST['url'] ) : '';
 		$post_id = url_to_postid( $url );
-		$post = get_post( $post_id );
+		$post    = get_post( $post_id );
 
 		// set cookie
-		$subscriber_id   = isset( $_POST['subscriber_id'] ) ? sanitize_text_field( $_POST['subscriber_id'] ): 0;
+		$subscriber_id               = isset( $_POST['subscriber_id'] ) ? sanitize_text_field( $_POST['subscriber_id'] ) : 0;
 		$_COOKIE['ck_subscriber_id'] = absint( $subscriber_id );
 
-		ConvertKit_Custom_Content::maybe_tag_subscriber( $post );
+		if ( isset( $post ) ) {
+			ConvertKit_Custom_Content::maybe_tag_subscriber( $post );
+		}
 		echo json_encode(
 			array(
 				'subscriber_id' => $subscriber_id,
@@ -224,8 +226,7 @@ class ConvertKit_Custom_Content {
 	 * If the user views page with a cookie 'ck_subscriber_id' then check if tags need to be applied based on visit.
 	 *
 	 * @see https://app.convertkit.com/account/edit#email_settings
-	 * @param $post
-	 * @param null|int $subscriber_id
+	 * @param $post WP_Post
 	 */
 	public static function maybe_tag_subscriber( $post ) {
 


### PR DESCRIPTION
Closes #152 

## Summary
`ConvertKit_Custom_Content::maybe_tag_subscriber()` is hooked to the `the_post`
action. This is great, because it lets us apply a tag if the visitor has a
`ck_subscriber_id` cookie and the content being viewed should apply a tag.

However, the `ConvertKit_Custom_Content::maybe_tag_subscriber()` method fires twice
per page load, because it's also called by
`ConvertKit_Custom_Content::maybe_tag_subscriber_ajax()`.

In cases where we're not on an individual page or post (e.g. the blog archive,
category archive, etc.), this is a problem, because
`ConvertKit_Custom_Content::maybe_tag_subscriber()` gets called with a null
`$post` argument.

Instead, we should only call `ConvertKit_Custom_Content::maybe_tag_subscriber()`
from `ConvertKit_Custom_Content::maybe_tag_subscriber()` if we're on an actual
post or page (so that `get_post()` returns a `WP_Post` object).


## Pull request checklist

* [x] Is the code easy to understand? Does it follow [the rules](https://robots.thoughtbot.com/sandi-metz-rules-for-developers)?
* [x] Are any complicated parts explained / documented?
* [x] Do you want feedback on anything in particular?
* [x] Does this require QA? What should be tested? 

## Ready for review?
- [x] Add "ready for review" label
- [x] Assign a reviewer (or two)
- [x] post RFR in #wordpress

**Handy links**
- [PR Checklist](https://github.com/ConvertKit/convertkit/wiki/Pull-Request-Checklist)
- [Code design](https://github.com/ConvertKit/convertkit/blob/master/README-coding-style.md)
