### PR TITLE
Plugin Performance when no Resources exist

### DIFF
--- a/lib/class-convertkit-resource.php
+++ b/lib/class-convertkit-resource.php
@@ -112,12 +112,6 @@ class ConvertKit_Resource {
 			return;
 		}
 
-		// If no resources exist, refresh them now.
-		if ( ! $this->resources ) {
-			$this->refresh();
-			return;
-		}
-
 		// If the resources have expired, refresh them now.
 		if ( time() > ( $this->last_queried + $this->cache_duration ) ) {
 			$this->refresh();


### PR DESCRIPTION
## Summary

Prevents querying the API on every WordPress Administration screen request if a ConvertKit account does not have a particular resource (such as forms or tags).  The frontend site is unaffected, as no API queries are made.

### Detail

If a ConvertKit account has no resources (forms or tags), the plugin's cache for these resources will be empty.
As a result, the plugin would query the API on every WordPress administration screen request, resulting in slow loading times (in this example, approximately ~ 3 seconds is added to the load time for an administration screen):
![Screenshot 2022-07-12 at 17 19 28](https://user-images.githubusercontent.com/1462305/178544995-66f5d667-26ad-4ed5-94ca-c88d326c5604.png)

Whilst the account _should_ have at least one form (the plugin isn't really useful otherwise), it's wrong for the plugin to presume that at least one tag will be defined in the ConvertKit account. Emulating an account that has one form and no tags still results in API queries for tags on every WordPress administration screen request (in this example, approximately ~ 1.5 seconds is added to the load time):
![Screenshot 2022-07-12 at 17 20 23](https://user-images.githubusercontent.com/1462305/178545303-092dd1da-22fa-41a0-9011-57248355a9c6.png)

If a user subsequently adds forms / tags to their ConvertKit account, they would navigate to `Settings > ConvertKit` to force an automatic refresh of resources; this is current plugin behaviour.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)