### PR TITLE
Remove class name that conflicted with Yoast SEO javascript

### DIFF
--- a/admin/class-convertkit-settings.php
+++ b/admin/class-convertkit-settings.php
@@ -285,7 +285,7 @@ class ConvertKit_Settings {
 		$forms = get_option( 'convertkit_forms' );
 		$default_form = get_term_meta( $tag->term_id, 'ck_default_form', true );
 
-		echo '<tr class="form-field term-description-wrap"><th scope="row"><label for="description">ConvertKit Form</label></th><td>';
+		echo '<tr class="form-field"><th scope="row"><label for="description">ConvertKit Form</label></th><td>';
 
 		// Check for error in response.
 		if ( isset( $forms[0]['id'] ) && '-2' === $forms[0]['id'] ) {


### PR DESCRIPTION
Closes #115

## Remove class name that conflicted with Yoast SEO javascript

The Yoast SEO plugin javascript targets .term-description-wrap here: https://github.com/Yoast/wordpress-seo/blob/b59bd349fbf7e3b0da834e87d0042e022e89f8f7/js/src/wp-seo-term-scraper.js#L72

The `<tr>` containing our form select menu on Category edit pages previously had that class name, causing breakage.

This change removes that class name.