### PR TITLE
Feature/release process

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -2,6 +2,7 @@
 bin
 tests
 vendor
+.distignore
 .env
 .gitignore
 .git

--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,17 @@
+.github
+bin
+tests
+vendor
+.env
+.gitignore
+.git
+.travis.yml
+circle.yml
+Gruntfile.js
+log.txt
+package.json
+package-lock.json
+phpcs.xml.dist
+phpunit.xml
+phpunit.xml.dist
+README.md

--- a/.distignore
+++ b/.distignore
@@ -7,6 +7,8 @@ vendor
 .git
 .travis.yml
 circle.yml
+composer.json
+composer.lock
 Gruntfile.js
 log.txt
 package.json

--- a/bin/package.sh
+++ b/bin/package.sh
@@ -12,7 +12,11 @@ download() {
 download https://github.com/ConvertKit/ConvertKit-WordPress/archive/$RELEASE_VERSION.zip $DOWNLOAD_LOCATION/convertkit.zip
 
 cd $DOWNLOAD_LOCATION
+
 unzip convertkit.zip
+
+rm convertkit.zip
+
 NEW_DIR=$(echo $RELEASE_VERSION | sed -e 's/\//-/g')
 cd ConvertKit-WordPress-$NEW_DIR
 
@@ -23,6 +27,6 @@ fi
 
 if [ -e .distignore ]
 then
-    wp dist-archive ./
+    wp dist-archive ./ $DOWNLOAD_LOCATION/convertkit-packaged.zip
 fi
 

--- a/bin/package.sh
+++ b/bin/package.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+TMPDIR=${TMPDIR-/tmp}
+TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
+RELEASE_VERSION=${1-master}
+DOWNLOAD_LOCATION=${2-$HOME/tmp}
+
+download() {
+    curl -s "$1" > "$2";
+}
+
+download https://github.com/ConvertKit/ConvertKit-WordPress/archive/$RELEASE_VERSION.zip $DOWNLOAD_LOCATION/convertkit.zip
+
+cd $DOWNLOAD_LOCATION
+unzip convertkit.zip
+NEW_DIR=$(echo $RELEASE_VERSION | sed -e 's/\//-/g')
+cd ConvertKit-WordPress-$NEW_DIR
+
+composer install --no-dev

--- a/bin/package.sh
+++ b/bin/package.sh
@@ -16,4 +16,13 @@ unzip convertkit.zip
 NEW_DIR=$(echo $RELEASE_VERSION | sed -e 's/\//-/g')
 cd ConvertKit-WordPress-$NEW_DIR
 
-composer install --no-dev
+if [ -e composer.json ]
+then
+    composer install --no-dev
+fi
+
+if [ -e .distignore ]
+then
+    wp dist-archive ./
+fi
+


### PR DESCRIPTION
## Summary

Adds some tooling for building releases.

`.distignore` is used by [`wp dist-archive`](https://developer.wordpress.org/cli/commands/dist-archive/) to build a zip of the plugin while leaving out files unwanted in the publicly distributed version.

`bin/package.sh` is a WIP script to build a public-ready release based on a GitHub release. This will be expanded in the future.

## Ready for review?
- [x] Add "ready for review" label
- [x] Assign a reviewer (or two)
- [ ] post RFR in #wordpress

**Handy links**
- [PR Checklist](https://github.com/ConvertKit/convertkit/wiki/Pull-Request-Checklist)
- [Code design](https://github.com/ConvertKit/convertkit/blob/master/README-coding-style.md)
