### PR TITLE
Fix Languages Folder Path

### DIFF
--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -331,7 +331,7 @@ class WP_ConvertKit {
 	 */
 	public function load_language_files() {
 
-		load_plugin_textdomain( 'convertkit', false, basename( dirname( __FILE__ ) ) . '/languages/' );
+		load_plugin_textdomain( 'convertkit', false, basename( dirname( CONVERTKIT_PLUGIN_FILE ) ) . '/languages/' );
 
 	}
 


### PR DESCRIPTION
## Summary

Correctly sets the path to the Plugin's `languages` folder to the Plugin's folder name, with `/languages` appended to the end, relative to the WordPress Plugin directory (e.g. `convertkit/languages`).

The previous use of `dirname( __FILE__ )` is incorrect, as this function is called from within a subfolder, and would result in the path being incorrectly set to `includes/languages`.

Docs: [load_plugin_textdomain](https://developer.wordpress.org/reference/functions/load_plugin_textdomain/)

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)