### PR TITLE
Tests: Drop WishList Member Database Tables

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -205,7 +205,7 @@ jobs:
       # Run Codeception Acceptance Tests.
       - name: Run Acceptance Tests
         working-directory: ${{ env.PLUGIN_DIR }}
-        run: php vendor/bin/codecept run acceptance --fail-fast
+        run: php vendor/bin/codecept run acceptance WishListMemberCest --fail-fast
 
       # If the repository has other tests, such as unit tests, add the Codeception commands here to run them now.
 

--- a/tests/_data/dump.sql
+++ b/tests/_data/dump.sql
@@ -7,6 +7,56 @@ SET sql_mode = 'NO_AUTO_VALUE_ON_ZERO';
 
 SET NAMES utf8mb4;
 
+-- Drop WishList Member tables, as Plugin activation will create these.
+DROP TABLE IF EXISTS `wp_wlcc_contentarchiver`;
+DROP TABLE IF EXISTS `wp_wlcc_contentmanager_move`;
+DROP TABLE IF EXISTS `wp_wlcc_contentmanager_repost`;
+DROP TABLE IF EXISTS `wp_wlcc_contentmanager_set`;
+DROP TABLE IF EXISTS `wp_wlcc_contentsched`;
+DROP TABLE IF EXISTS `wp_wlm_api_queue`;
+DROP TABLE IF EXISTS `wp_wlm_contentlevel_options`;
+DROP TABLE IF EXISTS `wp_wlm_contentlevels`;
+DROP TABLE IF EXISTS `wp_wlm_email_queue`;
+DROP TABLE IF EXISTS `wp_wlm_emailbroadcast`;
+DROP TABLE IF EXISTS `wp_wlm_level_options`;
+DROP TABLE IF EXISTS `wp_wlm_logs`;
+DROP TABLE IF EXISTS `wp_wlm_options`;
+DROP TABLE IF EXISTS `wp_wlm_presto_player_visits`;
+DROP TABLE IF EXISTS `wp_wlm_user_options`;
+DROP TABLE IF EXISTS `wp_wlm_userlevel_options`;
+DROP TABLE IF EXISTS `wp_wlm_userlevels`;
+
+-- Drop WooCommerce tables, as Plugin activation will create these.
+DROP TABLE IF EXISTS `wp_wc_admin_note_actions`;
+DROP TABLE IF EXISTS `wp_wc_admin_notes`;
+DROP TABLE IF EXISTS `wp_wc_category_lookup`;
+DROP TABLE IF EXISTS `wp_wc_customer_lookup`;
+DROP TABLE IF EXISTS `wp_wc_download_log`;
+DROP TABLE IF EXISTS `wp_wc_order_coupon_lookup`;
+DROP TABLE IF EXISTS `wp_wc_order_product_lookup`;
+DROP TABLE IF EXISTS `wp_wc_order_stats`;
+DROP TABLE IF EXISTS `wp_wc_order_tax_lookup`;
+DROP TABLE IF EXISTS `wp_wc_product_attributes_lookup`;
+DROP TABLE IF EXISTS `wp_wc_product_meta_lookup`;
+DROP TABLE IF EXISTS `wp_wc_rate_limits`;
+DROP TABLE IF EXISTS `wp_wc_reserved_stock`;
+DROP TABLE IF EXISTS `wp_wc_tax_rate_classes`;
+DROP TABLE IF EXISTS `wp_wc_webhooks`;
+DROP TABLE IF EXISTS `wp_woocommerce_api_keys`;
+DROP TABLE IF EXISTS `wp_woocommerce_attribute_taxonomies`;
+DROP TABLE IF EXISTS `wp_woocommerce_downloadable_product_permissions`;
+DROP TABLE IF EXISTS `wp_woocommerce_log`;
+DROP TABLE IF EXISTS `wp_woocommerce_order_itemmeta`;
+DROP TABLE IF EXISTS `wp_woocommerce_order_items`;
+DROP TABLE IF EXISTS `wp_woocommerce_payment_tokenmeta`;
+DROP TABLE IF EXISTS `wp_woocommerce_payment_tokens`;
+DROP TABLE IF EXISTS `wp_woocommerce_sessions`;
+DROP TABLE IF EXISTS `wp_woocommerce_shipping_zone_locations`;
+DROP TABLE IF EXISTS `wp_woocommerce_shipping_zone_methods`;
+DROP TABLE IF EXISTS `wp_woocommerce_shipping_zones`;
+DROP TABLE IF EXISTS `wp_woocommerce_tax_rate_locations`;
+DROP TABLE IF EXISTS `wp_woocommerce_tax_rates`;
+
 DROP TABLE IF EXISTS `wp_commentmeta`;
 CREATE TABLE `wp_commentmeta` (
   `meta_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -394,12 +394,6 @@ class Acceptance extends \Codeception\Module
 	{
 		// Load WishList Member Settings screen, which will load the first time configuration wizard.
 		$I->amOnAdminPage('admin.php?page=WishListMember');
-
-		// Skip Licensing
-		$I->click('a.skip-license');
-		$I->performOn( 'a[next-screen="start"]', function($I) {
-			$I->click('a[next-screen="start"]');
-		});
 		
 		// Step 1
 		$I->fillField('input[name="name"]', 'Bronze');

--- a/tests/acceptance/WishListMemberCest.php
+++ b/tests/acceptance/WishListMemberCest.php
@@ -126,5 +126,6 @@ class WishListMemberCest
 	{
 		$I->deactivateConvertKitPlugin($I);
 		$I->resetConvertKitPlugin($I);
+		$I->deactivateThirdPartyPlugin($I, 'wishlist-member');
 	}
 }


### PR DESCRIPTION
## Summary

Before running any tests, the contents of `tests/_data/dump.sql` are imported into the test database.

WishList Member tests would fail if running these tests locally multiple times, as the previous test's data (such as member levels and other configuration items) would persist in the test database, due to this data being stored in WLM's own database tables, and not WordPress' database tables.

Adding `DROP TABLE` to the dump.sql file ensures the test environment locally is reverted back to default as best as possible, reducing the likelihood of false positives in tests.

This isn't reproducible on GitHub Actions, as the tests are run once on a 'clean' environment every time.

## Testing

- Confirmed that `WishListMemberCest` works locally and on GitHub action.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)