### PR TITLE
ConvertKit Form Widget for Elementor Page Builder

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,15 +168,18 @@ jobs:
         working-directory: ${{ env.PLUGIN_DIR }}
         run: composer dump-autoload
 
-      # This ensures the Plugin's log file can be written to.
-      # We don't recursively do this, as it'll prevent Codeception from writing to the /tests/_output directory.
-      - name: Set chmod for Plugin Directory
-        run: sudo chmod g+w ${{ env.PLUGIN_DIR }}
+      # This ensures the wp-content/uploads folder can be written to by WordPress and third party Plugins.
+      - name: Set Permissions for Uploads Directory
+        run: |
+          sudo chmod g+w ${{ env.ROOT_DIR }}/wp-content/uploads
+          sudo chown www-data:www-data ${{ env.ROOT_DIR }}/wp-content/uploads
 
       # This ensures the Plugin's log file can be written to.
       # We don't recursively do this, as it'll prevent Codeception from writing to the /tests/_output directory.
-      - name: Set chown for Plugin Directory
-        run: sudo chown www-data:www-data ${{ env.PLUGIN_DIR }}
+      - name: Set Permissions for Plugin Directory
+        run: |
+          sudo chmod g+w ${{ env.PLUGIN_DIR }}
+          sudo chown www-data:www-data ${{ env.PLUGIN_DIR }}
 
       # We run these before the main tests, as typically CodeSniffer is fast. If there's a failure, we can tell
       # the user sooner.
@@ -202,7 +205,7 @@ jobs:
       # Run Codeception Acceptance Tests.
       - name: Run Acceptance Tests
         working-directory: ${{ env.PLUGIN_DIR }}
-        run: php vendor/bin/codecept run acceptance --fail-fast
+        run: php vendor/bin/codecept run acceptance PageElementorFormCest --fail-fast
 
       # If the repository has other tests, such as unit tests, add the Codeception commands here to run them now.
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       DB_USER: root
       DB_PASS: root
       DB_HOST: localhost
-      INSTALL_PLUGINS: "contact-form-7 disable-welcome-messages-and-tips woocommerce" # Don't include this repository's Plugin here.
+      INSTALL_PLUGINS: "contact-form-7 disable-welcome-messages-and-tips elementor woocommerce" # Don't include this repository's Plugin here.
       CONVERTKIT_API_KEY: ${{ secrets.CONVERTKIT_API_KEY }} # ConvertKit API Key, stored in the repository's Settings > Secrets
       CONVERTKIT_API_SECRET: ${{ secrets.CONVERTKIT_API_SECRET }} # ConvertKit API Secret, stored in the repository's Settings > Secrets
       CONVERTKIT_API_KEY_NO_DATA: ${{ secrets.CONVERTKIT_API_KEY_NO_DATA }} # ConvertKit API Key for ConvertKit account with no data, stored in the repository's Settings > Secrets

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -205,7 +205,7 @@ jobs:
       # Run Codeception Acceptance Tests.
       - name: Run Acceptance Tests
         working-directory: ${{ env.PLUGIN_DIR }}
-        run: php vendor/bin/codecept run acceptance PageElementorFormCest --fail-fast
+        run: php vendor/bin/codecept run acceptance --fail-fast
 
       # If the repository has other tests, such as unit tests, add the Codeception commands here to run them now.
 

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -159,7 +159,7 @@ class WP_ConvertKit {
 		$this->classes['ajax']                      = new ConvertKit_AJAX();
 		$this->classes['blocks_convertkit_content'] = new ConvertKit_Block_Content();
 		$this->classes['blocks_convertkit_form']    = new ConvertKit_Block_Form();
-		$this->classes['elementor'] 				= new ConvertKit_Elementor();
+		$this->classes['elementor']                 = new ConvertKit_Elementor();
 		$this->classes['gutenberg']                 = new ConvertKit_Gutenberg();
 		$this->classes['review_request']            = new ConvertKit_Review_Request( 'ConvertKit', 'convertkit' );
 		$this->classes['shortcodes']                = new ConvertKit_Shortcodes();

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -159,6 +159,7 @@ class WP_ConvertKit {
 		$this->classes['ajax']                      = new ConvertKit_AJAX();
 		$this->classes['blocks_convertkit_content'] = new ConvertKit_Block_Content();
 		$this->classes['blocks_convertkit_form']    = new ConvertKit_Block_Form();
+		$this->classes['elementor'] 				= new ConvertKit_Elementor();
 		$this->classes['gutenberg']                 = new ConvertKit_Gutenberg();
 		$this->classes['review_request']            = new ConvertKit_Review_Request( 'ConvertKit', 'convertkit' );
 		$this->classes['shortcodes']                = new ConvertKit_Shortcodes();

--- a/includes/integrations/elementor/class-convertkit-elementor-widget-form.php
+++ b/includes/integrations/elementor/class-convertkit-elementor-widget-form.php
@@ -17,9 +17,9 @@ class ConvertKit_Elementor_Widget_Form extends ConvertKit_Elementor_Widget {
 	/**
 	 * The module's slug. Must be different from the block's name i.e. cannot be convertkit-form.
 	 *
-	 * @since 	1.9.7.2
+	 * @since   1.9.7.2
 	 *
-	 * @var 	string
+	 * @var     string
 	 */
 	public $slug = 'convertkit-elementor-form';
 

--- a/includes/integrations/elementor/class-convertkit-elementor-widget-form.php
+++ b/includes/integrations/elementor/class-convertkit-elementor-widget-form.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Elementor Widget: ConvertKit Form.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Registers the ConvertKit Form Block as an Elementor Widget.
+ *
+ * @package ConvertKit
+ * @author  ConvertKit
+ */
+class ConvertKit_Elementor_Widget_Form extends ConvertKit_Elementor_Widget {
+
+	/**
+	 * The module's slug. Must be different from the block's name i.e. cannot be convertkit-form.
+	 *
+	 * @since 	1.9.7.2
+	 *
+	 * @var 	string
+	 */
+	public $slug = 'convertkit-elementor-form';
+
+}

--- a/includes/integrations/elementor/class-convertkit-elementor-widget.php
+++ b/includes/integrations/elementor/class-convertkit-elementor-widget.php
@@ -18,18 +18,18 @@ class ConvertKit_Elementor_Widget extends Elementor\Widget_Base {
 	/**
 	 * Holds the block's properties
 	 *
-	 * @since 	1.9.7.2
+	 * @since   1.9.7.2
 	 *
-	 * @var 	WP_Error|array
+	 * @var     WP_Error|array
 	 */
 	private $block;
 
 	/**
 	 * Defines the Widget Name
 	 *
-	 * @since 	1.9.7.2
-	 * 
-	 * @return 	string
+	 * @since   1.9.7.2
+	 *
+	 * @return  string
 	 */
 	public function get_name() {
 
@@ -41,9 +41,9 @@ class ConvertKit_Elementor_Widget extends Elementor\Widget_Base {
 	 * Defines the Block Name, which is the slug excluding the
 	 * `convertkit-elementor-` prefix.
 	 *
-	 * @since 	1.9.7.2
-	 * 
-	 * @return 	string
+	 * @since   1.9.7.2
+	 *
+	 * @return  string
 	 */
 	public function get_block_name() {
 
@@ -54,9 +54,9 @@ class ConvertKit_Elementor_Widget extends Elementor\Widget_Base {
 	/**
 	 * Defines the Widget Title
 	 *
-	 * @since 	1.9.7.2
-	 * 
-	 * @return 	string
+	 * @since   1.9.7.2
+	 *
+	 * @return  string
 	 */
 	public function get_title() {
 
@@ -76,34 +76,33 @@ class ConvertKit_Elementor_Widget extends Elementor\Widget_Base {
 	/**
 	 * Defines the Widget Icon
 	 *
-	 * @since 	1.9.7.2
-	 * 
-	 * @return 	string
+	 * @since   1.9.7.2
+	 *
+	 * @return  string
 	 */
 	public function get_icon() {
 
-		// @TODO Improve.
-		return 'fa fa-code';
+		return 'eicon-convertkit-' . $this->get_block_name();
 
 	}
 
 	/**
 	 * Defines the Widget Categories
 	 *
-	 * @since 	1.9.7.2
-	 * 
-	 * @return 	array
+	 * @since   1.9.7.2
+	 *
+	 * @return  array
 	 */
 	public function get_categories() {
 
 		return array( 'convertkit' );
 
 	}
-	
+
 	/**
 	 * Defines the fields for this Widget
 	 *
-	 * @since 	1.9.7.2
+	 * @since   1.9.7.2
 	 */
 	protected function register_controls() {
 
@@ -124,10 +123,11 @@ class ConvertKit_Elementor_Widget extends Elementor\Widget_Base {
 		foreach ( $this->block['panels'] as $panel_name => $panel_properties ) {
 			// Start section.
 			$this->start_controls_section(
-				'section_' . $panel_name, // Deliberately prefix, as if a tab and field have the same name, it won't render.
+				// Deliberately prefix, as if a tab and field have the same name, it won't render.
+				'section_' . $panel_name,
 				array(
 					'label' => $panel_properties['label'],
-					'tab' 	=> Elementor\Controls_Manager::TAB_CONTENT,
+					'tab'   => Elementor\Controls_Manager::TAB_CONTENT,
 				)
 			);
 
@@ -154,19 +154,19 @@ class ConvertKit_Elementor_Widget extends Elementor\Widget_Base {
 	 * Returns the given field's control arguments, so that the field can be registered
 	 * as an Elementor Control.
 	 *
-	 * @since 	1.9.7.2
+	 * @since   1.9.7.2
 	 *
-	 * @param 	array 	$field 	Block Field.
-	 * @return 	array 			Elementor Control Arguments, compatible with add_control()
+	 * @param   array $field  Block Field.
+	 * @return  array           Elementor Control Arguments, compatible with add_control()
 	 */
 	private function get_field_control_args( $field ) {
 
-		// Start building control
+		// Start building control.
 		$control = array(
-			'default'		=> ( isset( $field['default_value'] ) ? $field['default_value'] : '' ),
-			'label' 		=> $field['label'],
-			'placeholder' 	=> ( isset( $field['placeholder'] ) ? $field['placeholder'] : '' ),
-			'desc'   		=> ( isset( $field['description'] ) ? $field['description'] : '' ),
+			'default'     => ( isset( $field['default_value'] ) ? $field['default_value'] : '' ),
+			'label'       => $field['label'],
+			'placeholder' => ( isset( $field['placeholder'] ) ? $field['placeholder'] : '' ),
+			'desc'        => ( isset( $field['description'] ) ? $field['description'] : '' ),
 		);
 
 		// Add control depending on the field type.
@@ -175,37 +175,49 @@ class ConvertKit_Elementor_Widget extends Elementor\Widget_Base {
 			 * Select
 			 */
 			case 'select':
-				$control = array_merge( $control, array(
-					'type' 		=> Elementor\Controls_Manager::SELECT,
-					'options'	=> $field['values'],
-				) );
+				$control = array_merge(
+					$control,
+					array(
+						'type'    => Elementor\Controls_Manager::SELECT,
+						'options' => $field['values'],
+					)
+				);
 				break;
 
 			/**
 			 * Number
 			 */
 			case 'number':
-				$control = array_merge( $control, array(
-					'type' 	=> Elementor\Controls_Manager::NUMBER,
-					'min' 	=> $field['min'],
-					'max' 	=> $field['max'],
-					'step' 	=> $field['step'],
-				) );
+				$control = array_merge(
+					$control,
+					array(
+						'type' => Elementor\Controls_Manager::NUMBER,
+						'min'  => $field['min'],
+						'max'  => $field['max'],
+						'step' => $field['step'],
+					)
+				);
 				break;
 
 			/**
-		     * Toggle
-		     */
+			 * Toggle
+			 */
 			case 'toggle':
-				$control = array_merge( $control, array(
-					'type' 	=> Elementor\Controls_Manager::SWITCHER,
-				) );
+				$control = array_merge(
+					$control,
+					array(
+						'type' => Elementor\Controls_Manager::SWITCHER,
+					)
+				);
 				break;
 
 			default:
-				$control = array_merge( $control, array(
-					'type' 			=> Elementor\Controls_Manager::TEXT,
-				) );
+				$control = array_merge(
+					$control,
+					array(
+						'type' => Elementor\Controls_Manager::TEXT,
+					)
+				);
 				break;
 
 		}
@@ -217,7 +229,7 @@ class ConvertKit_Elementor_Widget extends Elementor\Widget_Base {
 	/**
 	 * Renders the block.
 	 *
-	 * @since 	1.9.7.2
+	 * @since   1.9.7.2
 	 */
 	protected function render() {
 
@@ -227,16 +239,16 @@ class ConvertKit_Elementor_Widget extends Elementor\Widget_Base {
 		}
 
 		// Render using Block class' render() function.
-		echo WP_ConvertKit()->get_class( 'blocks_convertkit_' . $this->get_block_name() )->render( $this->get_settings_for_display() );
+		echo WP_ConvertKit()->get_class( 'blocks_convertkit_' . $this->get_block_name() )->render( $this->get_settings_for_display() ); // phpcs:ignore
 
 	}
 
 	/**
 	 * Return the block for the Elementor Widget.
-	 * 
-	 * @since 	1.9.7.2
-	 * 
-	 * @return 	WP_Error|array
+	 *
+	 * @since   1.9.7.2
+	 *
+	 * @return  WP_Error|array
 	 */
 	private function get_block() {
 
@@ -251,7 +263,7 @@ class ConvertKit_Elementor_Widget extends Elementor\Widget_Base {
 		// Bail if block doesn't exist.
 		if ( ! array_key_exists( $this->get_block_name(), $blocks ) ) {
 			return new WP_Error(
-				'convertkit_elementor_widget_get_block_error', 
+				'convertkit_elementor_widget_get_block_error',
 				sprintf(
 					/* translators: %1$s: Block name, %2$s: Elementor Widget name */
 					__( 'Block %1$s is not registered. Register using the `convertkit_blocks` filter, and ensure the Elementor Widget for this block has its `slug` property set to %2$s.', 'convertkit' ),

--- a/includes/integrations/elementor/class-convertkit-elementor-widget.php
+++ b/includes/integrations/elementor/class-convertkit-elementor-widget.php
@@ -25,6 +25,15 @@ class ConvertKit_Elementor_Widget extends Elementor\Widget_Base {
 	private $block;
 
 	/**
+	 * The module's slug. Must be different from the block's name i.e. cannot be convertkit-form.
+	 *
+	 * @since   1.9.7.2
+	 *
+	 * @var     string
+	 */
+	public $slug = '';
+
+	/**
 	 * Defines the Widget Name
 	 *
 	 * @since   1.9.7.2

--- a/includes/integrations/elementor/class-convertkit-elementor-widget.php
+++ b/includes/integrations/elementor/class-convertkit-elementor-widget.php
@@ -1,0 +1,269 @@
+<?php
+/**
+ * ConvertKit Elementor Widget class.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Extend this class for a specific block; see class-convertkit-elementor-widget-form.php
+ * for an example.
+ *
+ * @package ConvertKit
+ * @author  ConvertKit
+ */
+class ConvertKit_Elementor_Widget extends Elementor\Widget_Base {
+
+	/**
+	 * Holds the block's properties
+	 *
+	 * @since 	1.9.7.2
+	 *
+	 * @var 	WP_Error|array
+	 */
+	private $block;
+
+	/**
+	 * Defines the Widget Name
+	 *
+	 * @since 	1.9.7.2
+	 * 
+	 * @return 	string
+	 */
+	public function get_name() {
+
+		return $this->slug;
+
+	}
+
+	/**
+	 * Defines the Block Name, which is the slug excluding the
+	 * `convertkit-elementor-` prefix.
+	 *
+	 * @since 	1.9.7.2
+	 * 
+	 * @return 	string
+	 */
+	public function get_block_name() {
+
+		return str_replace( 'convertkit-elementor-', '', $this->slug );
+
+	}
+
+	/**
+	 * Defines the Widget Title
+	 *
+	 * @since 	1.9.7.2
+	 * 
+	 * @return 	string
+	 */
+	public function get_title() {
+
+		// Get block.
+		$this->block = $this->get_block();
+
+		// Bail if the block could not be found.
+		if ( is_wp_error( $this->block ) ) {
+			return $this->block->get_error_message();
+		}
+
+		// Return block's title.
+		return $this->block['title'];
+
+	}
+
+	/**
+	 * Defines the Widget Icon
+	 *
+	 * @since 	1.9.7.2
+	 * 
+	 * @return 	string
+	 */
+	public function get_icon() {
+
+		// @TODO Improve.
+		return 'fa fa-code';
+
+	}
+
+	/**
+	 * Defines the Widget Categories
+	 *
+	 * @since 	1.9.7.2
+	 * 
+	 * @return 	array
+	 */
+	public function get_categories() {
+
+		return array( 'convertkit' );
+
+	}
+	
+	/**
+	 * Defines the fields for this Widget
+	 *
+	 * @since 	1.9.7.2
+	 */
+	protected function register_controls() {
+
+		// Bail if the request is not for the WordPress Administration or frontend editor.
+		if ( ! WP_ConvertKit()->is_admin_or_frontend_editor() ) {
+			return;
+		}
+
+		// Get block.
+		$this->block = $this->get_block();
+
+		// Bail if the block could not be found.
+		if ( is_wp_error( $this->block ) ) {
+			return;
+		}
+
+		// Iterate through panels, building a section for each.
+		foreach ( $this->block['panels'] as $panel_name => $panel_properties ) {
+			// Start section.
+			$this->start_controls_section(
+				'section_' . $panel_name, // Deliberately prefix, as if a tab and field have the same name, it won't render.
+				array(
+					'label' => $panel_properties['label'],
+					'tab' 	=> Elementor\Controls_Manager::TAB_CONTENT,
+				)
+			);
+
+			// Add controls to this section.
+			foreach ( $panel_properties['fields'] as $field_name ) {
+				// Get field.
+				$field = $this->block['fields'][ $field_name ];
+
+				// Get Elementor Control for this field.
+				$control = $this->get_field_control_args( $field );
+
+				// Finally, register the control for this field.
+				$this->add_control( $field_name, $control );
+			}
+
+			// Close the section.
+			$this->end_controls_section();
+
+		}
+
+	}
+
+	/**
+	 * Returns the given field's control arguments, so that the field can be registered
+	 * as an Elementor Control.
+	 *
+	 * @since 	1.9.7.2
+	 *
+	 * @param 	array 	$field 	Block Field.
+	 * @return 	array 			Elementor Control Arguments, compatible with add_control()
+	 */
+	private function get_field_control_args( $field ) {
+
+		// Start building control
+		$control = array(
+			'default'		=> ( isset( $field['default_value'] ) ? $field['default_value'] : '' ),
+			'label' 		=> $field['label'],
+			'placeholder' 	=> ( isset( $field['placeholder'] ) ? $field['placeholder'] : '' ),
+			'desc'   		=> ( isset( $field['description'] ) ? $field['description'] : '' ),
+		);
+
+		// Add control depending on the field type.
+		switch ( $field['type'] ) {
+			/**
+			 * Select
+			 */
+			case 'select':
+				$control = array_merge( $control, array(
+					'type' 		=> Elementor\Controls_Manager::SELECT,
+					'options'	=> $field['values'],
+				) );
+				break;
+
+			/**
+			 * Number
+			 */
+			case 'number':
+				$control = array_merge( $control, array(
+					'type' 	=> Elementor\Controls_Manager::NUMBER,
+					'min' 	=> $field['min'],
+					'max' 	=> $field['max'],
+					'step' 	=> $field['step'],
+				) );
+				break;
+
+			/**
+		     * Toggle
+		     */
+			case 'toggle':
+				$control = array_merge( $control, array(
+					'type' 	=> Elementor\Controls_Manager::SWITCHER,
+				) );
+				break;
+
+			default:
+				$control = array_merge( $control, array(
+					'type' 			=> Elementor\Controls_Manager::TEXT,
+				) );
+				break;
+
+		}
+
+		return $control;
+
+	}
+
+	/**
+	 * Renders the block.
+	 *
+	 * @since 	1.9.7.2
+	 */
+	protected function render() {
+
+		// Bail if the block could not be found.
+		if ( is_wp_error( $this->block ) ) {
+			return $this->block->get_error_message();
+		}
+
+		// Render using Block class' render() function.
+		echo WP_ConvertKit()->get_class( 'blocks_convertkit_' . $this->get_block_name() )->render( $this->get_settings_for_display() );
+
+	}
+
+	/**
+	 * Return the block for the Elementor Widget.
+	 * 
+	 * @since 	1.9.7.2
+	 * 
+	 * @return 	WP_Error|array
+	 */
+	private function get_block() {
+
+		// Get blocks.
+		$blocks = convertkit_get_blocks();
+
+		// Bail if no blocks are available.
+		if ( ! is_array( $blocks ) || ! count( $blocks ) ) {
+			return new WP_Error( 'convertkit_elementor_widget_get_block_error', __( 'No blocks are registered. Register blocks using the `convertkit_blocks` filter.', 'convertkit' ) );
+		}
+
+		// Bail if block doesn't exist.
+		if ( ! array_key_exists( $this->get_block_name(), $blocks ) ) {
+			return new WP_Error(
+				'convertkit_elementor_widget_get_block_error', 
+				sprintf(
+					/* translators: %1$s: Block name, %2$s: Elementor Widget name */
+					__( 'Block %1$s is not registered. Register using the `convertkit_blocks` filter, and ensure the Elementor Widget for this block has its `slug` property set to %2$s.', 'convertkit' ),
+					$this->get_block_name(),
+					$this->slug
+				)
+			);
+		}
+
+		// Return block.
+		return $blocks[ $this->get_block_name() ];
+
+	}
+
+}

--- a/includes/integrations/elementor/class-convertkit-elementor.php
+++ b/includes/integrations/elementor/class-convertkit-elementor.php
@@ -79,7 +79,7 @@ class ConvertKit_Elementor {
 	 *
 	 * @since   1.9.7.2
 	 *
-	 * @param   Widgets_Manager $widgets_manager    Widgets Manager, used to register/unregister Elementor Widgets.
+	 * @param   Elementor\Widgets_Manager $widgets_manager    Widgets Manager, used to register/unregister Elementor Widgets.
 	 */
 	public function register_widgets( $widgets_manager ) {
 

--- a/includes/integrations/elementor/class-convertkit-elementor.php
+++ b/includes/integrations/elementor/class-convertkit-elementor.php
@@ -14,76 +14,101 @@
  */
 class ConvertKit_Elementor {
 
-    /**
-     * Constructor
-     * 
-     * @since   1.9.7.2
-     */
-    public function __construct() {
+	/**
+	 * Constructor
+	 *
+	 * @since   1.9.7.2
+	 */
+	public function __construct() {
 
-        // Register Widget Category.
-        add_action( 'elementor/elements/categories_registered', array( $this, 'register_elementor_widget_categories' ) );
+		// Enqueue CSS when using the Elementor editor.
+		add_action( 'elementor/editor/after_enqueue_styles', array( $this, 'enqueue_styles' ) );
 
-        // Register Blocks as Elementor Widgets.
-        add_action( 'elementor/widgets/register', array( $this, 'register_widgets' ) );
+		// Register Widget Category.
+		add_action( 'elementor/elements/categories_registered', array( $this, 'register_elementor_widget_categories' ) );
 
-    }
+		// Register Blocks as Elementor Widgets.
+		add_action( 'elementor/widgets/register', array( $this, 'register_widgets' ) );
 
-    /**
-     * Registers this Plugin's Name as a Category for Elementor Widgets registered
-     * by this Plugin.
-     *
-     * @since   1.9.7.2
-     *
-     * @param   object  $elements_manager   Elements Manager
-     */
-    public function register_elementor_widget_categories( $elements_manager ) {
+	}
 
-        $elements_manager->add_category(
-            'convertkit',
-            array(
-                'title' => __( 'ConvertKit', 'convertkit' ),
-                'icon'  => 'fa fa-plug',
-            )
-        );
+	/**
+	 * Enqueue styles for widget icons.
+	 *
+	 * @since   1.9.7.2
+	 */
+	public function enqueue_styles() {
 
-    }
+		// Don't load stylesheets if not in editor mode.
+		if ( empty( $_GET['action'] ) || $_GET['action'] !== 'elementor' ) { // phpcs:ignore
+			return;
+		}
 
-    /**
-     * Registers Blocks as Elementor Widgets.
-     *
-     * @since   1.9.7.2
-     *
-     * @param   Widgets_Manager     $widgets_manager    Widgets Manager, used to register/unregister Elementor Widgets.
-     */
-    public function register_widgets( $widgets_manager ) {
+		// Enqueue styles for block icons.
+		wp_enqueue_style(
+			'convertkit-elementor',
+			CONVERTKIT_PLUGIN_URL . 'resources/backend/css/elementor.css',
+			array(),
+			CONVERTKIT_PLUGIN_VERSION
+		);
 
-        // Get blocks.
-        $blocks = convertkit_get_blocks();
+	}
 
-        // Bail if no blocks are available.
-        if ( ! is_array( $blocks ) || ! count( $blocks ) ) {
-            return;
-        }
+	/**
+	 * Registers this Plugin's Name as a Category for Elementor Widgets registered
+	 * by this Plugin.
+	 *
+	 * @since   1.9.7.2
+	 *
+	 * @param   object $elements_manager   Elements Manager.
+	 */
+	public function register_elementor_widget_categories( $elements_manager ) {
 
-        // Load widget class here, as we know that Elementor is active.
-        require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/elementor/class-convertkit-elementor-widget.php';
+		$elements_manager->add_category(
+			'convertkit',
+			array(
+				'title' => __( 'ConvertKit', 'convertkit' ),
+				'icon'  => 'fa fa-plug',
+			)
+		);
 
-        // Iterate through blocks, registering them.
-        foreach ( $blocks as $block => $properties ) {
-            // Skip if this block doesn't have an Elementor Widget class.
-            if ( ! file_exists( CONVERTKIT_PLUGIN_PATH . '/includes/integrations/elementor/class-convertkit-elementor-widget-' . $block . '.php' ) ) {
-                continue;
-            }
+	}
 
-            // Load widget class for this block.
-            require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/elementor/class-convertkit-elementor-widget-' . $block . '.php';
+	/**
+	 * Registers Blocks as Elementor Widgets.
+	 *
+	 * @since   1.9.7.2
+	 *
+	 * @param   Widgets_Manager $widgets_manager    Widgets Manager, used to register/unregister Elementor Widgets.
+	 */
+	public function register_widgets( $widgets_manager ) {
 
-            // Register Widget.
-            $class_name = 'ConvertKit_Elementor_Widget_' . str_replace( '-', '_', $block );
-            $widgets_manager->register_widget_type( new $class_name() );
-        }
+		// Get blocks.
+		$blocks = convertkit_get_blocks();
 
-    }
+		// Bail if no blocks are available.
+		if ( ! is_array( $blocks ) || ! count( $blocks ) ) {
+			return;
+		}
+
+		// Load widget class here, as we know that Elementor is active.
+		require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/elementor/class-convertkit-elementor-widget.php';
+
+		// Iterate through blocks, registering them.
+		foreach ( $blocks as $block => $properties ) {
+			// Skip if this block doesn't have an Elementor Widget class.
+			if ( ! file_exists( CONVERTKIT_PLUGIN_PATH . '/includes/integrations/elementor/class-convertkit-elementor-widget-' . $block . '.php' ) ) {
+				continue;
+			}
+
+			// Load widget class for this block.
+			require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/elementor/class-convertkit-elementor-widget-' . $block . '.php';
+
+			// Register Widget.
+			$class_name = 'ConvertKit_Elementor_Widget_' . str_replace( '-', '_', $block );
+			$widgets_manager->register_widget_type( new $class_name() );
+		}
+
+	}
 
 }

--- a/includes/integrations/elementor/class-convertkit-elementor.php
+++ b/includes/integrations/elementor/class-convertkit-elementor.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Elementor Integration class.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Registers blocks as Elementor Widgets.
+ *
+ * @package ConvertKit
+ * @author  ConvertKit
+ */
+class ConvertKit_Elementor {
+
+    /**
+     * Constructor
+     * 
+     * @since   1.9.7.2
+     */
+    public function __construct() {
+
+        // Register Widget Category.
+        add_action( 'elementor/elements/categories_registered', array( $this, 'register_elementor_widget_categories' ) );
+
+        // Register Blocks as Elementor Widgets.
+        add_action( 'elementor/widgets/register', array( $this, 'register_widgets' ) );
+
+    }
+
+    /**
+     * Registers this Plugin's Name as a Category for Elementor Widgets registered
+     * by this Plugin.
+     *
+     * @since   1.9.7.2
+     *
+     * @param   object  $elements_manager   Elements Manager
+     */
+    public function register_elementor_widget_categories( $elements_manager ) {
+
+        $elements_manager->add_category(
+            'convertkit',
+            array(
+                'title' => __( 'ConvertKit', 'convertkit' ),
+                'icon'  => 'fa fa-plug',
+            )
+        );
+
+    }
+
+    /**
+     * Registers Blocks as Elementor Widgets.
+     *
+     * @since   1.9.7.2
+     *
+     * @param   Widgets_Manager     $widgets_manager    Widgets Manager, used to register/unregister Elementor Widgets.
+     */
+    public function register_widgets( $widgets_manager ) {
+
+        // Get blocks.
+        $blocks = convertkit_get_blocks();
+
+        // Bail if no blocks are available.
+        if ( ! is_array( $blocks ) || ! count( $blocks ) ) {
+            return;
+        }
+
+        // Load widget class here, as we know that Elementor is active.
+        require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/elementor/class-convertkit-elementor-widget.php';
+
+        // Iterate through blocks, registering them.
+        foreach ( $blocks as $block => $properties ) {
+            // Skip if this block doesn't have an Elementor Widget class.
+            if ( ! file_exists( CONVERTKIT_PLUGIN_PATH . '/includes/integrations/elementor/class-convertkit-elementor-widget-' . $block . '.php' ) ) {
+                continue;
+            }
+
+            // Load widget class for this block.
+            require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/elementor/class-convertkit-elementor-widget-' . $block . '.php';
+
+            // Register Widget.
+            $class_name = 'ConvertKit_Elementor_Widget_' . str_replace( '-', '_', $block );
+            $widgets_manager->register_widget_type( new $class_name() );
+        }
+
+    }
+
+}

--- a/resources/backend/css/elementor.css
+++ b/resources/backend/css/elementor.css
@@ -1,0 +1,6 @@
+.eicon-convertkit-form {
+	width: 24px;
+	height: 24px;
+	background: url(../images/block-icon-form.svg) center no-repeat;
+	background-size: 24px 24px;
+}

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -1,8 +1,6 @@
 <?php
 namespace Helper;
 
-use \Facebook\WebDriver\WebDriverElement;
-
 // here you can define custom actions
 // all public methods declared in helper class will be available in $I
 
@@ -57,7 +55,7 @@ class Acceptance extends \Codeception\Module
 		} catch ( \Facebook\WebDriver\Exception\TimeoutException $e ) {
 		}
 	}
-
+	
 	/**
 	 * Helper method to activate the ConvertKit Plugin, checking
 	 * it activated and no errors were output.

--- a/tests/acceptance/PageElementorFormCest.php
+++ b/tests/acceptance/PageElementorFormCest.php
@@ -1,0 +1,371 @@
+<?php
+/**
+ * Tests for the ConvertKit Form's Elementor Widget.
+ * 
+ * @since 	1.9.6
+ */
+class PageElementorFormCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'elementor');
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
+		$I->wait(2);
+
+		// Navigate to Pages > Add New
+		$I->amOnAdminPage('post-new.php?post_type=page');
+
+		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
+		$I->maybeCloseGutenbergWelcomeModal($I);
+
+		// Change Form to None, so that no Plugin level Form is displayed, ensuring we only
+		// test the Form block in Gutenberg.
+		$I->selectOption('#wp-convertkit-form', 'None');
+	}
+
+	/**
+	 * Test the Form widget works when a valid Form is selected.
+	 * 
+	 * @since 	1.9.7.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testFormWidgetWithValidFormParameter(AcceptanceTester $I)
+	{
+		// Define a Page Title.
+		$I->fillField('.editor-post-title__input', 'ConvertKit: Form: Elementor: Valid Form Param');
+
+		// Click Edit with Elementor button.
+		$I->click('#elementor-switch-mode-button');
+
+		// When Elementor loads, search for the ConvertKit Form block.
+		$I->waitForElementVisible('#elementor-panel-content-wrapper');
+		$I->fillField('#elementor-panel-elements-search-input', 'ConvertKit Form');
+		$I->dragAndDrop('#elementor-panel-elements .elementor-element', '#elementor-add-new-section');
+
+		// When the sidebar appears, select the Form.
+		$I->waitForElementVisible('.elementor-control-form');
+		$I->selectOption('.elementor-control-form select', $_ENV['CONVERTKIT_API_FORM_NAME']);
+
+		// Click the Publish button.
+		$I->click('#elementor-panel-saver-button-publish');
+
+		// Open Elementor menu.
+		$I->click('#elementor-panel-header-menu-button');
+
+		// Click View Page.
+		$I->click('.elementor-panel-menu-item-view-page a');
+
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible('body.page-template-default');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the ConvertKit Form is displayed.
+		$I->seeElementInDOM('form[data-sv-form]');
+	}
+
+	/**
+	 * Test the Form block works when a valid Legacy Form is selected.
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testFormBlockWithValidLegacyFormParameter(AcceptanceTester $I)
+	{
+		// Define a Page Title.
+		$I->fillField('.editor-post-title__input', 'ConvertKit: Legacy Form: Block: Valid Form Param');
+
+		// Click Add Block Button.
+		$I->click('button.edit-post-header-toolbar__inserter-toggle');
+
+		// When the Blocks sidebar appears, search for the ConvertKit Form block.
+		$I->waitForElementVisible('.interface-interface-skeleton__secondary-sidebar[aria-label="Block library"]');
+		$I->fillField('.block-editor-inserter__content input[type=search]', 'ConvertKit Form');
+		$I->seeElementInDOM('.block-editor-inserter__panel-content button.editor-block-list-item-convertkit-form');
+		$I->click('.block-editor-inserter__panel-content button.editor-block-list-item-convertkit-form');
+
+		// When the sidebar appears, select the Form.
+		$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
+		$I->selectOption('#convertkit_form_form', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
+
+		// Click the Publish button.
+		$I->click('.editor-post-publish-button__button');
+		
+		// When the pre-publish panel displays, click Publish again.
+		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
+			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
+		});
+
+		// Wait for confirmation that the Page published.
+		$I->waitForElementVisible('.post-publish-panel__postpublish-buttons a.components-button');
+
+		// Load the Page on the frontend site.
+		$I->click('.post-publish-panel__postpublish-buttons a.components-button');
+
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible('body.page-template-default');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the ConvertKit Form is displayed.
+		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
+	}
+
+	/**
+	 * Test the Form block displays a message explaining why the block cannot be previewed
+	 * in the Gutenberg editor when a valid Modal Form is selected.
+	 * 
+	 * @since 	1.9.6.9
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testFormBlockWithValidModalFormParameter(AcceptanceTester $I)
+	{
+		// Define a Page Title.
+		$I->fillField('.editor-post-title__input', 'ConvertKit: Form: Block: Valid Modal Form Param');
+
+		// Click Add Block Button.
+		$I->click('button.edit-post-header-toolbar__inserter-toggle');
+
+		// When the Blocks sidebar appears, search for the ConvertKit Form block.
+		$I->waitForElementVisible('.interface-interface-skeleton__secondary-sidebar[aria-label="Block library"]');
+		$I->fillField('.block-editor-inserter__content input[type=search]', 'ConvertKit Form');
+		$I->seeElementInDOM('.block-editor-inserter__panel-content button.editor-block-list-item-convertkit-form');
+		$I->click('.block-editor-inserter__panel-content button.editor-block-list-item-convertkit-form');
+
+		// When the sidebar appears, select the Form.
+		$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
+		$I->selectOption('#convertkit_form_form', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME']);
+
+		// Switch to iframe preview for the Form block.
+		$I->switchToIFrame('iframe[class="components-sandbox"]');
+
+		// Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
+		// site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
+		$I->see('Modal form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . '" selected. View on the frontend site to see the modal form.');
+
+		// Switch back to main window.
+		$I->switchToIFrame();
+
+		// Click the Publish button.
+		$I->click('.editor-post-publish-button__button');
+		
+		// When the pre-publish panel displays, click Publish again.
+		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
+			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
+		});
+
+		// Wait for confirmation that the Page published.
+		$I->waitForElementVisible('.post-publish-panel__postpublish-buttons a.components-button');
+
+		// Load the Page on the frontend site.
+		$I->click('.post-publish-panel__postpublish-buttons a.components-button');
+
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible('body.page-template-default');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the ConvertKit Form is displayed.
+		$I->seeElementInDOM('form[data-sv-form]');
+	}
+
+	/**
+	 * Test the Form block displays a message explaining why the block cannot be previewed
+	 * in the Gutenberg editor when a valid Slide In Form is selected.
+	 * 
+	 * @since 	1.9.6.9
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testFormBlockWithValidSlideInFormParameter(AcceptanceTester $I)
+	{
+		// Define a Page Title.
+		$I->fillField('.editor-post-title__input', 'ConvertKit: Form: Block: Valid Slide In Form Param');
+
+		// Click Add Block Button.
+		$I->click('button.edit-post-header-toolbar__inserter-toggle');
+
+		// When the Blocks sidebar appears, search for the ConvertKit Form block.
+		$I->waitForElementVisible('.interface-interface-skeleton__secondary-sidebar[aria-label="Block library"]');
+		$I->fillField('.block-editor-inserter__content input[type=search]', 'ConvertKit Form');
+		$I->seeElementInDOM('.block-editor-inserter__panel-content button.editor-block-list-item-convertkit-form');
+		$I->click('.block-editor-inserter__panel-content button.editor-block-list-item-convertkit-form');
+
+		// When the sidebar appears, select the Form.
+		$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
+		$I->selectOption('#convertkit_form_form', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME']);
+
+		// Switch to iframe preview for the Form block.
+		$I->switchToIFrame('iframe[class="components-sandbox"]');
+
+		// Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
+		// site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
+		$I->see('Slide in form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] . '" selected. View on the frontend site to see the slide in form.');
+
+		// Switch back to main window.
+		$I->switchToIFrame();
+
+		// Click the Publish button.
+		$I->click('.editor-post-publish-button__button');
+		
+		// When the pre-publish panel displays, click Publish again.
+		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
+			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
+		});
+
+		// Wait for confirmation that the Page published.
+		$I->waitForElementVisible('.post-publish-panel__postpublish-buttons a.components-button');
+
+		// Load the Page on the frontend site.
+		$I->click('.post-publish-panel__postpublish-buttons a.components-button');
+
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible('body.page-template-default');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the ConvertKit Form is displayed.
+		$I->seeElementInDOM('form[data-sv-form]');
+	}
+
+	/**
+	 * Test the Form block displays a message explaining why the block cannot be previewed
+	 * in the Gutenberg editor when a valid Sticky Bar Form is selected.
+	 * 
+	 * @since 	1.9.6.9
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testFormBlockWithValidStickyBarFormParameter(AcceptanceTester $I)
+	{
+		// Define a Page Title.
+		$I->fillField('.editor-post-title__input', 'ConvertKit: Form: Block: Valid Sticky Bar Form Param');
+
+		// Click Add Block Button.
+		$I->click('button.edit-post-header-toolbar__inserter-toggle');
+
+		// When the Blocks sidebar appears, search for the ConvertKit Form block.
+		$I->waitForElementVisible('.interface-interface-skeleton__secondary-sidebar[aria-label="Block library"]');
+		$I->fillField('.block-editor-inserter__content input[type=search]', 'ConvertKit Form');
+		$I->seeElementInDOM('.block-editor-inserter__panel-content button.editor-block-list-item-convertkit-form');
+		$I->click('.block-editor-inserter__panel-content button.editor-block-list-item-convertkit-form');
+
+		// When the sidebar appears, select the Form.
+		$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
+		$I->selectOption('#convertkit_form_form', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME']);
+
+		// Switch to iframe preview for the Form block.
+		$I->switchToIFrame('iframe[class="components-sandbox"]');
+
+		// Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
+		// site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
+		$I->see('Sticky bar form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] . '" selected. View on the frontend site to see the sticky bar form.');
+
+		// Switch back to main window.
+		$I->switchToIFrame();
+
+		// Click the Publish button.
+		$I->click('.editor-post-publish-button__button');
+		
+		// When the pre-publish panel displays, click Publish again.
+		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
+			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
+		});
+
+		// Wait for confirmation that the Page published.
+		$I->waitForElementVisible('.post-publish-panel__postpublish-buttons a.components-button');
+
+		// Load the Page on the frontend site.
+		$I->click('.post-publish-panel__postpublish-buttons a.components-button');
+
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible('body.page-template-default');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the ConvertKit Form is displayed.
+		$I->seeElementInDOM('form[data-sv-form]');
+	}
+
+	/**
+	 * Test the Form block works when no Form is selected.
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testFormBlockWithNoFormParameter(AcceptanceTester $I)
+	{
+		// Define a Page Title.
+		$I->fillField('.editor-post-title__input', 'ConvertKit: Form: Block: No Form Param');
+
+		// Click Add Block Button.
+		$I->click('button.edit-post-header-toolbar__inserter-toggle');
+
+		// When the Blocks sidebar appears, search for the ConvertKit Form block.
+		$I->waitForElementVisible('.interface-interface-skeleton__secondary-sidebar[aria-label="Block library"]');
+		$I->fillField('.block-editor-inserter__content input[type=search]', 'ConvertKit Form');
+		$I->seeElementInDOM('.block-editor-inserter__panel-content button.editor-block-list-item-convertkit-form');
+		$I->click('.block-editor-inserter__panel-content button.editor-block-list-item-convertkit-form');
+
+		// Confirm that the Form block displays instructions to the user on how to select a Form.
+		$I->see('Select a Form using the Form option in the Gutenberg sidebar.', [
+			'css' => '.convertkit-form-no-content',
+		]);
+
+		// Click the Publish button.
+		$I->click('.editor-post-publish-button__button');
+		
+		// When the pre-publish panel displays, click Publish again.
+		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
+			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
+		});
+
+		// Wait for confirmation that the Page published.
+		$I->waitForElementVisible('.post-publish-panel__postpublish-buttons a.components-button');
+
+		// Load the Page on the frontend site.
+		$I->click('.post-publish-panel__postpublish-buttons a.components-button');
+
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible('body.page-template-default');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that no ConvertKit Form is displayed.
+		$I->dontSeeElementInDOM('form[data-sv-form]');
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
+	}
+}

--- a/tests/acceptance/PostElementorFormCest.php
+++ b/tests/acceptance/PostElementorFormCest.php
@@ -4,7 +4,7 @@
  * 
  * @since 	1.9.6
  */
-class PageElementorFormCest
+class PostElementorFormCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
@@ -31,8 +31,8 @@ class PageElementorFormCest
 	 */
 	public function testFormWidgetIsRegistered(AcceptanceTester $I)
 	{
-		// Navigate to Pages > Add New
-		$I->amOnAdminPage('post-new.php?post_type=page');
+		// Navigate to Posts > Add New
+		$I->amOnAdminPage('post-new.php');
 
 		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
 		$I->maybeCloseGutenbergWelcomeModal($I);
@@ -41,7 +41,7 @@ class PageElementorFormCest
 		// test the Form block in Gutenberg.
 		$I->selectOption('#wp-convertkit-form', 'None');
 
-		// Define a Page Title.
+		// Define a Post Title.
 		$I->fillField('.editor-post-title__input', 'ConvertKit: Form: Elementor: Valid Form Param');
 
 		// Click Edit with Elementor button.
@@ -64,11 +64,11 @@ class PageElementorFormCest
 	 */
 	public function testFormWidgetWithValidFormParameter(AcceptanceTester $I)
 	{
-		// Create Page with Form widget in Elementor.
-		$pageID = $this->_createPageWithFormWidget($I, 'ConvertKit: Form: Elementor Widget: Valid Form Param', $_ENV['CONVERTKIT_API_FORM_ID']);
+		// Create Post with Form widget in Elementor.
+		$postID = $this->_createPostWithFormWidget($I, 'ConvertKit: Form: Elementor Widget: Valid Form Param', $_ENV['CONVERTKIT_API_FORM_ID']);
 
-		// Load Page.
-		$I->amOnPage('?p='.$pageID);
+		// Load Post.
+		$I->amOnPage('?p='.$postID);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -86,11 +86,11 @@ class PageElementorFormCest
 	 */
 	public function testFormWidgetWithValidLegacyFormParameter(AcceptanceTester $I)
 	{
-		// Create Page with Form widget in Elementor.
-		$pageID = $this->_createPageWithFormWidget($I, 'ConvertKit: Legacy Form: Elementor Widget: Valid Form Param', $_ENV['CONVERTKIT_API_LEGACY_FORM_ID']);
+		// Create Post with Form widget in Elementor.
+		$postID = $this->_createPostWithFormWidget($I, 'ConvertKit: Legacy Form: Elementor Widget: Valid Form Param', $_ENV['CONVERTKIT_API_LEGACY_FORM_ID']);
 
-		// Load Page.
-		$I->amOnPage('?p='.$pageID);
+		// Load Post.
+		$I->amOnPage('?p='.$postID);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -108,11 +108,11 @@ class PageElementorFormCest
 	 */
 	public function testFormWidgetWithNoFormParameter(AcceptanceTester $I)
 	{
-		// Create Page with Form widget in Elementor.
-		$pageID = $this->_createPageWithFormWidget($I, 'ConvertKit: Form: Elementor Widget: No Form Param', '');
+		// Create Post with Form widget in Elementor.
+		$postID = $this->_createPostWithFormWidget($I, 'ConvertKit: Form: Elementor Widget: No Form Param', '');
 
-		// Load Page.
-		$I->amOnPage('?p='.$pageID);
+		// Load Post.
+		$I->amOnPage('?p='.$postID);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -122,14 +122,14 @@ class PageElementorFormCest
 	}
 
 	/**
-	 * Create a Page in the database comprising of Elementor Page Builder data
+	 * Create a Post in the database comprising of Elementor Page Builder data
 	 * containing a ConvertKit Form widget.
 	 * 
 	 * Codeception's dragAndDrop() method doesn't support dropping an element into an iframe, which is
-	 * how Elementor works for adding widgets to a Page.
+	 * how Elementor works for adding widgets to a Post.
 	 * 
-	 * Therefore, we directly create a Page in the database, with Elementor's data structure
-	 * as if we added the Form widget to a Page edited in Elementor.
+	 * Therefore, we directly create a Post in the database, with Elementor's data structure
+	 * as if we added the Form widget to a Post edited in Elementor.
 	 * 
 	 * testFormWidgetIsRegistered() above is a sanity check that the Form Widget is registered
 	 * and available to users in Elementor.
@@ -137,15 +137,15 @@ class PageElementorFormCest
 	 * @since 	1.9.7.2
 	 * 
 	 * @param 	AcceptanceTester 	$I 		Tester.
-	 * @param 	string 				$title 	Page Title.
+	 * @param 	string 				$title 	Post Title.
 	 * @param 	int 				$formID ConvertKit Form ID.
-	 * @return 	int 						Page ID
+	 * @return 	int 						Post ID
 	 */
-	private function _createPageWithFormWidget(AcceptanceTester $I, $title, $formID)
+	private function _createPostWithFormWidget(AcceptanceTester $I, $title, $formID)
 	{
 		return $I->havePostInDatabase([
 			'post_title'	=> $title,
-			'post_type'		=> 'page',
+			'post_type'		=> 'post',
 			'post_status'	=> 'publish',
 			'meta_input' => [
 				// Elementor.
@@ -178,13 +178,12 @@ class PageElementorFormCest
 				],
 				'_elementor_version' => '3.6.1',
 				'_elementor_edit_mode' => 'builder',
-				'_elementor_template_type' => 'wp-page',
+				'_elementor_template_type' => 'wp-post',
 
 				// Configure ConvertKit Plugin to not display a default Form,
 				// as we are testing for the Form in Elementor.
 				'_wp_convertkit_post_meta' => [
 					'form'         => '-1',
-					'landing_page' => '',
 					'tag'          => '',
 				],
 			],

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -55,6 +55,9 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/widgets/class-ck-widget-form.ph
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/contactform7/class-convertkit-contactform7.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/contactform7/class-convertkit-contactform7-settings.php';
 
+// Elementor Integration.
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/elementor/class-convertkit-elementor.php';
+
 // WishList Member Integration.
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/wishlist/class-convertkit-wishlist.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/wishlist/class-convertkit-wishlist-settings.php';


### PR DESCRIPTION
## Summary

Registers a ConvertKit Form Widget in [Elementor](https://en-gb.wordpress.org/plugins/elementor/), a popular page builder with ~ 5 million active installations of the free version.

Whilst Elementor provide a ConvertKit integration with their own Form widget:
1. It's only available to Elementor Pro users (those with a paid license for Elementor),
2. It doesn't allow the user to choose a ConvertKit Form to embed into their Page/Post.

This allows editors to insert ConvertKit Forms into Pages, Posts and Custom Post Types when editing with Elementor, similar to how we support [Gutenberg](https://github.com/ConvertKit/convertkit-wordpress/pull/273).

![Screenshot 2022-03-31 at 18 27 40](https://user-images.githubusercontent.com/1462305/161114939-941b83c0-c904-4e5d-8bae-dc0bb7009673.png)

Video:
https://www.loom.com/share/7d2a8cbb132d406085fc4a234a944074

## Testing
- PageElementorFormCest: Tests for adding, saving and viewing Pages with the ConvertKit Form widget when configured with a Form and Legacy Form.
- PostElementorFormCest: Tests for adding, saving and viewing Pages with the ConvertKit Form widget when configured with a Form and Legacy Form.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)