### PR TITLE
Testing: Use Form IDs in .env file

### DIFF
--- a/tests/acceptance/PageFormCest.php
+++ b/tests/acceptance/PageFormCest.php
@@ -164,14 +164,11 @@ class PageFormCest
 			'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 		]);
 
-		// Get Form ID.
-		$formID = $I->grabValueFrom('#wp-convertkit-form');
-
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the ConvertKit Form displays.
-		$I->seeElementInDOM('form[data-sv-form="' . $formID . '"]');
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 	}
 
 	/**
@@ -191,9 +188,6 @@ class PageFormCest
 		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
 			'form' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
 		]);
-
-		// Get Form ID.
-		$formID = $I->grabValueFrom('#wp-convertkit-form');
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);

--- a/tests/acceptance/PostFormCest.php
+++ b/tests/acceptance/PostFormCest.php
@@ -163,14 +163,11 @@ class PostFormCest
 			'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 		]);
 
-		// Get Form ID.
-		$formID = $I->grabValueFrom('#wp-convertkit-form');
-
 		// Publish and view the Post on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the ConvertKit Form displays.
-		$I->seeElementInDOM('form[data-sv-form="' . $formID . '"]');
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 	}
 
 	/**
@@ -190,9 +187,6 @@ class PostFormCest
 		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
 			'form' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
 		]);
-
-		// Get Form ID.
-		$formID = $I->grabValueFrom('#wp-convertkit-form');
 
 		// Publish and view the Post on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -290,9 +284,6 @@ class PostFormCest
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Get Form ID.
-		$formID = $I->grabValueFrom('#wp-convertkit-form');
-
 		// Load the Post on the frontend site
 		$I->amOnPage('/?p=' . $postID);
 
@@ -300,7 +291,7 @@ class PostFormCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the ConvertKit Form displays.
-		$I->seeElementInDOM('form[data-sv-form="' . $formID . '"]');
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 	}
 
   	/**


### PR DESCRIPTION
## Summary

Uses Form IDs specified in the .env file when performing assertions, instead of reading from the settings, due to some false failures in other tests and a minor performance improvement.

## Testing

- `PageFormCest` and `PostFormCest` updated to use .env file values when asserting Form IDs.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)