### PR TITLE
Add API function for posts endpoint

### DIFF
--- a/includes/class-convertkit-api.php
+++ b/includes/class-convertkit-api.php
@@ -732,6 +732,66 @@ class ConvertKit_API {
 	}
 
 	/**
+	 * Gets posts from the API.
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @param 	int 	$page 		Page number.
+	 * @param 	int 	$per_page 	Number of Posts to return.
+	 * @return  WP_Error|array
+	 */
+	public function get_posts( $page = 1, $per_page = 10 ) {
+
+		$this->log( 'API: get_posts()' );
+
+		// Sanitize some parameters.
+		$page = absint( $page );
+		$per_page = absint( $per_page );
+
+		// Sanity check that parameters aren't outside of the bounds as defined by the API.
+		if ( $page < 1 ) {
+			return new WP_Error( 'convertkit_api_error', __( 'get_posts(): the page parameter must be equal to or greater than 1.', 'convertkit' ) );
+		}
+		if ( $per_page < 1 ) {
+			return new WP_Error( 'convertkit_api_error', __( 'get_posts(): the per_page parameter must be equal to or greater than 1.', 'convertkit' ) );
+		}
+		if ( $per_page > 50) {
+			return new WP_Error( 'convertkit_api_error', __( 'get_posts(): the per_page parameter must be equal to or less than 50.', 'convertkit' ) );
+		}
+
+		$posts = array();
+
+		// Send request.
+		$response = $this->get(
+			'posts',
+			array(
+				'api_key' => $this->api_key,
+				'page'	  => $page,
+				'per_page'=> $per_page,
+			)
+		);
+
+		// If an error occured, return WP_Error.
+		if ( is_wp_error( $response ) ) {
+			$this->log( 'API: get_posts(): Error: ' . $response->get_error_message() );
+			return $response;
+		}
+
+		// If no custom fields exist, return WP_Error.
+		if ( ! isset( $response['posts'] ) ) {
+			$this->log( 'API: get_posts(): Error: No broadcasts exist in ConvertKit.' );
+			return new WP_Error( 'convertkit_api_error', __( 'No posts exist in ConvertKit. Visit your ConvertKit account and create your first broadcast.', 'convertkit' ) );
+		}
+		if ( ! count( $response['posts'] ) ) {
+			$this->log( 'API: get_posts(): Error: No broadcasts exist in ConvertKit.' );
+			return new WP_Error( 'convertkit_api_error', __( 'No posts exist in ConvertKit. Visit your ConvertKit account and create your first broadcast.', 'convertkit' ) );
+		}
+
+		return $response['posts'];
+
+	}
+
+	/**
 	 * Get HTML from ConvertKit for the given Legacy Form ID.
 	 *
 	 * This isn't specifically an API function, but for now it's best suited here.

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -499,6 +499,78 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
+	 * Test that the `get_posts()` function returns expected data.
+	 * 
+	 * @since 	1.9.7.4
+	 */
+	public function testGetPosts()
+	{
+		$result = $this->api->get_posts();
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', reset($result)); // @TODO
+		$this->assertArrayHasKey('name', reset($result)); // @TODO
+	}
+
+	/**
+	 * Test that the `get_posts()` function returns expected data
+	 * when valid parameters are included.
+	 * 
+	 * @since 	1.9.7.4
+	 */
+	public function testGetPostsWithValidParameters()
+	{
+		$result = $this->api->get_posts(1, 5);
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', reset($result)); // @TODO
+		$this->assertArrayHasKey('name', reset($result)); // @TODO
+		// @TODO Assert only 5 posts are returned
+	}
+
+	/**
+	 * Test that the `get_posts()` function returns an error
+	 * when the page parameter is less than 1.
+	 * 
+	 * @since 	1.9.7.4
+	 */
+	public function testGetPostsWithInvalidPageParameter()
+	{
+		$result = $this->api->get_posts(-1);
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+		$this->assertEquals('get_posts(): the page parameter must be equal to or greater than 1.', $result->get_error_message());
+	}
+
+	/**
+	 * Test that the `get_posts()` function returns an error
+	 * when the per_page parameter is less than 1.
+	 * 
+	 * @since 	1.9.7.4
+	 */
+	public function testGetPostsWithNegativePerPageParameter()
+	{
+		$result = $this->api->get_posts(1, -1);
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+		$this->assertEquals('get_posts(): the per_page parameter must be equal to or greater than 1.', $result->get_error_message());
+	}
+
+	/**
+	 * Test that the `get_posts()` function returns an error
+	 * when the per_page parameter is greater than 50.
+	 * 
+	 * @since 	1.9.7.4
+	 */
+	public function testGetPostsWithOutOfBoundsPerPageParameter()
+	{
+		$result = $this->api->get_posts(1, 100);
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+		$this->assertEquals('get_posts(): the per_page parameter must be equal to or less than 50.', $result->get_error_message());
+	}
+
+	/**
 	 * Test that the `purchase_create()` function returns expected data
 	 * when valid parameters are provided.
 	 * 


### PR DESCRIPTION
## Summary

Adds the `get_posts()` function to the Plugin's API class to query the `posts` API endpoint, which will be used by e.g. the broadcasts list/block in a later PR.

## Testing

- `APITest`: Added WordPress Unit tests for the `get_posts()` function. 

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)