### PR TITLE
Add pagination support to Broadcasts API / Resource classes

### DIFF
--- a/includes/class-convertkit-resource.php
+++ b/includes/class-convertkit-resource.php
@@ -122,6 +122,52 @@ class ConvertKit_Resource {
 
 	}
 
+
+	/**
+	 * Returns a paginated subset of resources, including whether
+	 * previous and next resources in the array exist.
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   int $page   Current Page.
+	 * @param   int $per_page   Number of resources to return per page.
+	 * @return  array
+	 */
+	public function get_paginated_subset( $page, $per_page ) {
+
+		// Calculate the maximum value for $page.
+		$total_pages = ( ( $per_page > 0 ) ? ceil( $this->count() / $per_page ) : 1 );
+
+		// If $page exceeds the total number of possible pages, reduce it.
+		if ( $page > $total_pages ) {
+			$page = $total_pages;
+		}
+
+		// If $page is less than 1, set it to 1.
+		if ( $page < 1 ) {
+			$page = 1;
+		}
+
+		return array(
+			// The subset of items based on the pagination.
+			'items'         => array_slice( $this->resources, ( $page * $per_page ) - $per_page, $per_page ),
+
+			// Sanitized inputs.
+			'page'          => $page,
+			'per_page'      => $per_page,
+
+			// The total number of pages in the pagination.
+			'total_pages'   => $total_pages,
+
+			// If the request page is lower than the total number of pages in the pagination, there's a next page.
+			'has_next_page' => ( ( $page < $total_pages ) ? true : false ),
+
+			// If the request page is higher than 1, there's a previous page.
+			'has_prev_page' => ( ( $page > 1 ) ? true : false ),
+		);
+
+	}
+
 	/**
 	 * Returns whether any resources exist in the options table.
 	 *
@@ -181,7 +227,7 @@ class ConvertKit_Resource {
 				break;
 
 			case 'posts':
-				$results = $api->get_posts();
+				$results = $api->get_all_posts();
 				break;
 
 			default:

--- a/includes/class-convertkit-resource.php
+++ b/includes/class-convertkit-resource.php
@@ -169,6 +169,19 @@ class ConvertKit_Resource {
 	}
 
 	/**
+	 * Returns the number of resources.
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @return  int
+	 */
+	public function count() {
+
+		return count( $this->resources );
+
+	}
+
+	/**
 	 * Returns whether any resources exist in the options table.
 	 *
 	 * @since   1.9.6

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -519,13 +519,23 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	public function testGetPosts()
 	{
 		$result = $this->api->get_posts();
+
+		// Test array was returned.
 		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertIsArray($result);
-		$this->assertArrayHasKey('id', reset($result));
-		$this->assertArrayHasKey('title', reset($result));
-		$this->assertArrayHasKey('url', reset($result));
-		$this->assertArrayHasKey('published_at', reset($result));
-		$this->assertArrayHasKey('is_paid', reset($result));
+
+		// Test expected response keys exist.
+		$this->assertArrayHasKey('total_posts', $result);
+		$this->assertArrayHasKey('page', $result);
+		$this->assertArrayHasKey('total_pages', $result);
+		$this->assertArrayHasKey('posts', $result);
+
+		// Test first post within posts array.
+		$this->assertArrayHasKey('id', reset($result['posts']));
+		$this->assertArrayHasKey('title', reset($result['posts']));
+		$this->assertArrayHasKey('url', reset($result['posts']));
+		$this->assertArrayHasKey('published_at', reset($result['posts']));
+		$this->assertArrayHasKey('is_paid', reset($result['posts']));
 	}
 
 	/**
@@ -537,14 +547,26 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	public function testGetPostsWithValidParameters()
 	{
 		$result = $this->api->get_posts(1, 2);
+
+		// Test array was returned.
 		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertIsArray($result);
-		$this->assertCount(2, $result);
-		$this->assertArrayHasKey('id', reset($result));
-		$this->assertArrayHasKey('title', reset($result));
-		$this->assertArrayHasKey('url', reset($result));
-		$this->assertArrayHasKey('published_at', reset($result));
-		$this->assertArrayHasKey('is_paid', reset($result));
+
+		// Test expected response keys exist.
+		$this->assertArrayHasKey('total_posts', $result);
+		$this->assertArrayHasKey('page', $result);
+		$this->assertArrayHasKey('total_pages', $result);
+		$this->assertArrayHasKey('posts', $result);
+
+		// Test expected number of posts returned.
+		$this->assertCount(2, $result['posts']);
+
+		// Test first post within posts array.
+		$this->assertArrayHasKey('id', reset($result['posts']));
+		$this->assertArrayHasKey('title', reset($result['posts']));
+		$this->assertArrayHasKey('url', reset($result['posts']));
+		$this->assertArrayHasKey('published_at', reset($result['posts']));
+		$this->assertArrayHasKey('is_paid', reset($result['posts']));
 	}
 
 	/**
@@ -587,6 +609,63 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
 		$this->assertEquals('get_posts(): the per_page parameter must be equal to or less than 50.', $result->get_error_message());
+	}
+
+	/**
+	 * Test that the `get_all_posts()` function returns expected data.
+	 * 
+	 * @since 	1.9.7.6
+	 */
+	public function testGetAllPosts()
+	{
+		$result = $this->api->get_all_posts();
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('title', reset($result));
+		$this->assertArrayHasKey('url', reset($result));
+		$this->assertArrayHasKey('published_at', reset($result));
+		$this->assertArrayHasKey('is_paid', reset($result));
+	}
+
+	/**
+	 * Test that the `get_all_posts()` function returns expected data
+	 * when valid parameters are included.
+	 * 
+	 * @since 	1.9.7.6
+	 */
+	public function testGetAllPostsWithValidParameters()
+	{
+		$result = $this->api->get_all_posts(2); // Number of posts to fetch in each request within the function.
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(4, $result);
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('title', reset($result));
+		$this->assertArrayHasKey('url', reset($result));
+		$this->assertArrayHasKey('published_at', reset($result));
+		$this->assertArrayHasKey('is_paid', reset($result));
+	}
+
+	/**
+	 * Test that the `get_all_posts()` function returns an error
+	 * when the page parameter is less than 1.
+	 * 
+	 * @since 	1.9.7.6
+	 */
+	public function testGetAllPostsWithInvalidPostsPerRequestParameter()
+	{
+		// Test with a number less than 1.
+		$result = $this->api->get_all_posts(0);
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+		$this->assertEquals('get_all_posts(): the posts_per_request parameter must be equal to or greater than 1.', $result->get_error_message());
+
+		// Test with a number greater than 50.
+		$result = $this->api->get_all_posts(51);
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+		$this->assertEquals('get_all_posts(): the posts_per_request parameter must be equal to or less than 50.', $result->get_error_message());
 	}
 
 	/**

--- a/tests/wpunit/ResourceFormsTest.php
+++ b/tests/wpunit/ResourceFormsTest.php
@@ -119,6 +119,17 @@ class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
+	 * Test that the count() function returns the number of resources.
+	 * 
+	 * @since 	1.9.7.6
+	 */
+	public function testCount()
+	{
+		$result = $this->resource->get();
+		$this->assertEquals($this->resource->count(), count($result));
+	}
+
+	/**
 	 * Test that the exist() function performs as expected, storing data in the options table.
 	 * 
 	 * @since 	1.9.7.4

--- a/tests/wpunit/ResourceLandingPagesTest.php
+++ b/tests/wpunit/ResourceLandingPagesTest.php
@@ -119,6 +119,17 @@ class ResourceLandingPagesTest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
+	 * Test that the count() function returns the number of resources.
+	 * 
+	 * @since 	1.9.7.6
+	 */
+	public function testCount()
+	{
+		$result = $this->resource->get();
+		$this->assertEquals($this->resource->count(), count($result));
+	}
+
+	/**
 	 * Test that the exist() function performs as expected, storing data in the options table.
 	 * 
 	 * @since 	1.9.7.4

--- a/tests/wpunit/ResourcePostsTest.php
+++ b/tests/wpunit/ResourcePostsTest.php
@@ -229,6 +229,94 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
+	 * Test that the get_paginated_subset() function performs as expected when requesting one item from the first page.
+	 * 
+	 * @since 	1.9.7.6
+	 */
+	public function testGetPaginatedSubsetFirstPage()
+	{
+		$this->testPagination(
+			$this->resource->get_paginated_subset(1, 1), // Paginated array of resources and metadata.
+			1, // Page.
+			1, // Per Page.
+			true, // Has a next page, as more results in the resultset exist.
+			false // Does not have a previous page, as this is the first page in the resultset.
+		);
+	}
+
+	/**
+	 * Test that the get_paginated_subset() function performs as expected when requesting one item from a page
+	 * that is not the first or last page.
+	 * 
+	 * @since 	1.9.7.6
+	 */
+	public function testGetPaginatedSubsetMiddlePage()
+	{
+		$this->testPagination(
+			$this->resource->get_paginated_subset(2, 1), // Paginated array of resources and metadata.
+			2, // Page.
+			1, // Per Page.
+			true, // Has a next page, as more results in the resultset exist.
+			true // Has a previous page, as more results in the resultset exist.
+		);
+	}
+
+	/**
+	 * Test that the get_paginated_subset() function performs as expected when requesting one item from the last page.
+	 * 
+	 * @since 	1.9.7.6
+	 */
+	public function testGetPaginatedSubsetLastPage()
+	{
+		// Query the API to establish how many resources exist.
+		$result = $this->resource->get();
+		$lastPage = count($result);
+
+		$this->testPagination(
+			$this->resource->get_paginated_subset($lastPage, 1), // Paginated array of resources and metadata.
+			$lastPage, // Page.
+			1, // Per Page.
+			false, // Does not have a next page, as this is the last page in the resultset.
+			true // Has a previous page, as more results in the resultset exist.
+		);
+	}
+
+	/**
+	 * Shared tests for paginated resources, ensuring the response contains expected values for pagination,
+	 * next/previous links etc.
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	array 	$result 	Result.
+	 * @param 	int 	$page 		Page.
+	 * @param 	int 	$perPage 	Results per page.
+	 * @param 	bool 	$hasNextPage 	Response should indicate pagination is available for older resources.
+	 * @param 	bool 	$hasPrevPage 	Response should indicate pagination is available for newer resources.
+	 */
+	private function testPagination($result, $page, $perPage, $hasNextPage, $hasPrevPage)
+	{
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('items', $result);
+		$this->assertArrayHasKey('page', $result);
+		$this->assertArrayHasKey('per_page', $result);
+		$this->assertArrayHasKey('has_next_page', $result);
+		$this->assertArrayHasKey('has_prev_page', $result);
+
+		// Check posts exist.
+		$this->assertIsArray($result);
+		$this->assertCount($perPage, $result['items']);
+		$this->assertArrayHasKey('id', reset($result['items']));
+		$this->assertArrayHasKey('title', reset($result['items']));
+
+		// Check other array values are as expected.
+		$this->assertEquals($result['page'], $page);
+		$this->assertEquals($result['per_page'], $perPage);
+		$this->assertEquals($result['has_next_page'], $hasNextPage);
+		$this->assertEquals($result['has_prev_page'], $hasPrevPage);
+	}
+
+	/**
 	 * Test that the exist() function performs as expected, storing data in the options table.
 	 * 
 	 * @since 	1.9.7.4

--- a/tests/wpunit/ResourcePostsTest.php
+++ b/tests/wpunit/ResourcePostsTest.php
@@ -282,6 +282,17 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
+	 * Test that the count() function returns the number of resources.
+	 * 
+	 * @since 	1.9.7.6
+	 */
+	public function testCount()
+	{
+		$result = $this->resource->get();
+		$this->assertEquals($this->resource->count(), count($result));
+	}
+
+	/**
 	 * Shared tests for paginated resources, ensuring the response contains expected values for pagination,
 	 * next/previous links etc.
 	 * 

--- a/tests/wpunit/ResourceTagsTest.php
+++ b/tests/wpunit/ResourceTagsTest.php
@@ -119,6 +119,17 @@ class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
+	 * Test that the count() function returns the number of resources.
+	 * 
+	 * @since 	1.9.7.6
+	 */
+	public function testCount()
+	{
+		$result = $this->resource->get();
+		$this->assertEquals($this->resource->count(), count($result));
+	}
+
+	/**
 	 * Test that the exist() function performs as expected, storing data in the options table.
 	 * 
 	 * @since 	1.9.7.4


### PR DESCRIPTION
## Summary

Updates the API class to fetch all broadcasts from the API, now that [pagination is supported](https://github.com/ConvertKit/convertkit/pull/20651) in the posts API.

Caches all broadcasts, and provides a `get_paginated_subset()` function for cached resources, such as broadcasts, so that pagination is handled by the plugin, without needing to make repetitive requests to the API.

A separate PR will then utilize this pagination functionality on the Broadcasts block and shortcode.

## Testing

- `APITest`: Added tests for new API functions.
- `ResourcePostsTest`: Added tests for pagination.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)