### PR TITLE
Fix: Render Form Shortcode when new ConvertKit Form ID specified

### DIFF
--- a/includes/blocks/class-convertkit-block-form.php
+++ b/includes/blocks/class-convertkit-block-form.php
@@ -190,7 +190,18 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 		$forms = new ConvertKit_Resource_Forms();
 		$form  = $forms->get_html( $form_id );
 
-		// Bail if an error occured.
+		// If an error occured, it might be that we're requesting a Form ID that exists in ConvertKit
+		// but does not yet exist in the Plugin's Form Resources.
+		// If so, refresh the Form Resources and try again.
+		if ( is_wp_error( $form ) ) {
+			// Refresh Forms from the API.
+			$forms->refresh();
+
+			// Get Form HTML again.
+			$form = $forms->get_html( $form_id );
+		}
+
+		// If an error still occured, bail.
 		if ( is_wp_error( $form ) ) {
 			if ( $settings->debug_enabled() ) {
 				return '<!-- ' . $form->get_error_message() . ' -->';

--- a/readme.txt
+++ b/readme.txt
@@ -53,6 +53,9 @@ Navigate to the Plugin's Settings at Settings > ConvertKit.
 
 == Changelog ==
 
+### 1.9.6.2 2021-12-xx
+* Fix: Render Form Shortcode when a new ConvertKit Form ID specified that does not yet exist in Plugin's cached Form Resources
+
 ### 1.9.6.1 2021-12-16
 * Fix: Character encoding issue on Landing Pages
 * Fix: Removed unused .scripts directory and .MD files

--- a/tests/acceptance/PageShortcodeFormCest.php
+++ b/tests/acceptance/PageShortcodeFormCest.php
@@ -118,4 +118,46 @@ class PageShortcodeFormCest
 		// Confirm that the ConvertKit Form is not displayed.
 		$I->dontSeeElementInDOM('form[data-sv-form]');
 	}
+
+	/**
+	 * Test the [convertkit form] shortcode works when a valid Form ID is specified,
+	 * but the Form ID does not exist in the options table.
+	 * 
+	 * This emulates when a ConvertKit User has:
+	 * - added a new ConvertKit Form to their account at https://app.convertkit.com/
+	 * - copied the ConvertKit Form Shortcode at https://app.convertkit.com/
+	 * - pasted the ConvertKit Form Shortcode into a new WordPress Page
+	 * - not navigated to Settings > ConvertKit to refresh the Plugin's Form Resources.
+	 * 
+	 * @since 	1.9.6.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testFormShortcodeWhenFormDoesNotExistInPluginFormResources(AcceptanceTester $I)
+	{
+		// Update the Form Resource option table value to only contain a dummy Form with an ID
+		// that does not match the shortcode Form's ID.
+		$I->haveOptionInDatabase('convertkit_forms', [
+			1234 => [
+				'id' => 1234,
+				'uid' => 1234,
+				'embed_js' => 'fake',
+			],
+		]);
+
+		// Create Page with Shortcode.
+		$I->havePageInDatabase([
+			'post_name' 	=> 'convertkit-form-shortcode-no-form-resources',
+			'post_content' 	=> '[convertkit form=' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']',
+		]);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/convertkit-form-shortcode-no-form-resources');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the ConvertKit Form is displayed.
+		$I->seeElementInDOM('form[data-sv-form]');
+	}
 }

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -9,7 +9,7 @@
  * Plugin Name: ConvertKit
  * Plugin URI: https://convertkit.com/
  * Description: Quickly and easily integrate ConvertKit forms into your site.
- * Version: 1.9.6.1
+ * Version: 1.9.6.2
  * Author: ConvertKit
  * Author URI: https://convertkit.com/
  * Text Domain: convertkit
@@ -24,7 +24,7 @@ if ( class_exists( 'WP_ConvertKit' ) ) {
 define( 'CONVERTKIT_PLUGIN_FILE', plugin_basename( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_PATH', __DIR__ );
-define( 'CONVERTKIT_PLUGIN_VERSION', '1.9.6.1' );
+define( 'CONVERTKIT_PLUGIN_VERSION', '1.9.6.2' );
 
 // Load files that are always required.
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/functions.php';


### PR DESCRIPTION
## Summary

Fixes a form rendering issue where a newly created ConvertKit Form is added to a WordPress Page using a shortcode, and the Form's ID does not yet exist in the Plugin's cached Forms data.

In this case, a single API call to the `forms` endpoint of the ConvertKit API is made to refresh the list of Forms, caching the result and ensuring that the new Form correctly renders.

For context, the list of available Forms are cached in the Plugin by design when navigating to Settings > ConvertKit, to ensure that the Plugin does not make repeated calls to the `forms` endpoint of the ConvertKit API when using Forms elsewhere in the Plugin (e.g. when specifying a Form in a Page's meta box, adding as a shortcode etc, which would otherwise result in slow page loading times for site visitors and users).

As such, this is not a blocking issue, noting that the user can navigate to Settings > ConvertKit, which automatically refreshes the cached list of Forms, resulting in the new Form shortcode subsequently rendering.  However, this PR will prevent the user needing to do this extra step.

## Testing

- `PageShortcodeFormCest:testFormShortcodeWhenFormDoesNotExistInPluginFormResources`: added to test that a WordPress Page containing a ConvertKit Form Shortcode with a Form ID that does not exist in the Plugin's cached Forms data correctly renders.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)