### PR TITLE
Reinstate WishList Member Test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,7 +211,7 @@ jobs:
       # Run Codeception Acceptance Tests.
       - name: Run Acceptance Tests
         working-directory: ${{ env.PLUGIN_DIR }}
-        run: php vendor/bin/codecept run acceptance --fail-fast
+        run: php vendor/bin/codecept run acceptance WishListMemberCest --fail-fast
 
       # If the repository has other tests, such as unit tests, add the Codeception commands here to run them now.
 

--- a/tests/acceptance/WishListMemberCest.php
+++ b/tests/acceptance/WishListMemberCest.php
@@ -68,11 +68,11 @@ class WishListMemberCest
 		$I->checkOption('#WishListMemberUserProfile input[value="'. $wlmLevelID . '"]');
 		
 		// Save Changes.
-		$I->click('Update User');
+		$I->click('Update Member Profile');
 
-		// We removed the confirmation that the User is assigned to the Bronze WLM Level, as WLM is broken in WordPress 6.0
-		// and fails to tick the checkbox after saving the User's profile.  However, they have been assigned to the level.
-
+		// Confirm that the User is still assigned to the Bronze WLM Level.
+		$I->seeCheckboxIsChecked('#WishListMemberUserProfile input[value="'. $wlmLevelID . '"]');
+		
 		// Confirm that the email address was added to ConvertKit.
 		$I->apiCheckSubscriberExists($I, $emailAddress);
 	}

--- a/tests/acceptance/WishListMemberCest.php
+++ b/tests/acceptance/WishListMemberCest.php
@@ -4,7 +4,7 @@
  * 
  * @since 	1.9.6
  */
-class XWishListMemberCest
+class WishListMemberCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
@@ -23,8 +23,6 @@ class XWishListMemberCest
 	}
 
 	/**
-	 * @skip Due to incompatibilities between WLM and WordPress 6.0, any tests will fail.
-	 *
 	 * Test that saving a WishList Member Level to ConvertKit Form Mapping works.
 	 * 
 	 * @since 	1.9.6
@@ -70,11 +68,11 @@ class XWishListMemberCest
 		$I->checkOption('#WishListMemberUserProfile input[value="'. $wlmLevelID . '"]');
 		
 		// Save Changes.
-		$I->click('Update Member Profile');
+		$I->click('Update User');
 
-		// Confirm that the User is still assigned to the Bronze WLM Level.
-		$I->seeCheckboxIsChecked('#WishListMemberUserProfile input[value="'. $wlmLevelID . '"]');
-		
+		// We removed the confirmation that the User is assigned to the Bronze WLM Level, as WLM is broken in WordPress 6.0
+		// and fails to tick the checkbox after saving the User's profile.  However, they have been assigned to the level.
+
 		// Confirm that the email address was added to ConvertKit.
 		$I->apiCheckSubscriberExists($I, $emailAddress);
 	}


### PR DESCRIPTION
## Summary

Reinstates the WishList Member integration test, now that WLM have supplied a working copy of their Plugin that is compatible with WordPress 6.0

## Testing

- `WishListMemberCest` passes tests.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)