### PR TITLE
Plugin Activation and Deactivation routines

### DIFF
--- a/includes/class-convertkit-setup.php
+++ b/includes/class-convertkit-setup.php
@@ -23,7 +23,6 @@ class ConvertKit_Setup {
 	public function activate() {
 
 		// Call any functions to e.g. schedule WordPress Cron events now.
-	
 	}
 
 	/**
@@ -186,7 +185,6 @@ class ConvertKit_Setup {
 	public function deactivate() {
 
 		// Call any functions to e.g. unschedule WordPress Cron events now.
-
 	}
 
 }

--- a/includes/class-convertkit-setup.php
+++ b/includes/class-convertkit-setup.php
@@ -1,28 +1,46 @@
 <?php
 /**
- * ConvertKit Admin Upgrade class.
+ * Plugin activation, update and deactivation class.
  *
  * @package ConvertKit
- * @author ConvertKit
+ * @author  ConvertKit
  */
 
 /**
- * Runs upgrade routines when the Plugin is updated to a newer version
- * in WordPress.
+ * Runs any steps required on plugin activation, update and deactivation.
  *
- * @since   1.9.6
+ * @package ConvertKit
+ * @author  ConvertKit
+ * @version 1.9.7.4
  */
-class ConvertKit_Admin_Upgrade {
+class ConvertKit_Setup {
 
 	/**
-	 * Runs the upgrade routine once the plugin has loaded
+	 * Runs routines when the Plugin is activated.
 	 *
-	 * @since   1.9.6
+	 * @since   1.9.7.4
 	 */
-	public function run() {
+	public function activate() {
+
+		// Call any functions to e.g. schedule WordPress Cron events now.
+	
+	}
+
+	/**
+	 * Runs routines when the Plugin version has been updated.
+	 *
+	 * @since   1.9.7.4
+	 */
+	public function update() {
 
 		// Get installed Plugin version.
 		$current_version = get_option( 'convertkit_version' );
+
+		// If the version number matches the plugin version, no update routines
+		// need to run.
+		if ( $current_version === CONVERTKIT_PLUGIN_VERSION ) {
+			return;
+		}
 
 		/**
 		 * 1.4.1: Change ID to form_id for API version 3.0.
@@ -107,8 +125,8 @@ class ConvertKit_Admin_Upgrade {
 	private function change_id_to_form_id() {
 
 		// Bail if the API isn't configured.
-		$settings = new ConvertKit_Settings();
-		if ( ! $settings->has_api_key_and_secret() ) {
+		$convertkit_settings = new ConvertKit_Settings();
+		if ( ! $convertkit_settings->has_api_key_and_secret() ) {
 			return;
 		}
 
@@ -126,7 +144,7 @@ class ConvertKit_Admin_Upgrade {
 		}
 
 		// Initialize the API.
-		$api = new ConvertKit_API( $settings->get_api_key(), $settings->get_api_secret(), $settings->debug_enabled() );
+		$api = new ConvertKit_API( $convertkit_settings->get_api_key(), $convertkit_settings->get_api_secret(), $convertkit_settings->debug_enabled() );
 
 		// Get form mappings.
 		$mappings = $api->get_subscription_forms();
@@ -137,9 +155,9 @@ class ConvertKit_Admin_Upgrade {
 		}
 
 		// 1. Update global form.
-		$settings_data                 = $settings->get();
-		$settings_data['default_form'] = isset( $mappings[ $settings->get_default_form( 'post' ) ] ) ? $mappings[ $settings->get_default_form( 'post' ) ] : 0;
-		update_option( $settings::SETTINGS_NAME, $settings );
+		$settings_data                 = $convertkit_settings->get();
+		$settings_data['default_form'] = isset( $mappings[ $convertkit_settings->get_default_form( 'post' ) ] ) ? $mappings[ $convertkit_settings->get_default_form( 'post' ) ] : 0;
+		update_option( $convertkit_settings::SETTINGS_NAME, $settings_data );
 
 		// 2. Scan posts/pages for _wp_convertkit_post_meta and update IDs
 		// Scan content for shortcode and update
@@ -157,6 +175,17 @@ class ConvertKit_Admin_Upgrade {
 			unset( $posts[ $key ] );
 			update_option( '_wp_convertkit_upgrade_posts', $posts );
 		}
+
+	}
+
+	/**
+	 * Runs routines when the Plugin is deactivated.
+	 *
+	 * @since   1.9.7.4
+	 */
+	public function deactivate() {
+
+		// Call any functions to e.g. unschedule WordPress Cron events now.
 
 	}
 

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -68,11 +68,7 @@ class WP_ConvertKit {
 		$this->classes['admin_post']     = new ConvertKit_Admin_Post();
 		$this->classes['admin_settings'] = new ConvertKit_Admin_Settings();
 		$this->classes['admin_tinymce']  = new ConvertKit_Admin_TinyMCE();
-		$this->classes['admin_upgrade']  = new ConvertKit_Admin_Upgrade();
 		$this->classes['admin_user']     = new ConvertKit_Admin_User();
-
-		// Run upgrade routine.
-		add_action( 'init', array( $this->classes['admin_upgrade'], 'run' ), 2 );
 
 		/**
 		 * Initialize integration classes for the WordPress Administration interface.
@@ -163,8 +159,14 @@ class WP_ConvertKit {
 		$this->classes['elementor']                    = new ConvertKit_Elementor();
 		$this->classes['gutenberg']                    = new ConvertKit_Gutenberg();
 		$this->classes['review_request']               = new ConvertKit_Review_Request( 'ConvertKit', 'convertkit' );
+		$this->classes['setup']                        = new ConvertKit_Setup();
 		$this->classes['shortcodes']                   = new ConvertKit_Shortcodes();
 		$this->classes['widgets']                      = new ConvertKit_Widgets();
+
+		// Run the setup's update process on WordPress' init hook.
+		// Doing this sooner may result in errors with WordPress functions that are not yet
+		// available to the update routine.
+		add_action( 'init', array( $this, 'update' ) );
 
 		/**
 		 * Initialize integration classes for the frontend web site.
@@ -172,6 +174,19 @@ class WP_ConvertKit {
 		 * @since   1.9.6
 		 */
 		do_action( 'convertkit_initialize_global' );
+
+	}
+
+	/**
+	 * Runs the Plugin's update routine, which checks if
+	 * the Plugin has just been updated to a newer version,
+	 * and if so runs any specific processes that might be needed.
+	 *
+	 * @since   1.9.7.4
+	 */
+	public function update() {
+
+		$this->get_class( 'setup' )->update();
 
 	}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -7,6 +7,93 @@
  */
 
 /**
+ * Runs the activation and update routines when the plugin is activated.
+ *
+ * @since   1.9.7.4
+ *
+ * @param   bool $network_wide   Is network wide activation.
+ */
+function convertkit_plugin_activate( $network_wide ) {
+
+	// Initialise Plugin.
+	$convertkit = WP_ConvertKit();
+
+	// Check if we are on a multisite install, activating network wide, or a single install.
+	if ( ! is_multisite() || ! $network_wide ) {
+		// Single Site activation.
+		$convertkit->get_class( 'setup' )->activate();
+	} else {
+		// Multisite network wide activation.
+		$sites = get_sites(
+			array(
+				'number' => 0,
+			)
+		);
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site->blog_id );
+			$convertkit->get_class( 'setup' )->activate();
+			restore_current_blog();
+		}
+	}
+
+}
+
+/**
+ * Runs the activation and update routines when the plugin is activated
+ * on a WordPress multisite setup.
+ *
+ * @since   1.9.7.4
+ *
+ * @param   mixed $site_or_blog_id    WP_Site or Blog ID.
+ */
+function convertkit_plugin_activate_new_site( $site_or_blog_id ) {
+
+	// Check if $site_or_blog_id is a WP_Site or a blog ID.
+	if ( is_a( $site_or_blog_id, 'WP_Site' ) ) {
+		$site_or_blog_id = $site_or_blog_id->blog_id;
+	}
+
+	// Initialise Plugin.
+	$convertkit = WP_ConvertKit();
+
+	// Run installation routine.
+	switch_to_blog( $site_or_blog_id );
+	$convertkit->get_class( 'setup' )->activate();
+	restore_current_blog();
+
+}
+
+/**
+ * Runs the deactivation routine when the plugin is deactivated.
+ *
+ * @since   1.9.7.4
+ */
+function convertkit_plugin_deactivate() {
+
+	// Initialise Plugin.
+	$convertkit = WP_ConvertKit();
+
+	// Check if we are on a multisite install, activating network wide, or a single install.
+	if ( ! is_multisite() || ! $network_wide ) {
+		// Single Site activation.
+		$convertkit->get_class( 'setup' )->deactivate();
+	} else {
+		// Multisite network wide activation.
+		$sites = get_sites(
+			array(
+				'number' => 0,
+			)
+		);
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site->blog_id );
+			$convertkit->get_class( 'setup' )->deactivate();
+			restore_current_blog();
+		}
+	}
+
+}
+
+/**
  * Helper method to get supported Post Types.
  *
  * @since   1.9.6

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -67,8 +67,10 @@ function convertkit_plugin_activate_new_site( $site_or_blog_id ) {
  * Runs the deactivation routine when the plugin is deactivated.
  *
  * @since   1.9.7.4
+ *
+ * @param   bool $network_wide   Is network wide deactivation.
  */
-function convertkit_plugin_deactivate() {
+function convertkit_plugin_deactivate( $network_wide ) {
 
 	// Initialise Plugin.
 	$convertkit = WP_ConvertKit();

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -42,6 +42,7 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-resource-posts
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-resource-tags.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-review-request.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-settings.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-setup.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-shortcodes.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-system-info.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-term.php';
@@ -73,7 +74,6 @@ if ( is_admin() ) {
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-post.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-settings.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-tinymce.php';
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-upgrade.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-user.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-multi-value-field-table.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-settings-base.php';
@@ -86,6 +86,12 @@ if ( is_admin() ) {
 	// WishList Member Integration.
 	require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php';
 }
+
+// Register Plugin activation and deactivation functions.
+register_activation_hook( __FILE__, 'convertkit_plugin_activate' );
+add_action( 'wp_insert_site', 'convertkit_plugin_activate_new_site' );
+add_action( 'activate_blog', 'convertkit_plugin_activate_new_site' );
+register_deactivation_hook( __FILE__, 'convertkit_plugin_deactivate' );
 
 /**
  * Main function to return Plugin instance.


### PR DESCRIPTION
## Summary

Adds activation and deactivation functions to a single setup class, which are triggered when the Plugin is activated or deactivated in WordPress.

Also moves the existing update function into new setup class.

A future PR will then use these activation, update and deactivation hooks to schedule/unschedule a WordPress Cron event for automatically refreshing the broadcasts list from the API, as discussed in [this PR](https://github.com/ConvertKit/convertkit-wordpress/pull/302#pullrequestreview-951929261).

## Testing

Existing test coverage is sufficient; future PR's that use these activation / deactivation functions should include unit tests to confirm expected routines ran successfully.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)