### PR TITLE
Send PHP Version and Plugin Version with API Rquests

### DIFF
--- a/admin/section/class-convertkit-settings-tools.php
+++ b/admin/section/class-convertkit-settings-tools.php
@@ -242,7 +242,7 @@ class ConvertKit_Settings_Tools extends ConvertKit_Settings_Base {
 		$params = array(
 			'sslverify'     => false,
 			'timeout'       => 60,
-			'user-agent'    => 'ConvertKit/' . CONVERTKIT_PLUGIN_VERSION,
+			'user-agent'    => convertkit_wp_get_user_agent(),
 			'body'          => $request
 		);
 

--- a/includes/class-convertkit-api.php
+++ b/includes/class-convertkit-api.php
@@ -432,6 +432,7 @@ class ConvertKit_API {
 				array(
 					'timeout' => 10,
 					'Accept-Encoding' => 'gzip',
+					'user-agent' => convertkit_wp_get_user_agent(),
 				)
 			);
 
@@ -510,6 +511,7 @@ class ConvertKit_API {
 			array(
 				'timeout' => 10,
 				'Accept-Encoding' => 'gzip',
+				'user-agent' => convertkit_wp_get_user_agent(),
 			)
 		);
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -16,3 +16,22 @@ function convertkit_wp_debug_enabled() {
 
 	return ! empty( $options['debug'] ) && true == $options['debug']; // phpcs:ignore -- Okay use of loose comparison.
 }
+
+/**
+ * Gets a customized version of the WordPress default user agent; includes WP Version, PHP version, and ConvertKit plugin version.
+ *
+ * @return string
+ */
+function convertkit_wp_get_user_agent() {
+
+	// Include an unmodified $wp_version.
+	require ABSPATH . WPINC . '/version.php';
+
+	return sprintf(
+		'WordPress/%1$s;PHP/%2$s;ConvertKit/%3$s;%4$s',
+		$wp_version,
+		phpversion(),
+		CONVERTKIT_PLUGIN_VERSION,
+		home_url( '/' )
+	);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -932,9 +932,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "interpret": {
       "version": "1.1.0",


### PR DESCRIPTION
## Summary

- The default user-agent send by functions in WordPress' HTTP API just includes the WordPress version and the site's main URL
- These changes flesh out that user-agent so that it now also includes the ConvertKit WordPress plugin's version, and the site's PHP version as well

## Pull request checklist

* [x] Is the added/modified code sufficiently tested? Do all tests pass?
* [x] Is the code easy to understand? Does it follow [the rules](https://robots.thoughtbot.com/sandi-metz-rules-for-developers)?
* [x] Are the return values of public methods documented?
* [x] Are any complicated parts explained / documented?
* [x] Does this PR positively affect the code climate GPA score?

## Ready for review?
- [x] Add "ready for review" label
- [x] Assign a reviewer (or two)
- [x] post RFR in #wordpress

**Handy links**
- [PR Checklist](https://github.com/ConvertKit/convertkit/wiki/Pull-Request-Checklist)
- [Code design](https://github.com/ConvertKit/convertkit/blob/master/README-coding-style.md)
