### PR TITLE
Only strip out ck_subscriber_id from URL query parameters

### DIFF
--- a/resources/frontend/wp-convertkit.js
+++ b/resources/frontend/wp-convertkit.js
@@ -58,15 +58,15 @@ jQuery(document).ready(function($) {
      * This function removes the parameters so a customer won't share
      * a URL with their subscriber ID in it.
      *
-     * @param key
      * @param url
      */
-    function ckRemoveSubscriberId(key,url)
+    function ckRemoveSubscriberId(url)
     {
-        url = window.location.href;
-        var clean_url = url.substring(0, url.indexOf("?"));
+        var clean_url = url.substring(0, url.indexOf("?ck_subscriber_id"));
         var title = document.getElementsByTagName("title")[0].innerHTML;
-        window.history.pushState( null, title, clean_url );
+        if ( clean_url ) {
+            window.history.pushState( null, title, clean_url );
+        }
     }
 
     /**


### PR DESCRIPTION
Closes #168 

## Summary
Previously, if a URL with a query string is visited, e.g. example.com?foo=bar, our plugin javascript would strip out the ?foo=bar, even though it should really only strip out the query string if it's ?ck_subscriber_id={ID}.

Now, we confirm that the URL we're operating on contains `?ck_subscriber_id` before changing it.

A further enhancement _could_ be to selectively strip out `ck_subscriber_id={id}` but leave any other query parameters alone. However, this probably isn't necessary as the only time `ck_subscriber_id` should be present is when it's added in ConvertKit-sent emails, which in most cases wouldn't contain other query parameters.

## QA
- Install this version of the plugin: https://github.com/ConvertKit/ConvertKit-WordPress/archive/issue/168.zip
- Visit a page with a query parameter (not `ck_subscriber_id`), e.g. `?foo=bar` and verify that the URL is not changed
- Visit a page with e.g. `?ck_subscriber_id=123` and verify that the URL is changed.