### PR TITLE
Fix trailing comma.

### DIFF
--- a/admin/section/class-convertkit-settings-base.php
+++ b/admin/section/class-convertkit-settings-base.php
@@ -212,7 +212,7 @@ abstract class ConvertKit_Settings_Base {
 			$this->settings_key . '_' . $name,
 			$this->settings_key,
 			$name,
-			( is_array( $css_classes ) ? implode( ' ', $css_classes ) : '' ),
+			( is_array( $css_classes ) ? implode( ' ', $css_classes ) : '' )
 		);
 
 		// Build <option> tags.


### PR DESCRIPTION
## Summary

Fixing the following error:

```
Fatal error: Uncaught Error: syntax error, unexpected ')'
in /site/wp-content/plugins/convertkit/admin/section/class-convertkit-settings-base.php on line 216
```

Resulted in a fatal error on plugin activation. 

Happened on:
WordPress: 5.8.3
PHP version | 7.2.34 (Supports 64bit values)

## Testing

Did not have time to do further testing. Just removing the comma shouldn't break anything :)

## Checklist

* [ ] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](TESTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)