### PR TITLE
Don't remove ck_subscriber_id from URL until we set a cookie

### DIFF
--- a/resources/frontend/wp-convertkit.js
+++ b/resources/frontend/wp-convertkit.js
@@ -20,6 +20,7 @@ jQuery(document).ready(function($) {
             var values = JSON.parse(response);
             if ( 0 != values.subscriber_id) {
                 $.cookie('ck_subscriber_id', values.subscriber_id, {expires: 365, path: '/'});
+                ckRemoveSubscriberId( window.location.href );
             }
         }
 
@@ -43,7 +44,6 @@ jQuery(document).ready(function($) {
         for (var i=0;i<vars.length;i++) {
             var pair = vars[i].split("=");
             if(pair[0] == variable){
-                ckRemoveSubscriberId( window.location.href );
                 return parseInt( pair[1] );
             }
         }


### PR DESCRIPTION
Closes #156 

## Summary

Previously, `ck_subscriber_id` was remvoed from the URL immediately on fetching
the query var. This worked fine in most cases, but if the AJAX call to the
plugin failed for any reason, then the cookie with `ck_subscriber_id` would never
be set, and the subscriber ID would be lost (until the subscriber clicked on
another email link with their subscriber ID included).

Now, we only remove the URL parameter if the AJAX call is successful and we
have set the cookie.

## Ready for review?
- [x] Add "ready for review" label
- [x] Assign a reviewer (or two)
- [ ] post RFR in #wordpress
