### PR TITLE
Allow changing category default form back to None

### DIFF
--- a/admin/class-convertkit-settings.php
+++ b/admin/class-convertkit-settings.php
@@ -323,7 +323,9 @@ class ConvertKit_Settings {
 		$ck_default_form = isset( $_POST['ck_default_form'] ) ? intval( $_POST['ck_default_form']  ) : 0;
 		if ( $ck_default_form ) {
 			update_term_meta( $tag_id, 'ck_default_form', $ck_default_form );
-		}
+		} else {
+			update_term_meta( $tag_id, 'ck_default_form', 'default' );
+        }
 
 	}
 

--- a/tests/acceptance/ChangeCategoryFormCest.php
+++ b/tests/acceptance/ChangeCategoryFormCest.php
@@ -1,0 +1,40 @@
+<?php
+
+use Dotenv\Dotenv;
+
+/**
+ * Class ChangeCategoryFormCest
+ */
+class ChangeCategoryFormCest {
+	/**
+	 * @param AcceptanceTester $I
+	 */
+	public function _before( AcceptanceTester $I ) {
+
+		$dotenv = new Dotenv( dirname( dirname( __DIR__ ) ) );
+		$dotenv->load();
+
+		$this->ck_api_key    = getenv( 'CK_API_KEY' );
+		$this->ck_api_secret = getenv( 'CK_API_SECRET' );
+
+
+		$I->cli('plugin activate ConvertKit-WordPress');
+		$I->cli('plugin activate contact-form-7');
+		$I->loginAsAdmin();
+	}
+
+	/**
+	 * @param AcceptanceTester $I
+	 */
+	public function testChangeCategoryForm( AcceptanceTester $I ) {
+		$I->amOnPage( '/wp-admin/term.php?taxonomy=category&tag_ID=1' );
+		$I->selectOption( 'form select[id=ck_default_form]', 'Clean form' );
+		$I->click( 'Update', '.button' );
+		$I->see('Clean form');
+
+		$I->selectOption( 'form select[id=ck_default_form]', 'None' );
+		$I->click( 'Update', '.button' );
+		$I->seeOptionIsSelected('form select[id=ck_default_form]', 'None');
+		$I->see('None');
+	}
+}

--- a/tests/acceptance/SignInCest.php
+++ b/tests/acceptance/SignInCest.php
@@ -2,7 +2,15 @@
 
 use Dotenv\Dotenv;
 
+/**
+ * Class SignInCest
+ */
 class SignInCest {
+	/**
+	 * @param AcceptanceTester $I
+	 *
+	 * @throws \Codeception\Exception\ModuleException
+	 */
 	public function _before( AcceptanceTester $I ) {
 
 		$dotenv = new Dotenv( dirname( dirname( __DIR__ ) ) );
@@ -18,6 +26,10 @@ class SignInCest {
 	}
 
 	// tests
+
+	/**
+	 * @param AcceptanceTester $I
+	 */
 	public function testSettingsPage( AcceptanceTester $I ) {
 
 		$I->loginAsAdmin();
@@ -41,6 +53,9 @@ class SignInCest {
 		$I->seeOptionIsSelected( 'form select[id=_wp_convertkit_integration_contactform7_settings_5]', 'Clean form' );
 	}
 
+	/**
+	 * @param AcceptanceTester $I
+	 */
 	public function testJavascriptNotLoaded( AcceptanceTester $I ) {
 
 		$I->amOnPage( '/wp-admin/options-general.php?page=_wp_convertkit_settings' );
@@ -53,6 +68,9 @@ class SignInCest {
 		$I->dontSeeInSource('wp-convertkit.js');
 	}
 
+	/**
+	 * @param AcceptanceTester $I
+	 */
 	public function testJavascriptLoaded( AcceptanceTester $I ) {
 
 		$I->amOnPage( '/wp-admin/options-general.php?page=_wp_convertkit_settings' );


### PR DESCRIPTION
Closes #110 

## Summary
Previously, if a category were assigned a form, then changing that category's form assignment back to "None" would fail. This fixes that bug.
