### PR TITLE
Fix: Remove trailing comma in sprintf() call

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         wp-versions: [ '5.9' ] #[ '5.6.7', '5.7.5', '5.8.3', '5.9' ]
-        php-versions: [ '7.3', '7.4', '8.0' ] #[ '7.3', '7.4', '8.0', '8.1' ]
+        php-versions: [ '7.2', '7.3', '7.4', '8.0' ] #[ '7.3', '7.4', '8.0', '8.1' ]
       max-parallel: 1 # Run one at a time, otherwise reading API data after tests results in false positives due to concurrency
 
     # Steps to install, configure and run tests

--- a/admin/section/class-convertkit-settings-base.php
+++ b/admin/section/class-convertkit-settings-base.php
@@ -212,7 +212,7 @@ abstract class ConvertKit_Settings_Base {
 			$this->settings_key . '_' . $name,
 			$this->settings_key,
 			$name,
-			( is_array( $css_classes ) ? implode( ' ', $css_classes ) : '' ),
+			( is_array( $css_classes ) ? implode( ' ', $css_classes ) : '' )
 		);
 
 		// Build <option> tags.

--- a/readme.txt
+++ b/readme.txt
@@ -13,7 +13,9 @@ ConvertKit is an email marketing platform for capturing leads from your WordPres
 
 == Description ==
 
-[ConvertKit](https://convertkit.com) makes it easy to capture more leads and sell more products by easily embedding email capture forms anywhere. This plugin makes it even easier for those of us using WordPress by automatically appending a lead capture form to any post or page.
+[ConvertKit](https://convertkit.com) makes it easy to capture more leads and sell more products by easily embedding email capture forms anywhere.
+
+This plugin makes it even easier for those of us using WordPress by automatically appending a lead capture form to any post or page.
 
 If you choose a default form on the settings page, that form will be embedded at the bottom of every post or page (in single view only) across your site.
 
@@ -25,12 +27,14 @@ Full plugin documentation is located [here](https://help.convertkit.com/en/artic
 
 == Installation ==
 
-1. Upload `wp-convertkit` to the `/wp-content/plugins/` directory
-2. Activate the plugin through the 'Plugins' menu in WordPress
-3. Visit the settings page by clicking on the link under the plugin's name
-4. Enter your ConvertKit API key, which you can find [here](https://app.convertkit.com/account/edit), and save the settings
-5. Select your default form and save the settings
-6. If you wish, choose particular forms for each post or page by visiting the edit screen and choosing the correct form
+1. Upload the `convertkit` folder to the `/wp-content/plugins/` directory
+2. Active the ConvertKit plugin through the 'Plugins' menu in WordPress
+
+== Configuration ==
+
+1. Configure the plugin by navigating to Settings > ConvertKit in the WordPress Administration Menu, entering your [API Key](https://app.convertkit.com/account_settings/advanced_settings) and defining the default forms to display on Pages, Posts and/or Custom Post Types
+2. (Optional) choose a specific Form to display when editing a Page, Post or Custom Post Type in the Page/Post/Custom Post Type's ConvertKit settings
+3. (Optional) use the ConvertKit Form Shortcode or Block to insert Forms into your Page, Post or Custom Post Type content
 
 == Frequently asked questions ==
 
@@ -53,6 +57,9 @@ Navigate to the Plugin's Settings at Settings > ConvertKit.
 7. Another ConvertKit landing page example
 
 == Changelog ==
+
+### 1.9.6.6 2022-01-27
+* Fix: Plugin Activation: Parse error when using PHP 7.2 or below due to trailing comma in sprintf() call
 
 ### 1.9.6.5 2022-01-26
 * Added: ConvertKit Form Block for Gutenberg

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -9,7 +9,7 @@
  * Plugin Name: ConvertKit
  * Plugin URI: https://convertkit.com/
  * Description: Quickly and easily integrate ConvertKit forms into your site.
- * Version: 1.9.6.5
+ * Version: 1.9.6.6
  * Author: ConvertKit
  * Author URI: https://convertkit.com/
  * Text Domain: convertkit
@@ -24,7 +24,7 @@ if ( class_exists( 'WP_ConvertKit' ) ) {
 define( 'CONVERTKIT_PLUGIN_FILE', plugin_basename( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_PATH', __DIR__ );
-define( 'CONVERTKIT_PLUGIN_VERSION', '1.9.6.5' );
+define( 'CONVERTKIT_PLUGIN_VERSION', '1.9.6.6' );
 
 // Load files that are always required.
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/functions.php';


### PR DESCRIPTION
## Summary

Removes a trailing comma in a sprintf() call, which caused parse errors on Plugin activation when using PHP 7.2.x or earlier.

## Testing

Updated testing to run against PHP 7.2 as well as existing 7.3, 7.4 and 8.0 to ensure similar errors are caught in the future.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)