### PR TITLE
Fix Form Setting on Category

### DIFF
--- a/includes/class-convertkit-term.php
+++ b/includes/class-convertkit-term.php
@@ -49,7 +49,7 @@ class ConvertKit_Term {
 		$this->term_id = $term_id;
 
 		// Get Term Meta.
-		$meta = get_term_meta( $term_id, 'ck_default_form', true );
+		$meta = get_term_meta( $term_id, self::TERM_META_KEY, true );
 
 		if ( ! $meta ) {
 			// Fallback to default settings.
@@ -96,33 +96,20 @@ class ConvertKit_Term {
 	 */
 	public function has_form() {
 
+		// Backward compat. for Terms created/edited prior to 1.9.6, where
+		// 'default' was used instead of zero to denote the Post / Post Type
+		// setting should be used for determining the Form to display.
+		// Using a comparison operator on 'default' will return different results in:
+		// PHP < 8.0: 'default' > 0 is false
+		// PHP 8.0+: 'default' > 0 is true
+		// See https://www.php.net/manual/en/language.operators.comparison.php.
+		if ( $this->settings === 'default' ) {
+			return false;
+		}
+
+		// If the setting is greater than zero, it's a specific Form ID that
+		// should be used for Posts assigned to this Category.
 		return ( $this->settings > 0 );
-
-	}
-
-	/**
-	 * Whether the Term is set to use the Plugin's Default Form Setting.
-	 *
-	 * @since   1.9.6
-	 *
-	 * @return  bool
-	 */
-	public function uses_default_form() {
-
-		return ( $this->settings === '-1' );
-
-	}
-
-	/**
-	 * Whether the Term is set to use NO Form.
-	 *
-	 * @since   1.9.6
-	 *
-	 * @return  bool
-	 */
-	public function uses_no_form() {
-
-		return ( $this->settings === '0' );
 
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -58,6 +58,10 @@ Navigate to the Plugin's Settings at Settings > ConvertKit.
 
 == Changelog ==
 
+### 1.9.7.3 2022-xx-xx
+* Fix: Default Form would not display on Posts assigned to Categories, where Categories were created prior to 1.9.6.0 and site uses PHP 8.0 or greater
+* Fix: Categories: Improved wording of Form setting on per-Category level
+
 ### 1.9.7.2 2022-03-30
 * Fix: Default Form would not display on Posts due to regression in 1.9.7.1
 

--- a/views/backend/term/fields.php
+++ b/views/backend/term/fields.php
@@ -20,7 +20,7 @@
 			<div class="convertkit-select2-container">
 				<select name="wp-convertkit[form]" id="wp-convertkit-form" class="convertkit-select2">
 					<option value="0"<?php selected( 0, $convertkit_term->get_form() ); ?>>
-						<?php esc_html_e( 'None', 'convertkit' ); ?>
+						<?php esc_html_e( 'Default', 'convertkit' ); ?>
 					</option>
 					<?php
 					foreach ( $convertkit_forms->get() as $convertkit_form ) {
@@ -33,12 +33,12 @@
 					?>
 				</select>
 				<p class="description">
-					<?php _e( '<code>None</code>: do not display a form.', 'convertkit' ); /* phpcs:ignore */ ?>
+					<?php _e( '<code>Default</code>: Display a form based on the Post\'s settings.', 'convertkit' ); /* phpcs:ignore */ ?>
 					<br />
 					<?php
 					echo sprintf(
 						/* translators: Taxonomy Name */
-						esc_html__( 'Any other option will display that form after the main content for Posts in this %s.', 'convertkit' ),
+						esc_html__( 'Any other option will display that form after the main content for Posts assigned to this %s.', 'convertkit' ),
 						'category'
 					);
 					?>


### PR DESCRIPTION
## Summary

The Default Form for Posts would fail to display when all of the following conditions are met:
1. WordPress Categories are created prior to 1.9.6.0
2. Those WordPress Categories are assigned to WordPress Posts, regardless of the Plugin version
3. The site(s) in question use PHP 8.0 or greater.

This is because Plugin versions prior to 1.9.6.0 would store the Form setting at Category level as either `default` or a Form ID; 1.9.6.0 and later store the Form setting at Category level as either `0` or a Form ID.

(I made this change at the time working on 1.9.6.0 because the `None` label had a value of `default`, compared with the `None` label having a value of `0` for this setting on Pages or Posts, which seemed incorrect/inconsistent.  Turns out, `None` at Category level really means "Don't specify a Category-specific Form, but use the Post's Form setting, or failing that, the Plugin Default Post Form setting").

This check would return false regardless of whether the Category setting `$this->settings` is `default` or `0`, meaning that the Post (or Plugin) level Form would be correctly used:
https://github.com/ConvertKit/convertkit-wordpress/blob/fba68fa095558881088b56fbdcf7ea900cd7bcc3/includes/class-convertkit-term.php#L97-L101

However, due to changes in PHP 8.0 and greater, regarding [how string comparisons are performed](https://www.php.net/manual/en/language.operators.comparison.php) against numbers, this check would return:
- `false` if `$this->settings` is `0` (therefore meaning no Category specific Form exists)
- `true` if `$this->settings` is `default` (therefore meaning a Category specific Form exists, but really the setting is telling us to use the Post or Plugin level setting).

This PR resolves by:
- checking if the setting is a string matching `default` prior to the standard comparison check,
- removing unused functions in the `ConvertKit_Term` class,
- change the `None` label for Form selection when editing a Category to `Default`, and updated the description to explain that, Default = Display a form based on the Post's settings.
![Screenshot 2022-04-04 at 15 13 02](https://user-images.githubusercontent.com/1462305/161562930-882a0239-0e72-421c-b28a-cfd88eda7aad.png)

## Testing

- `PostFormCest:testAddNewPostUsingDefaultFormWithCategoryCreatedBefore1960`: Tests that the Default Form specified for Posts is honored when a Post is created and assigned to a Category created prior to 1.9.6.0.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)