### PR TITLE
Fix issue where global default form would never show for some categories

### DIFF
--- a/includes/class-convertkit.php
+++ b/includes/class-convertkit.php
@@ -201,7 +201,7 @@ class WP_ConvertKit {
 				// Get category form
 				$form_id = self::get_category_form( get_the_ID() );
 
-				if ( 0 === $form_id ) {
+				if ( 0 === $form_id || 'default' === $form_id ) {
 					// Get global default form
 					if ( '-1' === $attributes['form'] ) {
 						$form_id = self::_get_settings( 'default_form' );

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: nathanbarry, growdev, travisnorthcutt
 Donate link: https://convertkit.com
 Tags: email, marketing, embed form, convertkit, capture
 Requires at least: 3.6
-Tested up to: 5.0.3
+Tested up to: 5.1.0
 Stable tag: 1.7.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Closes #182 

## Summary
Before this, any category that had been edited (even with no changes) and saved would result in any posts in that category never showing the global default form, even if the post and category were both set to show the global default form.

This is because categories (which have been edited and saved) which have the default form set have a `$form_id` of `'default'` set, but our code was only fetching the global default form if the category's `$form_id` was `0`.

This changes the code to check if the category's `$form_id` is either `0` _or_ `'default'` and if so fetch the global form.
