### PR TITLE
Add expiration to cached resources

### DIFF
--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -269,12 +269,14 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 		// Fetch Posts.
 		$posts = new ConvertKit_Resource_Posts();
 
-		// If no Posts exist, fetch them now from the API, storing them in the resource.
-		if ( ! $posts->exist() ) {
+		// If this is an admin request, refresh the Posts resource now from the API,
+		// as it's an inexpensive query of ~ 0.5 seconds when we're editing a Page
+		// containing this block.
+		if ( function_exists( 'is_admin' ) && is_admin() ) {
 			$posts->refresh();
 		}
 
-		// If there are still no Posts after fetching them from the API, bail.
+		// If no Posts exist, bail.
 		if ( ! $posts->exist() ) {
 			if ( $settings->debug_enabled() ) {
 				return '<!-- ' . __( 'No Broadcasts exist in ConvertKit.', 'convertkit' ) . ' -->';
@@ -305,6 +307,27 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 		$html = apply_filters( 'convertkit_block_broadcasts_render', $html, $atts );
 
 		return $html;
+
+	}
+
+	/**
+	 * Helper function to determine if the request is a REST API request.
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @return  bool    Is REST API Request
+	 */
+	private function is_rest_api_request() {
+
+		if ( ! defined( 'REST_REQUEST' ) ) {
+			return false;
+		}
+
+		if ( ! REST_REQUEST ) {
+			return false;
+		}
+
+		return true;
 
 	}
 

--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -29,13 +29,6 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource {
 	public $type = 'forms';
 
 	/**
-	 * Holds the forms from the ConvertKit API
-	 *
-	 * @var     WP_Error|array
-	 */
-	public $resources = array();
-
-	/**
 	 * Returns the HTML/JS markup for the given Form ID.
 	 *
 	 * Legacy Forms will return HTML.

--- a/includes/class-convertkit-resource-landing-pages.php
+++ b/includes/class-convertkit-resource-landing-pages.php
@@ -29,13 +29,6 @@ class ConvertKit_Resource_Landing_Pages extends ConvertKit_Resource {
 	public $type = 'landing_pages';
 
 	/**
-	 * Holds the forms from the ConvertKit API
-	 *
-	 * @var     WP_Error|array
-	 */
-	public $resources = array();
-
-	/**
 	 * Returns the HTML/JS markup for the given Landing Page ID
 	 *
 	 * @since   1.9.6

--- a/includes/class-convertkit-resource-posts.php
+++ b/includes/class-convertkit-resource-posts.php
@@ -29,10 +29,11 @@ class ConvertKit_Resource_Posts extends ConvertKit_Resource {
 	public $type = 'posts';
 
 	/**
-	 * Holds the posts from the ConvertKit API
+	 * The number of seconds resources are valid, before they should be
+	 * fetched again from the API.
 	 *
-	 * @var     WP_Error|array
+	 * @var     int
 	 */
-	public $resources = array();
+	public $cache_for = DAY_IN_SECONDS;
 
 }

--- a/includes/class-convertkit-resource-posts.php
+++ b/includes/class-convertkit-resource-posts.php
@@ -34,6 +34,6 @@ class ConvertKit_Resource_Posts extends ConvertKit_Resource {
 	 *
 	 * @var     int
 	 */
-	public $cache_for = DAY_IN_SECONDS;
+	public $cache_duration = DAY_IN_SECONDS;
 
 }

--- a/includes/class-convertkit-resource-tags.php
+++ b/includes/class-convertkit-resource-tags.php
@@ -28,11 +28,4 @@ class ConvertKit_Resource_Tags extends ConvertKit_Resource {
 	 */
 	public $type = 'tags';
 
-	/**
-	 * Holds the forms from the ConvertKit API
-	 *
-	 * @var     WP_Error|array
-	 */
-	public $resources = array();
-
 }

--- a/tests/wpunit/ResourceFormsTest.php
+++ b/tests/wpunit/ResourceFormsTest.php
@@ -56,7 +56,7 @@ class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 		// Delete API Key, API Secret and Resources from Plugin's settings.
 		delete_option($this->settings::SETTINGS_NAME);
 		delete_option($this->resource->settings_name);
-		delete_option($this->resource->settings_name . '_expiry');
+		delete_option($this->resource->settings_name . '_last_queried');
 		parent::tearDown();
 	}
 
@@ -81,11 +81,11 @@ class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testExpiry()
 	{
-		// Define the expected expiry date based on the resource class' $cache_for setting.
-		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_for);
+		// Define the expected expiry date based on the resource class' $cache_duration setting.
+		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
 
 		// Fetch the actual expiry date set when the resource class was initialized.
-		$expiryDate = date('Y-m-d', $this->resource->expiry);
+		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
 
 		// Confirm both dates match.
 		$this->assertEquals($expectedExpiryDate, $expiryDate);

--- a/tests/wpunit/ResourceFormsTest.php
+++ b/tests/wpunit/ResourceFormsTest.php
@@ -42,11 +42,8 @@ class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 		]);
 
 		// Initialize the resource class we want to test.
-		$this->resource         = new ConvertKit_Resource_Forms();
-
-		// Refresh the resource, which will fetch the data from the API and store them in the option table.
-		$result = $this->resource->refresh();
-		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->resource = new ConvertKit_Resource_Forms();
+		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
 	}
 
 	/**
@@ -59,6 +56,7 @@ class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 		// Delete API Key, API Secret and Resources from Plugin's settings.
 		delete_option($this->settings::SETTINGS_NAME);
 		delete_option($this->resource->settings_name);
+		delete_option($this->resource->settings_name . '_expiry');
 		parent::tearDown();
 	}
 
@@ -70,10 +68,27 @@ class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 	public function testRefresh()
 	{
 		// Confirm that the data is stored in the options table and includes some expected keys.
-		$result = get_option($this->resource->settings_name);
+		$result = $this->resource->refresh();
 		$this->assertIsArray($result);
 		$this->assertArrayHasKey('id', reset($result));
 		$this->assertArrayHasKey('name', reset($result));
+	}
+
+	/**
+	 * Test that the expiry timestamp is set and returns the expected value.
+	 * 
+	 * @since 	1.9.7.4
+	 */
+	public function testExpiry()
+	{
+		// Define the expected expiry date based on the resource class' $cache_for setting.
+		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_for);
+
+		// Fetch the actual expiry date set when the resource class was initialized.
+		$expiryDate = date('Y-m-d', $this->resource->expiry);
+
+		// Confirm both dates match.
+		$this->assertEquals($expectedExpiryDate, $expiryDate);
 	}
 
 	/**

--- a/tests/wpunit/ResourceLandingPagesTest.php
+++ b/tests/wpunit/ResourceLandingPagesTest.php
@@ -42,11 +42,8 @@ class ResourceLandingPagesTest extends \Codeception\TestCase\WPTestCase
 		]);
 
 		// Initialize the resource class we want to test.
-		$this->resource         = new ConvertKit_Resource_Landing_Pages();
-
-		// Refresh the resource, which will fetch the data from the API and store them in the option table.
-		$result = $this->resource->refresh();
-		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->resource = new ConvertKit_Resource_Landing_Pages();
+		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
 	}
 
 	/**
@@ -59,6 +56,7 @@ class ResourceLandingPagesTest extends \Codeception\TestCase\WPTestCase
 		// Delete API Key, API Secret and Resources from Plugin's settings.
 		delete_option($this->settings::SETTINGS_NAME);
 		delete_option($this->resource->settings_name);
+		delete_option($this->resource->settings_name . '_expiry');
 		parent::tearDown();
 	}
 
@@ -70,10 +68,27 @@ class ResourceLandingPagesTest extends \Codeception\TestCase\WPTestCase
 	public function testRefresh()
 	{
 		// Confirm that the data is stored in the options table and includes some expected keys.
-		$result = get_option($this->resource->settings_name);
+		$result = $this->resource->refresh();
 		$this->assertIsArray($result);
 		$this->assertArrayHasKey('id', reset($result));
 		$this->assertArrayHasKey('name', reset($result));
+	}
+
+	/**
+	 * Test that the expiry timestamp is set and returns the expected value.
+	 * 
+	 * @since 	1.9.7.4
+	 */
+	public function testExpiry()
+	{
+		// Define the expected expiry date based on the resource class' $cache_for setting.
+		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_for);
+
+		// Fetch the actual expiry date set when the resource class was initialized.
+		$expiryDate = date('Y-m-d', $this->resource->expiry);
+
+		// Confirm both dates match.
+		$this->assertEquals($expectedExpiryDate, $expiryDate);
 	}
 
 	/**

--- a/tests/wpunit/ResourceLandingPagesTest.php
+++ b/tests/wpunit/ResourceLandingPagesTest.php
@@ -56,7 +56,7 @@ class ResourceLandingPagesTest extends \Codeception\TestCase\WPTestCase
 		// Delete API Key, API Secret and Resources from Plugin's settings.
 		delete_option($this->settings::SETTINGS_NAME);
 		delete_option($this->resource->settings_name);
-		delete_option($this->resource->settings_name . '_expiry');
+		delete_option($this->resource->settings_name . '_last_queried');
 		parent::tearDown();
 	}
 
@@ -81,11 +81,11 @@ class ResourceLandingPagesTest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testExpiry()
 	{
-		// Define the expected expiry date based on the resource class' $cache_for setting.
-		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_for);
+		// Define the expected expiry date based on the resource class' $cache_duration setting.
+		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
 
 		// Fetch the actual expiry date set when the resource class was initialized.
-		$expiryDate = date('Y-m-d', $this->resource->expiry);
+		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
 
 		// Confirm both dates match.
 		$this->assertEquals($expectedExpiryDate, $expiryDate);

--- a/tests/wpunit/ResourcePostsTest.php
+++ b/tests/wpunit/ResourcePostsTest.php
@@ -42,11 +42,8 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 		]);
 
 		// Initialize the resource class we want to test.
-		$this->resource         = new ConvertKit_Resource_Posts();
-
-		// Refresh the resource, which will fetch the data from the API and store them in the option table.
-		$result = $this->resource->refresh();
-		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->resource = new ConvertKit_Resource_Posts();
+		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
 	}
 
 	/**
@@ -59,6 +56,7 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 		// Delete API Key, API Secret and Resources from Plugin's settings.
 		delete_option($this->settings::SETTINGS_NAME);
 		delete_option($this->resource->settings_name);
+		delete_option($this->resource->settings_name . '_expiry');
 		parent::tearDown();
 	}
 
@@ -70,10 +68,27 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 	public function testRefresh()
 	{
 		// Confirm that the data is stored in the options table and includes some expected keys.
-		$result = get_option($this->resource->settings_name);
+		$result = $this->resource->refresh();
 		$this->assertIsArray($result);
 		$this->assertArrayHasKey('id', reset($result));
 		$this->assertArrayHasKey('title', reset($result));
+	}
+
+	/**
+	 * Test that the expiry timestamp is set and returns the expected value.
+	 * 
+	 * @since 	1.9.7.4
+	 */
+	public function testExpiry()
+	{
+		// Define the expected expiry date based on the resource class' $cache_for setting.
+		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_for);
+
+		// Fetch the actual expiry date set when the resource class was initialized.
+		$expiryDate = date('Y-m-d', $this->resource->expiry);
+
+		// Confirm both dates match.
+		$this->assertEquals($expectedExpiryDate, $expiryDate);
 	}
 
 	/**

--- a/tests/wpunit/ResourcePostsTest.php
+++ b/tests/wpunit/ResourcePostsTest.php
@@ -56,7 +56,7 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 		// Delete API Key, API Secret and Resources from Plugin's settings.
 		delete_option($this->settings::SETTINGS_NAME);
 		delete_option($this->resource->settings_name);
-		delete_option($this->resource->settings_name . '_expiry');
+		delete_option($this->resource->settings_name . '_last_queried');
 		parent::tearDown();
 	}
 
@@ -81,11 +81,11 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testExpiry()
 	{
-		// Define the expected expiry date based on the resource class' $cache_for setting.
-		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_for);
+		// Define the expected expiry date based on the resource class' $cache_duration setting.
+		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
 
 		// Fetch the actual expiry date set when the resource class was initialized.
-		$expiryDate = date('Y-m-d', $this->resource->expiry);
+		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
 
 		// Confirm both dates match.
 		$this->assertEquals($expectedExpiryDate, $expiryDate);

--- a/tests/wpunit/ResourceTagsTest.php
+++ b/tests/wpunit/ResourceTagsTest.php
@@ -56,7 +56,7 @@ class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 		// Delete API Key, API Secret and Resources from Plugin's settings.
 		delete_option($this->settings::SETTINGS_NAME);
 		delete_option($this->resource->settings_name);
-		delete_option($this->resource->settings_name . '_expiry');
+		delete_option($this->resource->settings_name . '_last_queried');
 		parent::tearDown();
 	}
 
@@ -81,11 +81,11 @@ class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testExpiry()
 	{
-		// Define the expected expiry date based on the resource class' $cache_for setting.
-		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_for);
+		// Define the expected expiry date based on the resource class' $cache_duration setting.
+		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
 
 		// Fetch the actual expiry date set when the resource class was initialized.
-		$expiryDate = date('Y-m-d', $this->resource->expiry);
+		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
 
 		// Confirm both dates match.
 		$this->assertEquals($expectedExpiryDate, $expiryDate);

--- a/tests/wpunit/ResourceTagsTest.php
+++ b/tests/wpunit/ResourceTagsTest.php
@@ -42,11 +42,8 @@ class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 		]);
 
 		// Initialize the resource class we want to test.
-		$this->resource         = new ConvertKit_Resource_Tags();
-
-		// Refresh the resource, which will fetch the data from the API and store them in the option table.
-		$result = $this->resource->refresh();
-		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->resource = new ConvertKit_Resource_Tags();
+		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
 	}
 
 	/**
@@ -59,6 +56,7 @@ class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 		// Delete API Key, API Secret and Resources from Plugin's settings.
 		delete_option($this->settings::SETTINGS_NAME);
 		delete_option($this->resource->settings_name);
+		delete_option($this->resource->settings_name . '_expiry');
 		parent::tearDown();
 	}
 
@@ -70,10 +68,27 @@ class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 	public function testRefresh()
 	{
 		// Confirm that the data is stored in the options table and includes some expected keys.
-		$result = get_option($this->resource->settings_name);
+		$result = $this->resource->refresh();
 		$this->assertIsArray($result);
 		$this->assertArrayHasKey('id', reset($result));
 		$this->assertArrayHasKey('name', reset($result));
+	}
+
+	/**
+	 * Test that the expiry timestamp is set and returns the expected value.
+	 * 
+	 * @since 	1.9.7.4
+	 */
+	public function testExpiry()
+	{
+		// Define the expected expiry date based on the resource class' $cache_for setting.
+		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_for);
+
+		// Fetch the actual expiry date set when the resource class was initialized.
+		$expiryDate = date('Y-m-d', $this->resource->expiry);
+
+		// Confirm both dates match.
+		$this->assertEquals($expectedExpiryDate, $expiryDate);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

When ConvertKit Forms, Tags, Landing Pages or Posts ('resources') are fetched from the API, they're presently cached indefinitely (with no expiration) in WordPress' options table for performance, and to prevent multiple calls to the API.

These cached resources are refreshed when navigating to `WordPress Admin > Settings > ConvertKit`.

For Forms, Landing Pages and Tags, it's unlikely that these resources are changed in ConvertKit often - so performing the above step to force a refresh isn't an issue.

However, for the list of broadcasts, it's likely that:
1. User adds the [broadcast block / shortcode](https://github.com/ConvertKit/convertkit-wordpress/pull/301) to a WordPress Page, configured to show e.g. the latest 3 broadcasts
2. User creates a new broadcast in ConvertKit the next day
3. Broadcast block / shortcode on the WordPress Page reads the cached resources, therefore not reflecting the change in (2).

It's not viable to query the `posts` endpoint every time a list of broadcasts are displayed, as this can take ~ 0.5 seconds, slowing the overall page load time accordingly:
![posts-query](https://user-images.githubusercontent.com/1462305/164247844-1ca19c67-a516-42c8-9ab2-31df52e4ea66.png)

To resolve, this PR:
- Adds an expiration option of 24 hours for cached broadcasts,
- Adds an expiration option of 1 year for cached forms, tags and landing pages,
- Force refreshes the broadcasts when editing a WordPress Page that includes the broadcast block / shortcode.

Subsequently, if a request is made to display e.g. a list of broadcasts, and the cache has expired, a single request is made to the API to update the cached resources.

This still isn't perfect, as there's a potential window of up to 24 hours from a broadcast being created in ConvertKit to appearing in the broadcasts list. I'm open to reducing these expiration times if there's a better suggestion that balances keeping resources up to date whilst avoiding a spike in API requests.

Longer term, it would be preferable that [webhook events from the API](https://developers.convertkit.com/#webhooks) can be extended to include when a form, tag, sequence, landing page or broadcast is added, edited or deleted.  This would allow the Plugin to register a webhook through the API, and proactively refresh the cached resources when notified by ConvertKit's events, instead of needing to use this expiry based system.

## Testing

- `WPUnit` tests updated to confirm resource cache expiration is honored

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)