### PR TITLE
Fix Undefined-Index Notices for API Key and Secret in Admin

### DIFF
--- a/admin/section/class-convertkit-settings-base.php
+++ b/admin/section/class-convertkit-settings-base.php
@@ -144,11 +144,15 @@ abstract class ConvertKit_Settings_Base {
 		$forms = get_transient( 'convertkit_forms' );
 
 		if ( false === $forms ) {
-			$this->api->update_resources( $this->options['api_key'], $this->options['api_secret'] );
 
-			$forms = get_option( 'convertkit_forms' );
+			if ( ! empty( $this->options['api_key'] ) && ! empty( $this->options['api_secret'] ) ) {
 
-			set_transient( 'convertkit_forms', $forms, 2 * MINUTE_IN_SECONDS );
+				$this->api->update_resources( $this->options['api_key'], $this->options['api_secret'] );
+
+				$forms = get_option( 'convertkit_forms' );
+
+				set_transient( 'convertkit_forms', $forms, 2 * MINUTE_IN_SECONDS );
+			}
 		}
 
 		return $forms;

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -37,17 +37,19 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 		$api_key    = isset( $_REQUEST['api_key'] ) ? $_REQUEST['api_key'] : WP_ConvertKit::get_api_key();
 		$api_secret = isset( $_REQUEST['api_secret'] ) ? $_REQUEST['api_secret'] : WP_ConvertKit::get_api_secret();
 
-		if ( !$api_key ) {
+		if ( ! $api_key ) {
 			update_option( 'convertkit_forms', array() );
 			wp_send_json_error( __( 'Please enter your API key, click "save changes", and try again.', 'convertkit' ) );
 			wp_die();
 		}
 
-		if ( !$api_secret ) {
+		if ( ! $api_secret ) {
 			update_option( 'convertkit_forms', array() );
 			wp_send_json_error( __( 'Please enter your API secret, click "save changes", and try again.', 'convertkit' ) );
 			wp_die();
 		}
+
+		delete_transient( 'convertkit_forms' );
 
 		$update_resources = $this->api->update_resources( $api_key, $api_secret );
 
@@ -71,6 +73,7 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 			 * So, if $update_resources is false, we check the character set, and if it's not utf8mb4 then we show a warning
 			 */
 			global $wpdb;
+
 			if ( $wpdb->get_col_charset( 'wp_options', 'option_value' ) !== 'utf8mb4' ) {
 				wp_send_json_error( __( 'Updating forms from ConvertKit may have failed. If so, this may be because your database uses the out of date utf8 character set, instead of the newer utf8mb4 character set. Please contact your host to upgrade your database.','convertkit' ) );
 				wp_die();


### PR DESCRIPTION
## Summary

Some users have reported undefined index notices like the following when navigating around their wp-admins:

```
PHP Notice:  Undefined index: api_key in [...]/plugins/convertkit-wordpress/admin/section/class-convertkit-settings-base.php on line 147

PHP Notice:  Undefined index: api_secret in [...]/plugins/convertkit-wordpress/admin/section/class-convertkit-settings-base.php on line 147
```

I wasn't recreating these all of the time, but finally started getting them in my local site. I've made some small tweaks to the code that fix this.

## Pull request checklist

* [x] Is the added/modified code sufficiently tested? Do all tests pass?
* [x] Is the code easy to understand? Does it follow [the rules](https://robots.thoughtbot.com/sandi-metz-rules-for-developers)?
* [x] Are the return values of public methods documented?
* [x] Are any complicated parts explained / documented?
* [x] Does this PR positively affect the code climate GPA score?

## Ready for review?
- [x] Add "ready for review" label
- [x] Assign a reviewer (or two)
- [x] post RFR in #wordpress

**Handy links**
- [PR Checklist](https://github.com/ConvertKit/convertkit/wiki/Pull-Request-Checklist)
- [Code design](https://github.com/ConvertKit/convertkit/blob/master/README-coding-style.md)
