### PR TITLE
API: Return array instead of `WP_Error` when no resources exist

### DIFF
--- a/includes/blocks/class-convertkit-block-content.php
+++ b/includes/blocks/class-convertkit-block-content.php
@@ -228,10 +228,19 @@ class ConvertKit_Block_Content extends ConvertKit_Block {
 		// Get the subscriber's tags, to see if they subscribed to this tag.
 		$tags = $api->get_subscriber_tags( $subscriber_id );
 
-		// Bail if an error occured i.e. the subscriber has no tags.
+		// Bail if an error occured.
 		if ( is_wp_error( $tags ) ) {
 			if ( $settings->debug_enabled() ) {
 				return '<!-- ConvertKit Custom Content: ' . $tags->get_error_message() . ' -->';
+			}
+
+			return '';
+		}
+
+		// Bail if the subscriber has no tags.
+		if ( ! count( $tags ) ) {
+			if ( $settings->debug_enabled() ) {
+				return '<!-- ConvertKit Custom Content: Subscriber has no tags -->';
 			}
 
 			return '';

--- a/lib/class-convertkit-api.php
+++ b/lib/class-convertkit-api.php
@@ -1401,7 +1401,7 @@ class ConvertKit_API {
 				$result = wp_remote_request(
 					$this->get_api_url( $endpoint ),
 					array(
-						'method'		  => 'PUT',
+						'method'          => 'PUT',
 						'Accept-Encoding' => 'gzip',
 						'headers'         => array(
 							'Content-Type' => 'application/json; charset=utf-8',

--- a/lib/class-convertkit-api.php
+++ b/lib/class-convertkit-api.php
@@ -126,15 +126,9 @@ class ConvertKit_API {
 			'form_subscribe_form_id_empty'                => __( 'form_subscribe(): the form_id parameter is empty.', 'convertkit' ),
 			'form_subscribe_email_empty'                  => __( 'form_subscribe(): the email parameter is empty.', 'convertkit' ),
 
-			// get_sequences().
-			'get_sequences_none'                          => __( 'No sequences exist in ConvertKit. Visit your ConvertKit account and create your first sequence.', 'convertkit' ),
-
 			// sequence_subscribe().
 			'sequence_subscribe_sequence_id_empty'        => __( 'sequence_subscribe(): the sequence_id parameter is empty.', 'convertkit' ),
 			'sequence_subscribe_email_empty'              => __( 'sequence_subscribe(): the email parameter is empty.', 'convertkit' ),
-
-			// get_tags().
-			'get_tags_none'                               => __( 'No tags exist in ConvertKit. Visit your ConvertKit account and create your first tag.', 'convertkit' ),
 
 			// tag_subscribe().
 			'tag_subscribe_tag_id_empty'                  => __( 'tag_subscribe(): the tag_id parameter is empty.', 'convertkit' ),
@@ -147,33 +141,21 @@ class ConvertKit_API {
 
 			// get_subscriber_by_id().
 			'get_subscriber_by_id_subscriber_id_empty'    => __( 'get_subscriber_by_id(): the subscriber_id parameter is empty.', 'convertkit' ),
-			/* translators: Subscriber ID */
-			'get_subscriber_by_id_none'                   => __( 'No subscriber(s) exist in ConvertKit matching the ID %s.', 'convertkit' ),
 
 			// get_subscriber_tags().
 			'get_subscriber_tags_subscriber_id_empty'     => __( 'get_subscriber_tags(): the subscriber_id parameter is empty.', 'convertkit' ),
-			/* translators: Subscriber ID */
-			'get_subscriber_tags_none'                    => __( 'No tags exist in ConvertKit for the subscriber ID %s.', 'convertkit' ),
 
 			// unsubscribe_email().
 			'unsubscribe_email_empty'                     => __( 'unsubscribe(): the email parameter is empty.', 'convertkit' ),
 
-			// get_custom_fields().
-			'get_custom_fields_none'                      => __( 'No custom fields exist in ConvertKit. Visit your ConvertKit account and create your first custom field.', 'convertkit' ),
-
 			// get_all_posts().
 			'get_all_posts_posts_per_request_bound_too_low' => __( 'get_all_posts(): the posts_per_request parameter must be equal to or greater than 1.', 'convertkit' ),
 			'get_all_posts_posts_per_request_bound_too_high' => __( 'get_all_posts(): the posts_per_request parameter must be equal to or less than 50.', 'convertkit' ),
-			'get_all_posts_none'                          => __( 'No posts exist in ConvertKit. Visit your ConvertKit account and create your first broadcast.', 'convertkit' ),
 
 			// get_posts().
 			'get_posts_page_parameter_bound_too_low'      => __( 'get_posts(): the page parameter must be equal to or greater than 1.', 'convertkit' ),
 			'get_posts_per_page_parameter_bound_too_low'  => __( 'get_posts(): the per_page parameter must be equal to or greater than 1.', 'convertkit' ),
 			'get_posts_per_page_parameter_bound_too_high' => __( 'get_posts(): the per_page parameter must be equal to or less than 50.', 'convertkit' ),
-			'get_posts_none'                              => __( 'No posts exist in ConvertKit. Visit your ConvertKit account and create your first broadcast.', 'convertkit' ),
-
-			// get_forms_landing_pages()
-			'get_forms_landing_pages_none'                => __( 'No forms exist in ConvertKit. Visit your ConvertKit account and create your first form.', 'convertkit' ),
 
 			// request().
 			/* translators: HTTP method */
@@ -377,10 +359,6 @@ class ConvertKit_API {
 		}
 
 		// If no sequences exist, log that no sequences exist and return a blank array.
-		if ( ! isset( $response['courses'] ) ) {
-			$this->log( 'API: get_sequences(): Error: No sequences exist in ConvertKit.' );
-			return $sequences;
-		}
 		if ( ! count( $response['courses'] ) ) {
 			$this->log( 'API: get_sequences(): Error: No sequences exist in ConvertKit.' );
 			return $sequences;
@@ -485,10 +463,6 @@ class ConvertKit_API {
 		}
 
 		// If no tags exist, log that no tags exist and return a blank array.
-		if ( ! isset( $response['tags'] ) ) {
-			$this->log( 'API: get_tags(): Error: No tags exist in ConvertKit.' );
-			return $tags;
-		}
 		if ( ! count( $response['tags'] ) ) {
 			$this->log( 'API: get_tags(): Error: No tags exist in ConvertKit.' );
 			return $tags;
@@ -600,8 +574,8 @@ class ConvertKit_API {
 			return $response;
 		}
 
-		// If no subscribers exist, return WP_Error.
-		if ( ! absint( $response['total_subscribers'] ) ) {
+		// If no matching subscribers exist, log that no matching subscribers exist and return a blank array.
+		if ( (int) $response['total_subscribers'] === 0 ) {
 			$error = new WP_Error(
 				'convertkit_api_error',
 				sprintf(
@@ -611,10 +585,10 @@ class ConvertKit_API {
 			);
 
 			$this->log( 'API: get_subscriber_by_email(): Error: ' . $error->get_error_message() );
-
 			return $error;
 		}
 
+		// Return subscriber.
 		return $response['subscribers'][0];
 
 	}
@@ -653,22 +627,6 @@ class ConvertKit_API {
 			return $response;
 		}
 
-		// If no subscriber exists, return WP_Error.
-		if ( ! isset( $response['subscriber'] ) ) {
-			$error = new WP_Error(
-				'convertkit_api_error',
-				sprintf(
-					/* translators: Subscriber ID */
-					$this->get_error_message( 'get_subscriber_by_id_none' ),
-					$subscriber_id
-				)
-			);
-
-			$this->log( 'API: get_subscriber_by_id(): Error: ' . $error->get_error_message() );
-
-			return $error;
-		}
-
 		return $response['subscriber'];
 
 	}
@@ -705,21 +663,6 @@ class ConvertKit_API {
 		if ( is_wp_error( $response ) ) {
 			$this->log( 'API: get_subscriber_tags(): Error: ' . $response->get_error_message() );
 			return $response;
-		}
-
-		// If no tags exists, return WP_Error.
-		if ( ! isset( $response['tags'] ) ) {
-			$error = new WP_Error(
-				'convertkit_api_error',
-				sprintf(
-					$this->get_error_message( 'get_subscriber_tags_none' ),
-					$subscriber_id
-				)
-			);
-
-			$this->log( 'API: get_subscriber_tags(): Error: ' . $error->get_error_message() );
-
-			return $error;
 		}
 
 		return $response['tags'];
@@ -826,10 +769,6 @@ class ConvertKit_API {
 		}
 
 		// If no custom fields exist, log that no custom fields exist and return a blank array.
-		if ( ! isset( $response['custom_fields'] ) ) {
-			$this->log( 'API: get_custom_fields(): Error: No custom fields exist in ConvertKit.' );
-			return $custom_fields;
-		}
 		if ( ! count( $response['custom_fields'] ) ) {
 			$this->log( 'API: get_custom_fields(): Error: No custom fields exist in ConvertKit.' );
 			return $custom_fields;
@@ -954,10 +893,6 @@ class ConvertKit_API {
 		}
 
 		// If no posts exist, log that no posts exist and return a blank array.
-		if ( ! isset( $response['posts'] ) ) {
-			$this->log( 'API: get_posts(): Error: No broadcasts exist in ConvertKit.' );
-			return $posts;
-		}
 		if ( ! count( $response['posts'] ) ) {
 			$this->log( 'API: get_posts(): Error: No broadcasts exist in ConvertKit.' );
 			return $posts;
@@ -1347,11 +1282,6 @@ class ConvertKit_API {
 		// If an error occured, log and return it now.
 		if ( is_wp_error( $response ) ) {
 			return $response;
-		}
-
-		// If no forms exist.
-		if ( ! isset( $response['forms'] ) ) {
-			return new WP_Error( 'convertkit_api_error', $this->get_error_message( 'get_forms_landing_pages_none' ) );
 		}
 
 		// Iterate through forms, determining if each form is a form or landing page.

--- a/lib/class-convertkit-api.php
+++ b/lib/class-convertkit-api.php
@@ -713,7 +713,7 @@ class ConvertKit_API {
 		}
 
 		// Send request.
-		$response = $this->post(
+		$response = $this->put(
 			'unsubscribe',
 			array(
 				'api_secret' => $this->api_secret,
@@ -1342,6 +1342,21 @@ class ConvertKit_API {
 	}
 
 	/**
+	 * Performs a PUT request.
+	 *
+	 * @since  1.9.7.8
+	 *
+	 * @param   string $endpoint       API Endpoint.
+	 * @param   array  $params         Params.
+	 * @return  WP_Error|array
+	 */
+	private function put( $endpoint, $params ) {
+
+		return $this->request( $endpoint, 'put', $params, true );
+
+	}
+
+	/**
 	 * Main function which handles sending requests to the API using WordPress functions.
 	 *
 	 * @since   1.9.6
@@ -1371,6 +1386,22 @@ class ConvertKit_API {
 				$result = wp_remote_post(
 					$this->get_api_url( $endpoint ),
 					array(
+						'Accept-Encoding' => 'gzip',
+						'headers'         => array(
+							'Content-Type' => 'application/json; charset=utf-8',
+						),
+						'body'            => wp_json_encode( $params ),
+						'timeout'         => $this->get_timeout(),
+						'user-agent'      => $this->get_user_agent(),
+					)
+				);
+				break;
+
+			case 'put':
+				$result = wp_remote_request(
+					$this->get_api_url( $endpoint ),
+					array(
+						'method'		  => 'PUT',
 						'Accept-Encoding' => 'gzip',
 						'headers'         => array(
 							'Content-Type' => 'application/json; charset=utf-8',

--- a/lib/class-convertkit-api.php
+++ b/lib/class-convertkit-api.php
@@ -376,14 +376,14 @@ class ConvertKit_API {
 			return $response;
 		}
 
-		// If no sequences exist, return WP_Error.
+		// If no sequences exist, log that no sequences exist and return a blank array.
 		if ( ! isset( $response['courses'] ) ) {
 			$this->log( 'API: get_sequences(): Error: No sequences exist in ConvertKit.' );
-			return new WP_Error( 'convertkit_api_error', $this->get_error_message( 'get_sequences_none' ) );
+			return $sequences;
 		}
 		if ( ! count( $response['courses'] ) ) {
 			$this->log( 'API: get_sequences(): Error: No sequences exist in ConvertKit.' );
-			return new WP_Error( 'convertkit_api_error', $this->get_error_message( 'get_sequences_none' ) );
+			return $sequences;
 		}
 
 		foreach ( $response['courses'] as $sequence ) {
@@ -484,14 +484,14 @@ class ConvertKit_API {
 			return $response;
 		}
 
-		// If no tags exist, return WP_Error.
+		// If no tags exist, log that no tags exist and return a blank array.
 		if ( ! isset( $response['tags'] ) ) {
 			$this->log( 'API: get_tags(): Error: No tags exist in ConvertKit.' );
-			return new WP_Error( 'convertkit_api_error', $this->get_error_message( 'get_tags_none' ) );
+			return $tags;
 		}
 		if ( ! count( $response['tags'] ) ) {
 			$this->log( 'API: get_tags(): Error: No tags exist in ConvertKit.' );
-			return new WP_Error( 'convertkit_api_error', $this->get_error_message( 'get_tags_none' ) );
+			return $tags;
 		}
 
 		foreach ( $response['tags'] as $tag ) {
@@ -825,14 +825,14 @@ class ConvertKit_API {
 			return $response;
 		}
 
-		// If no custom fields exist, return WP_Error.
+		// If no custom fields exist, log that no custom fields exist and return a blank array.
 		if ( ! isset( $response['custom_fields'] ) ) {
 			$this->log( 'API: get_custom_fields(): Error: No custom fields exist in ConvertKit.' );
-			return new WP_Error( 'convertkit_api_error', $this->get_error_message( 'get_custom_fields_none' ) );
+			return $custom_fields;
 		}
 		if ( ! count( $response['custom_fields'] ) ) {
 			$this->log( 'API: get_custom_fields(): Error: No custom fields exist in ConvertKit.' );
-			return new WP_Error( 'convertkit_api_error', $this->get_error_message( 'get_custom_fields_none' ) );
+			return $custom_fields;
 		}
 
 		foreach ( $response['custom_fields'] as $custom_field ) {
@@ -885,16 +885,20 @@ class ConvertKit_API {
 				return $response;
 			}
 
+			// Exit loop if no posts exist.
+			if ( ! count( $response ) ) {
+				break;
+			}
+
 			// Append posts to array.
 			foreach ( $response['posts'] as $post ) {
 				$posts[] = $post;
 			}
 		}
 
-		// If the array is empty, return an error.
+		// If no posts exist, log an error.
 		if ( ! count( $posts ) ) {
 			$this->log( 'API: get_posts(): Error: No broadcasts exist in ConvertKit.' );
-			return new WP_Error( 'convertkit_api_error', $this->get_error_message( 'get_all_posts_none' ) );
 		}
 
 		// Return posts.
@@ -949,14 +953,14 @@ class ConvertKit_API {
 			return $response;
 		}
 
-		// If no custom fields exist, return WP_Error.
+		// If no posts exist, log that no posts exist and return a blank array.
 		if ( ! isset( $response['posts'] ) ) {
 			$this->log( 'API: get_posts(): Error: No broadcasts exist in ConvertKit.' );
-			return new WP_Error( 'convertkit_api_error', $this->get_error_message( 'get_posts_none' ) );
+			return $posts;
 		}
 		if ( ! count( $response['posts'] ) ) {
 			$this->log( 'API: get_posts(): Error: No broadcasts exist in ConvertKit.' );
-			return new WP_Error( 'convertkit_api_error', $this->get_error_message( 'get_posts_none' ) );
+			return $posts;
 		}
 
 		return $response;

--- a/readme.txt
+++ b/readme.txt
@@ -112,6 +112,7 @@ Full Plugin documentation can be found [here](https://help.convertkit.com/en/art
 
 ### 1.9.7.8 2022-06-xx
 * Added: Elementor Page Builder: ConvertKit Broadcasts Widget
+* Fix: Integration: WishList Member: Unsubscribe email address from ConvertKit if 'unsubscribe' configured and member level removed
 
 ### 1.9.7.7 2022-06-09
 * Added: Broadcasts: Option to enable pagination on block/shortcode

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -182,13 +182,27 @@ class APITest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the `form_subscribe()` function returns a WP_Error
+	 * when an invalid $form_id parameter is provided.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testFormSubscribeWithInvalidFormID()
+	{
+		$result = $this->api->form_subscribe(12345, $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL'], 'First');
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+		$this->assertEquals('Not Found: The entity you were trying to find doesn\'t exist', $result->get_error_message());
+	}
+
+	/**
+	 * Test that the `form_subscribe()` function returns a WP_Error
 	 * when an empty $email parameter is provided.
 	 * 
 	 * @since 	1.9.6.9
 	 */
 	public function testFormSubscribeWithEmptyEmail()
 	{
-		$result = $this->api->form_subscribe( $_ENV['CONVERTKIT_API_FORM_ID'], '', 'First');
+		$result = $this->api->form_subscribe($_ENV['CONVERTKIT_API_FORM_ID'], '', 'First');
 		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
 		$this->assertEquals('form_subscribe(): the email parameter is empty.', $result->get_error_message());
@@ -206,6 +220,20 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
 		$this->assertEquals('form_subscribe(): the email parameter is empty.', $result->get_error_message());
+	}
+
+	/**
+	 * Test that the `form_subscribe()` function returns a WP_Error
+	 * when an invalid email parameter is provided.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testFormSubscribeWithInvalidEmail()
+	{
+		$result = $this->api->form_subscribe( $_ENV['CONVERTKIT_API_FORM_ID'], 'invalid-email-address', 'First');
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+		$this->assertEquals('Error updating subscriber: Email address is invalid', $result->get_error_message());
 	}
 
 	/**
@@ -275,7 +303,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testSequenceSubscribe()
 	{
-		$result = $this->api->sequence_subscribe( $_ENV['CONVERTKIT_API_SEQUENCE_ID'], $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL'], 'First', array(
+		$result = $this->api->sequence_subscribe($_ENV['CONVERTKIT_API_SEQUENCE_ID'], $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL'], 'First', array(
 			'last_name' => 'Last',
 			'phone_number' => '123-456-7890',
 		));
@@ -286,13 +314,27 @@ class APITest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the `sequence_subscribe()` function returns a WP_Error
+	 * when an invalid $sequence_id parameter is provided.
+	 * 
+	 * @since 	1.9.6.9
+	 */
+	public function testSequenceSubscribeWithInvalidSequenceID()
+	{
+		$result = $this->api->sequence_subscribe(12345, $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL'], 'First');
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+		$this->assertEquals('Course not found: ', $result->get_error_message());
+	}
+
+	/**
+	 * Test that the `sequence_subscribe()` function returns a WP_Error
 	 * when an empty $sequence_id parameter is provided.
 	 * 
 	 * @since 	1.9.6.9
 	 */
 	public function testSequenceSubscribeWithEmptySequenceID()
 	{
-		$result = $this->api->sequence_subscribe( '', $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL'], 'First');
+		$result = $this->api->sequence_subscribe('', $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL'], 'First');
 		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
 		$this->assertEquals('sequence_subscribe(): the sequence_id parameter is empty.', $result->get_error_message());
@@ -324,6 +366,20 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
 		$this->assertEquals('sequence_subscribe(): the email parameter is empty.', $result->get_error_message());
+	}
+
+	/**
+	 * Test that the `sequence_subscribe()` function returns a WP_Error
+	 * when an invalid $email parameter is provided.
+	 * 
+	 * @since 	1.9.6.9
+	 */
+	public function testSequenceSubscribeWithInvalidEmail()
+	{
+		$result = $this->api->sequence_subscribe($_ENV['CONVERTKIT_API_SEQUENCE_ID'], 'invalid-email-address', 'First');
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+		$this->assertEquals('Error updating subscriber: Email address is invalid', $result->get_error_message());
 	}
 
 	/**
@@ -362,7 +418,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testTagSubscribe()
 	{
-		$result = $this->api->tag_subscribe( $_ENV['CONVERTKIT_API_TAG_ID'], $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL'], 'First', array(
+		$result = $this->api->tag_subscribe($_ENV['CONVERTKIT_API_TAG_ID'], $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL'], 'First', array(
 			'last_name' => 'Last',
 			'phone_number' => '123-456-7890',
 		));
@@ -373,13 +429,27 @@ class APITest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the `tag_subscribe()` function returns a WP_Error
+	 * when an invalid $tag_id parameter is provided.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testTagSubscribeWithInvalidTagID()
+	{
+		$result = $this->api->tag_subscribe(12345, $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL'], 'First');
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+		$this->assertEquals('Tag not found: ', $result->get_error_message());
+	}
+
+	/**
+	 * Test that the `tag_subscribe()` function returns a WP_Error
 	 * when an empty $tag_id parameter is provided.
 	 * 
 	 * @since 	1.9.6.9
 	 */
 	public function testTagSubscribeWithEmptyTagID()
 	{
-		$result = $this->api->tag_subscribe( '', $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL'], 'First');
+		$result = $this->api->tag_subscribe('', $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL'], 'First');
 		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
 		$this->assertEquals('tag_subscribe(): the tag_id parameter is empty.', $result->get_error_message());
@@ -393,7 +463,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testTagSubscribeWithEmptyEmail()
 	{
-		$result = $this->api->tag_subscribe( $_ENV['CONVERTKIT_API_TAG_ID'], '', 'First');
+		$result = $this->api->tag_subscribe($_ENV['CONVERTKIT_API_TAG_ID'], '', 'First');
 		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
 		$this->assertEquals('tag_subscribe(): the email parameter is empty.', $result->get_error_message());
@@ -407,10 +477,24 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testTagSubscribeWithSpacesInEmail()
 	{
-		$result = $this->api->tag_subscribe( $_ENV['CONVERTKIT_API_TAG_ID'], '     ', 'First');
+		$result = $this->api->tag_subscribe($_ENV['CONVERTKIT_API_TAG_ID'], '     ', 'First');
 		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
 		$this->assertEquals('tag_subscribe(): the email parameter is empty.', $result->get_error_message());
+	}
+
+	/**
+	 * Test that the `tag_subscribe()` function returns a WP_Error
+	 * when an invalid $email parameter is provided.
+	 * 
+	 * @since 	1.9.6.9
+	 */
+	public function testTagSubscribeWithInvalidEmail()
+	{
+		$result = $this->api->tag_subscribe($_ENV['CONVERTKIT_API_TAG_ID'], 'invalid-email-address', 'First');
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+		$this->assertEquals('Error updating subscriber: Email address is invalid', $result->get_error_message());
 	}
 
 	/**
@@ -440,7 +524,21 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
 		$this->assertEquals('get_subscriber_by_email(): the email parameter is empty.', $result->get_error_message());
-	} 
+	}
+
+	/**
+	 * Test that the `get_subscriber_by_email()` function returns a WP_Error
+	 * when an invalid $email parameter is provided.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testGetSubscriberByEmailWithInvalidEmail()
+	{
+		$result = $this->api->get_subscriber_by_email('invalid-email-address');
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+		$this->assertEquals('No subscriber(s) exist in ConvertKit matching the email address invalid-email-address.', $result->get_error_message());
+	}
 
 	/**
 	 * Test that the `get_subscriber_by_id()` function returns expected data
@@ -459,7 +557,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the `get_subscriber_by_id()` function returns a WP_Error
-	 * when an empty $email parameter is provided.
+	 * when an empty ID parameter is provided.
 	 * 
 	 * @since 	1.9.6.9
 	 */
@@ -469,6 +567,20 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
 		$this->assertEquals('get_subscriber_by_id(): the subscriber_id parameter is empty.', $result->get_error_message());
+	}
+
+	/**
+	 * Test that the `get_subscriber_by_id()` function returns a WP_Error
+	 * when an invalid ID parameter is provided.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testGetSubscriberByIDWithInvalidID()
+	{
+		$result = $this->api->get_subscriber_by_id(12345);
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+		$this->assertEquals('Not Found: The entity you were trying to find doesn\'t exist', $result->get_error_message());
 	} 
 
 	/**
@@ -501,7 +613,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the `get_subscriber_by_id()` function returns a WP_Error
-	 * when an empty $email parameter is provided.
+	 * when an empty $id parameter is provided.
 	 * 
 	 * @since 	1.9.6.9
 	 */
@@ -511,6 +623,20 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
 		$this->assertEquals('get_subscriber_tags(): the subscriber_id parameter is empty.', $result->get_error_message());
+	}
+
+	/**
+	 * Test that the `get_subscriber_by_id()` function returns a WP_Error
+	 * when an invalid $id parameter is provided.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testGetSubscriberTagsWithInvalidID()
+	{
+		$result = $this->api->get_subscriber_tags(12345);
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+		$this->assertEquals('Not Found: The entity you were trying to find doesn\'t exist', $result->get_error_message());
 	} 
 
 	/**
@@ -540,7 +666,21 @@ class APITest extends \Codeception\TestCase\WPTestCase
 
 		// get_subscriber_by_email() is deliberate in this error message, as get_subscriber_id() calls get_subscriber_by_email().
 		$this->assertEquals('get_subscriber_by_email(): the email parameter is empty.', $result->get_error_message());
-	} 
+	}
+
+	/**
+	 * Test that the `get_subscriber_id()` function returns a WP_Error
+	 * when an invalid $email parameter is provided.
+	 * 
+	 * @since 	1.9.6.9
+	 */
+	public function testGetSubscriberIDWithInvalidEmail()
+	{
+		$result = $this->api->get_subscriber_id('invalid-email-address');
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+		$this->assertEquals('No subscriber(s) exist in ConvertKit matching the email address invalid-email-address.', $result->get_error_message());
+	}
 
 	/**
 	 * Test that the `unsubscribe()` function returns expected data

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -37,8 +37,9 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		// Activate Plugin.
 		activate_plugins('convertkit/wp-convertkit.php');
 
-		// Initialize the class we want to test.
+		// Initialize the classes we want to test.
 		$this->api = new ConvertKit_API( $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'] );
+		$this->api_no_data = new ConvertKit_API( $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA'] );
 	}
 
 	/**
@@ -101,6 +102,20 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
+	 * Test that the `get_subscription_forms()` function returns a blank array when no data
+	 * exists on the ConvertKit account.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testGetSubscriptionFormsNoData()
+	{
+		$result = $this->api_no_data->get_subscription_forms();
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
+	}
+
+	/**
 	 * Test that the `get_forms()` function returns expected data.
 	 * 
 	 * @since 	1.9.6.9
@@ -114,6 +129,20 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$this->assertArrayHasKey('name', reset($result));
 		$this->assertArrayHasKey('format', reset($result));
 		$this->assertArrayHasKey('embed_js', reset($result));
+	}
+
+	/**
+	 * Test that the `get_forms()` function returns a blank array when no data
+	 * exists on the ConvertKit account.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testGetFormsNoData()
+	{
+		$result = $this->api_no_data->get_forms();
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
 	}
 
 	/**
@@ -193,6 +222,20 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
+	 * Test that the `get_landing_pages()` function returns a blank array when no data
+	 * exists on the ConvertKit account.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testGetLandingPagesNoData()
+	{
+		$result = $this->api_no_data->get_landing_pages();
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
+	}
+
+	/**
 	 * Test that the `get_sequences()` function returns expected data.
 	 * 
 	 * @since 	1.9.6.9
@@ -204,7 +247,21 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$this->assertIsArray($result);
 		$this->assertArrayHasKey('id', reset($result));
 		$this->assertArrayHasKey('name', reset($result));
-	} 
+	}
+
+	/**
+	 * Test that the `get_sequences()` function returns a blank array when no data
+	 * exists on the ConvertKit account.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testGetSequencesNoData()
+	{
+		$result = $this->api_no_data->get_sequences();
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
+	}
 
 	/**
 	 * Test that the `sequence_subscribe()` function returns expected data
@@ -277,7 +334,21 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$this->assertIsArray($result);
 		$this->assertArrayHasKey('id', reset($result));
 		$this->assertArrayHasKey('name', reset($result));
-	} 
+	}
+
+	/**
+	 * Test that the `get_tags()` function returns a blank array when no data
+	 * exists on the ConvertKit account.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testGetTagsNoData()
+	{
+		$result = $this->api_no_data->get_tags();
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
+	}
 
 	/**
 	 * Test that the `tag_subscribe()` function returns expected data
@@ -508,6 +579,20 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
+	 * Test that the `get_custom_fields()` function returns a blank array when no data
+	 * exists on the ConvertKit account.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testGetCustomFieldsNoData()
+	{
+		$result = $this->api_no_data->get_custom_fields();
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
+	}
+
+	/**
 	 * Test that the `get_posts()` function returns expected data.
 	 * 
 	 * @since 	1.9.7.4
@@ -532,6 +617,20 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$this->assertArrayHasKey('url', reset($result['posts']));
 		$this->assertArrayHasKey('published_at', reset($result['posts']));
 		$this->assertArrayHasKey('is_paid', reset($result['posts']));
+	}
+
+	/**
+	 * Test that the `get_posts()` function returns a blank array when no data
+	 * exists on the ConvertKit account.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testGetPostsNoData()
+	{
+		$result = $this->api_no_data->get_posts();
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
 	}
 
 	/**
@@ -622,6 +721,20 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$this->assertArrayHasKey('url', reset($result));
 		$this->assertArrayHasKey('published_at', reset($result));
 		$this->assertArrayHasKey('is_paid', reset($result));
+	}
+
+	/**
+	 * Test that the `get_all_posts()` function returns a blank array when no data
+	 * exists on the ConvertKit account.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testGetAllPostsNoData()
+	{
+		$result = $this->api_no_data->get_all_posts();
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
 	}
 
 	/**

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -1051,10 +1051,22 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testBackwardCompatFormUnsubscribe()
 	{
+		// We don't use $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL'] for this test, as that email is relied upon as being a confirmed subscriber
+		// for other tests.
+
+		// Subscribe an email address.
+		$emailAddress = 'wordpress-' . date( 'Y-m-d-H-i-s' ) . '-php-' . PHP_VERSION_ID . '@convertkit.com';
+		$this->api->form_subscribe($_ENV['CONVERTKIT_API_FORM_ID'], $emailAddress);
+
+		// Unsubscribe the email address.
 		$result = $this->api->form_unsubscribe([
-			'email' => $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']
+			'email' => $emailAddress,
 		]);
 		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('subscriber', $result);
+		$this->assertArrayHasKey('email_address', $result['subscriber']);
+		$this->assertEquals($emailAddress, $result['subscriber']['email_address']);
 	} 
 
 	/**

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -1,5 +1,9 @@
 <?php
-
+/**
+ * Tests for the ConvertKit_API class.
+ * 
+ * @since 	1.9.7.4
+ */
 class APITest extends \Codeception\TestCase\WPTestCase
 {
 	/**

--- a/tests/wpunit/ResourceFormsNoDataTest.php
+++ b/tests/wpunit/ResourceFormsNoDataTest.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Tests for the ConvertKit_Resource_Forms class when no data is present in the API.
+ * 
+ * @since 	1.9.7.8
+ */
+class ResourceFormsNoDataTest extends \Codeception\TestCase\WPTestCase
+{
+	/**
+	 * @var \WpunitTester
+	 */
+	protected $tester;
+
+	/**
+	 * Holds the ConvertKit Settings class.
+	 * 
+	 * @since 	1.9.7.8
+	 * 
+	 * @var 	ConvertKit_Settings
+	 */
+	private $settings;
+
+	/**
+	 * Holds the ConvertKit Resource class.
+	 * 
+	 * @since 	1.9.7.8
+	 * 
+	 * @var 	ConvertKit_Resource_Forms
+	 */
+	private $resource;
+
+	/**
+	 * Performs actions before each test.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		// Activate Plugin.
+		activate_plugins('convertkit/wp-convertkit.php');
+
+		// Store API Key and Secret in Plugin's settings.
+		$this->settings = new ConvertKit_Settings();
+		update_option($this->settings::SETTINGS_NAME, [
+			'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+			'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+		]);
+
+		// Initialize the resource class we want to test.
+		$this->resource = new ConvertKit_Resource_Forms();
+
+		// Confirm initialization didn't result in an error.
+		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
+	}
+
+	/**
+	 * Performs actions after each test.
+	 * 
+	 * @since 	1.9.6.9
+	 */
+	public function tearDown(): void
+	{
+		// Delete API Key, API Secret and Resources from Plugin's settings.
+		delete_option($this->settings::SETTINGS_NAME);
+		delete_option($this->resource->settings_name);
+		delete_option($this->resource->settings_name . '_last_queried');
+
+		// Destroy the resource class we tested.
+		unset($this->resource);
+
+		// Deactivate Plugin.
+		deactivate_plugins('convertkit/wp-convertkit.php');
+		
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that the refresh() function performs as expected, storing data in the options table.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testRefresh()
+	{
+		// Confirm that the data is stored in the options table and includes some expected keys.
+		$result = $this->resource->refresh();
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
+	}
+
+	/**
+	 * Test that the expiry timestamp is set and returns the expected value.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testExpiry()
+	{
+		// Define the expected expiry date based on the resource class' $cache_duration setting.
+		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+
+		// Fetch the actual expiry date set when the resource class was initialized.
+		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+
+		// Confirm both dates match.
+		$this->assertEquals($expectedExpiryDate, $expiryDate);
+	}
+
+	/**
+	 * Test that the get() function performs as expected.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testGet()
+	{
+		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+		$result = $this->resource->get();
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
+	}
+
+	/**
+	 * Test that the count() function returns the number of resources.
+	 * 
+	 * @since 	1.9.7.6
+	 */
+	public function testCount()
+	{
+		$result = $this->resource->get();
+		$this->assertEquals($this->resource->count(), count($result));
+	}
+
+	/**
+	 * Test that the exist() function performs as expected.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testExist()
+	{
+		// Confirm that the function returns true, because resources exist.
+		$result = $this->resource->exist();
+		$this->assertSame($result, false);
+	}
+}

--- a/tests/wpunit/ResourceFormsTest.php
+++ b/tests/wpunit/ResourceFormsTest.php
@@ -1,5 +1,9 @@
 <?php
-
+/**
+ * Tests for the ConvertKit_Resource_Forms class.
+ * 
+ * @since 	1.9.7.4
+ */
 class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 {
 	/**
@@ -73,7 +77,7 @@ class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that the refresh() function performs as expected, storing data in the options table.
+	 * Test that the refresh() function performs as expected.
 	 * 
 	 * @since 	1.9.7.4
 	 */
@@ -104,7 +108,7 @@ class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that the get() function performs as expected, storing data in the options table.
+	 * Test that the get() function performs as expected.
 	 * 
 	 * @since 	1.9.7.4
 	 */
@@ -130,7 +134,7 @@ class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that the exist() function performs as expected, storing data in the options table.
+	 * Test that the exist() function performs as expected.
 	 * 
 	 * @since 	1.9.7.4
 	 */

--- a/tests/wpunit/ResourceLandingPagesNoDataTest.php
+++ b/tests/wpunit/ResourceLandingPagesNoDataTest.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Tests for the ConvertKit_Resource_Landing_Pages class when no data is present in the API.
+ * 
+ * @since 	1.9.7.8
+ */
+class ResourceLandingPagesNoDataTest extends \Codeception\TestCase\WPTestCase
+{
+	/**
+	 * @var \WpunitTester
+	 */
+	protected $tester;
+
+	/**
+	 * Holds the ConvertKit Settings class.
+	 * 
+	 * @since 	1.9.7.8
+	 * 
+	 * @var 	ConvertKit_Settings
+	 */
+	private $settings;
+
+	/**
+	 * Holds the ConvertKit Resource class.
+	 * 
+	 * @since 	1.9.7.8
+	 * 
+	 * @var 	ConvertKit_Resource_Forms
+	 */
+	private $resource;
+
+	/**
+	 * Performs actions before each test.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		// Activate Plugin.
+		activate_plugins('convertkit/wp-convertkit.php');
+
+		// Store API Key and Secret in Plugin's settings.
+		$this->settings = new ConvertKit_Settings();
+		update_option($this->settings::SETTINGS_NAME, [
+			'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+			'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+		]);
+
+		// Initialize the resource class we want to test.
+		$this->resource = new ConvertKit_Resource_Forms();
+
+		// Confirm initialization didn't result in an error.
+		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
+	}
+
+	/**
+	 * Performs actions after each test.
+	 * 
+	 * @since 	1.9.6.9
+	 */
+	public function tearDown(): void
+	{
+		// Delete API Key, API Secret and Resources from Plugin's settings.
+		delete_option($this->settings::SETTINGS_NAME);
+		delete_option($this->resource->settings_name);
+		delete_option($this->resource->settings_name . '_last_queried');
+
+		// Destroy the resource class we tested.
+		unset($this->resource);
+
+		// Deactivate Plugin.
+		deactivate_plugins('convertkit/wp-convertkit.php');
+		
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that the refresh() function performs as expected.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testRefresh()
+	{
+		// Confirm that the data is stored in the options table and includes some expected keys.
+		$result = $this->resource->refresh();
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
+	}
+
+	/**
+	 * Test that the expiry timestamp is set and returns the expected value.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testExpiry()
+	{
+		// Define the expected expiry date based on the resource class' $cache_duration setting.
+		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+
+		// Fetch the actual expiry date set when the resource class was initialized.
+		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+
+		// Confirm both dates match.
+		$this->assertEquals($expectedExpiryDate, $expiryDate);
+	}
+
+	/**
+	 * Test that the get() function performs as expected.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testGet()
+	{
+		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+		$result = $this->resource->get();
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
+	}
+
+	/**
+	 * Test that the count() function returns the number of resources.
+	 * 
+	 * @since 	1.9.7.6
+	 */
+	public function testCount()
+	{
+		$result = $this->resource->get();
+		$this->assertEquals($this->resource->count(), count($result));
+	}
+
+	/**
+	 * Test that the exist() function performs as expected.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testExist()
+	{
+		// Confirm that the function returns true, because resources exist.
+		$result = $this->resource->exist();
+		$this->assertSame($result, false);
+	}
+}

--- a/tests/wpunit/ResourceLandingPagesTest.php
+++ b/tests/wpunit/ResourceLandingPagesTest.php
@@ -1,5 +1,9 @@
 <?php
-
+/**
+ * Tests for the ConvertKit_Resource_Landing_Pages class.
+ * 
+ * @since 	1.9.7.4
+ */
 class ResourceLandingPagesTest extends \Codeception\TestCase\WPTestCase
 {
 	/**
@@ -73,7 +77,7 @@ class ResourceLandingPagesTest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that the refresh() function performs as expected, storing data in the options table.
+	 * Test that the refresh() function performs as expected.
 	 * 
 	 * @since 	1.9.7.4
 	 */
@@ -104,7 +108,7 @@ class ResourceLandingPagesTest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that the get() function performs as expected, storing data in the options table.
+	 * Test that the get() function performs as expected.
 	 * 
 	 * @since 	1.9.7.4
 	 */
@@ -130,7 +134,7 @@ class ResourceLandingPagesTest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that the exist() function performs as expected, storing data in the options table.
+	 * Test that the exist() function performs as expected.
 	 * 
 	 * @since 	1.9.7.4
 	 */

--- a/tests/wpunit/ResourcePostsNoDataTest.php
+++ b/tests/wpunit/ResourcePostsNoDataTest.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Tests for the ConvertKit_Resource_Posts class when no data is present in the API.
+ * 
+ * @since 	1.9.7.8
+ */
+class ResourcePostsNoDataTest extends \Codeception\TestCase\WPTestCase
+{
+	/**
+	 * @var \WpunitTester
+	 */
+	protected $tester;
+
+	/**
+	 * Holds the ConvertKit Settings class.
+	 * 
+	 * @since 	1.9.7.8
+	 * 
+	 * @var 	ConvertKit_Settings
+	 */
+	private $settings;
+
+	/**
+	 * Holds the ConvertKit Resource class.
+	 * 
+	 * @since 	1.9.7.8
+	 * 
+	 * @var 	ConvertKit_Resource_Forms
+	 */
+	private $resource;
+
+	/**
+	 * Performs actions before each test.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		// Activate Plugin.
+		activate_plugins('convertkit/wp-convertkit.php');
+
+		// Store API Key and Secret in Plugin's settings.
+		$this->settings = new ConvertKit_Settings();
+		update_option($this->settings::SETTINGS_NAME, [
+			'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+			'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+		]);
+
+		// Initialize the resource class we want to test.
+		$this->resource = new ConvertKit_Resource_Forms();
+
+		// Confirm initialization didn't result in an error.
+		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
+	}
+
+	/**
+	 * Performs actions after each test.
+	 * 
+	 * @since 	1.9.6.9
+	 */
+	public function tearDown(): void
+	{
+		// Delete API Key, API Secret and Resources from Plugin's settings.
+		delete_option($this->settings::SETTINGS_NAME);
+		delete_option($this->resource->settings_name);
+		delete_option($this->resource->settings_name . '_last_queried');
+
+		// Destroy the resource class we tested.
+		unset($this->resource);
+
+		// Deactivate Plugin.
+		deactivate_plugins('convertkit/wp-convertkit.php');
+		
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that the refresh() function performs as expected.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testRefresh()
+	{
+		// Confirm that the data is stored in the options table and includes some expected keys.
+		$result = $this->resource->refresh();
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
+	}
+
+	/**
+	 * Test that the expiry timestamp is set and returns the expected value.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testExpiry()
+	{
+		// Define the expected expiry date based on the resource class' $cache_duration setting.
+		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+
+		// Fetch the actual expiry date set when the resource class was initialized.
+		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+
+		// Confirm both dates match.
+		$this->assertEquals($expectedExpiryDate, $expiryDate);
+	}
+
+	/**
+	 * Test that the get() function performs as expected.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testGet()
+	{
+		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+		$result = $this->resource->get();
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
+	}
+
+	/**
+	 * Test that the count() function returns the number of resources.
+	 * 
+	 * @since 	1.9.7.6
+	 */
+	public function testCount()
+	{
+		$result = $this->resource->get();
+		$this->assertEquals($this->resource->count(), count($result));
+	}
+
+	/**
+	 * Test that the exist() function performs as expected.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testExist()
+	{
+		// Confirm that the function returns true, because resources exist.
+		$result = $this->resource->exist();
+		$this->assertSame($result, false);
+	}
+}

--- a/tests/wpunit/ResourcePostsTest.php
+++ b/tests/wpunit/ResourcePostsTest.php
@@ -1,5 +1,9 @@
 <?php
-
+/**
+ * Tests for the ConvertKit_Resource_Posts class.
+ * 
+ * @since 	1.9.7.4
+ */
 class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 {
 	/**
@@ -183,7 +187,7 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 	}
 	
 	/**
-	 * Test that the refresh() function performs as expected, storing data in the options table.
+	 * Test that the refresh() function performs as expected.
 	 * 
 	 * @since 	1.9.7.4
 	 */
@@ -214,7 +218,7 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that the get() function performs as expected, storing data in the options table.
+	 * Test that the get() function performs as expected.
 	 * 
 	 * @since 	1.9.7.4
 	 */
@@ -328,7 +332,7 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that the exist() function performs as expected, storing data in the options table.
+	 * Test that the exist() function performs as expected.
 	 * 
 	 * @since 	1.9.7.4
 	 */

--- a/tests/wpunit/ResourceTagsNoDataTest.php
+++ b/tests/wpunit/ResourceTagsNoDataTest.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Tests for the ConvertKit_Resource_Tags class when no data is present in the API.
+ * 
+ * @since 	1.9.7.8
+ */
+class ResourceTagsNoDataTest extends \Codeception\TestCase\WPTestCase
+{
+	/**
+	 * @var \WpunitTester
+	 */
+	protected $tester;
+
+	/**
+	 * Holds the ConvertKit Settings class.
+	 * 
+	 * @since 	1.9.7.8
+	 * 
+	 * @var 	ConvertKit_Settings
+	 */
+	private $settings;
+
+	/**
+	 * Holds the ConvertKit Resource class.
+	 * 
+	 * @since 	1.9.7.8
+	 * 
+	 * @var 	ConvertKit_Resource_Forms
+	 */
+	private $resource;
+
+	/**
+	 * Performs actions before each test.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		// Activate Plugin.
+		activate_plugins('convertkit/wp-convertkit.php');
+
+		// Store API Key and Secret in Plugin's settings.
+		$this->settings = new ConvertKit_Settings();
+		update_option($this->settings::SETTINGS_NAME, [
+			'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+			'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+		]);
+
+		// Initialize the resource class we want to test.
+		$this->resource = new ConvertKit_Resource_Forms();
+
+		// Confirm initialization didn't result in an error.
+		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
+	}
+
+	/**
+	 * Performs actions after each test.
+	 * 
+	 * @since 	1.9.6.9
+	 */
+	public function tearDown(): void
+	{
+		// Delete API Key, API Secret and Resources from Plugin's settings.
+		delete_option($this->settings::SETTINGS_NAME);
+		delete_option($this->resource->settings_name);
+		delete_option($this->resource->settings_name . '_last_queried');
+
+		// Destroy the resource class we tested.
+		unset($this->resource);
+
+		// Deactivate Plugin.
+		deactivate_plugins('convertkit/wp-convertkit.php');
+		
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that the refresh() function performs as expected.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testRefresh()
+	{
+		// Confirm that the data is stored in the options table and includes some expected keys.
+		$result = $this->resource->refresh();
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
+	}
+
+	/**
+	 * Test that the expiry timestamp is set and returns the expected value.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testExpiry()
+	{
+		// Define the expected expiry date based on the resource class' $cache_duration setting.
+		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+
+		// Fetch the actual expiry date set when the resource class was initialized.
+		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+
+		// Confirm both dates match.
+		$this->assertEquals($expectedExpiryDate, $expiryDate);
+	}
+
+	/**
+	 * Test that the get() function performs as expected.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testGet()
+	{
+		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+		$result = $this->resource->get();
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
+	}
+
+	/**
+	 * Test that the count() function returns the number of resources.
+	 * 
+	 * @since 	1.9.7.6
+	 */
+	public function testCount()
+	{
+		$result = $this->resource->get();
+		$this->assertEquals($this->resource->count(), count($result));
+	}
+
+	/**
+	 * Test that the exist() function performs as expected.
+	 * 
+	 * @since 	1.9.7.8
+	 */
+	public function testExist()
+	{
+		// Confirm that the function returns true, because resources exist.
+		$result = $this->resource->exist();
+		$this->assertSame($result, false);
+	}
+}

--- a/tests/wpunit/ResourceTagsTest.php
+++ b/tests/wpunit/ResourceTagsTest.php
@@ -1,5 +1,9 @@
 <?php
-
+/**
+ * Tests for the ConvertKit_Resource_Tags class.
+ * 
+ * @since 	1.9.7.4
+ */
 class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 {
 	/**
@@ -73,7 +77,7 @@ class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that the refresh() function performs as expected, storing data in the options table.
+	 * Test that the refresh() function performs as expected.
 	 * 
 	 * @since 	1.9.7.4
 	 */
@@ -104,7 +108,7 @@ class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that the get() function performs as expected, storing data in the options table.
+	 * Test that the get() function performs as expected.
 	 * 
 	 * @since 	1.9.7.4
 	 */
@@ -130,7 +134,7 @@ class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that the exist() function performs as expected, storing data in the options table.
+	 * Test that the exist() function performs as expected.
 	 * 
 	 * @since 	1.9.7.4
 	 */


### PR DESCRIPTION
## Summary

Returns an empty array instead of a `WP_Error` object when no resources (forms, landing pages, tags etc) exist in the ConvertKit account.

## Testing

- `APITest`: Added tests to confirm correct return type when no resources exist
- `ResourceFormsNoDataTest`: Added tests to confirm resource class returns expected values when no resources exist
- `ResourceLandingPagesNoDataTest`: Added tests to confirm resource class returns expected values when no resources exist
- `ResourcePostsNoDataTest`: Added tests to confirm resource class returns expected values when no resources exist
- `ResourceTagsNoDataTest`: Added tests to confirm resource class returns expected values when no resources exist

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)