### PR TITLE
Remove optional parameters preceding required function parameters for PHP 8.x compat

### DIFF
--- a/includes/class-convertkit-custom-content.php
+++ b/includes/class-convertkit-custom-content.php
@@ -355,7 +355,7 @@ class ConvertKit_Custom_Content {
 	 * @param int $user_id
 	 * @param string $user_email
 	 */
-	public function process_history( $subscriber_id = 0, $user_id = 0, $user_email ) {
+	public function process_history( $subscriber_id, $user_id, $user_email ) {
 
 		// TODO this needs to work with batch processing for larger user history
 
@@ -363,13 +363,9 @@ class ConvertKit_Custom_Content {
 		$sub_rows = array();
 
 		// get all rows
-		if ( $user_id ) {
-			$user_rows = $this->get( 'user_id', $user_id, '=' );
-		}
-		if ( $subscriber_id ) {
-			$sub_rows = $this->get( 'subscriber_id', $subscriber_id, '=' );
-		}
-
+		$user_rows = $this->get( 'user_id', $user_id, '=' );
+		$sub_rows = $this->get( 'subscriber_id', $subscriber_id, '=' );
+		
 		// get unique urls visited
 		$visits = array_merge( $user_rows, $sub_rows );
 		$urls = wp_list_pluck( $visits, 'url' );


### PR DESCRIPTION
The only call made to process_history() in the Plugin is on line 292, and is only performed if both subscriber and user ID exist. Therefore the function parameters for process_history() don't need to be optional.

In turn, this resolves PHP 8.x compatibility where optional arguments cannot precede required arguments in a function call.

Closes #260
