### PR TITLE
Gutenberg Blocks: Sort <select> field options alphabetically by label

### DIFF
--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -166,7 +166,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 
 											let a = x.label.toUpperCase(),
 											b     = y.label.toUpperCase();
-											return a == b ? 0 : a > b ? 1 : -1;
+											return a.localeCompare(b);
 
 										}
 									);

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -166,7 +166,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 
 											let a = x.label.toUpperCase(),
 											b     = y.label.toUpperCase();
-											return a.localeCompare(b);
+											return a.localeCompare( b );
 
 										}
 									);

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -159,6 +159,19 @@ function convertKitGutenbergRegisterBlock( block ) {
 											}
 										);
 									}
+
+									// Sort field's options alphabetically by label.
+									fieldOptions.sort(
+										function ( x, y ) {
+
+											let a = x.label.toUpperCase(),
+											b     = y.label.toUpperCase();
+											return a == b ? 0 : a > b ? 1 : -1;
+
+										}
+									);
+
+									// Assign options to field.
 									fieldProperties.options = fieldOptions;
 
 									// Define field element.


### PR DESCRIPTION
## Summary

Orders the Form block's dropdown options by form name (label), instead of ID (key), to match other Form dropdown selections used across the Plugin.

Before:
![Screenshot 2022-03-08 at 18 15 11](https://user-images.githubusercontent.com/1462305/157302333-d84fa909-ad21-4ae1-a149-e403d4f10a17.png)

After:
![Screenshot 2022-03-08 at 18 15 27](https://user-images.githubusercontent.com/1462305/157302338-2035fd3a-4c65-4de6-a562-b20075b5d1c5.png)

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)