### PR TITLE
Fix: API: Prevent fatal error when API returns `null`

### DIFF
--- a/lib/class-convertkit-api.php
+++ b/lib/class-convertkit-api.php
@@ -358,6 +358,12 @@ class ConvertKit_API {
 			return $response;
 		}
 
+		// If the response isn't an array as we expect, log that no sequences exist and return a blank array.
+		if ( ! is_array( $response['courses'] ) ) {
+			$this->log( 'API: get_sequences(): Error: No sequences exist in ConvertKit.' );
+			return $sequences;
+		}
+
 		// If no sequences exist, log that no sequences exist and return a blank array.
 		if ( ! count( $response['courses'] ) ) {
 			$this->log( 'API: get_sequences(): Error: No sequences exist in ConvertKit.' );
@@ -460,6 +466,12 @@ class ConvertKit_API {
 		if ( is_wp_error( $response ) ) {
 			$this->log( 'API: get_tags(): Error: ' . $response->get_error_message() );
 			return $response;
+		}
+
+		// If the response isn't an array as we expect, log that no tags exist and return a blank array.
+		if ( ! is_array( $response['tags'] ) ) {
+			$this->log( 'API: get_tags(): Error: No tags exist in ConvertKit.' );
+			return $tags;
 		}
 
 		// If no tags exist, log that no tags exist and return a blank array.
@@ -768,6 +780,12 @@ class ConvertKit_API {
 			return $response;
 		}
 
+		// If the response isn't an array as we expect, log that no tags exist and return a blank array.
+		if ( ! is_array( $response['custom_fields'] ) ) {
+			$this->log( 'API: get_custom_fields(): Error: No custom fields exist in ConvertKit.' );
+			return $custom_fields;
+		}
+
 		// If no custom fields exist, log that no custom fields exist and return a blank array.
 		if ( ! count( $response['custom_fields'] ) ) {
 			$this->log( 'API: get_custom_fields(): Error: No custom fields exist in ConvertKit.' );
@@ -890,6 +908,12 @@ class ConvertKit_API {
 		if ( is_wp_error( $response ) ) {
 			$this->log( 'API: get_posts(): Error: ' . $response->get_error_message() );
 			return $response;
+		}
+
+		// If the response isn't an array as we expect, log that no posts exist and return a blank array.
+		if ( ! is_array( $response['posts'] ) ) {
+			$this->log( 'API: get_posts(): Error: No broadcasts exist in ConvertKit.' );
+			return $posts;
 		}
 
 		// If no posts exist, log that no posts exist and return a blank array.

--- a/readme.txt
+++ b/readme.txt
@@ -110,6 +110,9 @@ Full Plugin documentation can be found [here](https://help.convertkit.com/en/art
 
 == Changelog ==
 
+### 1.9.7.9 2022-06-24
+* Fix: API: Prevent fatal error when API returns null instead of expected array
+
 ### 1.9.7.8 2022-06-23
 * Added: Elementor Page Builder: ConvertKit Broadcasts Widget
 * Fix: Integration: WishList Member: Unsubscribe email address from ConvertKit if 'unsubscribe' configured and member level removed

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -9,7 +9,7 @@
  * Plugin Name: ConvertKit
  * Plugin URI: https://convertkit.com/
  * Description: Quickly and easily integrate ConvertKit forms into your site.
- * Version: 1.9.7.8
+ * Version: 1.9.7.9
  * Author: ConvertKit
  * Author URI: https://convertkit.com/
  * Text Domain: convertkit
@@ -25,7 +25,7 @@ define( 'CONVERTKIT_PLUGIN_NAME', 'ConvertKit' ); // Used for user-agent in API 
 define( 'CONVERTKIT_PLUGIN_FILE', plugin_basename( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_PATH', __DIR__ );
-define( 'CONVERTKIT_PLUGIN_VERSION', '1.9.7.8' );
+define( 'CONVERTKIT_PLUGIN_VERSION', '1.9.7.9' );
 
 // Load shared classes, if they have not been included by another ConvertKit Plugin.
 if ( ! class_exists( 'ConvertKit_API' ) ) {


### PR DESCRIPTION
## Summary

Removing the `isset()` checks in [this PR](https://github.com/ConvertKit/convertkit-wordpress/pull/330/commits/871aa3f979d60d5e21a4b689bf4c528dfed5fc33) results in [this reported error](https://wordpress.org/support/topic/1-9-7-8-breaks-wordpress-6-0/) in 1.9.7.8.

This PR resolves by checking if the return value from the API is an array.

However, this isn't an issue I'm personally reproducing.  Specifically:
1. Our existing tests cover all API calls, using both an account with broadcasts and an account with no broadcasts.  These tests passed prior to this PR, meaning we weren't getting a `null` response from the API.
2. Querying the `posts` endpoint using API credentials for a ConvertKit account with no broadcasts returns the expected response, including a blank array for `posts`:
![Screenshot 2022-06-24 at 12 43 15](https://user-images.githubusercontent.com/1462305/175528315-1e0ed962-0357-43fa-9f5c-c19634c37829.png)

## Testing

Existing test coverage runs tests against the API for both accounts with data and accounts with no data.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)