### PR TITLE
Tests: Refactor Page/Post Tests

### DIFF
--- a/tests/_support/Helper/Acceptance/WPGutenberg.php
+++ b/tests/_support/Helper/Acceptance/WPGutenberg.php
@@ -132,7 +132,7 @@ class WPGutenberg extends \Codeception\Module
 		$I->click('.post-publish-panel__postpublish-buttons a.components-button');
 
 		// Wait for frontend web site to load.
-		$I->waitForElementVisible('body.page-template-default');
+		$I->waitForElementVisible('body');
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);

--- a/tests/_support/Helper/Acceptance/WPGutenberg.php
+++ b/tests/_support/Helper/Acceptance/WPGutenberg.php
@@ -25,16 +25,38 @@ class WPGutenberg extends \Codeception\Module
 	}
 
 	/**
+	 * Add a Page, Post or Custom Post Type using Gutenberg in WordPress.
+	 * 
+	 * @since 	1.9.7.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
+	 */
+	public function addGutenbergPage($I, $postType = 'page', $title)
+	{
+		// Navigate to Post Type (e.g. Pages / Posts) > Add New
+		$I->amOnAdminPage('post-new.php?post_type='.$postType);
+
+		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
+		$I->maybeCloseGutenbergWelcomeModal($I);
+
+		// Define the Title.
+		$I->fillField('.editor-post-title__input', $title);
+	}
+
+	/**
 	 * Add the given block when adding or editing a Page, Post or Custom Post Type
 	 * in Gutenberg.
+	 * 
+	 * If a block configuration is specified, applies it to the newly added block.
 	 * 
 	 * @since 	1.9.7.4
 	 * 
 	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
-	 * @param 	string 				$blockName 				Block Name (e.g. 'ConvertKit Form')
-	 * @param 	string 				$blockProgrammaticName 	Programmatic Block Name (e.g. 'convertkit-form')
+	 * @param 	string 				$blockName 				Block Name (e.g. 'ConvertKit Form').
+	 * @param 	string 				$blockProgrammaticName 	Programmatic Block Name (e.g. 'convertkit-form').
+	 * @param 	bool|array 			$blockConfiguration 	Block Configuration (field => value key/value array).
 	 */
-	public function addGutenbergBlock($I, $blockName, $blockProgrammaticName)
+	public function addGutenbergBlock($I, $blockName, $blockProgrammaticName, $blockConfiguration = false)
 	{
 		// Click Add Block Button.
 		$I->click('button.edit-post-header-toolbar__inserter-toggle');
@@ -44,6 +66,26 @@ class WPGutenberg extends \Codeception\Module
 		$I->fillField('.block-editor-inserter__content input[type=search]', $blockName);
 		$I->seeElementInDOM('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
 		$I->click('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
+
+		// If a Block configuration is specified, apply it to the Block now.
+		if ($blockConfiguration) {
+			$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
+			foreach ($blockConfiguration as $field=>$attributes) {
+				// Field ID will be block's programmatic name with underscores instead of hyphens,
+				// followed by the attribute name.
+				$fieldID = '#' . str_replace('-', '_', $blockProgrammaticName) . '_' . $field;
+				
+				// Depending on the field's type, define its value.
+				switch ($attributes[0]) {
+					case 'select':
+						$I->selectOption($fieldID, $attributes[1]);
+						break;
+					default:
+						$I->fillField($fieldID, $attributes[1]);
+						break;
+				}
+			}
+		}
 	}
 
 	/**
@@ -58,9 +100,41 @@ class WPGutenberg extends \Codeception\Module
 	public function checkGutenbergBlockHasNoErrors($I, $blockName)
 	{
 		// Wait a couple of seconds for the block to render.
+		// @TODO Improve this method.
 		sleep(2);
 
 		// Check that the "This block has encountered an error and cannot be previewed." element doesn't exist.
 		$I->dontSeeElementInDOM('.block-editor-block-list__layout div[data-title="'.$blockName.'"] .block-editor-block-list__block-crash-warning');
+	}
+
+	/**
+	 * Publish a Page, Post or Custom Post Type initiated by the addGutenbergPage() function,
+	 * loading it on the frontend web site.
+	 * 
+	 * @since 	1.9.7.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
+	 */
+	public function publishAndViewGutenbergPage($I)
+	{
+		// Click the Publish button.
+		$I->click('.editor-post-publish-button__button');
+		
+		// When the pre-publish panel displays, click Publish again.
+		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
+			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
+		});
+
+		// Wait for confirmation that the Page published.
+		$I->waitForElementVisible('.post-publish-panel__postpublish-buttons a.components-button');
+
+		// Load the Page on the frontend site.
+		$I->click('.post-publish-panel__postpublish-buttons a.components-button');
+
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible('body.page-template-default');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 	}
 }

--- a/tests/_support/Helper/Acceptance/WPMetabox.php
+++ b/tests/_support/Helper/Acceptance/WPMetabox.php
@@ -1,0 +1,46 @@
+<?php
+namespace Helper\Acceptance;
+
+// Define any custom actions related to metaboxes that
+// would be used across multiple tests.
+// These are then available in $I->{yourFunctionName}
+
+class WPMetabox extends \Codeception\Module
+{
+	/**
+	 * Configure a given metabox's fields with the given values.
+	 * 
+	 * @since 	1.9.7.5
+	 * 
+	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
+	 * @param 	string 	$metabox 		Programmatic Metabox Name.
+	 * @param 	array 	$coniguration 	Metabox Configuration (field => value key/value array).
+	 */
+	public function configureMetaboxSettings($I, $metabox, $configuration)
+	{
+		// Check that the metabox exists.
+		$I->seeElementInDOM('#' . $metabox);
+
+		// Apply configuration.
+		foreach ($configuration as $field=>$attributes) {
+			// Field ID will be prefixed with wp-convertkit- in the metabox.
+			$fieldID = 'wp-convertkit-' . $field;
+
+			// Check that the field exists.
+			$I->seeElementInDOM('#' . $fieldID);
+			
+			// Depending on the field's type, define its value.
+			switch ($attributes[0]) {
+				case 'select2':
+					$I->fillSelect2Field($I, '#select2-' . $fieldID . '-container', $attributes[1]);
+					break;
+				case 'select':
+					$I->selectOption('#' . $fieldID, $attributes[1]);
+					break;
+				default:
+					$I->fillField('#' . $fieldID, $attributes[1]);
+					break;
+			}
+		}
+	}
+}

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -25,6 +25,7 @@ modules:
         - \Helper\Acceptance\Plugin
         - \Helper\Acceptance\Select2
         - \Helper\Acceptance\ThirdPartyPlugin
+        - \Helper\Acceptance\WPMetabox
         - \Helper\Acceptance\WPGutenberg
         - \Helper\Acceptance\Xdebug
     config:

--- a/tests/acceptance/PageBlockBroadcastsCest.php
+++ b/tests/acceptance/PageBlockBroadcastsCest.php
@@ -18,17 +18,6 @@ class PageBlockBroadcastsCest
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
 		$I->enableDebugLog($I);
-		$I->wait(2);
-
-		// Navigate to Pages > Add New
-		$I->amOnAdminPage('post-new.php?post_type=page');
-
-		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
-		$I->maybeCloseGutenbergWelcomeModal($I);
-
-		// Change Form to None, so that no Plugin level Form is displayed, ensuring we only
-		// test the Form block in Gutenberg.
-		$I->selectOption('#wp-convertkit-form', 'None');
 	}
 
 	/**
@@ -40,31 +29,14 @@ class PageBlockBroadcastsCest
 	 */
 	public function testBroadcastsBlockWithDefaultParameters(AcceptanceTester $I)
 	{
-		// Define a Page Title.
-		$I->fillField('.editor-post-title__input', 'ConvertKit: Page: Broadcasts: Default Params');
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Default Params');
 
-		// Add block to Page.
+		// Add block to Page, setting its Form setting to the required ConvertKit Form.
 		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
 
-		// Click the Publish button.
-		$I->click('.editor-post-publish-button__button');
-		
-		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
-
-		// Wait for confirmation that the Page published.
-		$I->waitForElementVisible('.post-publish-panel__postpublish-buttons a.components-button');
-
-		// Load the Page on the frontend site.
-		$I->click('.post-publish-panel__postpublish-buttons a.components-button');
-
-		// Wait for frontend web site to load.
-		$I->waitForElementVisible('body.page-template-default');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the block displays.
 		$I->seeElementInDOM('ul.convertkit-broadcasts');
@@ -87,40 +59,19 @@ class PageBlockBroadcastsCest
 	 */
 	public function testBroadcastsBlockWithDateFormatParameter(AcceptanceTester $I)
 	{
-		// Define a Page Title.
-		$I->fillField('.editor-post-title__input', 'ConvertKit: Page: Broadcasts: Date Format Param');
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Date Format Param');
 
-		// Add block to Page.
-		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
+		// Add block to Page, setting its Form setting to the required ConvertKit Form.
+		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
+			'date_format' => [ 'select', 'Y-m-d' ],
+		]);
 
-		// When the sidebar appears, define the date format.
-		$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
-		$I->selectOption('#convertkit_broadcasts_date_format', 'Y-m-d');
-
-		// Click the Publish button.
-		$I->click('.editor-post-publish-button__button');
-		
-		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
-
-		// Wait for confirmation that the Page published.
-		$I->waitForElementVisible('.post-publish-panel__postpublish-buttons a.components-button');
-
-		// Load the Page on the frontend site.
-		$I->click('.post-publish-panel__postpublish-buttons a.components-button');
-
-		// Wait for frontend web site to load.
-		$I->waitForElementVisible('body.page-template-default');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the block displays.
-		$I->seeElementInDOM('ul.convertkit-broadcasts');
-		$I->seeElementInDOM('ul.convertkit-broadcasts li.convertkit-broadcast');
-		$I->seeElementInDOM('ul.convertkit-broadcasts li.convertkit-broadcast a');	
+		$this->_seeBroadcastsBlock($I);	
 
 		// Confirm that the date format is as expected.
 		$I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
@@ -138,40 +89,19 @@ class PageBlockBroadcastsCest
 	 */
 	public function testBroadcastsBlockWithLimitParameter(AcceptanceTester $I)
 	{
-		// Define a Page Title.
-		$I->fillField('.editor-post-title__input', 'ConvertKit: Page: Broadcasts: Limit Param');
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Limit Param');
 
-		// Add block to Page.
-		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
+		// Add block to Page, setting its Form setting to the required ConvertKit Form.
+		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
+			'limit' => [ 'input', '2' ],
+		]);
 
-		// When the sidebar appears, define the limit.
-		$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
-		$I->fillField('#convertkit_broadcasts_limit', 2);
-
-		// Click the Publish button.
-		$I->click('.editor-post-publish-button__button');
-		
-		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
-
-		// Wait for confirmation that the Page published.
-		$I->waitForElementVisible('.post-publish-panel__postpublish-buttons a.components-button');
-
-		// Load the Page on the frontend site.
-		$I->click('.post-publish-panel__postpublish-buttons a.components-button');
-
-		// Wait for frontend web site to load.
-		$I->waitForElementVisible('body.page-template-default');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the block displays.
-		$I->seeElementInDOM('ul.convertkit-broadcasts');
-		$I->seeElementInDOM('ul.convertkit-broadcasts li.convertkit-broadcast');
-		$I->seeElementInDOM('ul.convertkit-broadcasts li.convertkit-broadcast a');	
+		$this->_seeBroadcastsBlock($I);
 
 		// Confirm that the expected number of Broadcasts are displayed.
 		$I->seeNumberOfElements('li.convertkit-broadcast', 2);
@@ -186,10 +116,10 @@ class PageBlockBroadcastsCest
 	 */
 	public function testBroadcastsBlockWithBlankLimitParameter(AcceptanceTester $I)
 	{
-		// Define a Page Title.
-		$I->fillField('.editor-post-title__input', 'ConvertKit: Page: Broadcasts: Blank Limit Param');
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Blank Limit Param');
 
-		// Add block to Page.
+		// Add block to Page, setting its Form setting to the required ConvertKit Form.
 		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
 
 		// When the sidebar appears, blank the limit parameter as the user might, by pressing the backspace
@@ -201,30 +131,11 @@ class PageBlockBroadcastsCest
 		// Confirm that the block did not encounter an error and fail to render.
 		$I->checkGutenbergBlockHasNoErrors($I, 'ConvertKit Broadcasts');
 
-		// Click the Publish button.
-		$I->click('.editor-post-publish-button__button');
-		
-		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
-
-		// Wait for confirmation that the Page published.
-		$I->waitForElementVisible('.post-publish-panel__postpublish-buttons a.components-button');
-
-		// Load the Page on the frontend site.
-		$I->click('.post-publish-panel__postpublish-buttons a.components-button');
-
-		// Wait for frontend web site to load.
-		$I->waitForElementVisible('body.page-template-default');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the block displays.
-		$I->seeElementInDOM('ul.convertkit-broadcasts');
-		$I->seeElementInDOM('ul.convertkit-broadcasts li.convertkit-broadcast');
-		$I->seeElementInDOM('ul.convertkit-broadcasts li.convertkit-broadcast a');	
+		$this->_seeBroadcastsBlock($I);	
 
 		// Confirm that the expected number of Broadcasts are displayed.
 		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
@@ -239,6 +150,7 @@ class PageBlockBroadcastsCest
 	 */
 	public function testBroadcastsBlockWithThemeColorParameters(AcceptanceTester $I)
 	{
+		// Define colors.
 		$backgroundColor = 'white';
 		$textColor = 'purple';
 
@@ -261,9 +173,7 @@ class PageBlockBroadcastsCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the block displays.
-		$I->seeElementInDOM('ul.convertkit-broadcasts');
-		$I->seeElementInDOM('ul.convertkit-broadcasts li.convertkit-broadcast');
-		$I->seeElementInDOM('ul.convertkit-broadcasts li.convertkit-broadcast a');
+		$this->_seeBroadcastsBlock($I);
 
 		// Confirm that our stylesheet loaded.
 		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="'.$_ENV['TEST_SITE_WP_URL'].'/wp-content/plugins/convertkit/resources/frontend/css/gutenberg-block-broadcasts.css');
@@ -281,6 +191,7 @@ class PageBlockBroadcastsCest
 	 */
 	public function testBroadcastsBlockWithHexColorParameters(AcceptanceTester $I)
 	{
+		// Define colors.
 		$backgroundColor = '#ee1616';
 		$textColor = '#1212c0';
 
@@ -303,15 +214,29 @@ class PageBlockBroadcastsCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the block displays.
-		$I->seeElementInDOM('ul.convertkit-broadcasts');
-		$I->seeElementInDOM('ul.convertkit-broadcasts li.convertkit-broadcast');
-		$I->seeElementInDOM('ul.convertkit-broadcasts li.convertkit-broadcast a');
+		$this->_seeBroadcastsBlock($I);
 
 		// Confirm that our stylesheet loaded.
 		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="'.$_ENV['TEST_SITE_WP_URL'].'/wp-content/plugins/convertkit/resources/frontend/css/gutenberg-block-broadcasts.css');
 
 		// Confirm that the chosen colors are applied as CSS styles.
 		$I->seeInSource('<ul class="convertkit-broadcasts has-text-color has-background" style="color:'.$textColor.';background-color:'.$backgroundColor.'">');
+	}
+
+	/**
+	 * Check that expected HTML exists in the DOM of the page we're viewing for
+	 * a Broadcasts block.
+	 * 
+	 * @since 	1.9.7.5
+	 *
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	private function _seeBroadcastsBlock($I)
+	{
+		// Confirm that the block displays.
+		$I->seeElementInDOM('ul.convertkit-broadcasts');
+		$I->seeElementInDOM('ul.convertkit-broadcasts li.convertkit-broadcast');
+		$I->seeElementInDOM('ul.convertkit-broadcasts li.convertkit-broadcast a');
 	}
 
 	/**

--- a/tests/acceptance/PageBlockBroadcastsCest.php
+++ b/tests/acceptance/PageBlockBroadcastsCest.php
@@ -32,7 +32,7 @@ class PageBlockBroadcastsCest
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Default Params');
 
-		// Add block to Page, setting its Form setting to the required ConvertKit Form.
+		// Add block to Page.
 		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
 
 		// Publish and view the Page on the frontend site.
@@ -62,7 +62,7 @@ class PageBlockBroadcastsCest
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Date Format Param');
 
-		// Add block to Page, setting its Form setting to the required ConvertKit Form.
+		// Add block to Page, setting the date format.
 		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
 			'date_format' => [ 'select', 'Y-m-d' ],
 		]);
@@ -92,7 +92,7 @@ class PageBlockBroadcastsCest
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Limit Param');
 
-		// Add block to Page, setting its Form setting to the required ConvertKit Form.
+		// Add block to Page, setting the limit.
 		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
 			'limit' => [ 'input', '2' ],
 		]);
@@ -119,11 +119,10 @@ class PageBlockBroadcastsCest
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Blank Limit Param');
 
-		// Add block to Page, setting its Form setting to the required ConvertKit Form.
+		// Add block to Page.
 		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
 
-		// When the sidebar appears, blank the limit parameter as the user might, by pressing the backspace
-		// key twice.
+		// When the sidebar appears, blank the limit parameter as the user might, by pressing the backspace key twice.
 		$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
 		$I->pressKey('#convertkit_broadcasts_limit', \Facebook\WebDriver\WebDriverKeys::BACKSPACE );
 		$I->pressKey('#convertkit_broadcasts_limit', \Facebook\WebDriver\WebDriverKeys::BACKSPACE );

--- a/tests/acceptance/PageBlockFormCest.php
+++ b/tests/acceptance/PageBlockFormCest.php
@@ -32,10 +32,12 @@ class PageBlockFormCest
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Form Param');
 
-		// Change Form to None, so that no Plugin level Form is displayed, ensuring we only test the block in Gutenberg.
-		$I->selectOption('#wp-convertkit-form', 'None');
+		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'None' ],
+		]);
 
-		// Add block to Page, setting its Form setting to the required ConvertKit Form.
+		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form', [
 			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
 		]);
@@ -59,10 +61,12 @@ class PageBlockFormCest
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Legacy Form: Block: Valid Form Param');
 
-		// Change Form to None, so that no Plugin level Form is displayed, ensuring we only test the block in Gutenberg.
-		$I->selectOption('#wp-convertkit-form', 'None');
-
-		// Add block to Page.
+		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'None' ],
+		]);
+		
+		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form', [
 			'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ]
 		]);
@@ -87,10 +91,12 @@ class PageBlockFormCest
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Modal Form Param');
 
-		// Change Form to None, so that no Plugin level Form is displayed, ensuring we only test the block in Gutenberg.
-		$I->selectOption('#wp-convertkit-form', 'None');
+		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'None' ],
+		]);
 
-		// Add block to Page.
+		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form', [
 			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ]
 		]);
@@ -125,10 +131,12 @@ class PageBlockFormCest
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Slide In Form Param');
 
-		// Change Form to None, so that no Plugin level Form is displayed, ensuring we only test the block in Gutenberg.
-		$I->selectOption('#wp-convertkit-form', 'None');
+		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'None' ],
+		]);
 
-		// Add block to Page.
+		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form', [
 			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] ]
 		]);
@@ -163,10 +171,12 @@ class PageBlockFormCest
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Sticky Bar Form Param');
 
-		// Change Form to None, so that no Plugin level Form is displayed, ensuring we only test the block in Gutenberg.
-		$I->selectOption('#wp-convertkit-form', 'None');
+		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'None' ],
+		]);
 
-		// Add block to Page.
+		// Add block to Page, setting the Form setting to the value specified in the .env file.
 		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form', [
 			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ]
 		]);
@@ -200,8 +210,10 @@ class PageBlockFormCest
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Sticky Bar Form Param');
 
-		// Change Form to None, so that no Plugin level Form is displayed, ensuring we only test the block in Gutenberg.
-		$I->selectOption('#wp-convertkit-form', 'None');
+		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'None' ],
+		]);
 
 		// Add block to Page.
 		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form');

--- a/tests/acceptance/PageBlockFormCest.php
+++ b/tests/acceptance/PageBlockFormCest.php
@@ -18,17 +18,6 @@ class PageBlockFormCest
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
 		$I->enableDebugLog($I);
-		$I->wait(2);
-
-		// Navigate to Pages > Add New
-		$I->amOnAdminPage('post-new.php?post_type=page');
-
-		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
-		$I->maybeCloseGutenbergWelcomeModal($I);
-
-		// Change Form to None, so that no Plugin level Form is displayed, ensuring we only
-		// test the Form block in Gutenberg.
-		$I->selectOption('#wp-convertkit-form', 'None');
 	}
 
 	/**
@@ -40,35 +29,19 @@ class PageBlockFormCest
 	 */
 	public function testFormBlockWithValidFormParameter(AcceptanceTester $I)
 	{
-		// Define a Page Title.
-		$I->fillField('.editor-post-title__input', 'ConvertKit: Page: Form: Block: Valid Form Param');
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Form Param');
 
-		// Add block to Page.
-		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form');
+		// Change Form to None, so that no Plugin level Form is displayed, ensuring we only test the block in Gutenberg.
+		$I->selectOption('#wp-convertkit-form', 'None');
 
-		// When the sidebar appears, select the Form in the Block.
-		$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
-		$I->selectOption('#convertkit_form_form', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		// Add block to Page, setting its Form setting to the required ConvertKit Form.
+		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form', [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+		]);
 
-		// Click the Publish button.
-		$I->click('.editor-post-publish-button__button');
-		
-		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
-
-		// Wait for confirmation that the Page published.
-		$I->waitForElementVisible('.post-publish-panel__postpublish-buttons a.components-button');
-
-		// Load the Page on the frontend site.
-		$I->click('.post-publish-panel__postpublish-buttons a.components-button');
-
-		// Wait for frontend web site to load.
-		$I->waitForElementVisible('body.page-template-default');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the ConvertKit Form is displayed.
 		$I->seeElementInDOM('form[data-sv-form]');
@@ -83,35 +56,19 @@ class PageBlockFormCest
 	 */
 	public function testFormBlockWithValidLegacyFormParameter(AcceptanceTester $I)
 	{
-		// Define a Page Title.
-		$I->fillField('.editor-post-title__input', 'ConvertKit: Legacy Form: Block: Valid Form Param');
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Legacy Form: Block: Valid Form Param');
+
+		// Change Form to None, so that no Plugin level Form is displayed, ensuring we only test the block in Gutenberg.
+		$I->selectOption('#wp-convertkit-form', 'None');
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form');
+		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form', [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ]
+		]);
 
-		// When the sidebar appears, select the Form.
-		$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
-		$I->selectOption('#convertkit_form_form', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
-
-		// Click the Publish button.
-		$I->click('.editor-post-publish-button__button');
-		
-		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
-
-		// Wait for confirmation that the Page published.
-		$I->waitForElementVisible('.post-publish-panel__postpublish-buttons a.components-button');
-
-		// Load the Page on the frontend site.
-		$I->click('.post-publish-panel__postpublish-buttons a.components-button');
-
-		// Wait for frontend web site to load.
-		$I->waitForElementVisible('body.page-template-default');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the ConvertKit Form is displayed.
 		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
@@ -127,15 +84,16 @@ class PageBlockFormCest
 	 */
 	public function testFormBlockWithValidModalFormParameter(AcceptanceTester $I)
 	{
-		// Define a Page Title.
-		$I->fillField('.editor-post-title__input', 'ConvertKit: Page: Form: Block: Valid Modal Form Param');
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Modal Form Param');
+
+		// Change Form to None, so that no Plugin level Form is displayed, ensuring we only test the block in Gutenberg.
+		$I->selectOption('#wp-convertkit-form', 'None');
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form');
-
-		// When the sidebar appears, select the Form.
-		$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
-		$I->selectOption('#convertkit_form_form', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME']);
+		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form', [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ]
+		]);
 
 		// Switch to iframe preview for the Form block.
 		$I->switchToIFrame('iframe[class="components-sandbox"]');
@@ -147,25 +105,8 @@ class PageBlockFormCest
 		// Switch back to main window.
 		$I->switchToIFrame();
 
-		// Click the Publish button.
-		$I->click('.editor-post-publish-button__button');
-		
-		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
-
-		// Wait for confirmation that the Page published.
-		$I->waitForElementVisible('.post-publish-panel__postpublish-buttons a.components-button');
-
-		// Load the Page on the frontend site.
-		$I->click('.post-publish-panel__postpublish-buttons a.components-button');
-
-		// Wait for frontend web site to load.
-		$I->waitForElementVisible('body.page-template-default');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the ConvertKit Form is displayed.
 		$I->seeElementInDOM('form[data-sv-form]');
@@ -181,15 +122,16 @@ class PageBlockFormCest
 	 */
 	public function testFormBlockWithValidSlideInFormParameter(AcceptanceTester $I)
 	{
-		// Define a Page Title.
-		$I->fillField('.editor-post-title__input', 'ConvertKit: Page: Form: Block: Valid Slide In Form Param');
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Slide In Form Param');
+
+		// Change Form to None, so that no Plugin level Form is displayed, ensuring we only test the block in Gutenberg.
+		$I->selectOption('#wp-convertkit-form', 'None');
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form');
-
-		// When the sidebar appears, select the Form.
-		$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
-		$I->selectOption('#convertkit_form_form', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME']);
+		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form', [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] ]
+		]);
 
 		// Switch to iframe preview for the Form block.
 		$I->switchToIFrame('iframe[class="components-sandbox"]');
@@ -201,25 +143,8 @@ class PageBlockFormCest
 		// Switch back to main window.
 		$I->switchToIFrame();
 
-		// Click the Publish button.
-		$I->click('.editor-post-publish-button__button');
-		
-		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
-
-		// Wait for confirmation that the Page published.
-		$I->waitForElementVisible('.post-publish-panel__postpublish-buttons a.components-button');
-
-		// Load the Page on the frontend site.
-		$I->click('.post-publish-panel__postpublish-buttons a.components-button');
-
-		// Wait for frontend web site to load.
-		$I->waitForElementVisible('body.page-template-default');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the ConvertKit Form is displayed.
 		$I->seeElementInDOM('form[data-sv-form]');
@@ -235,15 +160,16 @@ class PageBlockFormCest
 	 */
 	public function testFormBlockWithValidStickyBarFormParameter(AcceptanceTester $I)
 	{
-		// Define a Page Title.
-		$I->fillField('.editor-post-title__input', 'ConvertKit: Page: Form: Block: Valid Sticky Bar Form Param');
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Sticky Bar Form Param');
+
+		// Change Form to None, so that no Plugin level Form is displayed, ensuring we only test the block in Gutenberg.
+		$I->selectOption('#wp-convertkit-form', 'None');
 
 		// Add block to Page.
-		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form');
-
-		// When the sidebar appears, select the Form.
-		$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
-		$I->selectOption('#convertkit_form_form', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME']);
+		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form', [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ]
+		]);
 
 		// Switch to iframe preview for the Form block.
 		$I->switchToIFrame('iframe[class="components-sandbox"]');
@@ -255,25 +181,8 @@ class PageBlockFormCest
 		// Switch back to main window.
 		$I->switchToIFrame();
 
-		// Click the Publish button.
-		$I->click('.editor-post-publish-button__button');
-		
-		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
-
-		// Wait for confirmation that the Page published.
-		$I->waitForElementVisible('.post-publish-panel__postpublish-buttons a.components-button');
-
-		// Load the Page on the frontend site.
-		$I->click('.post-publish-panel__postpublish-buttons a.components-button');
-
-		// Wait for frontend web site to load.
-		$I->waitForElementVisible('body.page-template-default');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the ConvertKit Form is displayed.
 		$I->seeElementInDOM('form[data-sv-form]');
@@ -288,8 +197,11 @@ class PageBlockFormCest
 	 */
 	public function testFormBlockWithNoFormParameter(AcceptanceTester $I)
 	{
-		// Define a Page Title.
-		$I->fillField('.editor-post-title__input', 'ConvertKit: Page: Form: Block: No Form Param');
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Sticky Bar Form Param');
+
+		// Change Form to None, so that no Plugin level Form is displayed, ensuring we only test the block in Gutenberg.
+		$I->selectOption('#wp-convertkit-form', 'None');
 
 		// Add block to Page.
 		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form');
@@ -299,25 +211,8 @@ class PageBlockFormCest
 			'css' => '.convertkit-form-no-content',
 		]);
 
-		// Click the Publish button.
-		$I->click('.editor-post-publish-button__button');
-		
-		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
-
-		// Wait for confirmation that the Page published.
-		$I->waitForElementVisible('.post-publish-panel__postpublish-buttons a.components-button');
-
-		// Load the Page on the frontend site.
-		$I->click('.post-publish-panel__postpublish-buttons a.components-button');
-
-		// Wait for frontend web site to load.
-		$I->waitForElementVisible('body.page-template-default');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that no ConvertKit Form is displayed.
 		$I->dontSeeElementInDOM('form[data-sv-form]');

--- a/tests/acceptance/PageElementorFormCest.php
+++ b/tests/acceptance/PageElementorFormCest.php
@@ -19,7 +19,6 @@ class PageElementorFormCest
 		$I->activateThirdPartyPlugin($I, 'elementor');
 		$I->setupConvertKitPlugin($I);
 		$I->enableDebugLog($I);
-		$I->wait(2);
 	}
 
 	/**
@@ -31,18 +30,8 @@ class PageElementorFormCest
 	 */
 	public function testFormWidgetIsRegistered(AcceptanceTester $I)
 	{
-		// Navigate to Pages > Add New
-		$I->amOnAdminPage('post-new.php?post_type=page');
-
-		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
-		$I->maybeCloseGutenbergWelcomeModal($I);
-
-		// Change Form to None, so that no Plugin level Form is displayed, ensuring we only
-		// test the Form block in Gutenberg.
-		$I->selectOption('#wp-convertkit-form', 'None');
-
-		// Define a Page Title.
-		$I->fillField('.editor-post-title__input', 'ConvertKit: Page: Form: Elementor: Valid Form Param');
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Elementor: Valid Form Param');
 
 		// Click Edit with Elementor button.
 		$I->click('#elementor-switch-mode-button');

--- a/tests/acceptance/PageFormCest.php
+++ b/tests/acceptance/PageFormCest.php
@@ -19,13 +19,6 @@ class PageFormCest
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
 		$I->enableDebugLog($I);
-		$I->wait(2);
-		
-		// Navigate to Pages > Add New
-		$I->amOnAdminPage('post-new.php?post_type=page');
-
-		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
-		$I->maybeCloseGutenbergWelcomeModal($I);
 	}
 
 	/**
@@ -39,42 +32,16 @@ class PageFormCest
 	 */
 	public function testAddNewPageUsingDefaultFormWithNoDefaultFormSpecifiedInPlugin(AcceptanceTester $I)
 	{
-		// Navigate to Pages > Add New
-		$I->amOnAdminPage('post-new.php?post_type=page');
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Default: None');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Configure metabox's Form setting = Default.
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'Default' ],
+		]);
 
-		// Check that the metabox is displayed.
-		$I->seeElementInDOM('#wp-convertkit-meta-box');
-
-		// Check that the Form option is displayed.
-		$I->seeElementInDOM('#wp-convertkit-form');
-
-		// Change Form to Default
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'Default');
-
-		// Define a Page Title.
-		$I->fillField('.editor-post-title__input', 'ConvertKit: Page: Form: Default: None');
-
-		// Click the Publish button.
-		$I->click('.editor-post-publish-button__button');
-		
-		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
-
-		// Check the value of the Form field matches the input provided.
-		$I->performOn( '.post-publish-panel__postpublish-buttons', function($I) {
-			$I->seeOptionIsSelected('#wp-convertkit-form', 'Default');
-		});
-
-		// Load the Page on the frontend site.
-		$I->amOnPage('/convertkit-page-form-default-none');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that no ConvertKit Form is displayed.
 		$I->dontSeeElementInDOM('form[data-sv-form]');
@@ -93,42 +60,16 @@ class PageFormCest
 		// Specify the Default Form in the Plugin Settings.
 		$defaultFormID = $I->setupConvertKitPluginDefaultForm($I);
 
-		// Navigate to Pages > Add New
-		$I->amOnAdminPage('post-new.php?post_type=page');
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Default');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Configure metabox's Form setting = Default.
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'Default' ],
+		]);
 
-		// Check that the metabox is displayed.
-		$I->seeElementInDOM('#wp-convertkit-meta-box');
-
-		// Check that the Form option is displayed.
-		$I->seeElementInDOM('#wp-convertkit-form');
-
-		// Change Form to Default
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'Default');
-
-		// Define a Page Title.
-		$I->fillField('.editor-post-title__input', 'ConvertKit: Page: Form: Default');
-
-		// Click the Publish button.
-		$I->click('.editor-post-publish-button__button');
-		
-		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
-
-		// Check the value of the Form field matches the input provided.
-		$I->performOn( '.post-publish-panel__postpublish-buttons', function($I) {
-			$I->seeOptionIsSelected('#wp-convertkit-form', 'Default');
-		});
-
-		// Load the Page on the frontend site
-		$I->amOnPage('/convertkit-page-form-default');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the ConvertKit Default Form displays.
 		$I->seeElementInDOM('form[data-sv-form="' . $defaultFormID . '"]');
@@ -147,42 +88,16 @@ class PageFormCest
 		// Specify the Default Legacy Form in the Plugin Settings.
 		$defaultLegacyFormID = $I->setupConvertKitPluginDefaultLegacyForm($I);
 
-		// Navigate to Pages > Add New
-		$I->amOnAdminPage('post-new.php?post_type=page');
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Legacy: Default');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Configure metabox's Form setting = Default.
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'Default' ],
+		]);
 
-		// Check that the metabox is displayed.
-		$I->seeElementInDOM('#wp-convertkit-meta-box');
-
-		// Check that the Form option is displayed.
-		$I->seeElementInDOM('#wp-convertkit-form');
-
-		// Change Form to Default
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'Default');
-
-		// Define a Page Title.
-		$I->fillField('.editor-post-title__input', 'ConvertKit: Page: Form: Legacy: Default');
-
-		// Click the Publish button.
-		$I->click('.editor-post-publish-button__button');
-		
-		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
-
-		// Check the value of the Form field matches the input provided.
-		$I->performOn( '.post-publish-panel__postpublish-buttons', function($I) {
-			$I->seeOptionIsSelected('#wp-convertkit-form', 'Default');
-		});
-
-		// Load the Page on the frontend site
-		$I->amOnPage('/convertkit-page-form-legacy-default');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the ConvertKit Default Legacy Form displays.
 		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $defaultLegacyFormID . '/subscribe" data-remote="true">');
@@ -198,42 +113,16 @@ class PageFormCest
 	 */
 	public function testAddNewPageUsingNoForm(AcceptanceTester $I)
 	{
-		// Navigate to Pages > Add New
-		$I->amOnAdminPage('post-new.php?post_type=page');
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: None');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Configure metabox's Form setting = None.
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'None' ],
+		]);
 
-		// Check that the metabox is displayed.
-		$I->seeElementInDOM('#wp-convertkit-meta-box');
-
-		// Check that the Form option is displayed.
-		$I->seeElementInDOM('#wp-convertkit-form');
-
-		// Change Form to 'None'
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None');
-
-		// Define a Page Title.
-		$I->fillField('.editor-post-title__input', 'ConvertKit: Page: Form: None');
-
-		// Click the Publish button.
-		$I->click('.editor-post-publish-button__button');
-
-		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
-
-		// Check the value of the Form field matches the input provided.
-		$I->performOn( '.post-publish-panel__postpublish-buttons', function($I) {
-			$I->seeOptionIsSelected('#wp-convertkit-form', 'None');
-		});
-
-		// Load the Page on the frontend site.
-		$I->amOnPage('/convertkit-page-form-none');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that no ConvertKit Form is displayed.
 		$I->dontSeeElementInDOM('form[data-sv-form]');
@@ -249,45 +138,19 @@ class PageFormCest
 	 */
 	public function testAddNewPageUsingDefinedForm(AcceptanceTester $I)
 	{
-		// Navigate to Pages > Add New
-		$I->amOnAdminPage('post-new.php?post_type=page');
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME']);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Check that the metabox is displayed.
-		$I->seeElementInDOM('#wp-convertkit-meta-box');
-
-		// Check that the Form option is displayed.
-		$I->seeElementInDOM('#wp-convertkit-form');
-
-		// Change Form to value specified in the .env file.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
-
-		// Define a Page Title.
-		$I->fillField('.editor-post-title__input', 'ConvertKit: Page: Form: Specific');
-
-		// Click the Publish button.
-		$I->click('.editor-post-publish-button__button');
-		
-		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
-
-		// Check the value of the Form field matches the input provided.
-		$I->performOn( '.post-publish-panel__postpublish-buttons', function($I) {
-			$I->seeOptionIsSelected('#wp-convertkit-form', $_ENV['CONVERTKIT_API_FORM_NAME']);
-		});
+		// Configure metabox's Form setting = None.
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+		]);
 
 		// Get Form ID.
 		$formID = $I->grabValueFrom('#wp-convertkit-form');
 
-		// Load the Page on the frontend site
-		$I->amOnPage('/convertkit-page-form-specific');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the ConvertKit Form displays.
 		$I->seeElementInDOM('form[data-sv-form="' . $formID . '"]');
@@ -303,47 +166,21 @@ class PageFormCest
 	 */
 	public function testAddNewPageUsingDefinedLegacyForm(AcceptanceTester $I)
 	{
-		// Navigate to Pages > Add New
-		$I->amOnAdminPage('post-new.php?post_type=page');
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Check that the metabox is displayed.
-		$I->seeElementInDOM('#wp-convertkit-meta-box');
-
-		// Check that the Form option is displayed.
-		$I->seeElementInDOM('#wp-convertkit-form');
-
-		// Change Form to value specified in the .env file.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
-
-		// Define a Page Title.
-		$I->fillField('.editor-post-title__input', 'ConvertKit: Page: Form: Legacy: Specific');
-
-		// Click the Publish button.
-		$I->click('.editor-post-publish-button__button');
-		
-		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
-
-		// Check the value of the Form field matches the input provided.
-		$I->performOn( '.post-publish-panel__postpublish-buttons', function($I) {
-			$I->seeOptionIsSelected('#wp-convertkit-form', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
-		});
+		// Configure metabox's Form setting = None.
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
+		]);
 
 		// Get Form ID.
 		$formID = $I->grabValueFrom('#wp-convertkit-form');
 
-		// Load the Page on the frontend site
-		$I->amOnPage('/convertkit-page-form-legacy-specific');
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm that the ConvertKit Default Legacy Form displays.
+		// Confirm that the ConvertKit Legacy Form displays.
 		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
 	}
 

--- a/tests/acceptance/PageFormCest.php
+++ b/tests/acceptance/PageFormCest.php
@@ -204,9 +204,9 @@ class PageFormCest
 
 		// Create Page, with an invalid Form ID, as if it were created prior to API credentials being changed and/or
 		// a Form being deleted in ConvertKit.
-		$postID = $I->havePostInDatabase([
+		$pageID = $I->havePostInDatabase([
 			'post_type' 	=> 'page',
-			'post_title' 	=> 'ConvertKit: Form: Specific: Invalid',
+			'post_title' 	=> 'ConvertKit: Page: Form: Specific: Invalid',
 			'meta_input'	=> [
 				'_wp_convertkit_post_meta' => [
 					'form'         => '11111',
@@ -217,7 +217,7 @@ class PageFormCest
 		]);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage('/?p='.$postID);
+		$I->amOnPage('/?p='.$pageID);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);

--- a/tests/acceptance/PageLandingPageCest.php
+++ b/tests/acceptance/PageLandingPageCest.php
@@ -19,13 +19,6 @@ class PageLandingPageCest
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
 		$I->enableDebugLog($I);
-		$I->wait(2);
-		
-		// Navigate to Pages > Add New
-		$I->amOnAdminPage('post-new.php?post_type=page');
-
-		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
-		$I->maybeCloseGutenbergWelcomeModal($I);
 	}
 
 	/**
@@ -38,42 +31,16 @@ class PageLandingPageCest
 	 */
 	public function testAddNewPageUsingNoLandingPage(AcceptanceTester $I)
 	{
-		// Navigate to Pages > Add New
-		$I->amOnAdminPage('post-new.php?post_type=page');
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Landing Page: None');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Configure metabox's Landing Page setting = None.
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'landing_page' => [ 'select2', 'None' ],
+		]);
 
-		// Check that the metabox is displayed.
-		$I->seeElementInDOM('#wp-convertkit-meta-box');
-
-		// Check that the Form option is displayed.
-		$I->seeElementInDOM('#wp-convertkit-landing_page');
-
-		// Change Landing Page to 'None'
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-landing_page-container', 'None');
-
-		// Define a Page Title.
-		$I->fillField('.editor-post-title__input', 'ConvertKit: Landing Page: None');
-
-		// Click the Publish button.
-		$I->click('.editor-post-publish-button__button');
-
-		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
-
-		// Check the value of the Landing Page field matches the input provided.
-		$I->performOn( '.post-publish-panel__postpublish-buttons', function($I) {
-			$I->seeOptionIsSelected('#wp-convertkit-landing_page', 'None');
-		});
-
-		// Load the Page on the frontend site.
-		$I->amOnPage('/convertkit-landing-page-none');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that no ConvertKit Landing Page is displayed.
 		$I->dontSeeElementInDOM('form[data-sv-form]');
@@ -89,45 +56,19 @@ class PageLandingPageCest
 	 */
 	public function testAddNewPageUsingDefinedLandingPage(AcceptanceTester $I)
 	{
-		// Navigate to Pages > Add New
-		$I->amOnAdminPage('post-new.php?post_type=page');
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME']);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Check that the metabox is displayed.
-		$I->seeElementInDOM('#wp-convertkit-meta-box');
-
-		// Check that the Form option is displayed.
-		$I->seeElementInDOM('#wp-convertkit-landing_page');
-
-		// Change Landing Page to value specified in the .env file.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-landing_page-container', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME']);
-
-		// Define a Page Title.
-		$I->fillField('.editor-post-title__input', 'ConvertKit: Landing Page: Specific');
-
-		// Click the Publish button.
-		$I->click('.editor-post-publish-button__button');
-		
-		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
-
-		// Check the value of the Landing Page field matches the input provided.
-		$I->performOn( '.post-publish-panel__postpublish-buttons', function($I) {
-			$I->seeOptionIsSelected('#wp-convertkit-landing_page', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME']);
-		});
+		// Configure metabox's Landing Page setting to value specified in the .env file.
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME'] ],
+		]);
 
 		// Get Landing Page ID.
 		$landingPageID = $I->grabValueFrom('#wp-convertkit-landing_page');
 
-		// Load the Page on the frontend site
-		$I->amOnPage('/convertkit-landing-page-specific');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the basic HTML structure is correct.
 		$I->seeInSource('<html>');
@@ -151,45 +92,19 @@ class PageLandingPageCest
 	 */
 	public function testLandingPageCharacterEncoding(AcceptanceTester $I)
 	{
-		// Navigate to Pages > Add New
-		$I->amOnAdminPage('post-new.php?post_type=page');
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LANDING_PAGE_CHARACTER_ENCODING_NAME']);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Check that the metabox is displayed.
-		$I->seeElementInDOM('#wp-convertkit-meta-box');
-
-		// Check that the Form option is displayed.
-		$I->seeElementInDOM('#wp-convertkit-landing_page');
-
-		// Change Landing Page to value specified in the .env file.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-landing_page-container', $_ENV['CONVERTKIT_API_LANDING_PAGE_CHARACTER_ENCODING_NAME']);
-
-		// Define a Page Title.
-		$I->fillField('.editor-post-title__input', 'ConvertKit: Landing Page: Character Encoding');
-
-		// Click the Publish button.
-		$I->click('.editor-post-publish-button__button');
-		
-		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
-
-		// Check the value of the Landing Page field matches the input provided.
-		$I->performOn( '.post-publish-panel__postpublish-buttons', function($I) {
-			$I->seeOptionIsSelected('#wp-convertkit-landing_page', $_ENV['CONVERTKIT_API_LANDING_PAGE_CHARACTER_ENCODING_NAME']);
-		});
+		// Configure metabox's Landing Page setting to value specified in the .env file.
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_CHARACTER_ENCODING_NAME'] ],
+		]);
 
 		// Get Landing Page ID.
 		$landingPageID = $I->grabValueFrom('#wp-convertkit-landing_page');
 
-		// Load the Page on the frontend site
-		$I->amOnPage('/convertkit-landing-page-character-encoding');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the basic HTML structure is correct.
 		$I->seeInSource('<html>');
@@ -213,45 +128,19 @@ class PageLandingPageCest
 	 */
 	public function testAddNewPageUsingDefinedLegacyLandingPage(AcceptanceTester $I)
 	{
-		// Navigate to Pages > Add New
-		$I->amOnAdminPage('post-new.php?post_type=page');
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME']);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Check that the metabox is displayed.
-		$I->seeElementInDOM('#wp-convertkit-meta-box');
-
-		// Check that the Form option is displayed.
-		$I->seeElementInDOM('#wp-convertkit-landing_page');
-
-		// Change Landing Page to value specified in the .env file.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-landing_page-container', $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME']);
-
-		// Define a Page Title.
-		$I->fillField('.editor-post-title__input', 'ConvertKit: Landing Page: Legacy: Specific');
-
-		// Click the Publish button.
-		$I->click('.editor-post-publish-button__button');
-		
-		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
-
-		// Check the value of the Landing Page field matches the input provided.
-		$I->performOn( '.post-publish-panel__postpublish-buttons', function($I) {
-			$I->seeOptionIsSelected('#wp-convertkit-landing_page', $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME']);
-		});
+		// Configure metabox's Landing Page setting to value specified in the .env file.
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME'] ],
+		]);
 
 		// Get Landing Page ID.
 		$landingPageID = $I->grabValueFrom('#wp-convertkit-landing_page');
 
-		// Load the Page on the frontend site
-		$I->amOnPage('/convertkit-landing-page-legacy-specific');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the basic HTML structure is correct.
 		$I->seeInSource('<html>');

--- a/tests/acceptance/PageTagCest.php
+++ b/tests/acceptance/PageTagCest.php
@@ -19,13 +19,6 @@ class PageTagCest
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
 		$I->enableDebugLog($I);
-		$I->wait(2);
-
-		// Navigate to Pages > Add New
-		$I->amOnAdminPage('post-new.php?post_type=page');
-
-		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
-		$I->maybeCloseGutenbergWelcomeModal($I);
 	}
 
 	/**
@@ -38,42 +31,16 @@ class PageTagCest
 	 */
 	public function testAddNewPageUsingNoTag(AcceptanceTester $I)
 	{
-		// Navigate to Pages > Add New
-		$I->amOnAdminPage('post-new.php?post_type=page');
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Tag: None');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Configure metabox's Tag setting = None.
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'tag' => [ 'select2', 'None' ],
+		]);
 
-		// Check that the metabox is displayed.
-		$I->seeElementInDOM('#wp-convertkit-meta-box');
-
-		// Check that the Form option is displayed.
-		$I->seeElementInDOM('#wp-convertkit-tag');
-
-		// Change Tag to 'None'
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-tag-container', 'None');
-
-		// Define a Page Title.
-		$I->fillField('.editor-post-title__input', 'ConvertKit: Tag: None');
-
-		// Click the Publish button.
-		$I->click('.editor-post-publish-button__button');
-
-		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
-
-		// Check the value of the Tag field matches the input provided.
-		$I->performOn( '.post-publish-panel__postpublish-buttons', function($I) {
-			$I->seeOptionIsSelected('#wp-convertkit-tag', 'None');
-		});
-
-		// Load the Page on the frontend site.
-		$I->amOnPage('/convertkit-tag-none');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the tag parameter is not set to the Tag ID.
 		$I->dontSeeInSource('"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"');
@@ -89,48 +56,25 @@ class PageTagCest
 	 */
 	public function testAddNewPageUsingDefinedTag(AcceptanceTester $I)
 	{
-		// Navigate to Pages > Add New
-		$I->amOnAdminPage('post-new.php?post_type=page');
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] );
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Check that the metabox is displayed.
-		$I->seeElementInDOM('#wp-convertkit-meta-box');
-
-		// Check that the Form option is displayed.
-		$I->seeElementInDOM('#wp-convertkit-tag');
-
-		// Change Tag to value specified in the .env file.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-tag-container', $_ENV['CONVERTKIT_API_TAG_NAME']);
-
-		// Define a Page Title.
-		$I->fillField('.editor-post-title__input', 'ConvertKit: Tag: Specific');
-
-		// Click the Publish button.
-		$I->click('.editor-post-publish-button__button');
-		
-		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
-
-		// Check the value of the Tag field matches the input provided.
-		$I->performOn( '.post-publish-panel__postpublish-buttons', function($I) {
-			$I->seeOptionIsSelected('#wp-convertkit-tag', $_ENV['CONVERTKIT_API_TAG_NAME']);
-		});
+		// Configure metabox's Tag setting to the value specified in the .env file.
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'tag' => [ 'select2', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
+		]);
 
 		// Get Tag ID.
 		$tagID = $I->grabValueFrom('#wp-convertkit-tag');
 
-		// Load the Page on the frontend site
-		$I->amOnPage('/convertkit-tag-specific');
+		// Confirm it matches the Tag ID in the .env file.
+		$I->assertEquals($tagID, $_ENV['CONVERTKIT_API_TAG_ID']);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the post_has_tag parameter is set to true in the source code.
-		$I->seeInSource('"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"');
+		$I->seeInSource('"tag":"' . $tagID . '"');
 	}
 
 	/**

--- a/tests/acceptance/PostElementorFormCest.php
+++ b/tests/acceptance/PostElementorFormCest.php
@@ -19,7 +19,6 @@ class PostElementorFormCest
 		$I->activateThirdPartyPlugin($I, 'elementor');
 		$I->setupConvertKitPlugin($I);
 		$I->enableDebugLog($I);
-		$I->wait(2);
 	}
 
 	/**
@@ -31,18 +30,8 @@ class PostElementorFormCest
 	 */
 	public function testFormWidgetIsRegistered(AcceptanceTester $I)
 	{
-		// Navigate to Posts > Add New
-		$I->amOnAdminPage('post-new.php');
-
-		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
-		$I->maybeCloseGutenbergWelcomeModal($I);
-
-		// Change Form to None, so that no Plugin level Form is displayed, ensuring we only
-		// test the Form block in Gutenberg.
-		$I->selectOption('#wp-convertkit-form', 'None');
-
-		// Define a Post Title.
-		$I->fillField('.editor-post-title__input', 'ConvertKit: Post: Form: Elementor: Valid Form Param');
+		// Add a Post using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: Elementor: Valid Form Param');
 
 		// Click Edit with Elementor button.
 		$I->click('#elementor-switch-mode-button');

--- a/tests/acceptance/PostFormCest.php
+++ b/tests/acceptance/PostFormCest.php
@@ -19,13 +19,6 @@ class PostFormCest
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
 		$I->enableDebugLog($I);
-		$I->wait(2);
-
-		// Navigate to Post > Add New
-		$I->amOnAdminPage('post-new.php');
-
-		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
-		$I->maybeCloseGutenbergWelcomeModal($I);
 	}
 
 	/**
@@ -39,42 +32,16 @@ class PostFormCest
 	 */
 	public function testAddNewPostUsingDefaultFormWithNoDefaultFormSpecifiedInPlugin(AcceptanceTester $I)
 	{
-		// Navigate to Post > Add New
-		$I->amOnAdminPage('post-new.php');
+		// Add a Post using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: Default: None');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Configure metabox's Form setting = Default.
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'Default' ],
+		]);
 
-		// Check that the metabox is displayed.
-		$I->seeElementInDOM('#wp-convertkit-meta-box');
-
-		// Check that the Form option is displayed.
-		$I->seeElementInDOM('#wp-convertkit-form');
-
-		// Change Form to Default
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'Default');
-
-		// Define a Post Title.
-		$I->fillField('.editor-post-title__input', 'ConvertKit: Post: Form: Default: None');
-
-		// Click the Publish button.
-		$I->click('.editor-post-publish-button__button');
-		
-		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
-
-		// Check the value of the Form field matches the input provided.
-		$I->performOn( '.post-publish-panel__postpublish-buttons', function($I) {
-			$I->seeOptionIsSelected('#wp-convertkit-form', 'Default');
-		});
-
-		// Load the Post on the frontend site.
-		$I->amOnPage('/convertkit-post-form-default-none');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Publish and view the Post on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that no ConvertKit Form is displayed.
 		$I->dontSeeElementInDOM('form[data-sv-form]');
@@ -93,45 +60,47 @@ class PostFormCest
 		// Specify the Default Form in the Plugin Settings.
 		$defaultFormID = $I->setupConvertKitPluginDefaultForm($I);
 
-		// Navigate to Post > Add New
-		$I->amOnAdminPage('post-new.php');
+		// Add a Post using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: Default');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Configure metabox's Form setting = Default.
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'Default' ],
+		]);
 
-		// Check that the metabox is displayed.
-		$I->seeElementInDOM('#wp-convertkit-meta-box');
-
-		// Check that the Form option is displayed.
-		$I->seeElementInDOM('#wp-convertkit-form');
-
-		// Change Form to Default
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'Default');
-
-		// Define a Post Title.
-		$I->fillField('.editor-post-title__input', 'ConvertKit: Post: Form: Default');
-
-		// Click the Publish button.
-		$I->click('.editor-post-publish-button__button');
-		
-		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
-
-		// Check the value of the Form field matches the input provided.
-		$I->performOn( '.post-publish-panel__postpublish-buttons', function($I) {
-			$I->seeOptionIsSelected('#wp-convertkit-form', 'Default');
-		});
-
-		// Load the Post on the frontend site
-		$I->amOnPage('/convertkit-post-form-default');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Publish and view the Post on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the ConvertKit Default Form displays.
 		$I->seeElementInDOM('form[data-sv-form="' . $defaultFormID . '"]');
+	}
+
+	/**
+	 * Test that the Default Legacy Form specified in the Plugin Settings works when
+	 * creating and viewing a new WordPress Post.
+	 * 
+	 * @since 	1.9.6.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testAddNewPostUsingDefaultLegacyForm(AcceptanceTester $I)
+	{
+		// Specify the Default Legacy Form in the Plugin Settings.
+		$defaultLegacyFormID = $I->setupConvertKitPluginDefaultLegacyForm($I);
+
+		// Add a Post using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: Legacy: Default');
+
+		// Configure metabox's Form setting = Default.
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'Default' ],
+		]);
+
+		// Publish and view the Post on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that the ConvertKit Default Legacy Form displays.
+		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $defaultLegacyFormID . '/subscribe" data-remote="true">');
 	}
 
 	/**
@@ -144,42 +113,16 @@ class PostFormCest
 	 */
 	public function testAddNewPostUsingNoForm(AcceptanceTester $I)
 	{
-		// Navigate to Posts > Add New
-		$I->amOnAdminPage('post-new.php');
+		// Add a Post using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: None');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Configure metabox's Form setting = None.
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'None' ],
+		]);
 
-		// Check that the metabox is displayed.
-		$I->seeElementInDOM('#wp-convertkit-meta-box');
-
-		// Check that the Form option is displayed.
-		$I->seeElementInDOM('#wp-convertkit-form');
-
-		// Change Form to 'None'
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None');
-
-		// Define a Post Title.
-		$I->fillField('.editor-post-title__input', 'ConvertKit: Post: Form: None');
-
-		// Click the Publish button.
-		$I->click('.editor-post-publish-button__button');
-
-		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
-
-		// Check the value of the Form field matches the input provided.
-		$I->performOn( '.post-publish-panel__postpublish-buttons', function($I) {
-			$I->seeOptionIsSelected('#wp-convertkit-form', 'None');
-		});
-
-		// Load the Post on the frontend site.
-		$I->amOnPage('/convertkit-post-form-none');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Publish and view the Post on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that no ConvertKit Form is displayed.
 		$I->dontSeeElementInDOM('form[data-sv-form]');
@@ -195,48 +138,95 @@ class PostFormCest
 	 */
 	public function testAddNewPostUsingDefinedForm(AcceptanceTester $I)
 	{
-		// Navigate to Posts > Add New
-		$I->amOnAdminPage('post-new.php');
+		// Add a Post using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME']);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Check that the metabox is displayed.
-		$I->seeElementInDOM('#wp-convertkit-meta-box');
-
-		// Check that the Form option is displayed.
-		$I->seeElementInDOM('#wp-convertkit-form');
-
-		// Change Form to value specified in the .env file.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
-
-		// Define a Post Title.
-		$I->fillField('.editor-post-title__input', 'ConvertKit: Post: Form: Specific');
-
-		// Click the Publish button.
-		$I->click('.editor-post-publish-button__button');
-		
-		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
-
-		// Check the value of the Form field matches the input provided.
-		$I->performOn( '.post-publish-panel__postpublish-buttons', function($I) {
-			$I->seeOptionIsSelected('#wp-convertkit-form', $_ENV['CONVERTKIT_API_FORM_NAME']);
-		});
+		// Configure metabox's Form setting = None.
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+		]);
 
 		// Get Form ID.
 		$formID = $I->grabValueFrom('#wp-convertkit-form');
 
-		// Load the Post on the frontend site
-		$I->amOnPage('/convertkit-post-form-specific');
+		// Publish and view the Post on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that the ConvertKit Form displays.
+		$I->seeElementInDOM('form[data-sv-form="' . $formID . '"]');
+	}
+
+	/**
+	 * Test that the Legacy Form specified in the Post Settings works when
+	 * creating and viewing a new WordPress Post.
+	 * 
+	 * @since 	1.9.6.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testAddNewPostUsingDefinedLegacyForm(AcceptanceTester $I)
+	{
+		// Add a Post using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
+
+		// Configure metabox's Form setting = None.
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
+		]);
+
+		// Get Form ID.
+		$formID = $I->grabValueFrom('#wp-convertkit-form');
+
+		// Publish and view the Post on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that the ConvertKit Legacy Form displays.
+		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
+	}
+
+	/**
+	 * Test that the Default Form for Posts displays when an invalid Form ID is specified
+	 * for a Post.
+	 * 
+	 * Whilst the on screen options won't permit selecting an invalid Form ID, a Post might
+	 * have an invalid Form ID because:
+	 * - the form belongs to another ConvertKit account (i.e. API credentials were changed in the Plugin, but this Post's specified Form was not changed)
+	 * - the form was deleted from the ConvertKit account.
+	 * 
+	 * @since 	1.9.7.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testAddNewPostUsingInvalidDefinedForm(AcceptanceTester $I)
+	{
+		// Setup the Default Form for Pages and Posts.
+		$I->setupConvertKitPluginDefaultForm($I);
+
+		// Create Post, with an invalid Form ID, as if it were created prior to API credentials being changed and/or
+		// a Form being deleted in ConvertKit.
+		$postID = $I->havePostInDatabase([
+			'post_type' 	=> 'post',
+			'post_title' 	=> 'ConvertKit: Post: Form: Specific: Invalid',
+			'meta_input'	=> [
+				'_wp_convertkit_post_meta' => [
+					'form'         => '11111',
+					'landing_page' => '',
+					'tag'          => '',
+				]
+			],
+		]);
+
+		// Load the Post on the frontend site.
+		$I->amOnPage('/?p='.$postID);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the ConvertKit Form displays.
-		$I->seeElementInDOM('form[data-sv-form="' . $formID . '"]');
+		// Confirm that the invalid ConvertKit Form does not display.
+		$I->dontSeeElementInDOM('form[data-sv-form="11111"]');
+
+		// Confirm that the Default Form for Posts does display as a fallback.
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 	}
 
 	/**
@@ -296,52 +286,7 @@ class PostFormCest
 		$I->seeElementInDOM('form[data-sv-form="' . $formID . '"]');
 	}
 
-  /**
-	 * Test that the Default Form for Posts displays when an invalid Form ID is specified
-	 * for a Post.
-	 * 
-	 * Whilst the on screen options won't permit selecting an invalid Form ID, a Post might
-	 * have an invalid Form ID because:
-	 * - the form belongs to another ConvertKit account (i.e. API credentials were changed in the Plugin, but this Post's specified Form was not changed)
-	 * - the form was deleted from the ConvertKit account.
-	 * 
-	 * @since 	1.9.7.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewPostUsingInvalidDefinedForm(AcceptanceTester $I)
-	{
-		// Setup the Default Form for Pages and Posts.
-		$I->setupConvertKitPluginDefaultForm($I);
-
-		// Create Post, with an invalid Form ID, as if it were created prior to API credentials being changed and/or
-		// a Form being deleted in ConvertKit.
-		$postID = $I->havePostInDatabase([
-			'post_type' 	=> 'post',
-			'post_title' 	=> 'ConvertKit: Form: Specific: Invalid',
-			'meta_input'	=> [
-				'_wp_convertkit_post_meta' => [
-					'form'         => '11111',
-					'landing_page' => '',
-					'tag'          => '',
-				]
-			],
-		]);
-
-		// Load the Post on the frontend site.
-		$I->amOnPage('/?p='.$postID);
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm that the invalid ConvertKit Form does not display.
-		$I->dontSeeElementInDOM('form[data-sv-form="11111"]');
-
-		// Confirm that the Default Form for Posts does display as a fallback.
-		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-	}
-
-  /**
+  	/**
 	 * Test that the Default Form specified at Plugin level for Posts displays when:
 	 * - A Category was created with ConvertKit Form = 'None' when 1.9.5.2 or earlier of the Plugin was activated,
 	 * - The WordPress Post is set to use the Default Form,


### PR DESCRIPTION
## Summary

Refactors Page and Post tests for Forms, Landing Pages and Tags that interact with the Gutenberg editor to use the new helper functions created in [this PR](https://github.com/ConvertKit/convertkit-wordpress/pull/307) for repetitive tasks, such as creating Pages/Posts.

## Testing

- Existing tests pass to confirm no breaking changes to testing framework.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)