### PR TITLE
Tests: Helper function for adding Gutenberg Block

### DIFF
--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -55,6 +55,28 @@ class Acceptance extends \Codeception\Module
 		} catch ( \Facebook\WebDriver\Exception\TimeoutException $e ) {
 		}
 	}
+
+	/**
+	 * Add the given block when adding or editing a Page, Post or Custom Post Type
+	 * in Gutenberg.
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
+	 * @param 	string 				$blockName 				Block Name (e.g. 'ConvertKit Form')
+	 * @param 	string 				$blockProgrammaticName 	Programmatic Block Name (e.g. 'convertkit-form')
+	 */
+	public function addGutenbergBlock($I, $blockName, $blockProgrammaticName)
+	{
+		// Click Add Block Button.
+		$I->click('button.edit-post-header-toolbar__inserter-toggle');
+
+		// When the Blocks sidebar appears, search for the block.
+		$I->waitForElementVisible('.interface-interface-skeleton__secondary-sidebar[aria-label="Block library"]');
+		$I->fillField('.block-editor-inserter__content input[type=search]', $blockName);
+		$I->seeElementInDOM('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
+		$I->click('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
+	}
 	
 	/**
 	 * Helper method to activate the ConvertKit Plugin, checking

--- a/tests/acceptance/PageBlockFormCest.php
+++ b/tests/acceptance/PageBlockFormCest.php
@@ -43,16 +43,10 @@ class PageBlockFormCest
 		// Define a Page Title.
 		$I->fillField('.editor-post-title__input', 'ConvertKit: Form: Block: Valid Form Param');
 
-		// Click Add Block Button.
-		$I->click('button.edit-post-header-toolbar__inserter-toggle');
+		// Add block to Page.
+		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form');
 
-		// When the Blocks sidebar appears, search for the ConvertKit Form block.
-		$I->waitForElementVisible('.interface-interface-skeleton__secondary-sidebar[aria-label="Block library"]');
-		$I->fillField('.block-editor-inserter__content input[type=search]', 'ConvertKit Form');
-		$I->seeElementInDOM('.block-editor-inserter__panel-content button.editor-block-list-item-convertkit-form');
-		$I->click('.block-editor-inserter__panel-content button.editor-block-list-item-convertkit-form');
-
-		// When the sidebar appears, select the Form.
+		// When the sidebar appears, select the Form in the Block.
 		$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
 		$I->selectOption('#convertkit_form_form', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
@@ -92,14 +86,8 @@ class PageBlockFormCest
 		// Define a Page Title.
 		$I->fillField('.editor-post-title__input', 'ConvertKit: Legacy Form: Block: Valid Form Param');
 
-		// Click Add Block Button.
-		$I->click('button.edit-post-header-toolbar__inserter-toggle');
-
-		// When the Blocks sidebar appears, search for the ConvertKit Form block.
-		$I->waitForElementVisible('.interface-interface-skeleton__secondary-sidebar[aria-label="Block library"]');
-		$I->fillField('.block-editor-inserter__content input[type=search]', 'ConvertKit Form');
-		$I->seeElementInDOM('.block-editor-inserter__panel-content button.editor-block-list-item-convertkit-form');
-		$I->click('.block-editor-inserter__panel-content button.editor-block-list-item-convertkit-form');
+		// Add block to Page.
+		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form');
 
 		// When the sidebar appears, select the Form.
 		$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
@@ -142,14 +130,8 @@ class PageBlockFormCest
 		// Define a Page Title.
 		$I->fillField('.editor-post-title__input', 'ConvertKit: Form: Block: Valid Modal Form Param');
 
-		// Click Add Block Button.
-		$I->click('button.edit-post-header-toolbar__inserter-toggle');
-
-		// When the Blocks sidebar appears, search for the ConvertKit Form block.
-		$I->waitForElementVisible('.interface-interface-skeleton__secondary-sidebar[aria-label="Block library"]');
-		$I->fillField('.block-editor-inserter__content input[type=search]', 'ConvertKit Form');
-		$I->seeElementInDOM('.block-editor-inserter__panel-content button.editor-block-list-item-convertkit-form');
-		$I->click('.block-editor-inserter__panel-content button.editor-block-list-item-convertkit-form');
+		// Add block to Page.
+		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form');
 
 		// When the sidebar appears, select the Form.
 		$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
@@ -202,14 +184,8 @@ class PageBlockFormCest
 		// Define a Page Title.
 		$I->fillField('.editor-post-title__input', 'ConvertKit: Form: Block: Valid Slide In Form Param');
 
-		// Click Add Block Button.
-		$I->click('button.edit-post-header-toolbar__inserter-toggle');
-
-		// When the Blocks sidebar appears, search for the ConvertKit Form block.
-		$I->waitForElementVisible('.interface-interface-skeleton__secondary-sidebar[aria-label="Block library"]');
-		$I->fillField('.block-editor-inserter__content input[type=search]', 'ConvertKit Form');
-		$I->seeElementInDOM('.block-editor-inserter__panel-content button.editor-block-list-item-convertkit-form');
-		$I->click('.block-editor-inserter__panel-content button.editor-block-list-item-convertkit-form');
+		// Add block to Page.
+		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form');
 
 		// When the sidebar appears, select the Form.
 		$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
@@ -262,14 +238,8 @@ class PageBlockFormCest
 		// Define a Page Title.
 		$I->fillField('.editor-post-title__input', 'ConvertKit: Form: Block: Valid Sticky Bar Form Param');
 
-		// Click Add Block Button.
-		$I->click('button.edit-post-header-toolbar__inserter-toggle');
-
-		// When the Blocks sidebar appears, search for the ConvertKit Form block.
-		$I->waitForElementVisible('.interface-interface-skeleton__secondary-sidebar[aria-label="Block library"]');
-		$I->fillField('.block-editor-inserter__content input[type=search]', 'ConvertKit Form');
-		$I->seeElementInDOM('.block-editor-inserter__panel-content button.editor-block-list-item-convertkit-form');
-		$I->click('.block-editor-inserter__panel-content button.editor-block-list-item-convertkit-form');
+		// Add block to Page.
+		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form');
 
 		// When the sidebar appears, select the Form.
 		$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
@@ -321,14 +291,8 @@ class PageBlockFormCest
 		// Define a Page Title.
 		$I->fillField('.editor-post-title__input', 'ConvertKit: Form: Block: No Form Param');
 
-		// Click Add Block Button.
-		$I->click('button.edit-post-header-toolbar__inserter-toggle');
-
-		// When the Blocks sidebar appears, search for the ConvertKit Form block.
-		$I->waitForElementVisible('.interface-interface-skeleton__secondary-sidebar[aria-label="Block library"]');
-		$I->fillField('.block-editor-inserter__content input[type=search]', 'ConvertKit Form');
-		$I->seeElementInDOM('.block-editor-inserter__panel-content button.editor-block-list-item-convertkit-form');
-		$I->click('.block-editor-inserter__panel-content button.editor-block-list-item-convertkit-form');
+		// Add block to Page.
+		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form');
 
 		// Confirm that the Form block displays instructions to the user on how to select a Form.
 		$I->see('Select a Form using the Form option in the Gutenberg sidebar.', [


### PR DESCRIPTION
## Summary

Refactors tests to use a helper function to insert a Gutenberg Block.

## Testing

- `PageBlockFormCest` tests the ConvertKit Form Block, and can be used to confirm no breaking changes to tests.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)