### PR TITLE
Broadcast Block: Setting `Number of posts` to blank would crash block 

### DIFF
--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -128,6 +128,15 @@ function convertKitGutenbergRegisterBlock( block ) {
 								value: 		props.attributes[ attribute ],
 								onChange: 	function( value ) {
 									if ( field.type == 'number' ) {
+										// If value is a blank string i.e. no attribute value was provided,
+										// cast it to the field's minimum number setting.
+										// This prevents WordPress' block renderer API returning a 400 error
+										// because a blank value will be passed as a string, when WordPress
+										// expects it to be a numerical value.
+										if ( value === '' ) {
+											value = field.min;
+										}
+
 										// Cast value to integer if a value exists.
 										if ( value.length > 0 ) {
 											value = Number( value );

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -77,23 +77,23 @@ class Acceptance extends \Codeception\Module
 		$I->seeElementInDOM('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
 		$I->click('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
 	}
-	
-	/**
-	 * Add the given block when adding or editing a Page, Post or Custom Post Type
-	 * in Gutenberg.
-	 * 
-	 * @since 	1.9.6.9
-	 */
-	public function gutenbergAddBlock($I, $blockName, $blockProgrammaticName)
-	{
-		// Click Add Block Button.
-		$I->click('button.edit-post-header-toolbar__inserter-toggle');
 
-		// When the Blocks sidebar appears, search for the block.
-		$I->waitForElementVisible('.interface-interface-skeleton__secondary-sidebar[aria-label="Block library"]');
-		$I->fillField('.block-editor-inserter__content input[type=search]', $blockName);
-		$I->seeElementInDOM('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
-		$I->click('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
+	/**
+	 * Check that the given block did not output any errors when rendered in the
+	 * Gutenberg editor.
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
+	 * @param 	string 				$blockName 				Block Name (e.g. 'ConvertKit Form')
+	 */
+	public function checkGutenbergBlockHasNoErrors($I, $blockName)
+	{
+		// Wait a couple of seconds for the block to render.
+		sleep(2);
+
+		// Check that the "This block has encountered an error and cannot be previewed." element doesn't exist.
+		$I->dontSeeElementInDOM('.block-editor-block-list__layout div[data-title="'.$blockName.'"] .block-editor-block-list__block-crash-warning');
 	}
 
 	/**

--- a/tests/acceptance/PageBlockBroadcastsCest.php
+++ b/tests/acceptance/PageBlockBroadcastsCest.php
@@ -44,7 +44,7 @@ class PageBlockBroadcastsCest
 		$I->fillField('.editor-post-title__input', 'ConvertKit: Page: Broadcasts: Default Params');
 
 		// Add block to Page.
-		$I->gutenbergAddBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
+		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
 
 		// Click the Publish button.
 		$I->click('.editor-post-publish-button__button');
@@ -91,7 +91,7 @@ class PageBlockBroadcastsCest
 		$I->fillField('.editor-post-title__input', 'ConvertKit: Page: Broadcasts: Date Format Param');
 
 		// Add block to Page.
-		$I->gutenbergAddBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
+		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
 
 		// When the sidebar appears, define the date format.
 		$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
@@ -142,7 +142,7 @@ class PageBlockBroadcastsCest
 		$I->fillField('.editor-post-title__input', 'ConvertKit: Page: Broadcasts: Limit Param');
 
 		// Add block to Page.
-		$I->gutenbergAddBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
+		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
 
 		// When the sidebar appears, define the limit.
 		$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
@@ -175,6 +175,59 @@ class PageBlockBroadcastsCest
 
 		// Confirm that the expected number of Broadcasts are displayed.
 		$I->seeNumberOfElements('li.convertkit-broadcast', 2);
+	}
+
+	/**
+	 * Test the Broadcasts block renders when the limit parameter is blank.
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testBroadcastsBlockWithBlankLimitParameter(AcceptanceTester $I)
+	{
+		// Define a Page Title.
+		$I->fillField('.editor-post-title__input', 'ConvertKit: Page: Broadcasts: Blank Limit Param');
+
+		// Add block to Page.
+		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
+
+		// When the sidebar appears, blank the limit parameter as the user might, by pressing the backspace
+		// key twice.
+		$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
+		$I->pressKey('#convertkit_broadcasts_limit', \Facebook\WebDriver\WebDriverKeys::BACKSPACE );
+		$I->pressKey('#convertkit_broadcasts_limit', \Facebook\WebDriver\WebDriverKeys::BACKSPACE );
+
+		// Confirm that the block did not encounter an error and fail to render.
+		$I->checkGutenbergBlockHasNoErrors($I, 'ConvertKit Broadcasts');
+
+		// Click the Publish button.
+		$I->click('.editor-post-publish-button__button');
+		
+		// When the pre-publish panel displays, click Publish again.
+		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
+			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
+		});
+
+		// Wait for confirmation that the Page published.
+		$I->waitForElementVisible('.post-publish-panel__postpublish-buttons a.components-button');
+
+		// Load the Page on the frontend site.
+		$I->click('.post-publish-panel__postpublish-buttons a.components-button');
+
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible('body.page-template-default');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the block displays.
+		$I->seeElementInDOM('ul.convertkit-broadcasts');
+		$I->seeElementInDOM('ul.convertkit-broadcasts li.convertkit-broadcast');
+		$I->seeElementInDOM('ul.convertkit-broadcasts li.convertkit-broadcast a');	
+
+		// Confirm that the expected number of Broadcasts are displayed.
+		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Whilst the `Number of posts` option on the Broadcasts block is a number field, it's possible to define a blank value by pressing the backspace key.

![Screenshot 2022-04-25 at 17 02 22](https://user-images.githubusercontent.com/1462305/165136453-08073107-2efe-43de-b7c0-b4dc521ca721.png)

This would result in the block crashing, and failing to render, because the `limit` parameter is expected to be a numerical value, not a blank string.

![Screenshot 2022-04-25 at 17 02 28](https://user-images.githubusercontent.com/1462305/165136470-f9946ce0-b6e3-4a68-96ab-d60645e2334a.png)

This PR resolves by checking if any numerical parameter is a blank string, and if so setting its value to the field's minimum value. 

## Testing

- `PageBlockBroadcastsCest:testBroadcastsBlockWithBlankLimitParameter`: Emulates the above behaviour, confirming that no block error appears.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)