### PR TITLE
Bump minimum required PHP version

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,7 @@ Donate link: https://convertkit.com
 Tags: email, marketing, embed form, convertkit, capture
 Requires at least: 4.9
 Tested up to: 5.8.3
+Requires PHP: 5.6.20
 Stable tag: trunk
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/tests/acceptance/PageCest.php
+++ b/tests/acceptance/PageCest.php
@@ -46,8 +46,7 @@ class PageCest
 		// Check that an expected message is displayed.
 		$I->seeInSource('To configure the ConvertKit Form / Landing Page to display on this Page, enter your ConvertKit API credentials');
 
-		// Check that a Plugin Settings link exists and loads the Plugin Settings screen.
-		$I->click('#wp-convertkit-meta-box a');
-		$I->seeElement('#api_key');
+		// Check that a link to the Plugin Settings exists.
+		$I->seeInSource('<a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/options-general.php?page=_wp_convertkit_settings">Plugin Settings</a>');
 	}
 }

--- a/tests/acceptance/PostCest.php
+++ b/tests/acceptance/PostCest.php
@@ -46,8 +46,7 @@ class PostCest
 		// Check that an expected message is displayed.
 		$I->seeInSource('To configure the ConvertKit Form / Landing Page to display on this Post, enter your ConvertKit API credentials');
 
-		// Check that a Plugin Settings link exists and loads the Plugin Settings screen.
-		$I->click('#wp-convertkit-meta-box a');
-		$I->seeElement('#api_key');
+		// Check that a link to the Plugin Settings exists.
+		$I->seeInSource('<a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/options-general.php?page=_wp_convertkit_settings">Plugin Settings</a>');
 	}
 }


### PR DESCRIPTION
## Summary

A WordPress Plugin may specify the minimum PHP version that is required for a Plugin to be installed or updated by adding the `Requires PHP` header in the `readme.txt` file.

As of now:
- PHP 7.4 and higher are the only currently supported versions: https://www.php.net/supported-versions.php
- WordPress recommends PHP 7.4 and higher: https://wordpress.org/about/requirements/

Many hosts lag behind providing up-to-date PHP versions (notably WP Engine only introducing support for PHP 8.0 earlier this month), so enforcing a strict PHP 7.4+ policy would most likely restrict who can use this Plugin (WordPress do not provide per-Plugin PHP version statistics).  However, we also cannot continue to appear to support out-of-date PHP versions (such as < 5.4), as this results in support requests for new installations [like this](https://github.com/ConvertKit/tier3-issues/issues/1974).

Having reviewed the [most popular Plugins](https://en-gb.wordpress.org/plugins/browse/popular/), the consensus is to support the minimum PHP version that WordPress is compatible with, [5.6.20](https://wordpress.org/about/requirements/).
![Screenshot 2022-01-17 at 18 30 32](https://user-images.githubusercontent.com/1462305/149822004-6974a14a-c2f7-40b0-b49d-f508dd88d401.png)

This PR would prompt WordPress to display the following when attempting to install the Plugin on a site that has a PHP version older than 5.6.20:
![Screenshot 2022-01-17 at 18 51 10](https://user-images.githubusercontent.com/1462305/149823910-f369a46d-acd5-4c26-b87d-3bc97c6dc865.png)

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)