### PR TITLE
Code changes to meet PHPStan static analysis tests

### DIFF
--- a/admin/class-convertkit-admin-settings.php
+++ b/admin/class-convertkit-admin-settings.php
@@ -86,7 +86,7 @@ class ConvertKit_Admin_Settings {
 		convertkit_select2_enqueue_styles();
 
 		// Enqueue Settings CSS.
-		wp_enqueue_style( 'convertkit-admin-settings', CONVERTKIT_PLUGIN_URL . '/resources/backend/css/settings.css', false, CONVERTKIT_PLUGIN_VERSION );
+		wp_enqueue_style( 'convertkit-admin-settings', CONVERTKIT_PLUGIN_URL . '/resources/backend/css/settings.css', array(), CONVERTKIT_PLUGIN_VERSION );
 
 		/**
 		 * Enqueue CSS for the Settings Screen at Settings > ConvertKit

--- a/admin/class-convertkit-admin-tinymce.php
+++ b/admin/class-convertkit-admin-tinymce.php
@@ -97,7 +97,7 @@ class ConvertKit_Admin_TinyMCE {
 		);
 
 		// Enqueue Quicktag CSS.
-		wp_enqueue_style( 'convertkit-admin-quicktags', CONVERTKIT_PLUGIN_URL . '/resources/backend/css/quicktags.css', false, CONVERTKIT_PLUGIN_VERSION );
+		wp_enqueue_style( 'convertkit-admin-quicktags', CONVERTKIT_PLUGIN_URL . '/resources/backend/css/quicktags.css', array(), CONVERTKIT_PLUGIN_VERSION );
 
 		// Output Backbone View Template.
 		?>
@@ -126,13 +126,13 @@ class ConvertKit_Admin_TinyMCE {
 
 		// Bail if no shortcodes are available.
 		if ( ! is_array( $shortcodes ) || ! count( $shortcodes ) ) {
-			return;
+			return $plugins;
 		}
 
 		// Enqueue TinyMCE CSS and JS.
 		wp_enqueue_script( 'convertkit-admin-tinymce', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/tinymce.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
 		wp_enqueue_script( 'convertkit-admin-modal', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/modal.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
-		wp_enqueue_style( 'convertkit-admin-tinymce', CONVERTKIT_PLUGIN_URL . '/resources/backend/css/tinymce.css', false, CONVERTKIT_PLUGIN_VERSION );
+		wp_enqueue_style( 'convertkit-admin-tinymce', CONVERTKIT_PLUGIN_URL . '/resources/backend/css/tinymce.css', array(), CONVERTKIT_PLUGIN_VERSION );
 
 		// Register JS variable convertkit_admin_tinymce.nonce for AJAX calls.
 		wp_localize_script(

--- a/admin/class-convertkit-admin-upgrade.php
+++ b/admin/class-convertkit-admin-upgrade.php
@@ -121,11 +121,8 @@ class ConvertKit_Admin_Upgrade {
 			);
 
 			$result = new WP_Query( $args );
-
-			if ( ! is_wp_error( $result ) ) {
-				$posts = $result->posts;
-				update_option( '_wp_convertkit_upgrade_posts', $posts );
-			}
+			$posts  = $result->posts;
+			update_option( '_wp_convertkit_upgrade_posts', $posts );
 		}
 
 		// Initialize the API.
@@ -141,7 +138,7 @@ class ConvertKit_Admin_Upgrade {
 
 		// 1. Update global form.
 		$settings_data                 = $settings->get();
-		$settings_data['default_form'] = isset( $mappings[ $settings->get_default_form() ] ) ? $mappings[ $settings->get_default_form() ] : 0;
+		$settings_data['default_form'] = isset( $mappings[ $settings->get_default_form( 'post' ) ] ) ? $mappings[ $settings->get_default_form( 'post' ) ] : 0;
 		update_option( $settings::SETTINGS_NAME, $settings );
 
 		// 2. Scan posts/pages for _wp_convertkit_post_meta and update IDs

--- a/admin/class-multi-value-field-table.php
+++ b/admin/class-multi-value-field-table.php
@@ -66,8 +66,10 @@ class Multi_Value_Field_Table extends WP_List_Table {
 	/**
 	 * Set default column attributes
 	 *
-	 * @param  array $item A singular item (one full row's worth of data).
-	 * @param  array $column_name The name/slug of the column to be processed.
+	 * @since   1.0.0
+	 *
+	 * @param  array  $item A singular item (one full row's worth of data).
+	 * @param  string $column_name The name/slug of the column to be processed.
 	 * @return string Text or HTML to be placed inside the column <td>
 	 */
 	public function column_default( $item, $column_name ) {

--- a/admin/section/class-convertkit-settings-base.php
+++ b/admin/section/class-convertkit-settings-base.php
@@ -47,7 +47,7 @@ abstract class ConvertKit_Settings_Base {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @var     mixed   ConvertKit_Settings
+	 * @var     false|ConvertKit_Settings|ConvertKit_ContactForm7_Settings|ConvertKit_Wishlist_Settings
 	 */
 	public $settings;
 
@@ -229,7 +229,7 @@ abstract class ConvertKit_Settings_Base {
 		$html .= '</select>';
 
 		// If no description exists, just return the select field.
-		if ( ! $description || empty( $description ) ) {
+		if ( empty( $description ) ) {
 			return $html;
 		}
 

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -28,7 +28,7 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @var     mixed   bool | WP_Error | array
+	 * @var     bool|WP_Error|array
 	 */
 	private $account = false;
 
@@ -37,7 +37,7 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @var     ConvertKit_Resource_Forms;
+	 * @var     bool|ConvertKit_Resource_Forms;
 	 */
 	private $forms = false;
 
@@ -131,37 +131,6 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 			$this->settings_key,
 			$this->name
 		);
-
-	}
-
-	/**
-	 * Register fields for supported custom post types.
-	 */
-	private function register_custom_post_type_fields() {
-
-		// Bail if no supported Post Types exist.
-		if ( ! $supported_post_types ) {
-			return;
-		}
-		if ( is_array( $supported_post_types ) && ! count( $supported_post_types ) ) {
-			return;
-		}
-
-		// Add a settings field for each supported Post Type that isn't a Page or Post.
-		foreach ( $supported_post_types as $supported_post_type ) {
-			add_settings_field(
-				'custom_post_types',
-				sprintf(
-					/* translators: Post Type Name */
-					__( 'Default Form (%s)', 'convertkit' ),
-					$supported_post_type
-				),
-				array( $this, 'custom_post_types_callback' ),
-				$this->settings_key,
-				$this->name,
-				$supported_post_type
-			);
-		}
 
 	}
 

--- a/includes/blocks/class-convertkit-block-content.php
+++ b/includes/blocks/class-convertkit-block-content.php
@@ -30,6 +30,8 @@ class ConvertKit_Block_Content extends ConvertKit_Block {
 	 * Returns this block's programmatic name, excluding the convertkit- prefix.
 	 *
 	 * @since   1.9.6
+	 *
+	 * @return  string
 	 */
 	public function get_name() {
 
@@ -46,6 +48,8 @@ class ConvertKit_Block_Content extends ConvertKit_Block {
 	 * Returns this block's Title, Icon, Categories, Keywords and properties.
 	 *
 	 * @since   1.9.6
+	 *
+	 * @return  array
 	 */
 	public function get_overview() {
 
@@ -77,6 +81,8 @@ class ConvertKit_Block_Content extends ConvertKit_Block {
 	 * Returns this block's Attributes
 	 *
 	 * @since   1.9.6.5
+	 *
+	 * @return  array
 	 */
 	public function get_attributes() {
 
@@ -92,6 +98,8 @@ class ConvertKit_Block_Content extends ConvertKit_Block {
 	 * Returns this block's Fields
 	 *
 	 * @since   1.9.6
+	 *
+	 * @return  mixed   bool | array
 	 */
 	public function get_fields() {
 
@@ -123,6 +131,8 @@ class ConvertKit_Block_Content extends ConvertKit_Block {
 	 * Returns this block's UI panels / sections.
 	 *
 	 * @since   1.9.6
+	 *
+	 * @return  mixed   bool | array
 	 */
 	public function get_panels() {
 
@@ -146,6 +156,8 @@ class ConvertKit_Block_Content extends ConvertKit_Block {
 	 * Returns this block's Default Values
 	 *
 	 * @since   1.9.6
+	 *
+	 * @return  array
 	 */
 	public function get_default_values() {
 

--- a/includes/blocks/class-convertkit-block-form.php
+++ b/includes/blocks/class-convertkit-block-form.php
@@ -61,6 +61,8 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 	 * Returns this block's programmatic name, excluding the convertkit- prefix.
 	 *
 	 * @since   1.9.6
+	 *
+	 * @return  string
 	 */
 	public function get_name() {
 
@@ -78,6 +80,8 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 	 * Returns this block's Title, Icon, Categories, Keywords and properties.
 	 *
 	 * @since   1.9.6
+	 *
+	 * @return  array
 	 */
 	public function get_overview() {
 
@@ -135,6 +139,8 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 	 * Returns this block's Attributes
 	 *
 	 * @since   1.9.6.5
+	 *
+	 * @return  array
 	 */
 	public function get_attributes() {
 
@@ -156,6 +162,8 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 	 * Returns this block's Fields
 	 *
 	 * @since   1.9.6
+	 *
+	 * @return  mixed   bool | array
 	 */
 	public function get_fields() {
 
@@ -194,6 +202,8 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 	 * Returns this block's UI panels / sections.
 	 *
 	 * @since   1.9.6
+	 *
+	 * @return  mixed   bool | array
 	 */
 	public function get_panels() {
 
@@ -217,6 +227,8 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 	 * Returns this block's Default Values
 	 *
 	 * @since   1.9.6
+	 *
+	 * @return  array
 	 */
 	public function get_default_values() {
 

--- a/includes/blocks/class-convertkit-block.php
+++ b/includes/blocks/class-convertkit-block.php
@@ -40,12 +40,94 @@ class ConvertKit_Block {
 	}
 
 	/**
+	 * Returns this block's programmatic name, excluding the convertkit- prefix.
+	 *
+	 * @since   1.9.6
+	 */
+	public function get_name() {
+
+		/**
+		 * This will register as:
+		 * - a shortcode, with the name [convertkit_form].
+		 * - a shortcode, with the name [convertkit], for backward compat.
+		 * - a Gutenberg block, with the name convertkit/form.
+		 */
+		return 'form';
+
+	}
+
+	/**
+	 * Returns this block's Title, Icon, Categories, Keywords and properties.
+	 *
+	 * @since   1.9.6
+	 *
+	 * @return  array
+	 */
+	public function get_overview() {
+
+		return array();
+
+	}
+
+	/**
+	 * Returns this block's Attributes
+	 *
+	 * @since   1.9.6.5
+	 *
+	 * @return  array
+	 */
+	public function get_attributes() {
+
+		return array();
+
+	}
+
+	/**
+	 * Returns this block's Fields
+	 *
+	 * @since   1.9.6
+	 *
+	 * @return  array
+	 */
+	public function get_fields() {
+
+		return array();
+
+	}
+
+	/**
+	 * Returns this block's UI panels / sections.
+	 *
+	 * @since   1.9.6
+	 *
+	 * @return  array
+	 */
+	public function get_panels() {
+
+		return array();
+
+	}
+
+	/**
+	 * Returns this block's Default Values
+	 *
+	 * @since   1.9.6
+	 *
+	 * @return  array
+	 */
+	public function get_default_values() {
+
+		return array();
+
+	}
+
+	/**
 	 * Returns the given block's field's Default Value
 	 *
 	 * @since   1.9.6
 	 *
 	 * @param   string $field Field Name.
-	 * @return  mixed   array|string
+	 * @return  string
 	 */
 	public function get_default_value( $field ) {
 

--- a/includes/class-convertkit-ajax.php
+++ b/includes/class-convertkit-ajax.php
@@ -49,7 +49,12 @@ class ConvertKit_AJAX {
 		if ( ! isset( $_REQUEST['subscriber_id'] ) ) {
 			wp_send_json_error( __( 'ConvertKit: Required parameter `subscriber_id` not included in AJAX request.', 'convertkit' ) );
 		}
-		$id = sanitize_text_field( $_REQUEST['subscriber_id'] );
+
+		// Bail if no subscriber ID provided.
+		$id = absint( sanitize_text_field( $_REQUEST['subscriber_id'] ) );
+		if ( empty( $id ) ) {
+			wp_send_json_error( __( 'ConvertKit: Required parameter `subscriber_id` empty in AJAX request.', 'convertkit' ) );
+		}
 
 		// Bail if the API hasn't been configured.
 		$settings = new ConvertKit_Settings();
@@ -156,8 +161,16 @@ class ConvertKit_AJAX {
 		if ( ! isset( $_REQUEST['tag'] ) ) {
 			wp_send_json_error( __( 'ConvertKit: Required parameter `tag` not included in AJAX request.', 'convertkit' ) );
 		}
-		$subscriber_id = sanitize_text_field( $_REQUEST['subscriber_id'] );
-		$tag           = sanitize_text_field( $_REQUEST['tag'] );
+		$subscriber_id = absint( sanitize_text_field( $_REQUEST['subscriber_id'] ) );
+		$tag_id        = absint( sanitize_text_field( $_REQUEST['tag'] ) );
+
+		// Bail if no subscriber ID or tag provided.
+		if ( empty( $subscriber_id ) ) {
+			wp_send_json_error( __( 'ConvertKit: Required parameter `subscriber_id` empty in AJAX request.', 'convertkit' ) );
+		}
+		if ( empty( $tag_id ) ) {
+			wp_send_json_error( __( 'ConvertKit: Required parameter `tag` empty in AJAX request.', 'convertkit' ) );
+		}
 
 		// Bail if the API hasn't been configured.
 		$settings = new ConvertKit_Settings();
@@ -177,7 +190,7 @@ class ConvertKit_AJAX {
 		}
 
 		// Tag the subscriber with the Post's tag.
-		$tag = $api->tag_subscribe( $tag, $subscriber['email_address'] );
+		$tag = $api->tag_subscribe( $tag_id, $subscriber['email_address'] );
 
 		// Bail if an error occured tagging the subscriber.
 		if ( is_wp_error( $tag ) ) {

--- a/includes/class-convertkit-api.php
+++ b/includes/class-convertkit-api.php
@@ -17,23 +17,23 @@ class ConvertKit_API {
 	/**
 	 * ConvertKit API Key
 	 *
-	 * @var string
+	 * @var mixed   bool | string
 	 */
-	protected $api_key;
+	protected $api_key = false;
 
 	/**
 	 * ConvertKit API Secret
 	 *
-	 * @var string
+	 * @var mixed   bool | string
 	 */
-	protected $api_secret;
+	protected $api_secret = false;
 
 	/**
 	 * Save debug data to log
 	 *
-	 * @var  string
+	 * @var  bool
 	 */
-	protected $debug;
+	protected $debug = false;
 
 	/**
 	 * Version of ConvertKit API
@@ -61,9 +61,9 @@ class ConvertKit_API {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @param   string $api_key        ConvertKit API Key.
-	 * @param   string $api_secret     ConvertKit API Secret.
-	 * @param   string $debug          Save data to log.
+	 * @param   mixed $api_key        ConvertKit API Key.
+	 * @param   mixed $api_secret     ConvertKit API Secret.
+	 * @param   bool  $debug         Save data to log.
 	 */
 	public function __construct( $api_key = false, $api_secret = false, $debug = false ) {
 
@@ -80,7 +80,7 @@ class ConvertKit_API {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  mixed   WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function account() {
 
@@ -100,7 +100,7 @@ class ConvertKit_API {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  mixed   WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function get_subscription_forms() {
 
@@ -121,7 +121,7 @@ class ConvertKit_API {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  mixed   WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function get_forms() {
 
@@ -145,16 +145,16 @@ class ConvertKit_API {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @param   string $form_id    Form ID.
+	 * @param   int    $form_id       Form ID.
 	 * @param   string $email      Email Address.
 	 * @param   string $first_name First Name.
 	 * @param   mixed  $fields     Custom Fields (false|array).
-	 * @return  mixed               WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function form_subscribe( $form_id, $email, $first_name = '', $fields = false ) {
 
 		// Backward compat. if $email is an array comprising of email and name keys.
-		if ( is_array( $email ) ) {
+		if ( is_array( $email ) ) { // @phpstan-ignore-line.
 			_deprecated_function( __FUNCTION__, '1.9.6', 'form_subscribe( $form_id, $email, $first_name )' );
 			$first_name = $email['name'];
 			$email      = $email['email'];
@@ -163,7 +163,7 @@ class ConvertKit_API {
 		$this->log( 'API: form_subscribe(): [ form_id: ' . $form_id . ', email: ' . $email . ', first_name: ' . $first_name . ' ]' );
 
 		// Sanitize some parameters.
-		$form_id    = trim( $form_id );
+		$form_id    = absint( $form_id );
 		$email      = trim( $email );
 		$first_name = trim( $first_name );
 
@@ -200,7 +200,7 @@ class ConvertKit_API {
 		 * @since   1.9.6
 		 *
 		 * @param   array   $response   API Response
-		 * @param   string  $form_id    Form ID
+		 * @param   int     $form_id    Form ID
 		 * @param   string  $email      Email Address
 		 * @param   string  $first_name First Name
 		 * @param   mixed   $fields     Custom Fields (false|array)
@@ -216,7 +216,7 @@ class ConvertKit_API {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  mixed   WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function get_landing_pages() {
 
@@ -240,7 +240,7 @@ class ConvertKit_API {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  mixed   WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function get_sequences() {
 
@@ -264,11 +264,11 @@ class ConvertKit_API {
 
 		// If no sequences exist, return WP_Error.
 		if ( ! isset( $response['courses'] ) ) {
-			$this->log( 'API: get_sequences(): Error: No sequences exist in ConvertKit.', 'convertkit' );
+			$this->log( 'API: get_sequences(): Error: No sequences exist in ConvertKit.' );
 			return new WP_Error( 'convertkit_api_error', __( 'No sequences exist in ConvertKit. Visit your ConvertKit account and create your first sequence.', 'convertkit' ) );
 		}
 		if ( ! count( $response['courses'] ) ) {
-			$this->log( 'API: get_sequences(): Error: No sequences exist in ConvertKit.', 'convertkit' );
+			$this->log( 'API: get_sequences(): Error: No sequences exist in ConvertKit.' );
 			return new WP_Error( 'convertkit_api_error', __( 'No sequences exist in ConvertKit. Visit your ConvertKit account and create your first sequence.', 'convertkit' ) );
 		}
 
@@ -289,7 +289,7 @@ class ConvertKit_API {
 	 * @param   string $email       Email Address.
 	 * @param   string $first_name  First Name.
 	 * @param   mixed  $fields      Custom Fields (false|array).
-	 * @return  mixed               WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function sequence_subscribe( $sequence_id, $email, $first_name = '', $fields = false ) {
 
@@ -348,7 +348,7 @@ class ConvertKit_API {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  mixed   WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function get_tags() {
 
@@ -372,11 +372,11 @@ class ConvertKit_API {
 
 		// If no tags exist, return WP_Error.
 		if ( ! isset( $response['tags'] ) ) {
-			$this->log( 'API: get_tags(): Error: No tags exist in ConvertKit.', 'convertkit' );
+			$this->log( 'API: get_tags(): Error: No tags exist in ConvertKit.' );
 			return new WP_Error( 'convertkit_api_error', __( 'No tags exist in ConvertKit. Visit your ConvertKit account and create your first tag.', 'convertkit' ) );
 		}
 		if ( ! count( $response['tags'] ) ) {
-			$this->log( 'API: get_tags(): Error: No tags exist in ConvertKit.', 'convertkit' );
+			$this->log( 'API: get_tags(): Error: No tags exist in ConvertKit.' );
 			return new WP_Error( 'convertkit_api_error', __( 'No tags exist in ConvertKit. Visit your ConvertKit account and create your first tag.', 'convertkit' ) );
 		}
 
@@ -393,18 +393,18 @@ class ConvertKit_API {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @param   string $tag_id     Tag ID.
+	 * @param   int    $tag_id     Tag ID.
 	 * @param   string $email      Email Address.
 	 * @param   string $first_name First Name.
 	 * @param   mixed  $fields     Custom Fields (false|array).
-	 * @return  mixed               WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function tag_subscribe( $tag_id, $email, $first_name = '', $fields = false ) {
 
 		$this->log( 'API: tag_subscribe(): [ tag_id: ' . $tag_id . ', email: ' . $email . ']' );
 
 		// Sanitize some parameters.
-		$tag_id     = trim( $tag_id );
+		$tag_id     = absint( $tag_id );
 		$email      = trim( $email );
 		$first_name = trim( $first_name );
 
@@ -441,7 +441,7 @@ class ConvertKit_API {
 		 * @since   1.9.6
 		 *
 		 * @param   array   $response   API Response
-		 * @param   string  $tag_id     Tag ID
+		 * @param   int     $tag_id     Tag ID
 		 * @param   string  $email      Email Address
 		 * @param   mixed   $fields     Custom Fields (false|array).
 		 */
@@ -457,7 +457,7 @@ class ConvertKit_API {
 	 * @since   1.9.6
 	 *
 	 * @param   string $email  Email Address.
-	 * @return  mixed           WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function get_subscriber_by_email( $email ) {
 
@@ -512,14 +512,14 @@ class ConvertKit_API {
 	 * @since   1.9.6
 	 *
 	 * @param   int $subscriber_id  Subscriber ID.
-	 * @return  mixed                   WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function get_subscriber_by_id( $subscriber_id ) {
 
 		$this->log( 'API: get_subscriber_by_id(): [ subscriber_id: ' . $subscriber_id . ']' );
 
 		// Sanitize some parameters.
-		$subscriber_id = trim( $subscriber_id );
+		$subscriber_id = absint( $subscriber_id );
 
 		// Return error if no Subscriber ID is specified.
 		if ( empty( $subscriber_id ) ) {
@@ -566,14 +566,14 @@ class ConvertKit_API {
 	 * @since   1.9.6
 	 *
 	 * @param   int $subscriber_id  Subscriber ID.
-	 * @return  mixed                   WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function get_subscriber_tags( $subscriber_id ) {
 
 		$this->log( 'API: get_subscriber_tags(): [ subscriber_id: ' . $subscriber_id . ']' );
 
 		// Sanitize some parameters.
-		$subscriber_id = trim( $subscriber_id );
+		$subscriber_id = absint( $subscriber_id );
 
 		// Return error if no Subscriber ID is specified.
 		if ( empty( $subscriber_id ) ) {
@@ -620,7 +620,7 @@ class ConvertKit_API {
 	 * @since   1.9.6
 	 *
 	 * @param   string $email_address  Email Address.
-	 * @return  mixed                   WP_Error | int
+	 * @return  WP_Error|int
 	 */
 	public function get_subscriber_id( $email_address ) {
 
@@ -643,7 +643,7 @@ class ConvertKit_API {
 	 * @since   1.9.6
 	 *
 	 * @param   string $email      Email Address.
-	 * @return  mixed               WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function unsubscribe( $email ) {
 
@@ -691,7 +691,7 @@ class ConvertKit_API {
 	 *
 	 * @since   1.9.6.9
 	 *
-	 * @return  mixed   WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function get_custom_fields() {
 
@@ -715,11 +715,11 @@ class ConvertKit_API {
 
 		// If no custom fields exist, return WP_Error.
 		if ( ! isset( $response['custom_fields'] ) ) {
-			$this->log( 'API: get_custom_fields(): Error: No custom fields exist in ConvertKit.', 'convertkit' );
+			$this->log( 'API: get_custom_fields(): Error: No custom fields exist in ConvertKit.' );
 			return new WP_Error( 'convertkit_api_error', __( 'No custom fields exist in ConvertKit. Visit your ConvertKit account and create your first custom field.', 'convertkit' ) );
 		}
 		if ( ! count( $response['custom_fields'] ) ) {
-			$this->log( 'API: get_custom_fields(): Error: No custom fields exist in ConvertKit.', 'convertkit' );
+			$this->log( 'API: get_custom_fields(): Error: No custom fields exist in ConvertKit.' );
 			return new WP_Error( 'convertkit_api_error', __( 'No custom fields exist in ConvertKit. Visit your ConvertKit account and create your first custom field.', 'convertkit' ) );
 		}
 
@@ -737,7 +737,7 @@ class ConvertKit_API {
 	 * This isn't specifically an API function, but for now it's best suited here.
 	 *
 	 * @param   int $id     Form ID.
-	 * @return  string          HTML
+	 * @return  WP_Error|string     HTML
 	 */
 	public function get_form_html( $id ) {
 
@@ -788,7 +788,7 @@ class ConvertKit_API {
 	 * @since   1.9.6.9
 	 *
 	 * @param   array $purchase   Purchase Data.
-	 * @return  mixed               WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function purchase_create( $purchase ) {
 
@@ -851,7 +851,7 @@ class ConvertKit_API {
 	 * @since   1.9.6
 	 *
 	 * @param   int $id     Subscriber ID.
-	 * @return  mixed           WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function get_subscriber( $id ) {
 
@@ -870,7 +870,7 @@ class ConvertKit_API {
 	 *
 	 * @param   int   $tag    Tag ID.
 	 * @param   array $args   Arguments.
-	 * @return  mixed           WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function add_tag( $tag, $args ) {
 
@@ -888,7 +888,7 @@ class ConvertKit_API {
 	 * @since   1.9.6
 	 *
 	 * @param   string $url    URL.
-	 * @return  mixed           WP_Error | string
+	 * @return  WP_Error|string
 	 */
 	public function get_resource( $url ) {
 
@@ -906,7 +906,7 @@ class ConvertKit_API {
 	 * @since   1.9.6
 	 *
 	 * @param   array $args   Arguments (single email key).
-	 * @return  mixed           WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function form_unsubscribe( $args ) {
 
@@ -925,7 +925,7 @@ class ConvertKit_API {
 	 *
 	 * @param   string $url    URL of Form or Landing Page.
 	 * @param   bool   $body_only   Return HTML between <body> and </body> tags only.
-	 * @return  string          HTML
+	 * @return  WP_Error|string
 	 */
 	private function get_html( $url, $body_only = true ) {
 
@@ -1017,9 +1017,9 @@ class ConvertKit_API {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @param   array  $elements   Elements.
-	 * @param   string $attribute  HTML Attribute.
-	 * @param   string $url        Absolute URL to prepend to relative URLs.
+	 * @param   DOMNodeList<DOMElement> $elements   Elements.
+	 * @param   string                  $attribute  HTML Attribute.
+	 * @param   string                  $url        Absolute URL to prepend to relative URLs.
 	 */
 	private function convert_relative_to_absolute_urls( $elements, $attribute, $url ) {
 
@@ -1073,7 +1073,7 @@ class ConvertKit_API {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  mixed   WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	private function get_forms_landing_pages() {
 
@@ -1132,7 +1132,7 @@ class ConvertKit_API {
 	 *
 	 * @param   string $endpoint       API Endpoint.
 	 * @param   array  $params         Params.
-	 * @return  mixed                   WP_Error | object
+	 * @return  WP_Error|array
 	 */
 	private function get( $endpoint, $params ) {
 
@@ -1147,7 +1147,7 @@ class ConvertKit_API {
 	 *
 	 * @param   string $endpoint       API Endpoint.
 	 * @param   array  $params         Params.
-	 * @return  mixed                   WP_Error | object
+	 * @return  WP_Error|array
 	 */
 	private function post( $endpoint, $params ) {
 
@@ -1164,7 +1164,7 @@ class ConvertKit_API {
 	 * @param   string $method                  HTTP Method (optional).
 	 * @param   mixed  $params                  Params (array|boolean|string).
 	 * @param   bool   $retry_if_rate_limit_hit Retry request if rate limit hit.
-	 * @return  mixed                           WP_Error | object
+	 * @return  WP_Error|array
 	 */
 	private function request( $endpoint, $method = 'get', $params = array(), $retry_if_rate_limit_hit = true ) {
 
@@ -1192,6 +1192,17 @@ class ConvertKit_API {
 						'body'            => wp_json_encode( $params ),
 						'timeout'         => $this->get_timeout(),
 						'user-agent'      => $this->get_user_agent(),
+					)
+				);
+				break;
+
+			default:
+				$result = new WP_Error(
+					'convertkit_api_error',
+					sprintf(
+						/* translators: HTTP method */
+						__( 'API request method %s is not supported in ConvertKit_API class.', 'convertkit' ),
+						$method
 					)
 				);
 				break;
@@ -1263,6 +1274,8 @@ class ConvertKit_API {
 	 * @return string User Agent
 	 */
 	private function get_user_agent() {
+
+		global $wp_version;
 
 		// Include an unmodified $wp_version.
 		require ABSPATH . WPINC . '/version.php';

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -19,7 +19,7 @@ class ConvertKit_Output {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @var     ConvertKit_Settings
+	 * @var     bool|ConvertKit_Settings
 	 */
 	private $settings = false;
 
@@ -28,7 +28,7 @@ class ConvertKit_Output {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @var     ConvertKit_Post_Settings
+	 * @var     bool|ConvertKit_Post
 	 */
 	private $post_settings = false;
 
@@ -37,7 +37,7 @@ class ConvertKit_Output {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @var     ConvertKit_Resource_Forms
+	 * @var     bool|ConvertKit_Resource_Forms
 	 */
 	private $forms = false;
 
@@ -46,7 +46,7 @@ class ConvertKit_Output {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @var     ConvertKit_Resource_Landing_Pages
+	 * @var     bool|ConvertKit_Resource_Landing_Pages
 	 */
 	private $landing_pages = false;
 
@@ -79,7 +79,6 @@ class ConvertKit_Output {
 		 *
 		 * @since   1.9.6
 		 *
-		 * @param   string  $content    Post Content
 		 * @return  string              Post Content with Form Appended, if applicable
 		 */
 		do_action( 'convertkit_output_output_form' );
@@ -130,7 +129,7 @@ class ConvertKit_Output {
 		$landing_page_id = apply_filters( 'convertkit_output_append_form_to_content_form_id', $landing_page_id, $post_id );
 
 		// Bail if no Landing Page is configured to be output.
-		if ( ! $landing_page_id || empty( $landing_page_id ) ) {
+		if ( empty( $landing_page_id ) ) {
 			return;
 		}
 
@@ -230,7 +229,7 @@ class ConvertKit_Output {
 	 * @since   1.9.6
 	 *
 	 * @param   int $post_id    Post ID.
-	 * @return  mixed               bool | int (ConvertKit Form ID)
+	 * @return  bool|string|int     false|'default'|Form ID
 	 */
 	private function get_post_form_id( $post_id ) {
 
@@ -261,10 +260,15 @@ class ConvertKit_Output {
 		}
 
 		// Get Post's Categories.
-		$categories = wp_get_post_categories( $post_id );
+		$categories = wp_get_post_categories(
+			$post_id,
+			array(
+				'fields' => 'ids',
+			)
+		);
 
 		// If no Categories exist, use the Default Form.
-		if ( ! is_array( $categories ) || is_wp_error( $categories ) || ! count( $categories ) ) {
+		if ( ! is_array( $categories ) || ! count( $categories ) ) {
 			// Get Post Type.
 			return $this->settings->get_default_form( get_post_type( $post_id ) );
 		}
@@ -345,7 +349,7 @@ class ConvertKit_Output {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  mixed   Subscriber ID
+	 * @return  int   Subscriber ID
 	 */
 	public function get_subscriber_id_from_request() {
 

--- a/includes/class-convertkit-post.php
+++ b/includes/class-convertkit-post.php
@@ -32,7 +32,7 @@ class ConvertKit_Post {
 	/**
 	 * Holds the Post's Settings
 	 *
-	 * @var     array
+	 * @var     bool|array
 	 */
 	private $settings = false;
 
@@ -94,7 +94,7 @@ class ConvertKit_Post {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  string
+	 * @return  int
 	 */
 	public function get_form() {
 
@@ -107,7 +107,7 @@ class ConvertKit_Post {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  string
+	 * @return  int
 	 */
 	public function get_landing_page() {
 
@@ -120,7 +120,7 @@ class ConvertKit_Post {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  string
+	 * @return  int
 	 */
 	public function get_tag() {
 
@@ -133,7 +133,7 @@ class ConvertKit_Post {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  string
+	 * @return  bool
 	 */
 	public function has_form() {
 
@@ -146,7 +146,7 @@ class ConvertKit_Post {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  string
+	 * @return  bool
 	 */
 	public function uses_default_form() {
 
@@ -159,7 +159,7 @@ class ConvertKit_Post {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  string
+	 * @return  bool
 	 */
 	public function uses_no_form() {
 
@@ -172,7 +172,7 @@ class ConvertKit_Post {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  string
+	 * @return  bool
 	 */
 	public function has_landing_page() {
 
@@ -185,7 +185,7 @@ class ConvertKit_Post {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  string
+	 * @return  bool
 	 */
 	public function has_tag() {
 

--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -31,7 +31,7 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource {
 	/**
 	 * Holds the forms from the ConvertKit API
 	 *
-	 * @var     array
+	 * @var     WP_Error|array
 	 */
 	public $resources = array();
 
@@ -44,7 +44,7 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource {
 	 * @since   1.9.6
 	 *
 	 * @param   int $id     Form ID.
-	 * @return  mixed           WP_Error | string
+	 * @return  WP_Error|string
 	 */
 	public function get_html( $id ) {
 

--- a/includes/class-convertkit-resource-landing-pages.php
+++ b/includes/class-convertkit-resource-landing-pages.php
@@ -31,7 +31,7 @@ class ConvertKit_Resource_Landing_Pages extends ConvertKit_Resource {
 	/**
 	 * Holds the forms from the ConvertKit API
 	 *
-	 * @var     array
+	 * @var     WP_Error|array
 	 */
 	public $resources = array();
 
@@ -41,7 +41,7 @@ class ConvertKit_Resource_Landing_Pages extends ConvertKit_Resource {
 	 * @since   1.9.6
 	 *
 	 * @param   mixed $id     Landing Page ID | Legacy Landing Page URL.
-	 * @return  mixed           WP_Error | string
+	 * @return  WP_Error|string
 	 */
 	public function get_html( $id ) {
 

--- a/includes/class-convertkit-resource-tags.php
+++ b/includes/class-convertkit-resource-tags.php
@@ -31,7 +31,7 @@ class ConvertKit_Resource_Tags extends ConvertKit_Resource {
 	/**
 	 * Holds the forms from the ConvertKit API
 	 *
-	 * @var     array
+	 * @var     WP_Error|array
 	 */
 	public $resources = array();
 

--- a/includes/class-convertkit-resource.php
+++ b/includes/class-convertkit-resource.php
@@ -15,6 +15,27 @@
 class ConvertKit_Resource {
 
 	/**
+	 * Holds the Settings Key that stores site wide ConvertKit settings
+	 *
+	 * @var     string
+	 */
+	public $settings_name = '';
+
+	/**
+	 * The type of resource
+	 *
+	 * @var     string
+	 */
+	public $type = '';
+
+	/**
+	 * Holds the resources from the ConvertKit API
+	 *
+	 * @var     WP_Error|array
+	 */
+	public $resources = array();
+
+	/**
 	 * Constructor. Populate the resources array of e.g. forms, landing pages or tags.
 	 *
 	 * @since   1.9.6
@@ -74,14 +95,14 @@ class ConvertKit_Resource {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  mixed           WP_Error | array
+	 * @return  bool|WP_Error|array
 	 */
 	public function refresh() {
 
 		// Bail if the API Key and Secret hasn't been defined in the Plugin Settings.
 		$settings = new ConvertKit_Settings();
 		if ( ! $settings->has_api_key_and_secret() ) {
-			return;
+			return false;
 		}
 
 		// Initialize the API.
@@ -100,6 +121,17 @@ class ConvertKit_Resource {
 			case 'tags':
 				$results = $api->get_tags();
 				break;
+
+			default:
+				$results = new WP_Error(
+					'convertkit_resource_refresh_error',
+					sprintf(
+						/* translators: Resource Type */
+						__( 'Resource type %s is not supported in ConvertKit_Resource class.', 'convertkit' ),
+						$this->type
+					)
+				);
+				break;
 		}
 
 		// Bail if an error occured.
@@ -114,27 +146,6 @@ class ConvertKit_Resource {
 		$this->resources = $results;
 
 		return $results;
-
-	}
-
-	/**
-	 * Sorts the given array of resources by name.
-	 *
-	 * @since   1.9.6
-	 *
-	 * @param   array $data   Forms or Landing Pages from API.
-	 * @return  array           Sorted Forms or Landing Pages.
-	 */
-	private function sort_alphabetically( $data ) {
-
-		return usort(
-			$data,
-			function( $a, $b ) {
-
-				return strcmp( $a['name'], $b['name'] );
-
-			}
-		);
 
 	}
 

--- a/includes/class-convertkit-resource.php
+++ b/includes/class-convertkit-resource.php
@@ -78,7 +78,7 @@ class ConvertKit_Resource {
 	 */
 	public function exist() {
 
-		if ( $this->resources === false ) {
+		if ( $this->resources === false ) { // @phpstan-ignore-line.
 			return false;
 		}
 

--- a/includes/class-convertkit-resource.php
+++ b/includes/class-convertkit-resource.php
@@ -78,6 +78,10 @@ class ConvertKit_Resource {
 	 */
 	public function exist() {
 
+		if ( $this->resources === false ) {
+			return false;
+		}
+
 		if ( is_wp_error( $this->resources ) ) {
 			return false;
 		}

--- a/includes/class-convertkit-review-request.php
+++ b/includes/class-convertkit-review-request.php
@@ -22,7 +22,7 @@ class ConvertKit_Review_Request {
 	 *
 	 * @var     string
 	 */
-	private $plugin_name;
+	private $plugin_name; // @phpstan-ignore-line
 
 	/**
 	 * Holds the Plugin slug.

--- a/includes/class-convertkit-settings.php
+++ b/includes/class-convertkit-settings.php
@@ -207,7 +207,7 @@ class ConvertKit_Settings {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  string
+	 * @return  bool
 	 */
 	public function debug_enabled() {
 
@@ -220,7 +220,7 @@ class ConvertKit_Settings {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  string
+	 * @return  bool
 	 */
 	public function scripts_disabled() {
 

--- a/includes/class-convertkit-system-info.php
+++ b/includes/class-convertkit-system-info.php
@@ -135,7 +135,7 @@ class ConvertKit_System_Info {
 		$return .= 'Table Prefix:             Length: ' . strlen( $wpdb->prefix ) . '   Status: ' . ( strlen( $wpdb->prefix ) > 16 ? 'ERROR: Too long' : 'Acceptable' ) . "\n";
 		$return .= 'WP_DEBUG:                 ' . ( defined( 'WP_DEBUG' ) ? WP_DEBUG ? 'Enabled' : 'Disabled' : 'Not set' ) . "\n";
 		$return .= 'Memory Limit:             ' . WP_MEMORY_LIMIT . "\n";
-		$return .= 'Registered Post Stati:    ' . implode( ', ', get_post_stati() ) . "\n";
+		$return .= 'Registered Post Stati:    ' . implode( ', ', get_post_stati() ) . "\n"; // @phpstan-ignore-line.
 
 		/**
 		 * Output System Information immediately after the WordPress Configuration section.
@@ -393,6 +393,8 @@ class ConvertKit_System_Info {
 	 * @return string
 	 */
 	private function get_user_agent() {
+
+		global $wp_version;
 
 		// Include an unmodified $wp_version.
 		require ABSPATH . WPINC . '/version.php';

--- a/includes/class-convertkit-term.php
+++ b/includes/class-convertkit-term.php
@@ -32,7 +32,7 @@ class ConvertKit_Term {
 	/**
 	 * Holds the Term's Settings
 	 *
-	 * @var     array
+	 * @var     bool|string
 	 */
 	private $settings = false;
 
@@ -66,7 +66,7 @@ class ConvertKit_Term {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  array
+	 * @return  string
 	 */
 	public function get() {
 
@@ -92,11 +92,15 @@ class ConvertKit_Term {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  string
+	 * @return  bool
 	 */
 	public function has_form() {
 
-		return ( $this->settings > 0 );
+		if ( $this->settings !== false ) {
+			return true;
+		}
+
+		return false;
 
 	}
 
@@ -105,7 +109,7 @@ class ConvertKit_Term {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  string
+	 * @return  bool
 	 */
 	public function uses_default_form() {
 
@@ -118,7 +122,7 @@ class ConvertKit_Term {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  string
+	 * @return  bool
 	 */
 	public function uses_no_form() {
 
@@ -131,7 +135,7 @@ class ConvertKit_Term {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @param   array $meta   Settings.
+	 * @param   string $meta   Settings.
 	 */
 	public function save( $meta ) {
 
@@ -145,7 +149,7 @@ class ConvertKit_Term {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  array
+	 * @return  string
 	 */
 	public function get_default_settings() {
 

--- a/includes/class-convertkit-user.php
+++ b/includes/class-convertkit-user.php
@@ -34,7 +34,7 @@ class ConvertKit_User {
 	 *
 	 * @var     array
 	 */
-	private $settings = false;
+	private $settings = array();
 
 	/**
 	 * Constructor. Populates the settings based on the given User ID.

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -189,7 +189,7 @@ class WP_ConvertKit {
 		}
 
 		// Pro.
-		if ( isset( $_SERVER ) ) {
+		if ( array_key_exists( 'REQUEST_URI', $_SERVER ) ) {
 			if ( strpos( sanitize_text_field( $_SERVER['REQUEST_URI'] ), '/pro/' ) !== false ) {
 				return true;
 			}
@@ -203,66 +203,64 @@ class WP_ConvertKit {
 
 		// If the request global exists, check for specific request keys which tell us
 		// that we're using a frontend editor.
-		if ( isset( $_REQUEST ) && ! empty( $_REQUEST ) ) { // phpcs:ignore
-			// Avada Live.
-			if ( array_key_exists( 'fb-edit', $_REQUEST ) ) { // phpcs:ignore
-				return true;
-			}
+		// Avada Live.
+		if ( array_key_exists( 'fb-edit', $_REQUEST ) ) { // phpcs:ignore
+			return true;
+		}
 
-			// Beaver Builder.
-			if ( array_key_exists( 'fl_builder', $_REQUEST ) ) { // phpcs:ignore
-				return true;
-			}
+		// Beaver Builder.
+		if ( array_key_exists( 'fl_builder', $_REQUEST ) ) { // phpcs:ignore
+			return true;
+		}
 
-			// Brizy.
-			if ( array_key_exists( 'brizy-edit', $_REQUEST ) ) { // phpcs:ignore
-				return true;
-			}
+		// Brizy.
+		if ( array_key_exists( 'brizy-edit', $_REQUEST ) ) { // phpcs:ignore
+			return true;
+		}
 
-			// Cornerstone (AJAX).
-			if ( array_key_exists( '_cs_nonce', $_REQUEST ) ) { // phpcs:ignore
-				return true;
-			}
+		// Cornerstone (AJAX).
+		if ( array_key_exists( '_cs_nonce', $_REQUEST ) ) { // phpcs:ignore
+			return true;
+		}
 
-			// Divi.
-			if ( array_key_exists( 'et_fb', $_REQUEST ) ) { // phpcs:ignore
-				return true;
-			}
+		// Divi.
+		if ( array_key_exists( 'et_fb', $_REQUEST ) ) { // phpcs:ignore
+			return true;
+		}
 
-			// Elementor.
-			if ( array_key_exists( 'action', $_REQUEST ) && sanitize_text_field( $_REQUEST['action'] ) === 'elementor' ) { // phpcs:ignore
-				return true;
-			}
+		// Elementor.
+		if ( array_key_exists( 'action', $_REQUEST ) && sanitize_text_field( $_REQUEST['action'] ) === 'elementor' ) { // phpcs:ignore
+			return true;
+		}
 
-			// Kallyas.
-			if ( array_key_exists( 'zn_pb_edit', $_REQUEST ) ) { // phpcs:ignore
-				return true;
-			}
+		// Kallyas.
+		if ( array_key_exists( 'zn_pb_edit', $_REQUEST ) ) { // phpcs:ignore
+			return true;
+		}
 
-			// Oxygen.
-			if ( array_key_exists( 'ct_builder', $_REQUEST ) ) { // phpcs:ignore
-				return true;
-			}
+		// Oxygen.
+		if ( array_key_exists( 'ct_builder', $_REQUEST ) ) { // phpcs:ignore
+			return true;
+		}
 
-			// Thrive Architect.
-			if ( array_key_exists( 'tve', $_REQUEST ) ) { // phpcs:ignore
-				return true;
-			}
+		// Thrive Architect.
+		if ( array_key_exists( 'tve', $_REQUEST ) ) { // phpcs:ignore
+			return true;
+		}
 
-			// Visual Composer.
-			if ( array_key_exists( 'vcv-editable', $_REQUEST ) ) { // phpcs:ignore
-				return true;
-			}
+		// Visual Composer.
+		if ( array_key_exists( 'vcv-editable', $_REQUEST ) ) { // phpcs:ignore
+			return true;
+		}
 
-			// WPBakery Page Builder.
-			if ( array_key_exists( 'vc_editable', $_REQUEST ) ) { // phpcs:ignore
-				return true;
-			}
+		// WPBakery Page Builder.
+		if ( array_key_exists( 'vc_editable', $_REQUEST ) ) { // phpcs:ignore
+			return true;
+		}
 
-			// Zion Builder.
-			if ( array_key_exists( 'action', $_REQUEST ) && sanitize_text_field( $_REQUEST['action'] ) === 'zion_builder_active' ) { // phpcs:ignore
-				return true;
-			}
+		// Zion Builder.
+		if ( array_key_exists( 'action', $_REQUEST ) && sanitize_text_field( $_REQUEST['action'] ) === 'zion_builder_active' ) { // phpcs:ignore
+			return true;
 		}
 
 		// Assume we're not in the Administration interface.
@@ -276,9 +274,8 @@ class WP_ConvertKit {
 		 * @since   1.9.6
 		 *
 		 * @param   bool    $is_admin_or_frontend_editor    Is WordPress Administration / Frontend Editor request.
-		 * @param   array   $_REQUEST                       $_REQUEST data.
 		 */
-		$is_admin_or_frontend_editor = apply_filters( 'convertkit_is_admin_or_frontend_editor', $is_admin_or_frontend_editor, $_REQUEST );  // phpcs:ignore
+		$is_admin_or_frontend_editor = apply_filters( 'convertkit_is_admin_or_frontend_editor', $is_admin_or_frontend_editor );  // phpcs:ignore
 
 		// Return filtered result.
 		return $is_admin_or_frontend_editor;
@@ -332,7 +329,7 @@ class WP_ConvertKit {
 	 */
 	public function load_language_files() {
 
-		load_plugin_textdomain( 'convertkit', false, basename( dirname( CONVERTKIT_PLUGIN_FILE ) ) . '/languages/' );
+		load_plugin_textdomain( 'convertkit', false, basename( dirname( CONVERTKIT_PLUGIN_FILE ) ) . '/languages/' );  // @phpstan-ignore-line.
 
 	}
 
@@ -363,7 +360,7 @@ class WP_ConvertKit {
 			// Admin UI.
 			if ( is_admin() ) {
 				wp_die(
-					esc_attr( $error ),
+					esc_attr( $error->get_error_message() ),
 					esc_html__( 'ConvertKit Error', 'convertkit' ),
 					array(
 						'back_link' => true,
@@ -389,7 +386,7 @@ class WP_ConvertKit {
 	 */
 	public static function get_instance() {
 
-		if ( ! isset( self::$instance ) && ! ( self::$instance instanceof self ) ) {
+		if ( ! isset( self::$instance ) && ! ( self::$instance instanceof self ) ) {  // @phpstan-ignore-line.
 			self::$instance = new self();
 		}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -147,7 +147,7 @@ function convertkit_select2_enqueue_scripts() {
  */
 function convertkit_select2_enqueue_styles() {
 
-	wp_enqueue_style( 'convertkit-select2', 'https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css', false, CONVERTKIT_PLUGIN_VERSION );
-	wp_enqueue_style( 'convertkit-admin-select2', CONVERTKIT_PLUGIN_URL . '/resources/backend/css/select2.css', false, CONVERTKIT_PLUGIN_VERSION );
+	wp_enqueue_style( 'convertkit-select2', 'https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css', array(), CONVERTKIT_PLUGIN_VERSION );
+	wp_enqueue_style( 'convertkit-admin-select2', CONVERTKIT_PLUGIN_URL . '/resources/backend/css/select2.css', array(), CONVERTKIT_PLUGIN_VERSION );
 
 }

--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
@@ -114,7 +114,7 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 					'title' => $cf7_form['name'],
 					'form'  => $this->get_select_field(
 						$cf7_form['id'],
-						$this->settings->get_convertkit_form_id_by_cf7_form_id( $cf7_form['id'] ),
+						(string) $this->settings->get_convertkit_form_id_by_cf7_form_id( $cf7_form['id'] ),
 						$options
 					),
 					'email' => 'your-email',

--- a/includes/integrations/contactform7/class-convertkit-contactform7-settings.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-settings.php
@@ -72,7 +72,7 @@ class ConvertKit_ContactForm7_Settings {
 		if ( empty( $this->get() ) ) {
 			return false;
 		}
-		if ( ! count( $this->get() ) ) {
+		if ( count( $this->get() ) === 0 ) { // @phpstan-ignore-line.
 			return false;
 		}
 
@@ -86,7 +86,7 @@ class ConvertKit_ContactForm7_Settings {
 	 * @since   1.9.6
 	 *
 	 * @param   int $cf7_form_id    Contact Form 7 Form ID.
-	 * @return  mixed                   bool (false) | ConvertKit Form ID
+	 * @return  bool|int
 	 */
 	public function get_convertkit_form_id_by_cf7_form_id( $cf7_form_id ) {
 

--- a/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php
@@ -130,12 +130,12 @@ class ConvertKit_Wishlist_Admin_Settings extends ConvertKit_Settings_Base {
 					'title'       => $wlm_level['name'],
 					'form'        => $this->get_select_field(
 						$wlm_level['id'] . '_form',
-						$this->settings->get_convertkit_form_id_by_wishlist_member_level_id( $wlm_level['id'] ),
+						(string) $this->settings->get_convertkit_form_id_by_wishlist_member_level_id( $wlm_level['id'] ),
 						$form_options
 					),
 					'unsubscribe' => $this->get_select_field(
 						$wlm_level['id'] . '_unsubscribe',
-						$this->settings->get_convertkit_tag_id_by_wishlist_member_level_id( $wlm_level['id'] ),
+						(string) $this->settings->get_convertkit_tag_id_by_wishlist_member_level_id( $wlm_level['id'] ),
 						$tag_options
 					),
 				)
@@ -157,7 +157,7 @@ class ConvertKit_Wishlist_Admin_Settings extends ConvertKit_Settings_Base {
 	/**
 	 * Gets membership levels from WishList Member API
 	 *
-	 * @return array Membership levels
+	 * @return mixed bool|array
 	 */
 	public function get_wlm_levels() {
 

--- a/includes/integrations/wishlist/class-convertkit-wishlist-settings.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist-settings.php
@@ -72,7 +72,7 @@ class ConvertKit_Wishlist_Settings {
 		if ( empty( $this->get() ) ) {
 			return false;
 		}
-		if ( ! count( $this->get() ) ) {
+		if ( count( $this->get() ) === 0 ) { // @phpstan-ignore-line.
 			return false;
 		}
 
@@ -86,7 +86,7 @@ class ConvertKit_Wishlist_Settings {
 	 * @since   1.9.6
 	 *
 	 * @param   int $wlm_level_id   WishList Member Level ID.
-	 * @return  mixed                   bool (false) | ConvertKit Form ID
+	 * @return  bool|int
 	 */
 	public function get_convertkit_form_id_by_wishlist_member_level_id( $wlm_level_id ) {
 
@@ -110,7 +110,7 @@ class ConvertKit_Wishlist_Settings {
 	 * @since   1.9.6
 	 *
 	 * @param   int $wlm_level_id   WishList Member Level ID.
-	 * @return  mixed                   bool (false) | ConvertKit Tag ID
+	 * @return  bool|string|int     false|'unsubscribe'|Tag ID
 	 */
 	public function get_convertkit_tag_id_by_wishlist_member_level_id( $wlm_level_id ) {
 

--- a/includes/integrations/wishlist/class-convertkit-wishlist.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist.php
@@ -110,16 +110,16 @@ class ConvertKit_Wishlist {
 	/**
 	 * Subscribes a member to a ConvertKit Form.
 	 *
-	 * @param   array  $member  UserInfo from WishList Member.
-	 * @param   string $form_id ConvertKit Form ID.
-	 * @return  mixed           API Response (WP_Error | array)
+	 * @param   array $member  UserInfo from WishList Member.
+	 * @param   int   $form_id ConvertKit Form ID.
+	 * @return  bool|WP_Error|array
 	 */
 	public function member_resource_subscribe( $member, $form_id ) {
 
 		// Bail if the API hasn't been configured.
 		$settings = new ConvertKit_Settings();
 		if ( ! $settings->has_api_key_and_secret() ) {
-			return;
+			return false;
 		}
 
 		// Initialize the API.
@@ -151,14 +151,14 @@ class ConvertKit_Wishlist {
 	 * Unsubscribes a member from ConvertKit.
 	 *
 	 * @param   array $member  UserInfo from WishList Member.
-	 * @return  mixed           API Response (WP_Error | array)
+	 * @return  bool|WP_Error|array
 	 */
 	public function member_resource_unsubscribe( $member ) {
 
 		// Bail if the API hasn't been configured.
 		$settings = new ConvertKit_Settings();
 		if ( ! $settings->has_api_key_and_secret() ) {
-			return;
+			return false;
 		}
 
 		// Initialize the API.
@@ -179,16 +179,16 @@ class ConvertKit_Wishlist {
 	/**
 	 * Tag a ConvertKit User with the given Tag ID.
 	 *
-	 * @param   array  $member  UserInfo from WishList Member.
-	 * @param   string $tag_id  ConvertKit Tag ID.
-	 * @return  mixed           API Response (WP_Error | array)
+	 * @param   array $member  UserInfo from WishList Member.
+	 * @param   int   $tag_id  ConvertKit Tag ID.
+	 * @return  bool|WP_Error|array
 	 */
 	public function member_tag( $member, $tag_id ) {
 
 		// Bail if the API hasn't been configured.
 		$settings = new ConvertKit_Settings();
 		if ( ! $settings->has_api_key_and_secret() ) {
-			return;
+			return false;
 		}
 
 		// Initialize the API.
@@ -202,7 +202,7 @@ class ConvertKit_Wishlist {
 	 * Gets a WLM member using the wlmapi functions
 	 *
 	 * @param  string $id The member id.
-	 * @return array The member fields from the API request
+	 * @return bool|array
 	 */
 	public function get_member( $id ) {
 

--- a/includes/widgets/class-ck-widget-form.php
+++ b/includes/widgets/class-ck-widget-form.php
@@ -14,9 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Form Widget.
  *
  * @author   ConvertKit
- * @category Widgets
  * @version  1.0.0
- * @extends  WP_Widget
  */
 class CK_Widget_Form extends WP_Widget {
 
@@ -40,7 +38,10 @@ class CK_Widget_Form extends WP_Widget {
 	/**
 	 * Outputs the settings update form.
 	 *
-	 * @param array $instance Widget settings.
+	 * @since   1.0.0
+	 *
+	 * @param   array $instance   Current settings.
+	 * @return  string              Default return is 'noform'
 	 */
 	public function form( $instance ) {
 
@@ -54,7 +55,6 @@ class CK_Widget_Form extends WP_Widget {
 			</p>
 			<?php
 		}
-
 		?>
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Title', 'convertkit' ); ?></label>
@@ -76,32 +76,7 @@ class CK_Widget_Form extends WP_Widget {
 		</p>
 		<?php
 
-	}
-
-	/**
-	 * Output the html at the start of a widget.
-	 *
-	 * @param array $args Widget arguments.
-	 * @param array $instance Widget settings.
-	 */
-	public function widget_start( $args, $instance ) {
-
-		echo $args['before_widget']; // phpcs:ignore
-		$title = apply_filters( 'widget_title', empty( $instance['title'] ) ? '' : $instance['title'], $instance, $this->id_base );
-		if ( $title ) {
-			echo $args['before_title'] . $title . $args['after_title']; // phpcs:ignore
-		}
-
-	}
-
-	/**
-	 * Output the html at the end of a widget.
-	 *
-	 * @param array $args After widget setting.
-	 */
-	public function widget_end( $args ) {
-
-		echo $args['after_widget']; // phpcs:ignore
+		return '';
 
 	}
 
@@ -130,12 +105,14 @@ class CK_Widget_Form extends WP_Widget {
 		}
 
 		// Output Form.
-		$this->widget_start( $args, $instance );
+		echo $args['before_widget']; // phpcs:ignore
+		if ( $instance['title'] ) {
+			echo $args['before_title'] . $instance['title'] . $args['after_title']; // phpcs:ignore
+		}
 		echo $form; // phpcs:ignore
-		$this->widget_end( $args );
+		echo $args['after_widget']; // phpcs:ignore
 
 	}
-
 
 	/**
 	 * Updates a particular instance of a widget.


### PR DESCRIPTION
## Summary

Code changes to pass PHPStan's static analysis, broadly covering:
- Incorrect parameter type passed to `wp_enqueue_style()`
- Incorrect DocBlock parameter types (e.g. `string` when it is an `int`)
- More accurate DocBlock return types (e.g. `WP_Error|array` instead of `mixed`)
- Removal of unused functions, such as `register_custom_post_type_fields()`

## Testing

Existing tests confirm working functionality of Plugin.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)