### PR TITLE
Updated PHPStan configuration to support PHPStan 1.7

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -30,6 +30,3 @@ parameters:
     ignoreErrors:
         - '#Access to an undefined property WP_Theme::#'
         - '#Constant WP_MEMORY_LIMIT not found.#'
-        - '#Constant DB_HOST not found.#'
-        - '#Constant WPINC not found.#'
-        - '#Function apply_filters invoked with#' # apply_filters() accepted a variable number of parameters, which PHPStan fails to detect


### PR DESCRIPTION
## Summary

PHPStan 1.7 better detects some WordPress constants and fixes some false positives, which can be safely removed from the `phpstan.neon.dist` configuration.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)