### PR TITLE
Broadcasts: Add utm_source and utm_content parameters

### DIFF
--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -449,10 +449,19 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 			// Convert UTC date to timestamp.
 			$date_timestamp = strtotime( $broadcast['published_at'] );
 
+			// Build broadcast URL.
+			$url = add_query_arg(
+				array(
+					'utm_source'  => 'wordpress',
+					'utm_content' => 'convertkit',
+				),
+				$broadcast['url']
+			);
+
 			// Add broadcast as list item.
 			$html .= '<li class="convertkit-broadcast">
 				<time datetime="' . date_i18n( 'Y-m-d', $date_timestamp ) . '">' . date_i18n( $atts['date_format'], $date_timestamp ) . '</time>
-				<a href="' . $broadcast['url'] . '" target="_blank" rel="nofollow noopener">' . $broadcast['title'] . '</a>
+				<a href="' . $url . '" target="_blank" rel="nofollow noopener">' . $broadcast['title'] . '</a>
 			</li>';
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -110,6 +110,9 @@ Full Plugin documentation can be found [here](https://help.convertkit.com/en/art
 
 == Changelog ==
 
+### 1.9.7.7 2022-06-xx
+* Added: Broadcasts: utm_source and utm_content to links
+
 ### 1.9.7.6 2022-06-01
 * Added: ConvertKit Broadcasts Block when editing Widgets using the block editor in WordPress 5.8+
 * Added: ConvertKit Form Block when editing Widgets using the block editor in WordPress 5.8+

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -280,6 +280,12 @@ class Plugin extends \Codeception\Module
 		$I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast');
 		$I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast a');
 
+		// Confirm that UTM parameters exist on a broadcast link.
+		$I->assertStringContainsString(
+			'utm_source=wordpress&utm_content=convertkit',
+			$I->grabAttributeFrom('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast a', 'href')
+		);
+
 		// Confirm that the number of expected broadcasts displays.
 		if ($numberOfPosts !== false) {
 			$I->seeNumberOfElements('li.convertkit-broadcast', $numberOfPosts);


### PR DESCRIPTION
## Summary

Adds `utm_source` and `utm_content` parameters to broadcast links, as requested by @brendancarney

## Testing

- Helper `seeBroadcastsOutput()` checks that a link includes the `utm_source` and `utm_content` parameters; this helper function is used when testing broadcast blocks / shortcodes.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)