### PR TITLE
Force WishList Member integration settings to be saved as an array

### DIFF
--- a/admin/section/class-convertkit-settings-wishlist.php
+++ b/admin/section/class-convertkit-settings-wishlist.php
@@ -235,14 +235,14 @@ class ConvertKit_Settings_Wishlist extends ConvertKit_Settings_Base {
 	 */
 	public function sanitize_settings( $input ) {
 		// Settings page can be paginated; combine input with existing options.
-		$output = $this->options;
+		// If saved options are not an array, start fresh. Fixes rogue saved options
+		$output = is_array( $this->options ) ? $this->options : array();
 
 		foreach ( $input as $key => $value ) {
-			list( $level_id, $setting ) = explode( '_', $key );
-
-			$output[ $key ] = stripslashes( $input[ $key ] );
+			$output[ $key ] = sanitize_text_field( $value );
 		}
 		$sanitize_filter = 'sanitize' . $this->settings_key;
+
 		return apply_filters( $sanitize_filter, $output, $input );
 	}
 }


### PR DESCRIPTION
Closes #159 

## Summary
This enforces that we actually use an array for saving WishList Member integration settings. It also moves to the WP builtin `sanitize_text_field()` over `stripslashes()`

## QA
- [ ] Navigate to ConvertKit plugin settings page
- [ ] Switch to WishList Member tab
- [ ] Attempt to save form settings
- [ ] Ensure no errors or timeouts occur

## Ready for review?
- [x] Add "ready for review" label
- [x] Assign a reviewer (or two)
- [x] post RFR in #wordpress

**Handy links**
- [PR Checklist](https://github.com/ConvertKit/convertkit/wiki/Pull-Request-Checklist)
- [Code design](https://github.com/ConvertKit/convertkit/blob/master/README-coding-style.md)
