### PR TITLE
Quick Edit

### DIFF
--- a/admin/class-convertkit-admin-bulk-quick-edit.php
+++ b/admin/class-convertkit-admin-bulk-quick-edit.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * ConvertKit Admin Bulk and Quick Edit class.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Registers a metabox on Posts, Pages and public facing Custom Post Types
+ * and saves its settings when the Post is saved in the WordPress Administration
+ * interface.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+class ConvertKit_Admin_Bulk_Quick_Edit {
+
+	public $column_name = 'convertkit';
+
+	/**
+	 * Registers action and filter hooks.
+	 *
+	 * @since   1.9.6
+	 */
+	public function __construct() {
+
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_filter( 'manage_page_posts_columns', array( $this, 'define_columns' ) );
+		add_action( 'manage_pages_custom_column', array( $this, 'output_columns' ), 10, 2 );
+		add_action( 'quick_edit_custom_box',  array( $this, 'quick_edit_fields' ), 10, 2 );
+		add_action( 'save_post', array( $this, 'quick_edit_save' ) );
+
+	}
+
+	public function enqueue_scripts( $pagehook ) {
+
+		// Bail if we're not on a Post Type Edit screen.
+		if ( 'edit.php' !== $pagehook ) {
+			return;
+		}
+
+		wp_enqueue_script( 'convertkit-quick-edit', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/quick-edit.js', array( 'jquery' ) );
+
+	}
+
+	/**
+	 * Adds a ConvertKit column to a Post, Page or Custom Post WP_List_Table immediately
+	 * after the Author column.
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	array 	$columns 	Table Columns.
+	 * @return 	array 				Table Columns
+	 */
+	public function define_columns( $columns ) {
+
+		// Insert the ConvertKit column after the Title column.
+		return $this->array_insert_after(
+			$columns,
+			'author',
+			array(
+				$this->column_name => __( 'ConvertKit', 'convertkit' ),
+			)
+		);
+
+	}
+
+	/**
+	 * Outputs data in the ConvertKit column, as well as hidden data attributes
+	 * used by the Quick Edit functionality.
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	string 	$column_name 	Column Name.
+	 * @param 	int 	$post_id 		Post ID.
+	 */
+	public function output_columns( $column_name, $post_id ) {
+
+		// Do nothing if the column name isn't for this Plugin.
+		if ( $column_name !== $this->column_name ) {
+			return;
+		}
+
+		// Fetch Post's Settings.
+		$settings = new ConvertKit_Post( $post_id );
+
+		// Output Form.
+		echo 'Default';
+
+		// Output as data- attributes for Quick Edit.
+		foreach ( $settings->get() as $key => $value ) {
+			?>
+			<span class="convertkit_post" data-key="<?php echo esc_attr( $key ); ?>" data-value="<?php echo esc_attr( $value ); ?>"></span>
+			<?php
+		}
+
+	}
+
+	public function quick_edit_fields( $column_name, $post_type ) {
+
+		// Do nothing if the column name isn't for this Plugin.
+		if ( $column_name !== $this->column_name ) {
+			return;
+		}
+
+		// Output Quick Edit fields.
+		echo '<fieldset class="inline-edit-col-right">
+					<div class="inline-edit-col">
+						<div class="inline-edit-group wp-clearfix">
+							<label class="alignleft">
+								<span class="title">Form</span>
+								<span class="input-text-wrap"><input type="text" name="form" value=""></span>
+							</label>
+						</div>
+					</div>
+				</fieldset>';
+
+	}
+
+	public function quick_edit_save( $post_id ) {
+
+	}
+
+	/**
+	 * Insert an array value after the given key for the given array
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   array  $array      Current Array.
+	 * @param   string $key        Key (new array will be inserted after this key).
+	 * @param   array  $new        Array data to insert.
+	 * @return  array               New Array
+	 */
+	private function array_insert_after( array $array, $key, array $new ) {
+
+		$keys  = array_keys( $array );
+		$index = array_search( $key, $keys ); /* phpcs:ignore */
+		$pos   = false === $index ? count( $array ) : $index + 1; /* phpcs:ignore */
+		return array_merge( array_slice( $array, 0, $pos ), $new, array_slice( $array, $pos ) );
+
+	}
+
+}

--- a/admin/class-convertkit-admin-post.php
+++ b/admin/class-convertkit-admin-post.php
@@ -165,7 +165,7 @@ class ConvertKit_Admin_Post {
 
 		// Get Post's settings.
 		$convertkit_post = new ConvertKit_Post( $post_id );
-		$meta = $convertkit_post->get();
+		$meta            = $convertkit_post->get();
 
 		// Update Post's setting values if they were included in the $_POST data.
 		// Some values may not be included in the $_POST data e.g. if Quick Edit is used and no Landing Page was specified,

--- a/admin/class-convertkit-admin-post.php
+++ b/admin/class-convertkit-admin-post.php
@@ -130,7 +130,7 @@ class ConvertKit_Admin_Post {
 	}
 
 	/**
-	 * Save Post Settings.
+	 * Saves Post Settings when either editing a Post/Page or using the Quick Edit functionality.
 	 *
 	 * @since   1.9.6
 	 *
@@ -163,15 +163,25 @@ class ConvertKit_Admin_Post {
 			return;
 		}
 
-		// Build metadata.
-		$meta = array(
-			'form'         => ( isset( $_POST['wp-convertkit']['form'] ) ? sanitize_text_field( wp_unslash( $_POST['wp-convertkit']['form'] ) ) : '-1' ),
-			'landing_page' => ( isset( $_POST['wp-convertkit']['landing_page'] ) ? sanitize_text_field( wp_unslash( $_POST['wp-convertkit']['landing_page'] ) ) : '' ),
-			'tag'          => ( isset( $_POST['wp-convertkit']['tag'] ) ? sanitize_text_field( wp_unslash( $_POST['wp-convertkit']['tag'] ) ) : '' ),
-		);
-
-		// Save metadata.
+		// Get Post's settings.
 		$convertkit_post = new ConvertKit_Post( $post_id );
+		$meta = $convertkit_post->get();
+
+		// Update Post's setting values if they were included in the $_POST data.
+		// Some values may not be included in the $_POST data e.g. if Quick Edit is used and no Landing Page was specified,
+		// in which case the existing Post's value will be used.
+		// This ensures settings are not deleted by accident.
+		foreach ( $meta as $key => $value ) {
+			// Skip if this setting isn't included in the $_POST data.
+			if ( ! isset( $_POST['wp-convertkit'][ $key ] ) ) {
+				continue;
+			}
+
+			// Update setting using posted value.
+			$meta[ $key ] = sanitize_text_field( wp_unslash( $_POST['wp-convertkit'][ $key ] ) );
+		}
+
+		// Save settings.
 		$convertkit_post->save( $meta );
 
 		// If a Form or Landing Page was specified, request a review.

--- a/admin/class-convertkit-admin-quick-edit.php
+++ b/admin/class-convertkit-admin-quick-edit.php
@@ -1,38 +1,41 @@
 <?php
 /**
- * ConvertKit Admin Bulk and Quick Edit class.
+ * ConvertKit Admin Quick Edit class.
  *
  * @package ConvertKit
  * @author ConvertKit
  */
 
 /**
- * Registers a metabox on Posts, Pages and public facing Custom Post Types
- * and saves its settings when the Post is saved in the WordPress Administration
- * interface.
+ * Registers settings fields for output when using WordPress' Quick Edit functionality
+ * in a Post, Page or Custom Post Type WP_List_Table.
  *
  * @package ConvertKit
  * @author ConvertKit
  */
-class ConvertKit_Admin_Bulk_Quick_Edit {
-
-	public $column_name = 'convertkit';
+class ConvertKit_Admin_Quick_Edit {
 
 	/**
 	 * Registers action and filter hooks.
 	 *
-	 * @since   1.9.6
+	 * @since   1.9.8.0
 	 */
 	public function __construct() {
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-		add_filter( 'manage_page_posts_columns', array( $this, 'define_columns' ) );
-		add_action( 'manage_pages_custom_column', array( $this, 'output_columns' ), 10, 2 );
-		add_action( 'quick_edit_custom_box',  array( $this, 'quick_edit_fields' ), 10, 2 );
+		add_action( 'add_inline_data', array( $this, 'quick_edit_inline_data' ), 10, 2 );
+		add_action( 'in_admin_footer',  array( $this, 'quick_edit_fields' ), 10, 2 );
 		add_action( 'save_post', array( $this, 'quick_edit_save' ) );
 
 	}
 
+	/**
+	 * Enqueues scripts for quick edit functionality in the Post, Page and Custom Post WP_List_Tables
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	string 	$pagehook 	Page hook name.
+	 */
 	public function enqueue_scripts( $pagehook ) {
 
 		// Bail if we're not on a Post Type Edit screen.
@@ -45,64 +48,35 @@ class ConvertKit_Admin_Bulk_Quick_Edit {
 	}
 
 	/**
-	 * Adds a ConvertKit column to a Post, Page or Custom Post WP_List_Table immediately
-	 * after the Author column.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	array 	$columns 	Table Columns.
-	 * @return 	array 				Table Columns
-	 */
-	public function define_columns( $columns ) {
-
-		// Insert the ConvertKit column after the Title column.
-		return $this->array_insert_after(
-			$columns,
-			'author',
-			array(
-				$this->column_name => __( 'ConvertKit', 'convertkit' ),
-			)
-		);
-
-	}
-
-	/**
-	 * Outputs data in the ConvertKit column, as well as hidden data attributes
-	 * used by the Quick Edit functionality.
+	 * Outputs hidden inline data in each Post's Title column, which the Quick Edit
+	 * JS can read when the user clicks the Quick Edit link in a WP_List_Table.
 	 * 
 	 * @since 	1.9.8.0
 	 * 
 	 * @param 	string 	$column_name 	Column Name.
 	 * @param 	int 	$post_id 		Post ID.
 	 */
-	public function output_columns( $column_name, $post_id ) {
-
-		// Do nothing if the column name isn't for this Plugin.
-		if ( $column_name !== $this->column_name ) {
-			return;
-		}
+	public function quick_edit_inline_data( $post, $post_type_object ) {
 
 		// Fetch Post's Settings.
-		$settings = new ConvertKit_Post( $post_id );
+		$settings = new ConvertKit_Post( $post->ID );
 
-		// Output Form.
-		echo 'Default';
-
-		// Output as data- attributes for Quick Edit.
+		// Output the Post's ConvertKit settings as hidden data- attributes, which
+		// the Quick Edit JS can read.
 		foreach ( $settings->get() as $key => $value ) {
 			?>
-			<span class="convertkit_post" data-key="<?php echo esc_attr( $key ); ?>" data-value="<?php echo esc_attr( $value ); ?>"></span>
+			<div class="convertkit" data-setting="<?php echo esc_attr( $key ); ?>" data-value="<?php echo esc_attr( $value ); ?>"><?php echo esc_attr( $value ); ?></div>
 			<?php
 		}
 
 	}
 
-	public function quick_edit_fields( $column_name, $post_type ) {
-
-		// Do nothing if the column name isn't for this Plugin.
-		if ( $column_name !== $this->column_name ) {
-			return;
-		}
+	/**
+	 * Outputs Quick Edit settings fields.
+	 * 
+	 * @since 	1.9.8.0
+	 */
+	public function quick_edit_fields() {
 
 		// Output Quick Edit fields.
 		echo '<fieldset class="inline-edit-col-right">
@@ -118,6 +92,13 @@ class ConvertKit_Admin_Bulk_Quick_Edit {
 
 	}
 
+	/**
+	 * Saves submitted Quick Edit fields.
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	int 	$post_id 	Post ID.
+	 */
 	public function quick_edit_save( $post_id ) {
 
 	}

--- a/admin/class-convertkit-admin-quick-edit.php
+++ b/admin/class-convertkit-admin-quick-edit.php
@@ -51,10 +51,10 @@ class ConvertKit_Admin_Quick_Edit {
 		}
 
 		// Enqueue JS.
-		wp_enqueue_script( 'convertkit-quick-edit', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/quick-edit.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
+		wp_enqueue_script( 'convertkit-admin-quick-edit', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/quick-edit.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
 
 		// Enqueue CSS.
-		wp_enqueue_style( 'convertkit-admin-tinymce', CONVERTKIT_PLUGIN_URL . 'resources/backend/css/quick-edit.css', array(), CONVERTKIT_PLUGIN_VERSION );
+		wp_enqueue_style( 'convertkit-admin-quick-edit', CONVERTKIT_PLUGIN_URL . 'resources/backend/css/quick-edit.css', array(), CONVERTKIT_PLUGIN_VERSION );
 
 	}
 

--- a/admin/class-convertkit-admin-quick-edit.php
+++ b/admin/class-convertkit-admin-quick-edit.php
@@ -22,17 +22,17 @@ class ConvertKit_Admin_Quick_Edit {
 	 */
 	public function __construct() {
 
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 		add_action( 'add_inline_data', array( $this, 'quick_edit_inline_data' ) );
 
 	}
 
 	/**
-	 * Enqueues scripts for Quick Edit functionality in the Post, Page and Custom Post WP_List_Tables
+	 * Enqueues scripts and CSS for Quick Edit functionality in the Post, Page and Custom Post WP_List_Tables
 	 *
 	 * @since   1.9.8.0
 	 */
-	public function enqueue_scripts() {
+	public function enqueue_assets() {
 
 		// Bail if we cannot determine the screen.
 		if ( ! function_exists( 'get_current_screen' ) ) {
@@ -46,11 +46,15 @@ class ConvertKit_Admin_Quick_Edit {
 		}
 
 		// Bail if the Post isn't a supported Post Type.
-		if ( ! in_array( $screen->post_type, convertkit_get_supported_post_types() ) ) {
+		if ( ! in_array( $screen->post_type, convertkit_get_supported_post_types(), true ) ) {
 			return;
 		}
-		
+
+		// Enqueue JS.
 		wp_enqueue_script( 'convertkit-quick-edit', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/quick-edit.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
+
+		// Enqueue CSS.
+		wp_enqueue_style( 'convertkit-admin-tinymce', CONVERTKIT_PLUGIN_URL . 'resources/backend/css/quick-edit.css', array(), CONVERTKIT_PLUGIN_VERSION );
 
 	}
 
@@ -65,7 +69,7 @@ class ConvertKit_Admin_Quick_Edit {
 	public function quick_edit_inline_data( $post ) {
 
 		// Bail if the Post isn't a supported Post Type.
-		if ( ! in_array( $post->post_type, convertkit_get_supported_post_types() ) ) {
+		if ( ! in_array( $post->post_type, convertkit_get_supported_post_types(), true ) ) {
 			return;
 		}
 

--- a/admin/class-convertkit-admin-quick-edit.php
+++ b/admin/class-convertkit-admin-quick-edit.php
@@ -23,17 +23,17 @@ class ConvertKit_Admin_Quick_Edit {
 	public function __construct() {
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-		add_action( 'add_inline_data', array( $this, 'quick_edit_inline_data' ), 10, 2 );
-		add_action( 'in_admin_footer',  array( $this, 'quick_edit_fields' ), 10, 2 );
+		add_action( 'add_inline_data', array( $this, 'quick_edit_inline_data' ) );
+		add_action( 'in_admin_footer', array( $this, 'quick_edit_fields' ), 10, 2 );
 
 	}
 
 	/**
 	 * Enqueues scripts for Quick Edit functionality in the Post, Page and Custom Post WP_List_Tables
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	string 	$pagehook 	Page hook name.
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   string $pagehook   Page hook name.
 	 */
 	public function enqueue_scripts( $pagehook ) {
 
@@ -42,20 +42,19 @@ class ConvertKit_Admin_Quick_Edit {
 			return;
 		}
 
-		wp_enqueue_script( 'convertkit-quick-edit', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/quick-edit.js', array( 'jquery' ) );
+		wp_enqueue_script( 'convertkit-quick-edit', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/quick-edit.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
 
 	}
 
 	/**
 	 * Outputs hidden inline data in each Post's Title column, which the Quick Edit
 	 * JS can read when the user clicks the Quick Edit link in a WP_List_Table.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	string 	$column_name 	Column Name.
-	 * @param 	int 	$post_id 		Post ID.
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   WP_Post $post               Post.
 	 */
-	public function quick_edit_inline_data( $post, $post_type_object ) {
+	public function quick_edit_inline_data( $post ) {
 
 		// Fetch Post's Settings.
 		$settings = new ConvertKit_Post( $post->ID );
@@ -77,11 +76,11 @@ class ConvertKit_Admin_Quick_Edit {
 
 	/**
 	 * Outputs Quick Edit settings fields in the footer of the administration screen.
-	 * 
+	 *
 	 * The Quick Edit JS will then move these hidden fields into the Quick Edit row
 	 * when the user clicks on a Quick Edit link in the WP_List_Table.
-	 * 
-	 * @since 	1.9.8.0
+	 *
+	 * @since   1.9.8.0
 	 */
 	public function quick_edit_fields() {
 

--- a/composer.json
+++ b/composer.json
@@ -48,5 +48,10 @@
             "readme.md",
             "tags"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -64,9 +64,9 @@ class WP_ConvertKit {
 			return;
 		}
 
-		$this->classes['admin_bulk_quick_edit'] = new ConvertKit_Admin_Bulk_Quick_Edit();
 		$this->classes['admin_category'] 		= new ConvertKit_Admin_Category();
 		$this->classes['admin_post']     		= new ConvertKit_Admin_Post();
+		$this->classes['admin_quick_edit'] 		= new ConvertKit_Admin_Quick_Edit();
 		$this->classes['admin_settings'] 		= new ConvertKit_Admin_Settings();
 		$this->classes['admin_tinymce']  		= new ConvertKit_Admin_TinyMCE();
 		$this->classes['admin_user']     		= new ConvertKit_Admin_User();

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -64,11 +64,12 @@ class WP_ConvertKit {
 			return;
 		}
 
-		$this->classes['admin_category'] = new ConvertKit_Admin_Category();
-		$this->classes['admin_post']     = new ConvertKit_Admin_Post();
-		$this->classes['admin_settings'] = new ConvertKit_Admin_Settings();
-		$this->classes['admin_tinymce']  = new ConvertKit_Admin_TinyMCE();
-		$this->classes['admin_user']     = new ConvertKit_Admin_User();
+		$this->classes['admin_bulk_quick_edit'] = new ConvertKit_Admin_Bulk_Quick_Edit();
+		$this->classes['admin_category'] 		= new ConvertKit_Admin_Category();
+		$this->classes['admin_post']     		= new ConvertKit_Admin_Post();
+		$this->classes['admin_settings'] 		= new ConvertKit_Admin_Settings();
+		$this->classes['admin_tinymce']  		= new ConvertKit_Admin_TinyMCE();
+		$this->classes['admin_user']     		= new ConvertKit_Admin_User();
 
 		/**
 		 * Initialize integration classes for the WordPress Administration interface.

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -64,12 +64,12 @@ class WP_ConvertKit {
 			return;
 		}
 
-		$this->classes['admin_category'] 		= new ConvertKit_Admin_Category();
-		$this->classes['admin_post']     		= new ConvertKit_Admin_Post();
-		$this->classes['admin_quick_edit'] 		= new ConvertKit_Admin_Quick_Edit();
-		$this->classes['admin_settings'] 		= new ConvertKit_Admin_Settings();
-		$this->classes['admin_tinymce']  		= new ConvertKit_Admin_TinyMCE();
-		$this->classes['admin_user']     		= new ConvertKit_Admin_User();
+		$this->classes['admin_category']   = new ConvertKit_Admin_Category();
+		$this->classes['admin_post']       = new ConvertKit_Admin_Post();
+		$this->classes['admin_quick_edit'] = new ConvertKit_Admin_Quick_Edit();
+		$this->classes['admin_settings']   = new ConvertKit_Admin_Settings();
+		$this->classes['admin_tinymce']    = new ConvertKit_Admin_TinyMCE();
+		$this->classes['admin_user']       = new ConvertKit_Admin_User();
 
 		/**
 		 * Initialize integration classes for the WordPress Administration interface.

--- a/resources/backend/css/quick-edit.css
+++ b/resources/backend/css/quick-edit.css
@@ -1,0 +1,8 @@
+.convertkit-quick-edit {
+	display: none;
+}
+.convertkit-quick-edit label span.title {
+	background: url(../images/block-icon-form.png) 0% 50% no-repeat;
+	background-size: 16px 16px;
+	text-indent: 24px;
+}

--- a/resources/backend/js/quick-edit.js
+++ b/resources/backend/js/quick-edit.js
@@ -6,8 +6,12 @@
  */
 
 /**
- * Reads and saves Post meta values for this Plugin when editing a Page,
- * Post or Custom Post type using WordPress' Quick Edit functionality
+ * Populates Quick Edit fields for this Plugin with the values output
+ * in the `add_inline_data` WordPress action when the user clicks
+ * a Quick Edit link in a Post, Page or Custom Post Type WP_List_Table.
+ * 
+ * WordPress' built in Quick Edit functionality does not do this automatically
+ * for Plugins that register settings, which is why we have this code here.
  *
  * @since 	1.9.8.0
  */
@@ -15,39 +19,27 @@ jQuery( document ).ready(
 
 	function( $ ) {
 
-		var wp_inline_edit_function = inlineEditPost.edit;
+		var convertKitInlineEditPost = inlineEditPost.edit;
 
 		// Extend WordPress' quick edit function.
-		inlineEditPost.edit = function( post_id ) {
+		inlineEditPost.edit = function( id ) {
 
 			// Merge arguments from original function.
-			wp_inline_edit_function.apply( this, arguments );
+			convertKitInlineEditPost.apply( this, arguments );
 
 			// Get Post ID.
-			var id = 0;
-			if ( typeof( post_id ) === 'object' ) {
-				id = parseInt( this.getId( post_id ) );
+			if ( typeof( id ) === 'object' ) {
+				id = parseInt( this.getId( id ) );
 			}
 
-			// 
-			if ( id > 0 ) {
+			// Iterate through any ConvertKit inline data, assigning values to Quick Edit fields.
+			$( '.convertkit', $( '#inline_' + id ) ).each( function() {
 
-				// @TODO Get hidden data.
+				// Assign the setting's value to the setting's Quick Edit field.
+				$( 'select[name="wp-convertkit[' + $( this ).data( 'setting' ) + ']"]' ).val( $( this ).data( 'value' ) );
 
-				// add rows to variables
-				/*
-				var specific_post_edit_row = $( '#edit-' + id ),
-				    specific_post_row = $( '#post-' + id ),
-				    product_price = $( '.column-price', specific_post_row ).text().substring(1), //  remove $ sign
-				    featured_product = false; // let's say by default checkbox is unchecked
-				*/
+			} );
 
-				// Populate inputs with hidden data.
-				// @TODO.
-				$( ':input[name="price"]', specific_post_edit_row ).val( product_price );
-				$( ':input[name="featured"]', specific_post_edit_row ).prop('checked', featured_product );
-
-			}
 		}
 
 	}

--- a/resources/backend/js/quick-edit.js
+++ b/resources/backend/js/quick-edit.js
@@ -32,11 +32,17 @@ jQuery( document ).ready(
 				id = parseInt( this.getId( id ) );
 			}
 
+			// Move Plugin's Quick Edit fields container into the inline editor, if they don't yet exist.
+			// This only needs to be done once.
+			if ( $( '.inline-edit-wrapper fieldset.inline-edit-col-left .convertkit-quick-edit' ).length === 0 ) {
+				$( '.convertkit-quick-edit' ).appendTo( '.inline-edit-wrapper fieldset.inline-edit-col-left' ).show();	
+			}
+
 			// Iterate through any ConvertKit inline data, assigning values to Quick Edit fields.
 			$( '.convertkit', $( '#inline_' + id ) ).each( function() {
 
 				// Assign the setting's value to the setting's Quick Edit field.
-				$( 'select[name="wp-convertkit[' + $( this ).data( 'setting' ) + ']"]' ).val( $( this ).data( 'value' ) );
+				$( '.convertkit-quick-edit select[name="wp-convertkit[' + $( this ).data( 'setting' ) + ']"]' ).val( $( this ).data( 'value' ) );
 
 			} );
 

--- a/resources/backend/js/quick-edit.js
+++ b/resources/backend/js/quick-edit.js
@@ -9,14 +9,13 @@
  * Populates Quick Edit fields for this Plugin with the values output
  * in the `add_inline_data` WordPress action when the user clicks
  * a Quick Edit link in a Post, Page or Custom Post Type WP_List_Table.
- * 
+ *
  * WordPress' built in Quick Edit functionality does not do this automatically
  * for Plugins that register settings, which is why we have this code here.
  *
  * @since 	1.9.8.0
  */
 jQuery( document ).ready(
-
 	function( $ ) {
 
 		var convertKitInlineEditPost = inlineEditPost.edit;
@@ -35,19 +34,20 @@ jQuery( document ).ready(
 			// Move Plugin's Quick Edit fields container into the inline editor, if they don't yet exist.
 			// This only needs to be done once.
 			if ( $( '.inline-edit-wrapper fieldset.inline-edit-col-left .convertkit-quick-edit' ).length === 0 ) {
-				$( '.convertkit-quick-edit' ).appendTo( '.inline-edit-wrapper fieldset.inline-edit-col-left' ).show();	
+				$( '.convertkit-quick-edit' ).appendTo( '.inline-edit-wrapper fieldset.inline-edit-col-left' ).show();
 			}
 
 			// Iterate through any ConvertKit inline data, assigning values to Quick Edit fields.
-			$( '.convertkit', $( '#inline_' + id ) ).each( function() {
+			$( '.convertkit', $( '#inline_' + id ) ).each(
+				function() {
 
-				// Assign the setting's value to the setting's Quick Edit field.
-				$( '.convertkit-quick-edit select[name="wp-convertkit[' + $( this ).data( 'setting' ) + ']"]' ).val( $( this ).data( 'value' ) );
+					// Assign the setting's value to the setting's Quick Edit field.
+					$( '.convertkit-quick-edit select[name="wp-convertkit[' + $( this ).data( 'setting' ) + ']"]' ).val( $( this ).data( 'value' ) );
 
-			} );
+				}
+			);
 
 		}
 
 	}
-	
 );

--- a/resources/backend/js/quick-edit.js
+++ b/resources/backend/js/quick-edit.js
@@ -33,8 +33,8 @@ jQuery( document ).ready(
 
 			// Move Plugin's Quick Edit fields container into the inline editor, if they don't yet exist.
 			// This only needs to be done once.
-			if ( $( '.inline-edit-wrapper fieldset.inline-edit-col-left .convertkit-quick-edit' ).length === 0 ) {
-				$( '.convertkit-quick-edit' ).appendTo( '.inline-edit-wrapper fieldset.inline-edit-col-left' ).show();
+			if ( $( '.inline-edit-wrapper fieldset.inline-edit-col-left:first-child .convertkit-quick-edit' ).length === 0 ) {
+				$( '.convertkit-quick-edit' ).appendTo( '.inline-edit-wrapper fieldset.inline-edit-col-left:first-child' ).show();
 			}
 
 			// Iterate through any ConvertKit inline data, assigning values to Quick Edit fields.

--- a/resources/backend/js/quick-edit.js
+++ b/resources/backend/js/quick-edit.js
@@ -1,0 +1,55 @@
+/**
+ * Quick Edit
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Reads and saves Post meta values for this Plugin when editing a Page,
+ * Post or Custom Post type using WordPress' Quick Edit functionality
+ *
+ * @since 	1.9.8.0
+ */
+jQuery( document ).ready(
+
+	function( $ ) {
+
+		var wp_inline_edit_function = inlineEditPost.edit;
+
+		// Extend WordPress' quick edit function.
+		inlineEditPost.edit = function( post_id ) {
+
+			// Merge arguments from original function.
+			wp_inline_edit_function.apply( this, arguments );
+
+			// Get Post ID.
+			var id = 0;
+			if ( typeof( post_id ) === 'object' ) {
+				id = parseInt( this.getId( post_id ) );
+			}
+
+			// 
+			if ( id > 0 ) {
+
+				// @TODO Get hidden data.
+
+				// add rows to variables
+				/*
+				var specific_post_edit_row = $( '#edit-' + id ),
+				    specific_post_row = $( '#post-' + id ),
+				    product_price = $( '.column-price', specific_post_row ).text().substring(1), //  remove $ sign
+				    featured_product = false; // let's say by default checkbox is unchecked
+				*/
+
+				// Populate inputs with hidden data.
+				// @TODO.
+				$( ':input[name="price"]', specific_post_edit_row ).val( product_price );
+				$( ':input[name="featured"]', specific_post_edit_row ).prop('checked', featured_product );
+
+			}
+		}
+
+	}
+	
+);

--- a/tests/_support/Helper/Acceptance/WPQuickEdit.php
+++ b/tests/_support/Helper/Acceptance/WPQuickEdit.php
@@ -24,6 +24,9 @@ class WPQuickEdit extends \Codeception\Module
 
 		// Hover mouse over Post's table row.
 		$I->moveMouseOver('tr#post-'.$postID);
+
+		// Wait for Quick edit link to be visible.
+		$I->waitForElementVisible('button.editinline');
 		
 		// Click Quick Edit link.
 		$I->click('button.editinline');

--- a/tests/_support/Helper/Acceptance/WPQuickEdit.php
+++ b/tests/_support/Helper/Acceptance/WPQuickEdit.php
@@ -1,0 +1,56 @@
+<?php
+namespace Helper\Acceptance;
+
+// Define any custom actions related to WordPress' Quick Edit functionality that
+// would be used across multiple tests.
+// These are then available in $I->{yourFunctionName}
+
+class WPQuickEdit extends \Codeception\Module
+{
+	/**
+	 * Quick Edits the given Post ID, changing form field values and saving.
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
+	 * @param 	string 	$postType 		Programmatic Post Type.
+	 * @param 	int 	$postID 		Post ID.
+	 * @param 	array 	$configuration 	Configuration (field => value key/value array).
+	 */
+	public function quickEdit($I, $postType, $postID, $configuration)
+	{
+		// Navigate to Post Type's WP_List_Table.
+		$I->amOnAdminPage('edit.php?post_type='.$postType);
+
+		// Hover mouse over Post's table row.
+		$I->moveMouseOver('tr#post-'.$postID);
+		
+		// Click Quick Edit link.
+		$I->click('button.editinline');
+
+		// Apply configuration.
+		foreach ($configuration as $field=>$attributes) {
+			// Field ID will be prefixed with wp-convertkit-.
+			$fieldID = 'wp-convertkit-' . $field;
+
+			// Check that the field exists.
+			$I->seeElementInDOM('#' . $fieldID);
+			
+			// Depending on the field's type, define its value.
+			switch ($attributes[0]) {
+				case 'select2':
+					$I->fillSelect2Field($I, '#select2-' . $fieldID . '-container', $attributes[1]);
+					break;
+				case 'select':
+					$I->selectOption('#' . $fieldID, $attributes[1]);
+					break;
+				default:
+					$I->fillField('#' . $fieldID, $attributes[1]);
+					break;
+			}
+		}
+
+		// Click Update.
+		$I->click('Update');
+	}
+}

--- a/tests/_support/Helper/Acceptance/WPQuickEdit.php
+++ b/tests/_support/Helper/Acceptance/WPQuickEdit.php
@@ -26,10 +26,10 @@ class WPQuickEdit extends \Codeception\Module
 		$I->moveMouseOver('tr#post-'.$postID);
 
 		// Wait for Quick edit link to be visible.
-		$I->waitForElementVisible('button.editinline');
+		$I->waitForElementVisible('tr#post-'.$postID.' button.editinline');
 		
 		// Click Quick Edit link.
-		$I->click('button.editinline');
+		$I->click('tr#post-'.$postID.' button.editinline');
 
 		// Apply configuration.
 		foreach ($configuration as $field=>$attributes) {

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -28,6 +28,7 @@ modules:
         - \Helper\Acceptance\WPClassicEditor
         - \Helper\Acceptance\WPGutenberg
         - \Helper\Acceptance\WPMetabox
+        - \Helper\Acceptance\WPQuickEdit
         - \Helper\Acceptance\WPWidget
         - \Helper\Acceptance\Xdebug
     config:

--- a/tests/acceptance/forms/PageFormCest.php
+++ b/tests/acceptance/forms/PageFormCest.php
@@ -242,6 +242,71 @@ class PageFormCest
 	}
 
 	/**
+	 * Test that the Default Form for Pages displays when the Default option is chosen via
+	 * WordPress' Quick Edit functionality.
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testQuickEditUsingDefaultForm(AcceptanceTester $I)
+	{
+		// Specify the Default Form in the Plugin Settings.
+		$I->setupConvertKitPluginDefaultForm($I);
+
+		// Programmatically create a Page.
+		$pageID = $I->havePostInDatabase([
+			'post_type' 	=> 'page',
+			'post_title' 	=> 'ConvertKit: Page: Form: Default: Quick Edit',
+		]);
+
+		// Quick Edit the Page in the Pages WP_List_Table.
+		$I->quickEdit($I, 'page', $pageID, [
+			'form' => [ 'select', 'Default' ],
+		]);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/?p='.$pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the ConvertKit Default Form displays.
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+	}
+
+	/**
+	 * Test that the defined form displays when chosen via
+	 * WordPress' Quick Edit functionality.
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testQuickEditUsingDefinedForm(AcceptanceTester $I)
+	{
+		// Programmatically create a Page.
+		$pageID = $I->havePostInDatabase([
+			'post_type' 	=> 'page',
+			'post_title' 	=> 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
+		]);
+
+		// Quick Edit the Page in the Pages WP_List_Table.
+		$I->quickEdit($I, 'page', $pageID, [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+		]);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/?p='.$pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the ConvertKit Default Form displays.
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/acceptance/forms/PostFormCest.php
+++ b/tests/acceptance/forms/PostFormCest.php
@@ -344,6 +344,71 @@ class PostFormCest
 	}
 
 	/**
+	 * Test that the Default Form for Pages displays when the Default option is chosen via
+	 * WordPress' Quick Edit functionality.
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testQuickEditUsingDefaultForm(AcceptanceTester $I)
+	{
+		// Specify the Default Form in the Plugin Settings.
+		$I->setupConvertKitPluginDefaultForm($I);
+
+		// Programmatically create a Post.
+		$postID = $I->havePostInDatabase([
+			'post_type' 	=> 'post',
+			'post_title' 	=> 'ConvertKit: Post: Form: Default: Quick Edit',
+		]);
+
+		// Quick Edit the Post in the Posts WP_List_Table.
+		$I->quickEdit($I, 'page', $postID, [
+			'form' => [ 'select', 'Default' ],
+		]);
+
+		// Load the Post on the frontend site.
+		$I->amOnPage('/?p='.$postID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the ConvertKit Default Form displays.
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+	}
+
+	/**
+	 * Test that the defined form displays when chosen via
+	 * WordPress' Quick Edit functionality.
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testQuickEditUsingDefinedForm(AcceptanceTester $I)
+	{
+		// Programmatically create a Post.
+		$postID = $I->havePostInDatabase([
+			'post_type' 	=> 'post',
+			'post_title' 	=> 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
+		]);
+
+		// Quick Edit the Post in the Posts WP_List_Table.
+		$I->quickEdit($I, 'post', $postID, [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+		]);
+
+		// Load the Post on the frontend site.
+		$I->amOnPage('/?p='.$postID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the ConvertKit Default Form displays.
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/acceptance/forms/PostFormCest.php
+++ b/tests/acceptance/forms/PostFormCest.php
@@ -363,7 +363,7 @@ class PostFormCest
 		]);
 
 		// Quick Edit the Post in the Posts WP_List_Table.
-		$I->quickEdit($I, 'page', $postID, [
+		$I->quickEdit($I, 'post', $postID, [
 			'form' => [ 'select', 'Default' ],
 		]);
 

--- a/tests/acceptance/integrations/WooCommerceProductFormCest.php
+++ b/tests/acceptance/integrations/WooCommerceProductFormCest.php
@@ -136,6 +136,71 @@ class WooCommerceProductFormCest
 	}
 
 	/**
+	 * Test that the Default Form for Products displays when the Default option is chosen via
+	 * WordPress' Quick Edit functionality.
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testQuickEditUsingDefaultForm(AcceptanceTester $I)
+	{
+		// Specify the Default Form in the Plugin Settings.
+		$I->setupConvertKitPluginDefaultFormForWooCommerceProducts($I);
+
+		// Programmatically create a Product.
+		$productID = $I->havePostInDatabase([
+			'post_type' 	=> 'product',
+			'post_title' 	=> 'ConvertKit: Product: Form: Default: Quick Edit',
+		]);
+
+		// Quick Edit the Product in the Products WP_List_Table.
+		$I->quickEdit($I, 'product', $productID, [
+			'form' => [ 'select', 'Default' ],
+		]);
+
+		// Load the Product on the frontend site.
+		$I->amOnPage('/?p='.$productID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the ConvertKit Default Form displays.
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+	}
+
+	/**
+	 * Test that the defined form displays when chosen via
+	 * WordPress' Quick Edit functionality.
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testQuickEditUsingDefinedForm(AcceptanceTester $I)
+	{
+		// Programmatically create a Product.
+		$productID = $I->havePostInDatabase([
+			'post_type' 	=> 'product',
+			'post_title' 	=> 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
+		]);
+
+		// Quick Edit the Product in the Products WP_List_Table.
+		$I->quickEdit($I, 'product', $productID, [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+		]);
+
+		// Load the Product on the frontend site.
+		$I->amOnPage('/?p='.$productID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the ConvertKit Default Form displays.
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/acceptance/tags/PageTagCest.php
+++ b/tests/acceptance/tags/PageTagCest.php
@@ -78,6 +78,37 @@ class PageTagCest
 	}
 
 	/**
+	 * Test that the defined tag is honored when chosen via
+	 * WordPress' Quick Edit functionality.
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testQuickEditUsingDefinedTag(AcceptanceTester $I)
+	{
+		// Programmatically create a Page.
+		$pageID = $I->havePostInDatabase([
+			'post_type' 	=> 'page',
+			'post_title' 	=> 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Quick Edit',
+		]);
+
+		// Quick Edit the Page in the Pages WP_List_Table.
+		$I->quickEdit($I, 'page', $pageID, [
+			'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
+		]);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/?p='.$pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+		
+		// Confirm that the post_has_tag parameter is set to true in the source code.
+		$I->seeInSource('"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/views/backend/post/quick-edit.php
+++ b/views/backend/post/quick-edit.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Quick Edit view
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+?>
+<div class="convertkit-quick-edit" style="display:none;">
+	<!-- Form -->
+	<label>
+		<span class="title"><?php esc_html_e( 'Form', 'convertkit' ); ?></span>
+		<select name="wp-convertkit[form]" size="1">
+			<option value="-1"><?php esc_html_e( 'Default', 'convertkit' ); ?></option>
+			<option value="0"><?php esc_html_e( 'None', 'convertkit' ); ?></option>
+			<?php
+			foreach ( $convertkit_forms->get() as $form ) {
+				?>
+				<option value="<?php echo esc_attr( $form['id'] ); ?>"><?php echo esc_attr( $form['name'] ); ?></option>
+				<?php
+			}
+			?>
+		</select>
+	</label>
+
+	<!-- Tag -->
+	<label>
+		<span class="title"><?php esc_html_e( 'Tag', 'convertkit' ); ?></span>
+		<select name="wp-convertkit[tag]">
+			<option value="0">
+				<?php esc_html_e( 'None', 'convertkit' ); ?>
+			</option>
+			<?php
+			foreach ( $convertkit_tags->get() as $convertkit_tag ) {
+				?>
+				<option value="<?php echo esc_attr( $convertkit_tag['id'] ); ?>"><?php echo esc_attr( $convertkit_tag['name'] ); ?></option>
+				<?php
+			}
+			?>
+		</select>
+	</label>
+	<?php wp_nonce_field( 'wp-convertkit-save-meta', 'wp-convertkit-save-meta-nonce' ); ?>
+</div>
+

--- a/views/backend/post/quick-edit.php
+++ b/views/backend/post/quick-edit.php
@@ -9,9 +9,9 @@
 ?>
 <div class="convertkit-quick-edit" style="display:none;">
 	<!-- Form -->
-	<label>
+	<label for="wp-convertkit-form">
 		<span class="title"><?php esc_html_e( 'Form', 'convertkit' ); ?></span>
-		<select name="wp-convertkit[form]" size="1">
+		<select name="wp-convertkit[form]" id="wp-convertkit-form" size="1">
 			<option value="-1"><?php esc_html_e( 'Default', 'convertkit' ); ?></option>
 			<option value="0"><?php esc_html_e( 'None', 'convertkit' ); ?></option>
 			<?php
@@ -25,9 +25,9 @@
 	</label>
 
 	<!-- Tag -->
-	<label>
+	<label for="wp-convertkit-tag">
 		<span class="title"><?php esc_html_e( 'Tag', 'convertkit' ); ?></span>
-		<select name="wp-convertkit[tag]">
+		<select name="wp-convertkit[tag]" id="wp-convertkit-tag" size="1">
 			<option value="0">
 				<?php esc_html_e( 'None', 'convertkit' ); ?>
 			</option>

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -82,6 +82,7 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/woocommerce/class-
 
 // Load files that are only used in the WordPress Administration interface.
 if ( is_admin() ) {
+	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-bulk-quick-edit.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-category.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-post.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-settings.php';

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -82,7 +82,7 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/woocommerce/class-
 
 // Load files that are only used in the WordPress Administration interface.
 if ( is_admin() ) {
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-bulk-quick-edit.php';
+	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-quick-edit.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-category.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-post.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-settings.php';


### PR DESCRIPTION
## Summary

Adds options to WordPress' [Quick Edit](https://wordpress.com/support/pages/edit-pages-screen/#quick-edit) functionality to change the ConvertKit Form or Tag associated with a Page, Post or WooCommerce Product

![Screenshot 2022-07-06 at 16 52 46](https://user-images.githubusercontent.com/1462305/177592770-9bc883c6-4e7c-4e94-b691-506b4f39bfb3.png)

Video:
https://www.loom.com/share/edc790cc466a419b97716977ce9c4c98

## Testing

- `PageFormCest:testQuickEditUsingDefaultForm`: Tests that using the Quick Edit functionality on an existing WordPress Page works when choosing the `Default` option.
- `PageFormCest:testQuickEditUsingDefinedForm`: Tests that using the Quick Edit functionality on an existing WordPress Page works when choosing a specific form.
- `PostFormCest:testQuickEditUsingDefaultForm`: Tests that using the Quick Edit functionality on an existing WordPress Post works when choosing the `Default` option.
- `PostFormCest:testQuickEditUsingDefinedForm`: Tests that using the Quick Edit functionality on an existing WordPress Post works when choosing a specific form.
- `WooCommerceProductFormCest:testQuickEditUsingDefaultForm`: Tests that using the Quick Edit functionality on an existing WordPress Product works when choosing the `Default` option.
- `WooCommerceProductFormCest:testQuickEditUsingDefinedForm`: Tests that using the Quick Edit functionality on an existing WordPress Product works when choosing a specific form.
- `PageTagCest:testQuickEditUsingDefinedTag`: Tests that using the Quick Edit functionality on an existing WordPress Page works when choosing a specific tag.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)