### PR TITLE
Add back wp-convertkit.php to try and prevent plugin deactivations

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "title": "ConvertKit",
   "author": "ConvertKit",
   "license": "GPL-2.0",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "",
   "homepage": "https://github.com/convertkit/ConvertKit-WordPress",
   "main": "Gruntfile.js",

--- a/plugin.php
+++ b/plugin.php
@@ -3,20 +3,20 @@
  * Plugin Name: ConvertKit
  * Plugin URI: https://convertkit.com/
  * Description: Quickly and easily integrate ConvertKit forms into your site.
- * Version: 1.9.3
+ * Version: 1.9.4
  * Author: ConvertKit
  * Author URI: https://convertkit.com/
  * Text Domain: convertkit
  */
 
 if ( class_exists( 'WP_ConvertKit' ) ) {
-	return;
+    return;
 }
 
 define( 'CONVERTKIT_PLUGIN_FILE', plugin_basename( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_PATH', __DIR__ );
-define( 'CONVERTKIT_PLUGIN_VERSION', '1.9.3' );
+define( 'CONVERTKIT_PLUGIN_VERSION', '1.9.4' );
 
 require_once CONVERTKIT_PLUGIN_PATH . '/vendor/autoload.php';
 
@@ -29,16 +29,16 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/integration/class-convertkit-wi
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integration/class-convertkit-contactform7-integration.php';
 
 if ( is_admin() ) {
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-settings.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-multi-value-field-table.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-tinymce.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-settings-base.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-settings-general.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-settings-tools.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-settings-wishlist.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-settings-contactform7.php';
+    require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-settings.php';
+    require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-multi-value-field-table.php';
+    require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-tinymce.php';
+    require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-settings-base.php';
+    require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-settings-general.php';
+    require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-settings-tools.php';
+    require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-settings-wishlist.php';
+    require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-settings-contactform7.php';
 
-	$convertkit_settings = new ConvertKit_Settings();
+    $convertkit_settings = new ConvertKit_Settings();
 }
 
 WP_ConvertKit::init();

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://convertkit.com
 Tags: email, marketing, embed form, convertkit, capture
 Requires at least: 4.8
 Tested up to: 5.5.3
-Stable tag: 1.9.3
+Stable tag: 1.9.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Plugin Name: ConvertKit
+ * Plugin URI: https://convertkit.com/
+ * Description: Quickly and easily integrate ConvertKit forms into your site.
+ * Version: 1.9.4
+ * Author: ConvertKit
+ * Author URI: https://convertkit.com/
+ * Text Domain: convertkit
+ */
+
+require_once 'plugin.php';


### PR DESCRIPTION
Requires plugin.php, so people who have already upgraded and reactivated
don't get deactivated again
