### PR TITLE
Support Blocks as Widgets

### DIFF
--- a/includes/class-convertkit-gutenberg.php
+++ b/includes/class-convertkit-gutenberg.php
@@ -179,6 +179,4 @@ class ConvertKit_Gutenberg {
 
 	}
 
-
-
 }

--- a/includes/widgets/class-ck-widget-form.php
+++ b/includes/widgets/class-ck-widget-form.php
@@ -11,10 +11,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Form Widget.
+ * Registers a ConvertKit Form Widget with WordPress' widgets functionality.
+ *
+ * Since 1.9.7.6, the ConvertKit Form Block can be used on WordPress 5.8+ sites
+ * that make use of the block editor for Widgets at Apperance > Widgets, and therefore
+ * on WordPress 5.8+, this widget will appear as a 'legacy' widget in WordPress.
+ * 
+ * It's retained as not all users may be on WordPress 5.8+, and users may already
+ * have this widget configured on their site. 
  *
  * @author   ConvertKit
- * @version  1.0.0
+ * @version  1.4.3
  */
 class CK_Widget_Form extends WP_Widget {
 
@@ -38,7 +45,7 @@ class CK_Widget_Form extends WP_Widget {
 	/**
 	 * Outputs the settings update form.
 	 *
-	 * @since   1.0.0
+	 * @since   1.4.3
 	 *
 	 * @param   array $instance   Current settings.
 	 * @return  string              Default return is 'noform'

--- a/includes/widgets/class-ck-widget-form.php
+++ b/includes/widgets/class-ck-widget-form.php
@@ -16,9 +16,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Since 1.9.7.6, the ConvertKit Form Block can be used on WordPress 5.8+ sites
  * that make use of the block editor for Widgets at Apperance > Widgets, and therefore
  * on WordPress 5.8+, this widget will appear as a 'legacy' widget in WordPress.
- * 
+ *
  * It's retained as not all users may be on WordPress 5.8+, and users may already
- * have this widget configured on their site. 
+ * have this widget configured on their site.
  *
  * @author   ConvertKit
  * @version  1.4.3

--- a/readme.txt
+++ b/readme.txt
@@ -58,6 +58,10 @@ Navigate to the Plugin's Settings at Settings > ConvertKit.
 
 == Changelog ==
 
+### 1.9.7.6 2022-05-xx
+* Added: ConvertKit Broadcasts Block when editing Widgets using the block editor in WordPress 5.8+
+* Added: ConvertKit Form Block when editing Widgets using the block editor in WordPress 5.8+
+
 ### 1.9.7.5 2022-05-12
 * Fix: PHP Warning: Cannot modify header information, caused by QuickTags modal template output
 * Fix: Text Editor: Quicktag Buttons: Block could not be found error when using a Quicktag

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -11,9 +11,7 @@
 // This prevents JS errors if this script is accidentally enqueued on a non-
 // Gutenberg editor screen, or the Classic Editor Plugin is active.
 if ( typeof wp !== 'undefined' &&
-	typeof wp.data !== 'undefined' &&
-	typeof wp.data.dispatch( 'core/edit-post' ) !== 'undefined' &&
-	wp.data.dispatch( 'core/edit-post' ) !== null ) {
+	typeof wp.blocks !== 'undefined' ) {
 
 	// Register each ConvertKit Block in Gutenberg.
 	for ( const block in convertkit_blocks ) {

--- a/tests/_support/Helper/Acceptance/WPWidget.php
+++ b/tests/_support/Helper/Acceptance/WPWidget.php
@@ -1,0 +1,160 @@
+<?php
+namespace Helper\Acceptance;
+
+// Define any custom actions related to metaboxes that
+// would be used across multiple tests.
+// These are then available in $I->{yourFunctionName}
+
+class WPWidget extends \Codeception\Module
+{
+	/**
+	 * Configure a given legacy widget's fields with the given values.
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
+	 * @param 	string 				$blockName 				Block Name (e.g. 'ConvertKit Form').
+	 * @param 	string 				$blockProgrammaticName 	Programmatic Block Name (e.g. 'convertkit-form').
+	 * @param 	bool|array 			$blockConfiguration 	Block Configuration (field => value key/value array).
+	 */
+	public function addLegacyWidget($I, $blockName, $blockProgrammaticName, $blockConfiguration = false)
+	{
+		// Navigate to Appearance > Widgets.
+		$I->amOnAdminPage('widgets.php');
+
+		// Dismiss welcome message.
+		$I->maybeCloseGutenbergWelcomeModal($I);
+
+		// Click Add Block Button.
+		$I->click('button.edit-widgets-header-toolbar__inserter-toggle');
+
+		// When the Blocks sidebar appears, search for the legacy widget.
+		$I->waitForElementVisible('.interface-interface-skeleton__secondary-sidebar');
+		$I->fillField('.block-editor-inserter__content input[type=search]', $blockName);
+		$I->seeElementInDOM('.block-editor-inserter__panel-content .block-editor-block-types-list__list-item button[tabindex="0"]');
+		$I->click('.block-editor-inserter__panel-content .block-editor-block-types-list__list-item button[tabindex="0"]');
+
+		// If a Block configuration is specified, apply it to the Block now.
+		if ($blockConfiguration) {
+			$I->waitForElementVisible('.wp-block-legacy-widget form');
+
+			foreach ($blockConfiguration as $field=>$attributes) {
+				$fieldID = '#widget-' . str_replace('-', '_', $blockProgrammaticName) . '-1-' . $field;
+				
+				// Depending on the field's type, define its value.
+				switch ($attributes[0]) {
+					case 'select':
+						$I->selectOption($fieldID, $attributes[1]);
+						break;
+					default:
+						$I->fillField($fieldID, $attributes[1]);
+						break;
+				}
+			}
+		}
+
+		// Save.
+		$I->click('Update');
+
+		// Wait until the preview is displayed.
+		$I->waitForElementVisible('iframe.wp-block-legacy-widget__edit-preview-iframe');
+	}
+
+	/**
+	 * Check a given legacy widget is displayed on the frontend site.
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
+	 * @param 	string 				$blockName 				Block Name (e.g. 'ConvertKit Form').
+	 * @param 	string 				$blockProgrammaticName 	Programmatic Block Name (e.g. 'convertkit-form').
+	 * @param 	bool|array 			$blockConfiguration 	Block Configuration (field => value key/value array).
+	 */
+	public function seeLegacyWidget($I, $blockProgrammaticName, $expectedMarkup)
+	{
+		// View the home page.
+		$I->amOnPage('/');
+
+		// Confirm that the widget exists in an expected widget area.
+		$I->seeElementInDOM('aside.widget-area .widget_'.str_replace('-', '_', $blockProgrammaticName));
+
+		// Confirm that the ConvertKit Form is displayed in the widget.
+		$I->seeElementInDOM($expectedMarkup);
+	}
+
+	/**
+	 * Add the given block when editing widgets using Gutenberg.
+	 * 
+	 * If a block configuration is specified, applies it to the newly added block.
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
+	 * @param 	string 				$blockName 				Block Name (e.g. 'ConvertKit Form').
+	 * @param 	string 				$blockProgrammaticName 	Programmatic Block Name (e.g. 'convertkit-form').
+	 * @param 	bool|array 			$blockConfiguration 	Block Configuration (field => value key/value array).
+	 */
+	public function addBlockWidget($I, $blockName, $blockProgrammaticName, $blockConfiguration = false)
+	{
+		// Navigate to Appearance > Widgets.
+		$I->amOnAdminPage('widgets.php');
+
+		// Dismiss welcome message.
+		$I->maybeCloseGutenbergWelcomeModal($I);
+
+		// Click Add Block Button.
+		$I->click('button.edit-widgets-header-toolbar__inserter-toggle');
+
+		// When the Blocks sidebar appears, search for the legacy widget.
+		$I->waitForElementVisible('.interface-interface-skeleton__secondary-sidebar');
+		$I->fillField('.block-editor-inserter__content input[type=search]', $blockName);
+		$I->seeElementInDOM('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
+		$I->click('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
+
+		// If a Block configuration is specified, apply it to the Block now.
+		if ($blockConfiguration) {
+			$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Widgets settings"]');
+
+			foreach ($blockConfiguration as $field=>$attributes) {
+				// Field ID will be block's programmatic name with underscores instead of hyphens,
+				// followed by the attribute name.
+				$fieldID = '#' . str_replace('-', '_', $blockProgrammaticName) . '_' . $field;
+				
+				// Depending on the field's type, define its value.
+				switch ($attributes[0]) {
+					case 'select':
+						$I->selectOption($fieldID, $attributes[1]);
+						break;
+					default:
+						$I->fillField($fieldID, $attributes[1]);
+						break;
+				}
+			}
+		}
+
+		// Save.
+		$I->click('Update');
+
+		// Wait.
+		$I->wait(2);
+	}
+
+	/**
+	 * Check a given block widget is displayed on the frontend site.
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
+	 * @param 	string 				$blockName 				Block Name (e.g. 'ConvertKit Form').
+	 * @param 	string 				$blockProgrammaticName 	Programmatic Block Name (e.g. 'convertkit-form').
+	 * @param 	bool|array 			$blockConfiguration 	Block Configuration (field => value key/value array).
+	 */
+	public function seeBlockWidget($I, $blockProgrammaticName, $expectedMarkup)
+	{
+		// View the home page.
+		$I->amOnPage('/');
+
+		// Confirm that the ConvertKit Form is displayed in the widget area.
+		$I->seeElementInDOM('aside.widget-area '.$expectedMarkup);
+	}
+}

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -26,8 +26,9 @@ modules:
         - \Helper\Acceptance\Select2
         - \Helper\Acceptance\ThirdPartyPlugin
         - \Helper\Acceptance\WPClassicEditor
-        - \Helper\Acceptance\WPMetabox
         - \Helper\Acceptance\WPGutenberg
+        - \Helper\Acceptance\WPMetabox
+        - \Helper\Acceptance\WPWidget
         - \Helper\Acceptance\Xdebug
     config:
         WPDb:

--- a/tests/acceptance/WidgetBroadcastsCest.php
+++ b/tests/acceptance/WidgetBroadcastsCest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Tests for the ConvertKit Broadcasts block when used as a widget.
+ * 
+ * A widget area is typically defined by a Theme in a shared area, such as a sidebar or footer.
+ * 
+ * @since 	1.9.7.6
+ */
+class WidgetBroadcastsCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
+
+		// Activate an older WordPress Theme that supports Widgets.
+		$I->useTheme('twentytwentyone');
+	}
+
+	/**
+	 * Test the Broadcasts block works when using the default parameters.
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testBroadcastsBlockWidgetWithDefaultParameters(AcceptanceTester $I)
+	{
+		// Add block widget, setting the Form setting to the value specified in the .env file.
+		$I->addBlockWidget($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
+
+		// View the home page.
+		$I->amOnPage('/');
+
+		// Confirm that the block displays.
+		$I->seeBroadcastsOutput($I);
+
+		// Confirm that the default date format is as expected.
+		$I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
+
+		// Confirm that the default expected number of Broadcasts are displayed.
+		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
+	}
+
+	/**
+	 * Test the Broadcasts block's date format parameter works.
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testBroadcastsBlockWidgetWithDateFormatParameter(AcceptanceTester $I)
+	{
+		// Add block widget, setting the Form setting to the value specified in the .env file.
+		$I->addBlockWidget($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
+			'date_format' => [ 'select', 'Y-m-d' ],
+		]);
+
+		// View the home page.
+		$I->amOnPage('/');
+
+		// Confirm that the block displays.
+		$I->seeBroadcastsOutput($I);
+
+		// Confirm that the date format is as expected.
+		$I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
+
+		// Confirm that the default expected number of Broadcasts are displayed.
+		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
+	}
+
+	/**
+	 * Test the Broadcasts block's limit parameter works.
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testBroadcastsBlockWidgetWithLimitParameter(AcceptanceTester $I)
+	{
+		// Add block widget, setting the Form setting to the value specified in the .env file.
+		$I->addBlockWidget($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
+			'limit' => [ 'input', '2' ],
+		]);
+
+		// View the home page.
+		$I->amOnPage('/');
+
+		// Confirm that the block displays.
+		$I->seeBroadcastsOutput($I);
+
+		// Confirm that the expected number of Broadcasts are displayed.
+		$I->seeNumberOfElements('li.convertkit-broadcast', 2);
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		// Activate the current theme.
+		$I->useTheme('twentytwentytwo');
+		$I->resetWidgets($I);
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
+	}
+}

--- a/tests/acceptance/WidgetFormCest.php
+++ b/tests/acceptance/WidgetFormCest.php
@@ -10,7 +10,7 @@
  * 
  * @since 	1.9.7.6
  */
-class WidgetsFormCest
+class WidgetFormCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
@@ -61,8 +61,11 @@ class WidgetsFormCest
 			'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ]
 		]);
 
+		// View the home page.
+		$I->amOnPage('/');
+
 		// Confirm that the widget displays.
-		$I->seeLegacyWidget($I, 'convertkit-form', '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
+		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
 	}
 
 	/**
@@ -97,8 +100,11 @@ class WidgetsFormCest
 			'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ]
 		]);
 
+		// View the home page.
+		$I->amOnPage('/');
+
 		// Confirm that the widget displays.
-		$I->seeBlockWidget($I, 'convertkit-form', '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
+		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
 	}
 
 	/**
@@ -199,6 +205,9 @@ class WidgetsFormCest
 	 */
 	public function _passed(AcceptanceTester $I)
 	{
+		// Activate the current theme.
+		$I->useTheme('twentytwentytwo');
+		$I->resetWidgets($I);
 		$I->deactivateConvertKitPlugin($I);
 		$I->resetConvertKitPlugin($I);
 	}

--- a/tests/acceptance/WidgetFormCest.php
+++ b/tests/acceptance/WidgetFormCest.php
@@ -32,6 +32,10 @@ class WidgetFormCest
 	/**
 	 * Test that the legacy Form widget works when a valid Form is selected.
 	 * 
+	 * We retain this legacy non-block widget, because it's been available since 1.4.3,
+	 * and there is no smooth conversion path to making legacy widgets into widget blocks
+	 * for WordPress 5.8+. 
+	 * 
 	 * @since 	1.9.7.6
 	 * 
 	 * @param 	AcceptanceTester 	$I 	Tester
@@ -49,7 +53,11 @@ class WidgetFormCest
 
 	/**
 	 * Test that the legacy Form widget works when a valid Legacy Form is selected.
-	 * 
+	 *
+	 * We retain this legacy non-block widget, because it's been available since 1.4.3,
+	 * and there is no smooth conversion path to making legacy widgets into widget blocks
+	 * for WordPress 5.8+.
+	 *
 	 * @since 	1.9.7.6
 	 * 
 	 * @param 	AcceptanceTester 	$I 	Tester

--- a/tests/acceptance/WidgetsFormCest.php
+++ b/tests/acceptance/WidgetsFormCest.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * Tests for the ConvertKit Form widget.
+ * 
+ * A widget area is typically defined by a Theme in a shared area, such as a sidebar or footer.
+ * 
+ * We test both legacy widgets (registered in includes/widgets/class-ck-widget-form.php),
+ * and the Gutenberg Form Block, which can be inserted into a widget area starting from
+ * WordPress 5.8.
+ * 
+ * @since 	1.9.7.6
+ */
+class WidgetsFormCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
+
+		// Activate an older WordPress Theme that supports Widgets.
+		$I->useTheme('twentytwentyone');
+	}
+
+	/**
+	 * Test that the legacy Form widget works when a valid Form is selected.
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testLegacyFormWidgetWithValidFormParameter(AcceptanceTester $I)
+	{
+		// Add legacy widget, setting the Form setting to the value specified in the .env file.
+		$I->addLegacyWidget($I, 'ConvertKit Form', 'convertkit-form', [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+		]);
+
+		// Confirm that the widget displays.
+		$I->seeLegacyWidget($I, 'convertkit-form', 'form[data-sv-form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]');
+	}
+
+	/**
+	 * Test that the legacy Form widget works when a valid Legacy Form is selected.
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testLegacyFormWidgetWithValidLegacyFormParameter(AcceptanceTester $I)
+	{
+		// Add legacy widget, setting the Form setting to the value specified in the .env file.
+		$I->addLegacyWidget($I, 'ConvertKit Form', 'convertkit-form', [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ]
+		]);
+
+		// Confirm that the widget displays.
+		$I->seeLegacyWidget($I, 'convertkit-form', '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
+	}
+
+	/**
+	 * Test the Form widget works when a valid Form is selected.
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testBlockFormWidgetWithValidFormParameter(AcceptanceTester $I)
+	{
+		// Add block widget, setting the Form setting to the value specified in the .env file.
+		$I->addBlockWidget($I, 'ConvertKit Form', 'convertkit-form', [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+		]);
+
+		// Confirm that the widget displays.
+		$I->seeBlockWidget($I, 'convertkit-form', 'form[data-sv-form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]');
+	}
+
+	/**
+	 * Test the Form widget works when a valid Legacy Form is selected.
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testBlockFormBlockWithValidLegacyFormParameter(AcceptanceTester $I)
+	{
+		// Add block widget, setting the Form setting to the value specified in the .env file.
+		$I->addBlockWidget($I, 'ConvertKit Form', 'convertkit-form', [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ]
+		]);
+
+		// Confirm that the widget displays.
+		$I->seeBlockWidget($I, 'convertkit-form', '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
+	}
+
+	/**
+	 * Test the Form widget displays a message explaining why the block cannot be previewed
+	 * when a valid Modal Form is selected.
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testFormWidgetWithValidModalFormParameter(AcceptanceTester $I)
+	{
+		// Add block widget, setting the Form setting to the value specified in the .env file.
+		$I->addBlockWidget($I, 'ConvertKit Form', 'convertkit-form', [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ]
+		]);
+
+		// Switch to iframe preview for the Form block.
+		$I->switchToIFrame('iframe[class="components-sandbox"]');
+
+		// Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
+		// site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
+		$I->see('Modal form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . '" selected. View on the frontend site to see the modal form.');
+
+		// Switch back to main window.
+		$I->switchToIFrame();
+
+		// Confirm that the widget displays.
+		$I->seeBlockWidget($I, 'convertkit-form', 'form[data-sv-form]');
+	}
+
+	/**
+	 * Test the Form widget displays a message explaining why the block cannot be previewed
+	 *  when a valid Slide In Form is selected.
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testBlockFormWidgetWithValidSlideInFormParameter(AcceptanceTester $I)
+	{
+		// Add block widget, setting the Form setting to the value specified in the .env file.
+		$I->addBlockWidget($I, 'ConvertKit Form', 'convertkit-form', [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] ]
+		]);
+
+		// Switch to iframe preview for the Form block.
+		$I->switchToIFrame('iframe[class="components-sandbox"]');
+
+		// Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
+		// site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
+		$I->see('Slide in form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] . '" selected. View on the frontend site to see the slide in form.');
+
+		// Switch back to main window.
+		$I->switchToIFrame();
+
+		// Confirm that the widget displays.
+		$I->seeBlockWidget($I, 'convertkit-form', 'form[data-sv-form]');
+	}
+
+	/**
+	 * Test the Form widget displays a message explaining why the block cannot be previewed
+	 * when a valid Sticky Bar Form is selected.
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testBlockFormWidgetWithValidStickyBarFormParameter(AcceptanceTester $I)
+	{
+		// Add block widget, setting the Form setting to the value specified in the .env file.
+		$I->addBlockWidget($I, 'ConvertKit Form', 'convertkit-form', [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ]
+		]);
+
+		// Switch to iframe preview for the Form block.
+		$I->switchToIFrame('iframe[class="components-sandbox"]');
+
+		// Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
+		// site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
+		$I->see('Sticky bar form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] . '" selected. View on the frontend site to see the sticky bar form.');
+
+		// Switch back to main window.
+		$I->switchToIFrame();
+
+		// Confirm that the widget displays.
+		$I->seeBlockWidget($I, 'convertkit-form', 'form[data-sv-form]');
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
+	}
+}


### PR DESCRIPTION
## Summary

Currently, we have a[ Form Widget](https://github.com/ConvertKit/convertkit-wordpress/blob/master/includes/widgets/class-ck-widget-form.php) which is registered in WordPress' widget system using the `WP_Widget` class, allowing site owners to place ConvertKit Forms in their site's sidebars or footers, depending on their theme.

[Since WordPress 5.8](https://wordpress.org/news/2021/08/widgets-in-wordpress-5-8-and-beyond/), the widget interface has been replaced with the Gutenberg editor, allowing site owners to place blocks in their site's sidebars and footers, again depending on their theme.

![Screenshot 2022-05-17 at 18 03 13](https://user-images.githubusercontent.com/1462305/168870409-f2faaa72-97d2-4b4f-a1be-0da36dd135ee.png)

![Screenshot 2022-05-17 at 18 03 39](https://user-images.githubusercontent.com/1462305/168870478-b43dd9c3-2867-4ee3-a619-a97399dfe4b7.png)

This PR:
- Enables the ConvertKit Form Block and ConvertKit Broadcasts Block to be added and configured to WordPress 5.8+ widget areas, and not just Pages/Posts.
- Adds tests for the Form and Broadcast blocks when added to a widget area in WordPress 5.8+
- Adds tests for the Form legacy widget when added to a widget area.

This PR doesn't remove the legacy form widget registered using the `WP_Widget` method, as this ensures continued compatibility with:
- WordPress versions < 5.8
- WordPress 5.0+ sites that already use this legacy widget (removing it would be a breaking change, resulting in the loss of form output, and there is no smooth automated upgrade path to convert a legacy widget into a block)

## Testing

- `WidgetFormCest`: Added tests for both the legacy widget and block when added to a widget area
- `WidgetBroadcastsCest`: Added tests for the broadcasts block when added to a widget area

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)