### PR TITLE
Improve performance of our javascript for fun and profit

### DIFF
--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -105,6 +105,14 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 			$this->settings_key,
 			$this->name
 		);
+
+		add_settings_field(
+			'no_scripts',
+			'Disable javascript',
+			array( $this, 'no_scripts_callback' ),
+			$this->settings_key,
+			$this->name
+		);
 	}
 
 	/**
@@ -224,6 +232,24 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 	}
 
 	/**
+	 * Renders the input for no_scripts setting
+	 */
+	public function no_scripts_callback() {
+
+		$no_scripts = '';
+		if ( isset( $this->options['no_scripts'] ) && 'on' === $this->options['no_scripts'] ) {
+			$no_scripts = 'checked';
+		}
+
+		echo sprintf( // WPCS: XSS OK
+			'<label><input type="checkbox" class="" id="no_scripts" name="%s[no_scripts]"  %s />%s</label>',
+			$this->settings_key,
+			$no_scripts,
+			__( 'Prevent plugin from loading javascript files. This will disable the custom content and tagging features of the plugin. Does not apply to landing pages. Use with caution!','convertkit' )
+		);
+
+	}
+	/**
 	 * Sanitizes the settings
 	 *
 	 * @param  array $settings The settings fields submitted.
@@ -238,11 +264,16 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 				$this->api->update_resources( $settings['api_key'] );
 			}
 		}
-		return shortcode_atts( array(
-			'api_key'      => '',
-			'api_secret'   => '',
-			'default_form' => 0,
-			'debug' => '',
-		), $settings );
+
+		return shortcode_atts(
+			array(
+				'api_key'      => '',
+				'api_secret'   => '',
+				'default_form' => 0,
+				'debug'        => '',
+				'no_scripts'   => '',
+			),
+			$settings
+		);
 	}
 }

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -223,7 +223,7 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 		}
 
 		echo sprintf( // WPCS: XSS OK
-			'<input type="checkbox" class="" id="debug" name="%s[debug]"  %s />%s',
+			'<label><input type="checkbox" class="" id="debug" name="%s[debug]"  %s />%s</label>',
 			$this->settings_key,
 			$debug,
 			__( 'Save connection data to a log file.','convertkit' )

--- a/includes/class-convertkit.php
+++ b/includes/class-convertkit.php
@@ -304,6 +304,9 @@ class WP_ConvertKit {
 	 */
 	public static function enqueue_scripts() {
 
+		// Only check for tags if we're on a singular post; otherwise, no tags
+		$has_tag = is_singular() ? self::post_has_tag( get_post() ) : false;
+
 		// Only load scripts if no scripts setting is not checked
 		$no_scripts = self::_get_settings( 'no_scripts' );
 		if ( ! $no_scripts ) {
@@ -325,7 +328,8 @@ class WP_ConvertKit {
 				'convertkit-js',
 				'ck_data',
 				array(
-					'ajaxurl' => admin_url( 'admin-ajax.php' )
+					'ajaxurl' => admin_url( 'admin-ajax.php' ),
+					'post_has_tag' => $has_tag,
 				)
 			);
 
@@ -641,5 +645,20 @@ class WP_ConvertKit {
 			}
 			update_option( 'convertkit_version', CONVERTKIT_PLUGIN_VERSION );
 		}// End if().
+	}
+
+
+	/**
+	 * @param $post WP_Post
+	 *
+	 * @return boolean
+	 */
+	public static function post_has_tag( $post ) {
+		$meta = get_post_meta( $post->ID, '_wp_convertkit_post_meta', true );
+
+		if ( isset( $meta['tag'] ) ) {
+			return ( $meta['tag'] == 0 ) ? false : true;
+		}
+		return false;
 	}
 }

--- a/includes/class-convertkit.php
+++ b/includes/class-convertkit.php
@@ -345,7 +345,7 @@ class WP_ConvertKit {
 	 *
 	 * @param array $attributes Shortcode attributes.
 	 * @param null $content
-	 * @return mixed|void
+	 * @return string
 	 */
 	public static function shortcode( $attributes, $content = null ) {
 
@@ -453,7 +453,7 @@ class WP_ConvertKit {
 	 * Get plugin settings
 	 *
 	 * @param null $settings_key
-	 * @return mixed|null|void
+	 * @return mixed|null
 	 */
 	public static function _get_settings( $settings_key = null ) {
 		$settings = get_option( self::SETTINGS_NAME, self::$settings_defaults );

--- a/includes/class-convertkit.php
+++ b/includes/class-convertkit.php
@@ -30,8 +30,11 @@ class WP_ConvertKit {
 	 * @var array
 	 */
 	private static $settings_defaults = array(
-		'api_key' => '',
+		'api_key'      => '',
+		'api_secret'   => '',
 		'default_form' => 0,
+		'debug'        => false,
+		'no_scripts'   => false,
 	);
 
 	/**
@@ -300,13 +303,34 @@ class WP_ConvertKit {
 	 * Enqueue scripts
 	 */
 	public static function enqueue_scripts() {
-		wp_enqueue_script( 'jquery-cookie', CONVERTKIT_PLUGIN_URL . 'resources/frontend/jquery.cookie.min.js', array( 'jquery' ), '1.4.0' );
 
-        wp_register_script( 'convertkit-js', CONVERTKIT_PLUGIN_URL . 'resources/frontend/wp-convertkit.js', array( 'jquery-cookie' ), CONVERTKIT_PLUGIN_VERSION );
-		wp_localize_script( 'convertkit-js', 'ck_data', array(
-			'ajaxurl' => admin_url( 'admin-ajax.php' ),
-		) );
-		wp_enqueue_script( 'convertkit-js' );
+		// Only load scripts if no scripts setting is not checked
+		$no_scripts = self::_get_settings( 'no_scripts' );
+		if ( ! $no_scripts ) {
+			wp_register_script(
+				'jquery-cookie',
+				CONVERTKIT_PLUGIN_URL . 'resources/frontend/jquery.cookie.min.js',
+				array( 'jquery' ),
+				'1.4.0'
+			);
+
+			wp_register_script(
+				'convertkit-js',
+				CONVERTKIT_PLUGIN_URL . 'resources/frontend/wp-convertkit.js',
+				array( 'jquery-cookie' ),
+				CONVERTKIT_PLUGIN_VERSION
+			);
+
+			wp_localize_script(
+				'convertkit-js',
+				'ck_data',
+				array(
+					'ajaxurl' => admin_url( 'admin-ajax.php' )
+				)
+			);
+
+			wp_enqueue_script( 'convertkit-js' );
+		}
 	}
 
 	/**

--- a/resources/frontend/wp-convertkit.js
+++ b/resources/frontend/wp-convertkit.js
@@ -7,8 +7,9 @@ jQuery(document).ready(function($) {
         subscriber_id = ckGetQueryVariable('ck_subscriber_id');
     }
 
-    // Only POST to admin-ajax.php if we have a subscriber_id to use
-    if ( subscriber_id ) {
+    // Only POST to admin-ajax.php if we have a subscriber_id to use...
+    // ...and the current post has a tag assigned to it
+    if ( subscriber_id && ck_data.post_has_tag ) {
         /* Check if subscriber_id is valid and maybe do add tags */
         $.ajax({
             type: "POST",

--- a/resources/frontend/wp-convertkit.js
+++ b/resources/frontend/wp-convertkit.js
@@ -1,34 +1,37 @@
 jQuery(document).ready(function($) {
 
     // Manage visit cookie
-    var subscriber_id = $.cookie( 'ck_subscriber_id' );
+    var subscriber_id = parseInt($.cookie('ck_subscriber_id')) ? parseInt($.cookie('ck_subscriber_id')) : false;
 
     if ( ! subscriber_id ) {
         subscriber_id = ckGetQueryVariable('ck_subscriber_id');
     }
 
-    /* Check if subscriber_id is valid and maybe do add tags */
-    $.ajax({
-        type: "POST",
-        data: {
-            action: 'ck_add_user_visit',
-            subscriber_id: subscriber_id,
-            url: document.URL
-        },
-        url: ck_data.ajaxurl,
-        success: function (response) {
-            var values = JSON.parse(response);
-            if ( 0 != values.subscriber_id) {
-                $.cookie('ck_subscriber_id', values.subscriber_id, {expires: 365, path: '/'});
-                ckRemoveSubscriberId( window.location.href );
+    // Only POST to admin-ajax.php if we have a subscriber_id to use
+    if ( subscriber_id ) {
+        /* Check if subscriber_id is valid and maybe do add tags */
+        $.ajax({
+            type: "POST",
+            data: {
+                action: 'ck_add_user_visit',
+                subscriber_id: subscriber_id,
+                url: document.URL
+            },
+            url: ck_data.ajaxurl,
+            success: function (response) {
+                var values = JSON.parse(response);
+                if ( 0 != values.subscriber_id) {
+                    $.cookie('ck_subscriber_id', values.subscriber_id, {expires: 365, path: '/'});
+                    ckRemoveSubscriberId( window.location.href );
+                }
             }
-        }
 
-    }).fail(function (response) {
-        if ( window.console && window.console.log ) {
-            console.log( "AJAX ERROR" + response );
-        }
-    });
+        }).fail(function (response) {
+            if ( window.console && window.console.log ) {
+                console.log( "AJAX ERROR" + response );
+            }
+        });
+    }
 
     /**
      * This function will check for the `ck_subscriber_id` query parameter
@@ -47,7 +50,7 @@ jQuery(document).ready(function($) {
                 return parseInt( pair[1] );
             }
         }
-        return(0);
+        return false;
     }
 
     /**


### PR DESCRIPTION
Closes #127 

## Summary
Before this PR, our javascript makes an ajax request on _every page load_ 😱 

This PR adds a few things:
- An option to turn off loading of our javascript entirely. This is the Nuclear Option™ and will prevent tagging and custom content (using our shortcode, and in the future a Gutenberg block) from functioning.
- Only sends an ajax request to tag subscribers on page load _if_ we are on a page with tags AND we have a subscriber id (either via cookie or URL query param).

## QA
- Use this version of the plugin: https://github.com/ConvertKit/ConvertKit-WordPress/archive/issue/127.zip
- Set up a page or post with a tag assigned to it
- Set up a page or post without a tag assigned to it
- Visit both pages/posts without a `ck_subscriber_id` (e.g. in an incognito window) and verify that no requests are made to `admin-ajax.php`
- Visit a page with a tag assigned to it, with a `ck_subscriber_id` (e.g. by appending `?ck_subscriber_id={id_here}` to the URL) that belongs to the account the site is connected to, and verify that a request is made to `admin-ajax.php`
- Verify that the above page load also triggers the assigned tag being added to the subscriber in ConvertKit
- Visit a page without a tag assigned, but with a `ck_subscriber_id` (e.g. in the URL as above), and verify that no request is made to `admin-ajax.php`
- Check the box in the settings area to disable ConvertKit javascript entirely, then visit pages both with and without tags assigned and verify that `wp-convertkit.js` is not loaded.
- Re-enable ConvertKit javascript in the settings, then visit a page with a ConvertKit form on it, and subscribe through the form. Verify that a request is made to `admin-ajax.php` with `action: ck_get_subscriber` in the Form Data portion of the request.

## Ready for review?
- [x] Add "ready for review" label
- [x] Assign a reviewer (or two)
- [x] post RFR in #wordpress
