### PR TITLE
Prevent Select2 styling from applying to non-Plugin elements

### DIFF
--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -355,7 +355,7 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 		}
 
 		// Output field.
-		echo $this->get_select_field( $post_type . '_form', $this->settings->get_default_form( $post_type ), $options, false, array( 'convertkit-select2' ) ); // phpcs:ignore
+		echo '<div class="convertkit-select2-container">' . $this->get_select_field( $post_type . '_form', $this->settings->get_default_form( $post_type ), $options, false, array( 'convertkit-select2' ) ) . '</div>'; // phpcs:ignore
 
 	}
 

--- a/resources/backend/css/select2.css
+++ b/resources/backend/css/select2.css
@@ -2,17 +2,17 @@
  * Additional Select2 styling to override WordPress styling defaults that
  * affect the layout of a Select2 dropdown.
  */
-.select2-container .select2-selection--single {
+.convertkit-select2-container .select2-container .select2-selection--single {
 	height: 30px;
 }
-.select2-container--default .select2-selection--single .select2-selection__rendered {
+.convertkit-select2-container .select2-container--default .select2-selection--single .select2-selection__rendered {
 	line-height: 30px;
 }
-.select2-search--dropdown .select2-search__field {
+.convertkit-select2-container .select2-search--dropdown .select2-search__field {
 	line-height: 1;
 	min-height: 24px;
 }
-li.select2-results__option {
+.convertkit-select2-container li.select2-results__option {
 	margin: 0;
 }
 
@@ -20,12 +20,12 @@ li.select2-results__option {
  * Force width of Select2 dropdowns, as using JS options dropdownAutoWidth=true and width='auto'
  * result in incorrect layout on some older browsers and our tests fail.
  */
-select + .select2-container {
+.convertkit-select2-container select + .select2-container {
 	width: 50% !important;
 	min-width: 350px !important;
 }
 @media screen and (max-width: 782px) {
-	select + .select2-container {
+	.convertkit-select2-container select + .select2-container {
 		width: 100% !important;
 		font-size: 16px;
 		line-height: 2;

--- a/views/backend/post/meta-box.php
+++ b/views/backend/post/meta-box.php
@@ -20,36 +20,38 @@
 					esc_html_e( 'No Forms exist in ConvertKit.', 'convertkit' );
 				} else {
 					?>
-					<select name="wp-convertkit[form]" id="wp-convertkit-form" class="convertkit-select2">
-						<option value="-1"<?php selected( - 1, $convertkit_post->get_form() ); ?>>
-							<?php esc_html_e( 'Default', 'convertkit' ); ?>
-						</option>
-						<option value="0"<?php selected( 0, $convertkit_post->get_form() ); ?>>
-							<?php esc_html_e( 'None', 'convertkit' ); ?>
-						</option>
-						<?php
-						foreach ( $convertkit_forms->get() as $form ) {
-							?>
-							<option value="<?php echo esc_attr( $form['id'] ); ?>"<?php selected( $form['id'], $convertkit_post->get_form() ); ?>>
-								<?php echo esc_attr( $form['name'] ); ?>
+					<div class="convertkit-select2-container">
+						<select name="wp-convertkit[form]" id="wp-convertkit-form" class="convertkit-select2">
+							<option value="-1"<?php selected( - 1, $convertkit_post->get_form() ); ?>>
+								<?php esc_html_e( 'Default', 'convertkit' ); ?>
+							</option>
+							<option value="0"<?php selected( 0, $convertkit_post->get_form() ); ?>>
+								<?php esc_html_e( 'None', 'convertkit' ); ?>
 							</option>
 							<?php
-						}
-						?>
-					</select>
-					<p class="description">
-						<?php
-						printf(
-							/* translators: settings url */
-							__( '<code>Default</code>: Uses the form specified on the <a href="%s" target="_blank">settings page</a>.', 'convertkit' ), /* phpcs:ignore */
-							esc_attr( esc_url( $settings_link ) )
-						);
-						?>
-						<br />
-						<?php _e( '<code>None</code>: do not display a form.', 'convertkit' ); /* phpcs:ignore */ ?>
-						<br />
-						<?php esc_html_e( 'Any other option will display that form after the main content.', 'convertkit' ); ?>
-					</p>
+							foreach ( $convertkit_forms->get() as $form ) {
+								?>
+								<option value="<?php echo esc_attr( $form['id'] ); ?>"<?php selected( $form['id'], $convertkit_post->get_form() ); ?>>
+									<?php echo esc_attr( $form['name'] ); ?>
+								</option>
+								<?php
+							}
+							?>
+						</select>
+						<p class="description">
+							<?php
+							printf(
+								/* translators: settings url */
+								__( '<code>Default</code>: Uses the form specified on the <a href="%s" target="_blank">settings page</a>.', 'convertkit' ), /* phpcs:ignore */
+								esc_attr( esc_url( $settings_link ) )
+							);
+							?>
+							<br />
+							<?php _e( '<code>None</code>: do not display a form.', 'convertkit' ); /* phpcs:ignore */ ?>
+							<br />
+							<?php esc_html_e( 'Any other option will display that form after the main content.', 'convertkit' ); ?>
+						</p>
+					</div>
 					<?php
 				}
 				?>
@@ -80,31 +82,33 @@
 						esc_html_e( 'No Landing Pages exist in ConvertKit.', 'convertkit' );
 					} else {
 						?>
-						<select name="wp-convertkit[landing_page]" id="wp-convertkit-landing_page" class="convertkit-select2">
-							<option <?php selected( '', $convertkit_post->get_landing_page() ); ?> value="0">
-								<?php esc_html_e( 'None', 'convertkit' ); ?>
-							</option>
-							<?php
-							foreach ( $convertkit_landing_pages->get() as $landing_page ) {
-								if ( isset( $convertkit_landing_page['url'] ) ) {
-									?>
-									<option value="<?php echo esc_attr( $landing_page['url'] ); ?>"<?php selected( $landing_page['url'], $convertkit_post->get_landing_page() ); ?>>
-										<?php echo esc_attr( $landing_page['name'] ); ?>
-									</option>
-									<?php
-								} else {
-									?>
-									<option value="<?php echo esc_attr( $landing_page['id'] ); ?>"<?php selected( $landing_page['id'], $convertkit_post->get_landing_page() ); ?>>
-										<?php echo esc_attr( $landing_page['name'] ); ?>
-									</option>
-									<?php
+						<div class="convertkit-select2-container">
+							<select name="wp-convertkit[landing_page]" id="wp-convertkit-landing_page" class="convertkit-select2">
+								<option <?php selected( '', $convertkit_post->get_landing_page() ); ?> value="0">
+									<?php esc_html_e( 'None', 'convertkit' ); ?>
+								</option>
+								<?php
+								foreach ( $convertkit_landing_pages->get() as $landing_page ) {
+									if ( isset( $convertkit_landing_page['url'] ) ) {
+										?>
+										<option value="<?php echo esc_attr( $landing_page['url'] ); ?>"<?php selected( $landing_page['url'], $convertkit_post->get_landing_page() ); ?>>
+											<?php echo esc_attr( $landing_page['name'] ); ?>
+										</option>
+										<?php
+									} else {
+										?>
+										<option value="<?php echo esc_attr( $landing_page['id'] ); ?>"<?php selected( $landing_page['id'], $convertkit_post->get_landing_page() ); ?>>
+											<?php echo esc_attr( $landing_page['name'] ); ?>
+										</option>
+										<?php
+									}
 								}
-							}
-							?>
-						</select>
-						<p class="description">
-							<?php esc_html_e( 'Select a landing page to make it appear in place of this page.', 'convertkit' ); ?>
-						</p>
+								?>
+							</select>
+							<p class="description">
+								<?php esc_html_e( 'Select a landing page to make it appear in place of this page.', 'convertkit' ); ?>
+							</p>
+						</div>
 						<?php
 					}
 					?>
@@ -130,33 +134,35 @@
 				<label for="wp-convertkit-tag"><?php esc_html_e( 'Add a Tag', 'convertkit' ); ?></label>
 			</th>
 			<td>
-				<?php
-				if ( ! $convertkit_tags->exist() ) {
-					esc_html_e( 'No Tags exist in ConvertKit.', 'convertkit' );
-				} else {
-					?>
-					<select name="wp-convertkit[tag]" id="wp-convertkit-tag" class="convertkit-select2">
-						<option value="0"<?php selected( '', $convertkit_post->get_tag() ); ?>>
-							<?php esc_html_e( 'None', 'convertkit' ); ?>
-						</option>
-						<?php
-						foreach ( $convertkit_tags->get() as $convertkit_tag ) {
-							?>
-							<option value="<?php echo esc_attr( $convertkit_tag['id'] ); ?>"<?php selected( $convertkit_tag['id'], $convertkit_post->get_tag() ); ?>>
-								<?php echo esc_attr( $convertkit_tag['name'] ); ?>
+				<div class="convertkit-select2-container">
+					<?php
+					if ( ! $convertkit_tags->exist() ) {
+						esc_html_e( 'No Tags exist in ConvertKit.', 'convertkit' );
+					} else {
+						?>
+						<select name="wp-convertkit[tag]" id="wp-convertkit-tag" class="convertkit-select2">
+							<option value="0"<?php selected( '', $convertkit_post->get_tag() ); ?>>
+								<?php esc_html_e( 'None', 'convertkit' ); ?>
 							</option>
 							<?php
-						}
-						?>
-					</select>
-					<?php
-				}
-				?>
-				<p class="description">
-					<?php esc_html_e( 'Select a tag to apply to visitors of this page who are subscribed.', 'convertkit' ); ?>
-					<br />
-					<?php esc_html_e( 'A visitor is deemed to be subscribed if they have clicked a link in an email to this site which includes their subscriber ID, or have entered their email address in a ConvertKit Form on this site.', 'convertkit' ); ?>
-				</p>
+							foreach ( $convertkit_tags->get() as $convertkit_tag ) {
+								?>
+								<option value="<?php echo esc_attr( $convertkit_tag['id'] ); ?>"<?php selected( $convertkit_tag['id'], $convertkit_post->get_tag() ); ?>>
+									<?php echo esc_attr( $convertkit_tag['name'] ); ?>
+								</option>
+								<?php
+							}
+							?>
+						</select>
+						<?php
+					}
+					?>
+					<p class="description">
+						<?php esc_html_e( 'Select a tag to apply to visitors of this page who are subscribed.', 'convertkit' ); ?>
+						<br />
+						<?php esc_html_e( 'A visitor is deemed to be subscribed if they have clicked a link in an email to this site which includes their subscriber ID, or have entered their email address in a ConvertKit Form on this site.', 'convertkit' ); ?>
+					</p>
+				</div>
 			</td>
 		</tr>
 	</tbody>

--- a/views/backend/term/fields.php
+++ b/views/backend/term/fields.php
@@ -17,31 +17,33 @@
 			esc_html_e( 'No Forms exist in ConvertKit.', 'convertkit' );
 		} else {
 			?>
-			<select name="wp-convertkit[form]" id="wp-convertkit-form" class="convertkit-select2">
-				<option value="0"<?php selected( 0, $convertkit_term->get_form() ); ?>>
-					<?php esc_html_e( 'None', 'convertkit' ); ?>
-				</option>
-				<?php
-				foreach ( $convertkit_forms->get() as $convertkit_form ) {
-					?>
-					<option value="<?php echo esc_attr( $convertkit_form['id'] ); ?>"<?php selected( $convertkit_form['id'], $convertkit_term->get_form() ); ?>>
-						<?php echo esc_html( $convertkit_form['name'] ); ?>
+			<div class="convertkit-select2-container">
+				<select name="wp-convertkit[form]" id="wp-convertkit-form" class="convertkit-select2">
+					<option value="0"<?php selected( 0, $convertkit_term->get_form() ); ?>>
+						<?php esc_html_e( 'None', 'convertkit' ); ?>
 					</option>
 					<?php
-				}
-				?>
-			</select>
-			<p class="description">
-				<?php _e( '<code>None</code>: do not display a form.', 'convertkit' ); /* phpcs:ignore */ ?>
-				<br />
-				<?php
-				echo sprintf(
-					/* translators: Taxonomy Name */
-					esc_html__( 'Any other option will display that form after the main content for Posts in this %s.', 'convertkit' ),
-					'category'
-				);
-				?>
-			</p>
+					foreach ( $convertkit_forms->get() as $convertkit_form ) {
+						?>
+						<option value="<?php echo esc_attr( $convertkit_form['id'] ); ?>"<?php selected( $convertkit_form['id'], $convertkit_term->get_form() ); ?>>
+							<?php echo esc_html( $convertkit_form['name'] ); ?>
+						</option>
+						<?php
+					}
+					?>
+				</select>
+				<p class="description">
+					<?php _e( '<code>None</code>: do not display a form.', 'convertkit' ); /* phpcs:ignore */ ?>
+					<br />
+					<?php
+					echo sprintf(
+						/* translators: Taxonomy Name */
+						esc_html__( 'Any other option will display that form after the main content for Posts in this %s.', 'convertkit' ),
+						'category'
+					);
+					?>
+				</p>
+			</div>
 			<?php
 			wp_nonce_field( 'wp-convertkit-save-meta', 'wp-convertkit-save-meta-nonce' );
 		}


### PR DESCRIPTION
## Summary

Prevents Plugin's additional Select2 styling from being applied to non-Plugin Select2 instances, [as reported here](https://github.com/ConvertKit/convertkit-wordpress/issues/287), by:
- wrapping Select2 instances inside a container element with a Plugin-specific class name,
- applying additional Select2 styling to the Plugin-specific class name.

Before, noting Plugin Select2 styles wrongly applied to a third party Gutenberg Block that also uses Select2, resulting in a scroll bar:
![before](https://user-images.githubusercontent.com/1462305/158604116-b99e768b-670f-45bc-80e9-7cb5738647f3.png)

After, noting Plugin Select2 styles no longer applied to third party Gutenberg Block:
![after-1](https://user-images.githubusercontent.com/1462305/158604100-598988e7-9ae5-4209-ad13-a19147eadc8a.png)
![after-2](https://user-images.githubusercontent.com/1462305/158604110-b20f9875-8a33-4128-944d-6116378b41a3.png)

## Testing

UI and visual tests to confirm styling correctly applies.
Existing acceptance tests confirm Select2 instances still work as expected.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)