### PR TITLE
Add checks for outdated character set use

### DIFF
--- a/admin/class-convertkit-settings.php
+++ b/admin/class-convertkit-settings.php
@@ -99,37 +99,68 @@ class ConvertKit_Settings {
 		} else {
 			$active_section = $this->sections[0]->name;
 		}
-
 		?>
-		<div class="wrap convertkit-settings-wrap">
-		<?php
-		if ( count( $this->sections ) > 1 ) {
-			$this->display_section_nav( $active_section );
-		} else {
-			?>
-			<h2><?php esc_html_e( 'ConvertKit', 'convertkit' ); ?></h2>
+        <div class="wrap convertkit-settings-wrap">
 			<?php
-		}
-		?>
+			if ( count( $this->sections ) > 1 ) {
+				$this->display_section_nav( $active_section );
+			} else {
+				?>
+                <h2><?php esc_html_e( 'ConvertKit', 'convertkit' ); ?></h2>
+				<?php
+			}
+			?>
 
-		<form method="post" action="options.php">
-		<?php
-		foreach ( $this->sections as $section ) :
-			if ( $active_section === $section->name ) :
-				$section->render();
-			endif;
-		endforeach;
+            <form method="post" action="options.php">
+				<?php
+				foreach ( $this->sections as $section ) :
+					if ( $active_section === $section->name ) :
+						$section->render();
+					endif;
+				endforeach;
 
-		// Check for Multibyte string PHP extension.
-		if ( ! extension_loaded( 'mbstring' ) ) {
-			?><p><strong><?php
-			echo  sprintf( __( 'Note: Your server does not support the %s functions - this is required for better character encoding. Please contact your webhost to have it installed.', 'woocommerce' ), '<a href="https://php.net/manual/en/mbstring.installation.php">mbstring</a>' ) . '</mark>';
-			?></strong></p><?php
-		}
-		?><p class="description"><?php
-				printf( 'If you need help setting up the plugin please refer to the %s plugin documentation.</a>', '<a href="http://help.convertkit.com/article/99-the-convertkit-wordpress-plugin" target="_blank">' ); ?></p>
-		</form>
-		</div>
+				/**
+				 * Check for utf8mb4 support.
+				 * Lack of support will cause problems if any content pulled in from ConvertKit contains emoji characters
+				 */
+				global $wpdb;
+				if ( $wpdb->get_col_charset( 'wp_options', 'option_value' ) !== 'utf8mb4' ) {
+					?>
+                    <div class="inline notice notice-warning">
+                        <p>
+                            <strong>
+		                        <?php
+		                        echo sprintf( __( 'Notice: Your database does not appear to support the %s. If you experience difficulties connecting to ConvertKit this may be why. Please contact your webhost to have your database upgraded.',
+		                                          'convertkit' ),
+		                                      '<a href="https://make.wordpress.org/core/2015/04/02/the-utf8mb4-upgrade/">utf8mb4 character set</a>' );
+		                        ?>
+                            </strong>
+                        </p>
+                    </div>
+					<?php
+				}
+
+				// Check for Multibyte string PHP extension.
+				if ( ! extension_loaded( 'mbstring' ) ) {
+					?>
+                    <div class="inline notice notice-warning">
+                        <p>
+                            <strong>
+		                        <?php
+		                        echo sprintf( __( 'Notice: Your server does not support the %s function - this is required for better character encoding. Please contact your webhost to have it installed.',
+		                                          'convertkit' ),
+		                                      '<a href="https://php.net/manual/en/mbstring.installation.php">mbstring</a>' );
+		                        ?>
+                            </strong>
+                        </p>
+                    </div>
+					<?php
+				}
+				?><p class="description"><?php
+					printf( 'If you need help setting up the plugin please refer to the %s plugin documentation.</a>',
+					        '<a href="http://help.convertkit.com/article/99-the-convertkit-wordpress-plugin" target="_blank">' ); ?></p>
+            </form>
+        </div>
 		<?php
 	}
 

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -51,10 +51,10 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 		} else if ( ! $update_resources ) {
 			/**
 			 * There are two reasons $update_resources could be false:
-             * 1) Saving failed because the wp_options table does not use the utf8mb4 character set
-             * 2) No updates were needed (values passed to update_option() were the same as current values) for one of forms, landing pages, or tags
-             *
-             * So, if $update_resources is false, we check the character set, and if it's not utf8mb4 then we show a warning
+			 * 1) Saving failed because the wp_options table does not use the utf8mb4 character set
+			 * 2) No updates were needed (values passed to update_option() were the same as current values) for one of forms, landing pages, or tags
+			 *
+			 * So, if $update_resources is false, we check the character set, and if it's not utf8mb4 then we show a warning
 			 */
 			global $wpdb;
 			if ( $wpdb->get_col_charset( 'wp_options', 'option_value' ) !== 'utf8mb4' ) {

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -42,15 +42,26 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 			wp_die();
 		}
 
-		$this->api->update_resources( $api_key );
+		$update_resources = $this->api->update_resources( $api_key );
 
 		$forms = get_option( 'convertkit_forms', array() );
-		if ( isset( $forms[0] ) && isset( $forms[0]['id'] ) && '-2' === $forms[0]['id'] ) {
-			wp_send_json_error( __( 'Error connecting to API. Please verify your site can connect to <code>https://api.convertkit.com</code>','convertkit' ) );
+		if ( $update_resources && isset( $forms[0] ) && isset( $forms[0]['id'] ) && '-2' === $forms[0]['id'] ) {
+			wp_send_json_error( __( 'Error connecting to API. Please verify your site can connect to https://api.convertkit.com','convertkit' ) );
 			wp_die();
+		} else if ( ! $update_resources ) {
+			/**
+			 * There are two reasons $update_resources could be false:
+             * 1) Saving failed because the wp_options table does not use the utf8mb4 character set
+             * 2) No updates were needed (values passed to update_option() were the same as current values) for one of forms, landing pages, or tags
+             *
+             * So, if $update_resources is false, we check the character set, and if it's not utf8mb4 then we show a warning
+			 */
+			global $wpdb;
+			if ( $wpdb->get_col_charset( 'wp_options', 'option_value' ) !== 'utf8mb4' ) {
+				wp_send_json_error( __( 'Updating forms from ConvertKit may have failed. If so, this may be because your database uses the out of date utf8 character set, instead of the newer utf8mb4 character set. Please contact your host to upgrade your database.','convertkit' ) );
+				wp_die();
+            }
 		}
-
-		$html = '';
 
 		ob_start();
 		$this->default_form_callback( $forms );

--- a/includes/class-convertkit-api.php
+++ b/includes/class-convertkit-api.php
@@ -122,9 +122,10 @@ class ConvertKit_API {
 				'id' => '-2',
 				'name' => 'Error contacting API',
 			);
-			update_option( 'convertkit_forms', $forms );
-			update_option( 'convertkit_landing_pages', $landing_pages );
-			update_option( 'convertkit_tags', $tags );
+
+			$update_forms         = update_option( 'convertkit_forms', $forms );
+			$update_landing_pages = update_option( 'convertkit_landing_pages', $landing_pages );
+			$update_tags          = update_option( 'convertkit_tags', $tags );
 
 		} else {
 
@@ -140,8 +141,8 @@ class ConvertKit_API {
 					$forms[ $form['id'] ] = $form;
 				}
 			}
-			update_option( 'convertkit_forms', $forms );
-			update_option( 'convertkit_landing_pages', $landing_pages );
+			$update_forms         = update_option( 'convertkit_forms', $forms );
+			$update_landing_pages = update_option( 'convertkit_landing_pages', $landing_pages );
 
 			// Tags
 			$api_response = $this->_get_api_response( 'tags' );
@@ -149,8 +150,10 @@ class ConvertKit_API {
 			foreach ( $response as $tag ) {
 				$tags[] = $tag;
 			}
-			update_option( 'convertkit_tags', $tags );
+			$update_tags = update_option( 'convertkit_tags', $tags );
 		}
+
+		return $update_forms && $update_landing_pages && $update_tags;
 	}
 
 	/**


### PR DESCRIPTION
Closes #184 

## Summary
If a site using the utf8 character set, instead of the newer utf8mb4 character set, AND the connected ConvertKit account has forms/tags/landing pages with emoji characters, then saving that in the site's database will fail.

More info: https://make.wordpress.org/core/2015/04/02/the-utf8mb4-upgrade/

This PR adds checks and messaging to guard against this. We can't prevent the problem (the plugin will still not work if emojis are present and the site uses utf8), but we can (usually) detect it and warn the user.