### PR TITLE
Legacy Forms: Removed erroneous <html>, <head> and <body> tags

### DIFF
--- a/includes/class-convertkit-api.php
+++ b/includes/class-convertkit-api.php
@@ -708,10 +708,10 @@ class ConvertKit_API {
 	public function get_resource( $url ) {
 
 		// Warn the developer that they shouldn't use this function.
-		_deprecated_function( __FUNCTION__, '1.9.6', 'get_form_html( $form_id ) or get_landing_page_html( $url, false )' );
+		_deprecated_function( __FUNCTION__, '1.9.6', 'get_form_html( $form_id ) or get_landing_page_html( $url )' );
 
 		// Pass request to new function.
-		return $this->get_landing_page_html( $url, false );
+		return $this->get_landing_page_html( $url );
 
 	}
 

--- a/includes/class-convertkit-api.php
+++ b/includes/class-convertkit-api.php
@@ -621,7 +621,7 @@ class ConvertKit_API {
 	public function get_landing_page_html( $url ) {
 
 		// Get HTML.
-		$body = $this->get_html( $url , false );
+		$body = $this->get_html( $url, false );
 
 		// Inject JS for subscriber forms to work.
 		$scripts = new WP_Scripts();
@@ -739,7 +739,7 @@ class ConvertKit_API {
 	 * This isn't specifically an API function, but for now it's best suited here.
 	 *
 	 * @param   string $url    URL of Form or Landing Page.
-	 * @param 	bool   $body_only 	Return HTML between <body> and </body> tags only.
+	 * @param   bool   $body_only   Return HTML between <body> and </body> tags only.
 	 * @return  string          HTML
 	 */
 	private function get_html( $url, $body_only = true ) {
@@ -864,11 +864,11 @@ class ConvertKit_API {
 
 	/**
 	 * Strips <html>, <head> and <body> opening and closing tags from the given markup.
-	 * 
-	 * @since 	1.9.6.5
-	 * 
-	 * @param 	string 	$markup 	HTML Markup.
-	 * @return 	string 				HTML Markup
+	 *
+	 * @since   1.9.6.5
+	 *
+	 * @param   string $markup     HTML Markup.
+	 * @return  string              HTML Markup
 	 * */
 	private function strip_html_head_body_tags( $markup ) {
 

--- a/readme.txt
+++ b/readme.txt
@@ -56,6 +56,7 @@ Navigate to the Plugin's Settings at Settings > ConvertKit.
 
 ### 1.9.6.5 2022-01-xx
 * Added: Select2 dropdown for Forms, Landing Pages and Tags with search functionality for improved UX.
+* Fix: Legacy Forms: Removed erronous <html>, <head> and <body> tags from markup 
 
 ### 1.9.6.4 2022-01-11
 * Fix: Render Legacy Form when shortcode is copied from app.convertkit.com for a Legacy Form

--- a/tests/acceptance/PageFormCest.php
+++ b/tests/acceptance/PageFormCest.php
@@ -53,7 +53,7 @@ class PageFormCest
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'Default');
 
 		// Define a Page Title.
-		$I->fillField('#post-title-0', 'ConvertKit: Form: Default: None');
+		$I->fillField('.editor-post-title__input', 'ConvertKit: Form: Default: None');
 
 		// Click the Publish button.
 		$I->click('.editor-post-publish-button__button');
@@ -107,7 +107,7 @@ class PageFormCest
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'Default');
 
 		// Define a Page Title.
-		$I->fillField('#post-title-0', 'ConvertKit: Form: Default');
+		$I->fillField('.editor-post-title__input', 'ConvertKit: Form: Default');
 
 		// Click the Publish button.
 		$I->click('.editor-post-publish-button__button');
@@ -161,7 +161,7 @@ class PageFormCest
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'Default');
 
 		// Define a Page Title.
-		$I->fillField('#post-title-0', 'ConvertKit: Form: Legacy: Default');
+		$I->fillField('.editor-post-title__input', 'ConvertKit: Form: Legacy: Default');
 
 		// Click the Publish button.
 		$I->click('.editor-post-publish-button__button');
@@ -212,7 +212,7 @@ class PageFormCest
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None');
 
 		// Define a Page Title.
-		$I->fillField('#post-title-0', 'ConvertKit: Form: None');
+		$I->fillField('.editor-post-title__input', 'ConvertKit: Form: None');
 
 		// Click the Publish button.
 		$I->click('.editor-post-publish-button__button');
@@ -263,7 +263,7 @@ class PageFormCest
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
 		// Define a Page Title.
-		$I->fillField('#post-title-0', 'ConvertKit: Form: Specific');
+		$I->fillField('.editor-post-title__input', 'ConvertKit: Form: Specific');
 
 		// Click the Publish button.
 		$I->click('.editor-post-publish-button__button');
@@ -317,7 +317,7 @@ class PageFormCest
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
 
 		// Define a Page Title.
-		$I->fillField('#post-title-0', 'ConvertKit: Form: Legacy: Specific');
+		$I->fillField('.editor-post-title__input', 'ConvertKit: Form: Legacy: Specific');
 
 		// Click the Publish button.
 		$I->click('.editor-post-publish-button__button');

--- a/tests/acceptance/PageLandingPageCest.php
+++ b/tests/acceptance/PageLandingPageCest.php
@@ -52,7 +52,7 @@ class PageLandingPageCest
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-landing_page-container', 'None');
 
 		// Define a Page Title.
-		$I->fillField('#post-title-0', 'ConvertKit: Landing Page: None');
+		$I->fillField('.editor-post-title__input', 'ConvertKit: Landing Page: None');
 
 		// Click the Publish button.
 		$I->click('.editor-post-publish-button__button');
@@ -103,7 +103,7 @@ class PageLandingPageCest
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-landing_page-container', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME']);
 
 		// Define a Page Title.
-		$I->fillField('#post-title-0', 'ConvertKit: Landing Page: Specific');
+		$I->fillField('.editor-post-title__input', 'ConvertKit: Landing Page: Specific');
 
 		// Click the Publish button.
 		$I->click('.editor-post-publish-button__button');
@@ -127,9 +127,17 @@ class PageLandingPageCest
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
+		// Confirm that the basic HTML structure is correct.
+		$I->seeInSource('<html>');
+		$I->seeInSource('<head>');
+		$I->seeInSource('</head>');
+		$I->seeInSource('<body');
+		$I->seeInSource('</body>');
+		$I->seeInSource('</html>');
+		
 		// Confirm that the ConvertKit Landing Page displays.
 		$I->dontSeeElementInDOM('body.page'); // WordPress didn't load its template, which is correct.
-		$I->seeElementInDOM('form[data-sv-form="' . $landingPageID . '"]'); // ConvertKit injected its Landing Page Form, which is correct.
+		$I->seeElementInDOM('form[data-sv-form="' . $landingPageID . '"]'); // ConvertKit injected its Landing Page Form, which is correct.		
 	}
 
 	/**
@@ -157,7 +165,7 @@ class PageLandingPageCest
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-landing_page-container', $_ENV['CONVERTKIT_API_LANDING_PAGE_CHARACTER_ENCODING_NAME']);
 
 		// Define a Page Title.
-		$I->fillField('#post-title-0', 'ConvertKit: Landing Page: Character Encoding');
+		$I->fillField('.editor-post-title__input', 'ConvertKit: Landing Page: Character Encoding');
 
 		// Click the Publish button.
 		$I->click('.editor-post-publish-button__button');
@@ -180,6 +188,14 @@ class PageLandingPageCest
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the basic HTML structure is correct.
+		$I->seeInSource('<html>');
+		$I->seeInSource('<head>');
+		$I->seeInSource('</head>');
+		$I->seeInSource('<body');
+		$I->seeInSource('</body>');
+		$I->seeInSource('</html>');
 
 		// Confirm that the Landing Page title is the same as defined on ConvertKit i.e. that character encoding is correct.
 		$I->seeInSource('Vantar þinn ungling sjálfstraust í stærðfræði?');
@@ -211,7 +227,7 @@ class PageLandingPageCest
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-landing_page-container', $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME']);
 
 		// Define a Page Title.
-		$I->fillField('#post-title-0', 'ConvertKit: Landing Page: Legacy: Specific');
+		$I->fillField('.editor-post-title__input', 'ConvertKit: Landing Page: Legacy: Specific');
 
 		// Click the Publish button.
 		$I->click('.editor-post-publish-button__button');
@@ -234,6 +250,14 @@ class PageLandingPageCest
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the basic HTML structure is correct.
+		$I->seeInSource('<html>');
+		$I->seeInSource('<head>');
+		$I->seeInSource('</head>');
+		$I->seeInSource('<body');
+		$I->seeInSource('</body>');
+		$I->seeInSource('</html>');
 
 		// Confirm that the ConvertKit Landing Page displays.
 		$I->dontSeeElementInDOM('body.page'); // WordPress didn't load its template, which is correct.
@@ -273,6 +297,14 @@ class PageLandingPageCest
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the basic HTML structure is correct.
+		$I->seeInSource('<html>');
+		$I->seeInSource('<head>');
+		$I->seeInSource('</head>');
+		$I->seeInSource('<body');
+		$I->seeInSource('</body>');
+		$I->seeInSource('</html>');
 
 		// Confirm that the ConvertKit Landing Page displays.
 		$I->dontSeeElementInDOM('body.page'); // WordPress didn't load its template, which is correct.

--- a/tests/acceptance/PageTagCest.php
+++ b/tests/acceptance/PageTagCest.php
@@ -52,7 +52,7 @@ class PageTagCest
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-tag-container', 'None');
 
 		// Define a Page Title.
-		$I->fillField('#post-title-0', 'ConvertKit: Tag: None');
+		$I->fillField('.editor-post-title__input', 'ConvertKit: Tag: None');
 
 		// Click the Publish button.
 		$I->click('.editor-post-publish-button__button');
@@ -103,7 +103,7 @@ class PageTagCest
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-tag-container', $_ENV['CONVERTKIT_API_TAG_NAME']);
 
 		// Define a Page Title.
-		$I->fillField('#post-title-0', 'ConvertKit: Tag: Specific');
+		$I->fillField('.editor-post-title__input', 'ConvertKit: Tag: Specific');
 
 		// Click the Publish button.
 		$I->click('.editor-post-publish-button__button');

--- a/tests/acceptance/PostFormCest.php
+++ b/tests/acceptance/PostFormCest.php
@@ -53,7 +53,7 @@ class PostFormCest
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'Default');
 
 		// Define a Post Title.
-		$I->fillField('#post-title-0', 'ConvertKit: Form: Default: None');
+		$I->fillField('.editor-post-title__input', 'ConvertKit: Form: Default: None');
 
 		// Click the Publish button.
 		$I->click('.editor-post-publish-button__button');
@@ -107,7 +107,7 @@ class PostFormCest
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'Default');
 
 		// Define a Post Title.
-		$I->fillField('#post-title-0', 'ConvertKit: Form: Default');
+		$I->fillField('.editor-post-title__input', 'ConvertKit: Form: Default');
 
 		// Click the Publish button.
 		$I->click('.editor-post-publish-button__button');
@@ -158,7 +158,7 @@ class PostFormCest
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None');
 
 		// Define a Post Title.
-		$I->fillField('#post-title-0', 'ConvertKit: Form: None');
+		$I->fillField('.editor-post-title__input', 'ConvertKit: Form: None');
 
 		// Click the Publish button.
 		$I->click('.editor-post-publish-button__button');
@@ -209,7 +209,7 @@ class PostFormCest
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
 		// Define a Post Title.
-		$I->fillField('#post-title-0', 'ConvertKit: Form: Specific');
+		$I->fillField('.editor-post-title__input', 'ConvertKit: Form: Specific');
 
 		// Click the Publish button.
 		$I->click('.editor-post-publish-button__button');

--- a/tests/acceptance/PostLandingPageCest.php
+++ b/tests/acceptance/PostLandingPageCest.php
@@ -50,7 +50,7 @@ class PostLandingPageCest
 		$I->dontSeeElementInDOM('#wp-convertkit-landing_page');
 
 		// Define a Post Title.
-		$I->fillField('#post-title-0', 'ConvertKit: Post: Landing Page');
+		$I->fillField('.editor-post-title__input', 'ConvertKit: Post: Landing Page');
 
 		// Click the Publish button.
 		$I->click('.editor-post-publish-button__button');


### PR DESCRIPTION
## Summary

Legacy Forms would wrongly include `<html>`, `<head>` and `<body>` tags due to using PHP's `DOMDocument` functionality (this being used to convert relative to absolute URIs).
![Screenshot 2022-01-24 at 16 17 51](https://user-images.githubusercontent.com/1462305/150821469-481d9711-3865-42a5-9a11-cb8aae0bdd19.png)

This did not affect output, noting browsers ignore these erroneous duplicated tags:
![Screenshot 2022-01-24 at 16 20 21](https://user-images.githubusercontent.com/1462305/150821884-b5604c42-12b9-4e36-8791-2ce6b3d22185.png)

Output when applying this PR is now correct:
![Screenshot 2022-01-24 at 16 19 42](https://user-images.githubusercontent.com/1462305/150821759-495fd549-475b-4436-9ab0-f7074504f279.png)

This was missed through testing because Codeception removes these duplicate tags when loading a page's source into a DOM parser prior to performing assertions within tests.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)