### PR TITLE
Standardize Log and System info filenames

### DIFF
--- a/admin/section/class-convertkit-settings-tools.php
+++ b/admin/section/class-convertkit-settings-tools.php
@@ -95,7 +95,7 @@ class ConvertKit_Settings_Tools extends ConvertKit_Settings_Base {
 
 		// Download.
 		header( 'Content-type: application/octet-stream' );
-		header( 'Content-Disposition: attachment; filename=' . $log->get_filename() . '.txt' );
+		header( 'Content-Disposition: attachment; filename=convertkit-log.txt' );
 		header( 'Pragma: no-cache' );
 		header( 'Expires: 0' );
 		echo $wp_filesystem->get_contents( $log->get_filename() ); // phpcs:ignore
@@ -131,7 +131,7 @@ class ConvertKit_Settings_Tools extends ConvertKit_Settings_Base {
 
 		// Download.
 		header( 'Content-type: application/octet-stream' );
-		header( 'Content-Disposition: attachment; filename=system-info.txt' );
+		header( 'Content-Disposition: attachment; filename=convertkit-system-info.txt' );
 		header( 'Pragma: no-cache' );
 		header( 'Expires: 0' );
 		echo $wp_filesystem->get_contents( $filename ); // phpcs:ignore

--- a/tests/acceptance/PluginSettingsToolsCest.php
+++ b/tests/acceptance/PluginSettingsToolsCest.php
@@ -36,6 +36,35 @@ class PluginSettingsToolsCest
 	}
 
 	/**
+	 * Test that the Download Log option works.
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testDownloadLog(AcceptanceTester $I)
+	{
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
+		$I->loadConvertKitSettingsToolsScreen($I);
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Click the Export button.
+		// This will download the file to $_ENV['WP_ROOT_FOLDER'].
+		$I->click('input#convertkit-download-debug-log');
+
+		// Wait 2 seconds for the download to complete.
+		sleep(2);
+
+		// Check downloaded file exists and contains some expected information.
+		$I->openFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-log.txt');
+		$I->seeInThisFile('API: account()');
+	
+		// Delete the file.
+		$I->deleteFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-log.txt');
+	}
+
+	/**
 	 * Test that the System Info section is populated.
 	 * 
 	 * @since 	1.9.6
@@ -52,6 +81,36 @@ class PluginSettingsToolsCest
 		// Check that the System Info textarea contains some expected output.
 		$I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### Begin System Info ###'));
 		$I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### End System Info ###'));
+	}
+
+	/**
+	 * Test that the Download System Info option works.
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testDownloadSystemInfo(AcceptanceTester $I)
+	{
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
+		$I->loadConvertKitSettingsToolsScreen($I);
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Click the Export button.
+		// This will download the file to $_ENV['WP_ROOT_FOLDER'].
+		$I->click('input#convertkit-download-system-info');
+
+		// Wait 2 seconds for the download to complete.
+		sleep(2);
+
+		// Check downloaded file exists and contains some expected information.
+		$I->openFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-system-info.txt');
+		$I->seeInThisFile('### Begin System Info ###');
+		$I->seeInThisFile('### End System Info ###');
+
+		// Delete the file.
+		$I->deleteFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-system-info.txt');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Standardizes the filenames when downloading the Plugin's Log and System info to `convertkit-log.txt` and `convertkit-system-info.txt`.

Previously, the Log would include the server's full path in the filename, which was messy.

PR also adds tests to confirm that downloading the log and system info work.

## Testing

- `PluginSettingsToolsCest:testDownloadLog`: Tests that downloading the plugin's log file works
- `PluginSettingsToolsCest:testDownloadSystemInfo`: Tests that downloading the plugin's system info works

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)