### PR TITLE
Add Refresh Buttons for Forms, Landing Pages and Tags

### DIFF
--- a/admin/class-convertkit-admin-category.php
+++ b/admin/class-convertkit-admin-category.php
@@ -49,6 +49,7 @@ class ConvertKit_Admin_Category {
 			return;
 		}
 		$screen = get_current_screen();
+
 		if ( $screen->id !== 'edit-category' ) {
 			return;
 		}

--- a/admin/class-convertkit-admin-refresh-resources.php
+++ b/admin/class-convertkit-admin-refresh-resources.php
@@ -57,16 +57,6 @@ class ConvertKit_Admin_Refresh_Resources {
 				$results = $tags->refresh();
 				break;
 
-			case 'sequences':
-				$sequences = new ConvertKit_Resource_Sequences();
-				$results   = $sequences->refresh();
-				break;
-
-			case 'custom_fields':
-				$custom_fields = new ConvertKit_Resource_Custom_Fields();
-				$results       = $custom_fields->refresh();
-				break;
-
 			case 'posts':
 				$posts   = new ConvertKit_Resource_Posts();
 				$results = $posts->refresh();
@@ -86,7 +76,6 @@ class ConvertKit_Admin_Refresh_Resources {
 		// Bail if an error occured.
 		if ( is_wp_error( $results ) ) {
 			wp_send_json_error( $results->get_error_message() );
-			die();
 		}
 
 		// Return resources as a zero based sequential array, so that JS retains the order of resources.

--- a/admin/class-convertkit-admin-refresh-resources.php
+++ b/admin/class-convertkit-admin-refresh-resources.php
@@ -104,7 +104,7 @@ class ConvertKit_Admin_Refresh_Resources {
 	public function enqueue_scripts( $hook ) {
 
 		// Bail if we are not on an Edit or Term screen.
-		if ( $hook !== 'edit.php' && $hook !== 'term.php' ) {
+		if ( $hook !== 'edit.php' && $hook !== 'post-new.php' && $hook !== 'term.php' ) {
 			return;
 		}
 

--- a/admin/class-convertkit-admin-refresh-resources.php
+++ b/admin/class-convertkit-admin-refresh-resources.php
@@ -23,9 +23,8 @@ class ConvertKit_Admin_Refresh_Resources {
 	public function __construct() {
 
 		add_action( 'wp_ajax_convertkit_admin_refresh_resources', array( $this, 'refresh_resources' ) );
-		add_action( 'convertkit_admin_post_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-		add_action( 'convertkit_admin_category_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		
 	}
 
 	/**
@@ -99,8 +98,15 @@ class ConvertKit_Admin_Refresh_Resources {
 	 * Enqueue JavaScript when editing a Page, Post, Custom Post Type or Category.
 	 *
 	 * @since   1.9.8.0
+	 *
+	 * @param   string $hook   Hook.
 	 */
-	public function enqueue_scripts() {
+	public function enqueue_scripts( $hook ) {
+
+		// Bail if we are not on an Edit or Term screen.
+		if ( $hook !== 'edit.php' && $hook !== 'term.php' ) {
+			return;
+		}
 
 		// Get settings.
 		$settings = new ConvertKit_Settings();

--- a/admin/class-convertkit-admin-refresh-resources.php
+++ b/admin/class-convertkit-admin-refresh-resources.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * ConvertKit Admin Refresh Resources class.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Registers scripts, which run when a Refresh button is clicked, to refresh resources
+ * asynchronously whilst editing a Page, Post or Category.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+class ConvertKit_Admin_Refresh_Resources {
+
+	/**
+	 * Registers action and filter hooks.
+	 *
+	 * @since   1.9.8.0
+	 */
+	public function __construct() {
+
+		add_action( 'wp_ajax_convertkit_admin_refresh_resources', array( $this, 'refresh_resources' ) );
+		add_action( 'convertkit_admin_post_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'convertkit_admin_category_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+
+	}
+
+	/**
+	 * Refreshes resources (forms, landing pages or tags) from the API, returning them as a JSON string.
+	 *
+	 * @since   1.9.8.0
+	 */
+	public function refresh_resources() {
+
+		// Check nonce.
+		check_ajax_referer( 'convertkit_admin_refresh_resources', 'nonce' );
+
+		// Get resource type.
+		$resource = sanitize_text_field( $_REQUEST['resource'] );
+
+		// Fetch resources.
+		switch ( $resource ) {
+			case 'forms':
+				$forms = new ConvertKit_Resource_Forms();
+				$results = $forms->refresh();
+				break;
+
+			case 'landing_pages':
+				$landing_pages = new ConvertKit_Resource_Landing_Pages();
+				$results = $landing_pages->refresh();
+				break;
+
+			case 'tags':
+				$tags = new ConvertKit_Resource_Tags();
+				$results = $tags->refresh();
+				break;
+
+			case 'sequences':
+				$sequences = new ConvertKit_Resource_Sequences();
+				$results = $sequences->refresh();
+				break;
+
+			case 'custom_fields':
+				$custom_fields = new ConvertKit_Resource_Custom_Fields();
+				$results = $custom_fields->refresh();
+				break;
+
+			case 'posts':
+				$posts = new ConvertKit_Resource_Posts();
+				$results = $posts->refresh();
+				break;
+
+			default:
+				$results = new WP_Error(
+					'convertkit_admin_refresh_resources_error',
+					sprintf(
+						'Resource type %s is not supported in ConvertKit_Admin_Refresh_Resources class.',
+						$resource
+					)
+				);
+				break;
+		}
+
+		// Bail if an error occured.
+		if ( is_wp_error( $results ) ) {
+			wp_send_json_error( $results->get_error_message() );
+			die();
+		}
+
+		// Return resources as a zero based sequential array, so that JS retains the order of resources.
+		wp_send_json_success( array_values( $results ) );
+
+	}
+
+	/**
+	 * Enqueue JavaScript when editing a Page, Post, Custom Post Type or Category.
+	 *
+	 * @since   1.9.8.0
+	 */
+	public function enqueue_scripts() {
+
+		// Get settings.
+		$settings = new ConvertKit_Settings();
+
+		// Bail if no API keys are defined.
+		if ( ! $settings->has_api_key_and_secret() ) {
+			return;
+		}
+
+		// Enqueue JS to perform AJAX request to refresh resources.
+		wp_enqueue_script( 'convertkit-admin-refresh-resources', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/refresh-resources.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
+		wp_localize_script( 'convertkit-admin-refresh-resources', 'convertkit_admin_refresh_resources', array(
+			'action'		=> 'convertkit_admin_refresh_resources',
+			'ajaxurl'       => admin_url( 'admin-ajax.php' ),
+			'debug'         => $settings->debug_enabled(),
+			'nonce'         => wp_create_nonce( 'convertkit_admin_refresh_resources' ),
+		) );
+
+	}
+
+}

--- a/admin/class-convertkit-admin-refresh-resources.php
+++ b/admin/class-convertkit-admin-refresh-resources.php
@@ -24,7 +24,7 @@ class ConvertKit_Admin_Refresh_Resources {
 
 		add_action( 'wp_ajax_convertkit_admin_refresh_resources', array( $this, 'refresh_resources' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-		
+
 	}
 
 	/**
@@ -43,32 +43,32 @@ class ConvertKit_Admin_Refresh_Resources {
 		// Fetch resources.
 		switch ( $resource ) {
 			case 'forms':
-				$forms = new ConvertKit_Resource_Forms();
+				$forms   = new ConvertKit_Resource_Forms();
 				$results = $forms->refresh();
 				break;
 
 			case 'landing_pages':
 				$landing_pages = new ConvertKit_Resource_Landing_Pages();
-				$results = $landing_pages->refresh();
+				$results       = $landing_pages->refresh();
 				break;
 
 			case 'tags':
-				$tags = new ConvertKit_Resource_Tags();
+				$tags    = new ConvertKit_Resource_Tags();
 				$results = $tags->refresh();
 				break;
 
 			case 'sequences':
 				$sequences = new ConvertKit_Resource_Sequences();
-				$results = $sequences->refresh();
+				$results   = $sequences->refresh();
 				break;
 
 			case 'custom_fields':
 				$custom_fields = new ConvertKit_Resource_Custom_Fields();
-				$results = $custom_fields->refresh();
+				$results       = $custom_fields->refresh();
 				break;
 
 			case 'posts':
-				$posts = new ConvertKit_Resource_Posts();
+				$posts   = new ConvertKit_Resource_Posts();
 				$results = $posts->refresh();
 				break;
 
@@ -118,12 +118,16 @@ class ConvertKit_Admin_Refresh_Resources {
 
 		// Enqueue JS to perform AJAX request to refresh resources.
 		wp_enqueue_script( 'convertkit-admin-refresh-resources', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/refresh-resources.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
-		wp_localize_script( 'convertkit-admin-refresh-resources', 'convertkit_admin_refresh_resources', array(
-			'action'		=> 'convertkit_admin_refresh_resources',
-			'ajaxurl'       => admin_url( 'admin-ajax.php' ),
-			'debug'         => $settings->debug_enabled(),
-			'nonce'         => wp_create_nonce( 'convertkit_admin_refresh_resources' ),
-		) );
+		wp_localize_script(
+			'convertkit-admin-refresh-resources',
+			'convertkit_admin_refresh_resources',
+			array(
+				'action'  => 'convertkit_admin_refresh_resources',
+				'ajaxurl' => admin_url( 'admin-ajax.php' ),
+				'debug'   => $settings->debug_enabled(),
+				'nonce'   => wp_create_nonce( 'convertkit_admin_refresh_resources' ),
+			)
+		);
 
 	}
 

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -64,13 +64,14 @@ class WP_ConvertKit {
 			return;
 		}
 
-		$this->classes['admin_bulk_edit']  = new ConvertKit_Admin_Bulk_Edit();
-		$this->classes['admin_category']   = new ConvertKit_Admin_Category();
-		$this->classes['admin_post']       = new ConvertKit_Admin_Post();
-		$this->classes['admin_quick_edit'] = new ConvertKit_Admin_Quick_Edit();
-		$this->classes['admin_settings']   = new ConvertKit_Admin_Settings();
-		$this->classes['admin_tinymce']    = new ConvertKit_Admin_TinyMCE();
-		$this->classes['admin_user']       = new ConvertKit_Admin_User();
+		$this->classes['admin_bulk_edit']  			= new ConvertKit_Admin_Bulk_Edit();
+		$this->classes['admin_category']   			= new ConvertKit_Admin_Category();
+		$this->classes['admin_post']       			= new ConvertKit_Admin_Post();
+		$this->classes['admin_quick_edit'] 			= new ConvertKit_Admin_Quick_Edit();
+		$this->classes['admin_refresh_resources'] 	= new ConvertKit_Admin_Refresh_Resources();
+		$this->classes['admin_settings']   			= new ConvertKit_Admin_Settings();
+		$this->classes['admin_tinymce']    			= new ConvertKit_Admin_TinyMCE();
+		$this->classes['admin_user']       			= new ConvertKit_Admin_User();
 
 		/**
 		 * Initialize integration classes for the WordPress Administration interface.

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -64,14 +64,14 @@ class WP_ConvertKit {
 			return;
 		}
 
-		$this->classes['admin_bulk_edit']  			= new ConvertKit_Admin_Bulk_Edit();
-		$this->classes['admin_category']   			= new ConvertKit_Admin_Category();
-		$this->classes['admin_post']       			= new ConvertKit_Admin_Post();
-		$this->classes['admin_quick_edit'] 			= new ConvertKit_Admin_Quick_Edit();
-		$this->classes['admin_refresh_resources'] 	= new ConvertKit_Admin_Refresh_Resources();
-		$this->classes['admin_settings']   			= new ConvertKit_Admin_Settings();
-		$this->classes['admin_tinymce']    			= new ConvertKit_Admin_TinyMCE();
-		$this->classes['admin_user']       			= new ConvertKit_Admin_User();
+		$this->classes['admin_bulk_edit']         = new ConvertKit_Admin_Bulk_Edit();
+		$this->classes['admin_category']          = new ConvertKit_Admin_Category();
+		$this->classes['admin_post']              = new ConvertKit_Admin_Post();
+		$this->classes['admin_quick_edit']        = new ConvertKit_Admin_Quick_Edit();
+		$this->classes['admin_refresh_resources'] = new ConvertKit_Admin_Refresh_Resources();
+		$this->classes['admin_settings']          = new ConvertKit_Admin_Settings();
+		$this->classes['admin_tinymce']           = new ConvertKit_Admin_TinyMCE();
+		$this->classes['admin_user']              = new ConvertKit_Admin_User();
 
 		/**
 		 * Initialize integration classes for the WordPress Administration interface.

--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -46,7 +46,7 @@ jQuery( document ).ready(
                         var selectedOption = $( field ).val();
 
                         // Remove existing select options.
-                        $( field + ' option' ).each( function() {
+                        $( 'option', $( field ) ).each( function() {
                             // Skip if data-preserve-on-refresh is specified, as this means we want to keep this specific option.
                             // This will be present on the 'None' and 'Default' options.
                             if ( typeof $( this ).data( 'preserve-on-refresh' ) !== 'undefined' ) {
@@ -58,9 +58,9 @@ jQuery( document ).ready(
                         } );
 
                         // Populate select options from response data.
-                        for ( const [ index, item ] of Object.entries( response.data ) ) {
+                        response.data.forEach( function( item ) {
                             $( field ).append( new Option( item.name, item.id, false, ( selectedOption == item.id ? true : false ) ) );
-                        }
+                        } );
 
                         // Trigger a change event on the select field, to allow Select2 instances to repopulate their options.
                         $( field ).trigger( 'change' );

--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -1,0 +1,85 @@
+/**
+ * Refresh Resources
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Refreshes resources when the Refresh button is clicked.
+ *
+ * @since 	1.9.8.0
+ */
+jQuery( document ).ready(
+
+	function( $ ) {
+
+		$( 'button.wp-convertkit-refresh-resources' ).on( 'click', function( e ) {
+
+            e.preventDefault();
+
+            // Fetch some DOM elements.
+            var button = this,
+                resource = $( button ).data( 'resource' ),
+                field = $( button ).data( 'field' );
+
+            // Disable button.
+            $( button ).prop( 'disabled', true );
+
+            // Perform AJAX request to refresh resource.
+            $.ajax(
+                {
+                    type: 'POST',
+                    data: {
+                        action: 'convertkit_admin_refresh_resources',
+                        nonce: convertkit_admin_refresh_resources.nonce,
+                        resource: resource // e.g. forms, landing_pages, tags
+                    },
+                    url: convertkit_admin_refresh_resources.ajaxurl,
+                    success: function ( response ) {
+
+                        if ( convertkit_admin_refresh_resources.debug ) {
+                            console.log( response );
+                        }
+
+                        // Get currently selected option.
+                        var selectedOption = $( field ).val();
+
+                        // Remove existing select options.
+                        $( field + ' option' ).each( function() {
+                            // Skip if data-preserve-on-refresh is specified, as this means we want to keep this specific option.
+                            // This will be present on the 'None' and 'Default' options.
+                            if ( typeof $( this ).data( 'preserve-on-refresh' ) !== 'undefined' ) {
+                                return;
+                            }
+
+                            // Remove this option.
+                            $( this ).remove();
+                        } );
+
+                        // Populate select options from response data.
+                        for ( const [ index, item ] of Object.entries( response.data ) ) {
+                            $( field ).append( new Option( item.name, item.id, false, ( selectedOption == item.id ? true : false ) ) );
+                        }
+
+                        // Trigger a change event on the select field, to allow Select2 instances to repopulate their options.
+                        $( field ).trigger( 'change' );
+
+                        // Enable button.
+                        $( button ).prop( 'disabled', false );
+
+                    }
+                }
+            ).fail(
+                function (response) {
+                    if ( convertkit_admin_refresh_resources.debug ) {
+                        console.log( response );
+                    }
+                }
+            );
+
+        } );
+
+	}
+
+);

--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -11,75 +11,80 @@
  * @since 	1.9.8.0
  */
 jQuery( document ).ready(
-
 	function( $ ) {
 
-		$( 'button.wp-convertkit-refresh-resources' ).on( 'click', function( e ) {
+		$( 'button.wp-convertkit-refresh-resources' ).on(
+			'click',
+			function( e ) {
 
-            e.preventDefault();
+				e.preventDefault();
 
-            // Fetch some DOM elements.
-            var button = this,
-                resource = $( button ).data( 'resource' ),
-                field = $( button ).data( 'field' );
+				// Fetch some DOM elements.
+				var button = this,
+				resource   = $( button ).data( 'resource' ),
+				field      = $( button ).data( 'field' );
 
-            // Disable button.
-            $( button ).prop( 'disabled', true );
+				// Disable button.
+				$( button ).prop( 'disabled', true );
 
-            // Perform AJAX request to refresh resource.
-            $.ajax(
-                {
-                    type: 'POST',
-                    data: {
-                        action: 'convertkit_admin_refresh_resources',
-                        nonce: convertkit_admin_refresh_resources.nonce,
-                        resource: resource // e.g. forms, landing_pages, tags
-                    },
-                    url: convertkit_admin_refresh_resources.ajaxurl,
-                    success: function ( response ) {
+				// Perform AJAX request to refresh resource.
+				$.ajax(
+					{
+						type: 'POST',
+						data: {
+							action: 'convertkit_admin_refresh_resources',
+							nonce: convertkit_admin_refresh_resources.nonce,
+							resource: resource // e.g. forms, landing_pages, tags.
+						},
+						url: convertkit_admin_refresh_resources.ajaxurl,
+						success: function ( response ) {
 
-                        if ( convertkit_admin_refresh_resources.debug ) {
-                            console.log( response );
-                        }
+							if ( convertkit_admin_refresh_resources.debug ) {
+								console.log( response );
+							}
 
-                        // Get currently selected option.
-                        var selectedOption = $( field ).val();
+							// Get currently selected option.
+							var selectedOption = $( field ).val();
 
-                        // Remove existing select options.
-                        $( 'option', $( field ) ).each( function() {
-                            // Skip if data-preserve-on-refresh is specified, as this means we want to keep this specific option.
-                            // This will be present on the 'None' and 'Default' options.
-                            if ( typeof $( this ).data( 'preserve-on-refresh' ) !== 'undefined' ) {
-                                return;
-                            }
+							// Remove existing select options.
+							$( 'option', $( field ) ).each(
+								function() {
+									// Skip if data-preserve-on-refresh is specified, as this means we want to keep this specific option.
+									// This will be present on the 'None' and 'Default' options.
+									if ( typeof $( this ).data( 'preserve-on-refresh' ) !== 'undefined' ) {
+										return;
+									}
 
-                            // Remove this option.
-                            $( this ).remove();
-                        } );
+									// Remove this option.
+									$( this ).remove();
+								}
+							);
 
-                        // Populate select options from response data.
-                        response.data.forEach( function( item ) {
-                            $( field ).append( new Option( item.name, item.id, false, ( selectedOption == item.id ? true : false ) ) );
-                        } );
+							// Populate select options from response data.
+							response.data.forEach(
+								function( item ) {
+									$( field ).append( new Option( item.name, item.id, false, ( selectedOption == item.id ? true : false ) ) );
+								}
+							);
 
-                        // Trigger a change event on the select field, to allow Select2 instances to repopulate their options.
-                        $( field ).trigger( 'change' );
+							// Trigger a change event on the select field, to allow Select2 instances to repopulate their options.
+							$( field ).trigger( 'change' );
 
-                        // Enable button.
-                        $( button ).prop( 'disabled', false );
+							// Enable button.
+							$( button ).prop( 'disabled', false );
 
-                    }
-                }
-            ).fail(
-                function (response) {
-                    if ( convertkit_admin_refresh_resources.debug ) {
-                        console.log( response );
-                    }
-                }
-            );
+						}
+					}
+				).fail(
+					function (response) {
+						if ( convertkit_admin_refresh_resources.debug ) {
+							console.log( response );
+						}
+					}
+				);
 
-        } );
+			}
+		);
 
 	}
-
 );

--- a/tests/_support/Helper/Acceptance/Select2.php
+++ b/tests/_support/Helper/Acceptance/Select2.php
@@ -27,4 +27,21 @@ class Select2 extends \Codeception\Module
 		$I->waitForElementVisible('ul#select2-' . $fieldName . '-results li.select2-results__option--highlighted');
 		$I->pressKey('.select2-search__field[' . $ariaAttributeName . '="select2-' . $fieldName . '-results"]', \Facebook\WebDriver\WebDriverKeys::ENTER);
 	}
+
+	/**
+	 * Helper method to open a jQuery Select2 Field.
+	 * 
+	 * @since 	1.9.8.1
+	 * 
+	 * @param 	AcceptanceTester 	$I
+	 * @param 	string 				$container 	Field CSS Class / ID
+	 * @param 	string 				$value 		Field Value
+	 * @param 	string 				$ariaAttributeName 	Aria Attribute Name (aria-controls|aria-owns)
+	 */
+	public function openSelect2Field($I, $container, $value, $ariaAttributeName = 'aria-controls')
+	{
+		$fieldID = $I->grabAttributeFrom($container, 'id');
+		$fieldName = str_replace('-container', '', str_replace('select2-', '', $fieldID));
+		$I->click('#'.$fieldID);
+	}
 }

--- a/tests/_support/Helper/Acceptance/WPBulkEdit.php
+++ b/tests/_support/Helper/Acceptance/WPBulkEdit.php
@@ -24,8 +24,8 @@ class WPBulkEdit extends \Codeception\Module
 
 		// Apply configuration.
 		foreach ($configuration as $field=>$attributes) {
-			// Field ID will be prefixed with wp-convertkit-.
-			$fieldID = 'wp-convertkit-' . $field;
+			// Field ID will be prefixed with wp-convertkit-bulk-edit-.
+			$fieldID = 'wp-convertkit-bulk-edit-' . $field;
 
 			// Check that the field exists.
 			$I->seeElementInDOM('#convertkit-bulk-edit #' . $fieldID);

--- a/tests/_support/Helper/Acceptance/WPBulkEdit.php
+++ b/tests/_support/Helper/Acceptance/WPBulkEdit.php
@@ -20,7 +20,7 @@ class WPBulkEdit extends \Codeception\Module
 	public function bulkEdit($I, $postType, $postIDs, $configuration)
 	{
 		// Open Bulk Edit form for the Posts.
-		$I->openBulkEdit($I, $postType, $postID);
+		$I->openBulkEdit($I, $postType, $postIDs);
 
 		// Apply configuration.
 		foreach ($configuration as $field=>$attributes) {

--- a/tests/_support/Helper/Acceptance/WPBulkEdit.php
+++ b/tests/_support/Helper/Acceptance/WPBulkEdit.php
@@ -19,19 +19,8 @@ class WPBulkEdit extends \Codeception\Module
 	 */
 	public function bulkEdit($I, $postType, $postIDs, $configuration)
 	{
-		// Navigate to Post Type's WP_List_Table.
-		$I->amOnAdminPage('edit.php?post_type='.$postType);
-
-		// Check boxes for Post IDs.
-		foreach($postIDs as $postID) {
-			$I->checkOption('#cb-select-'.$postID);
-		}
-
-		// Select Edit from the Bulk actions dropdown.
-		$I->selectOption('#bulk-action-selector-top', 'Edit');
-
-		// Click Apply button.
-		$I->click('#doaction');
+		// Open Bulk Edit form for the Posts.
+		$I->openBulkEdit($I, $postType, $postID);
 
 		// Apply configuration.
 		foreach ($configuration as $field=>$attributes) {
@@ -60,5 +49,31 @@ class WPBulkEdit extends \Codeception\Module
 
 		// Confirm that Bulk Editing saved with no errors.
 		$I->seeInSource(count($postIDs).' '.$postType.'s updated');
+	}
+
+	/**
+	 * Opens the Bulk Edit form for the given Post ID.
+	 * 
+	 * @since 	1.9.8.1
+	 * 
+	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
+	 * @param 	string 	$postType 		Programmatic Post Type.
+	 * @param 	array 	$postIDs 		Post IDs.
+	 */
+	public function openBulkEdit($I, $postType, $postIDs)
+	{
+		// Navigate to Post Type's WP_List_Table.
+		$I->amOnAdminPage('edit.php?post_type='.$postType);
+
+		// Check boxes for Post IDs.
+		foreach($postIDs as $postID) {
+			$I->checkOption('#cb-select-'.$postID);
+		}
+
+		// Select Edit from the Bulk actions dropdown.
+		$I->selectOption('#bulk-action-selector-top', 'Edit');
+
+		// Click Apply button.
+		$I->click('#doaction');
 	}
 }

--- a/tests/_support/Helper/Acceptance/WPQuickEdit.php
+++ b/tests/_support/Helper/Acceptance/WPQuickEdit.php
@@ -24,8 +24,8 @@ class WPQuickEdit extends \Codeception\Module
 
 		// Apply configuration.
 		foreach ($configuration as $field=>$attributes) {
-			// Field ID will be prefixed with wp-convertkit-.
-			$fieldID = 'wp-convertkit-' . $field;
+			// Field ID will be prefixed with wp-convertkit-quick-edit.
+			$fieldID = 'wp-convertkit-quick-edit-' . $field;
 
 			// Check that the field exists.
 			$I->seeElementInDOM('#convertkit-quick-edit #' . $fieldID);

--- a/tests/_support/Helper/Acceptance/WPQuickEdit.php
+++ b/tests/_support/Helper/Acceptance/WPQuickEdit.php
@@ -19,17 +19,8 @@ class WPQuickEdit extends \Codeception\Module
 	 */
 	public function quickEdit($I, $postType, $postID, $configuration)
 	{
-		// Navigate to Post Type's WP_List_Table.
-		$I->amOnAdminPage('edit.php?post_type='.$postType);
-
-		// Hover mouse over Post's table row.
-		$I->moveMouseOver('tr#post-'.$postID);
-
-		// Wait for Quick edit link to be visible.
-		$I->waitForElementVisible('tr#post-'.$postID.' button.editinline');
-		
-		// Click Quick Edit link.
-		$I->click('tr#post-'.$postID.' button.editinline');
+		// Open Quick Edit form for the Post.
+		$I->openQuickEdit($I, $postType, $postID);
 
 		// Apply configuration.
 		foreach ($configuration as $field=>$attributes) {
@@ -52,5 +43,29 @@ class WPQuickEdit extends \Codeception\Module
 
 		// Click Update.
 		$I->click('Update');
+	}
+
+	/**
+	 * Opens the Quick Edit form for the given Post ID.
+	 * 
+	 * @since 	1.9.8.1
+	 * 
+	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
+	 * @param 	string 	$postType 		Programmatic Post Type.
+	 * @param 	int 	$postID 		Post ID.
+	 */
+	public function openQuickEdit($I, $postType, $postID)
+	{
+		// Navigate to Post Type's WP_List_Table.
+		$I->amOnAdminPage('edit.php?post_type='.$postType);
+
+		// Hover mouse over Post's table row.
+		$I->moveMouseOver('tr#post-'.$postID);
+
+		// Wait for Quick edit link to be visible.
+		$I->waitForElementVisible('tr#post-'.$postID.' button.editinline');
+		
+		// Click Quick Edit link.
+		$I->click('tr#post-'.$postID.' button.editinline');
 	}
 }

--- a/tests/acceptance/forms/PageNoFormCest.php
+++ b/tests/acceptance/forms/PageNoFormCest.php
@@ -25,27 +25,9 @@ class PageNoFormCest
 
 		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
 		$I->maybeCloseGutenbergWelcomeModal($I);
-	}
 
-	/**
-	 * Test that text is displayed stating no forms / landing pages exist when using API Keys
-	 * linked to a ConvertKit account that has no forms or landing pages.
-	 * 
-	 * @since 	1.9.6.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testNoFormsExistTextDisplayed(AcceptanceTester $I)
-	{
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Check that the metabox is displayed.
-		$I->seeElementInDOM('#wp-convertkit-meta-box');
-
-		// Check that the correct text is displayed.
-		$I->seeInSource('No Forms exist in ConvertKit.');
-		$I->seeInSource('No Landing Pages exist in ConvertKit.');
 	}
 
 	/**

--- a/tests/acceptance/general/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/general/RefreshResourcesButtonCest.php
@@ -1,10 +1,11 @@
 <?php
 /**
- * Tests Refresh buttons for resource fields.
+ * Tests Refresh Resource buttons, which are displayed next to settings fields
+ * across Page/Post editing, Bulk/Quick edit and Category editing.
  * 
  * @since 	1.9.8.0
  */
-class RefreshResourcesCest
+class RefreshResourcesButtonCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.

--- a/tests/acceptance/general/RefreshResourcesCest.php
+++ b/tests/acceptance/general/RefreshResourcesCest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Tests Refresh buttons for resource fields.
+ * 
+ * @since 	1.9.8.0
+ */
+class RefreshResourcesCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		// Activate and Setup ConvertKit plugin
+		$I->activateConvertKitPlugin($I);
+
+		// Use API keys that link a ConvertKit account with no forms, landing pages, tags etc.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
+		$I->enableDebugLog($I);
+	}
+
+	/**
+	 * Test that the refresh buttons for Forms, Landing Pages and Tags works when adding a new Page.
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testRefreshResourcesOnPage(AcceptanceTester $I)
+	{
+		// Navigate to Pages > Add New
+		$I->amOnAdminPage('post-new.php?post_type=page');
+
+		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
+		$I->maybeCloseGutenbergWelcomeModal($I);
+
+		// Programmatically change the Plugin's API keys to use a ConvertKit account that has resources.
+		$I->haveOptionInDatabase('_wp_convertkit_settings', [
+			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+		]);
+
+		// Click the Forms refresh button.
+		$I->click('button.wp-convertkit-refresh-resources[data-resources="forms"]');
+
+		// Wait for button to change its state from disabled.
+		$I->wait(2);
+
+		// Confirm that an expected Form now displays in the dropdown.
+		$I->seeElementInDOM('option[value="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+
+
+		// @TODO.
+
+		// Click the Landing Pages refresh button.
+		// @TODO.
+
+		// Confirm that Landing Pages now display in the dropdown.
+		// @TODO.
+
+		// Click the Tags refresh button.
+		// @TODO.
+
+		// Confirm that Tags now display in the dropdown.
+		// @TODO.
+	}
+
+	/**
+	 * Test that the refresh buttons for Forms and Tags works when Quick Editing a Page.
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testRefreshResourcesOnQuickEdit(AcceptanceTester $I)
+	{
+	}
+
+	/**
+	 * Test that the refresh buttons for Forms and Tags works when Bulk Editing Pages.
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testRefreshResourcesOnBulkEdit(AcceptanceTester $I)
+	{
+	}
+
+	/**
+	 * Test that the refresh button for Forms works when editing a Category.
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testRefreshResourcesOnCategory(AcceptanceTester $I)
+	{
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
+	}
+}

--- a/views/backend/post/bulk-edit.php
+++ b/views/backend/post/bulk-edit.php
@@ -11,7 +11,7 @@
 	<!-- Form -->
 	<label for="wp-convertkit-form">
 		<span class="title"><?php esc_html_e( 'Form', 'convertkit' ); ?></span>
-		<select name="wp-convertkit[form]" id="wp-convertkit-form" size="1">
+		<select name="wp-convertkit[form]" id="wp-convertkit-bulk-edit-form" size="1">
 			<?php
 			// For Bulk Edit, the 'No Change' value is -1. However, because this Plugin has historically used -1
 			// to mean that the Default form for the Post Type should be displayed, using -1 as 'No Change' in Bulk Edit
@@ -19,23 +19,28 @@
 			// have selected the 'Default' option.
 			// Therefore, we use -2 to denote 'No Change'.
 			?>
-			<option value="-2"><?php esc_html_e( '— No Change —', 'convertkit' ); ?></option>
-			<option value="-1"><?php esc_html_e( 'Default', 'convertkit' ); ?></option>
-			<option value="0"><?php esc_html_e( 'None', 'convertkit' ); ?></option>
+			<option value="-2" data-preserve-on-refresh="1"><?php esc_html_e( '— No Change —', 'convertkit' ); ?></option>
+			<option value="-1" data-preserve-on-refresh="1"><?php esc_html_e( 'Default', 'convertkit' ); ?></option>
+			<option value="0" data-preserve-on-refresh="1"><?php esc_html_e( 'None', 'convertkit' ); ?></option>
 			<?php
-			foreach ( $convertkit_forms->get() as $form ) {
-				?>
-				<option value="<?php echo esc_attr( $form['id'] ); ?>"><?php echo esc_attr( $form['name'] ); ?></option>
-				<?php
+			if ( $convertkit_forms->exist() ) {
+				foreach ( $convertkit_forms->get() as $form ) {
+					?>
+					<option value="<?php echo esc_attr( $form['id'] ); ?>"><?php echo esc_attr( $form['name'] ); ?></option>
+					<?php
+				}
 			}
 			?>
 		</select>
+		<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Forms from ConvertKit account', 'convertkit' ); ?>" data-resource="forms" data-field="wp-convertkit-bulk-edit-form">
+			<span class="dashicons dashicons-update"></span>
+		</button>
 	</label>
 
 	<!-- Tag -->
 	<label for="wp-convertkit-tag">
 		<span class="title"><?php esc_html_e( 'Tag', 'convertkit' ); ?></span>
-		<select name="wp-convertkit[tag]" id="wp-convertkit-tag" size="1">
+		<select name="wp-convertkit[tag]" id="wp-convertkit-bulk-edit-tag" size="1">
 			<?php
 			// For Bulk Edit, the 'No Change' value is -1. However, because this Plugin has historically used -1
 			// to mean that the Default form for the Post Type should be displayed, using -1 as 'No Change' in Bulk Edit
@@ -43,18 +48,23 @@
 			// have selected the 'Default' option.
 			// Therefore, we use -2 to denote 'No Change', even though this setting is for the Tag, so we're at least consistent.
 			?>
-			<option value="-2"><?php esc_html_e( '— No Change —', 'convertkit' ); ?></option>
-			<option value="0">
+			<option value="-2" data-preserve-on-refresh="1"><?php esc_html_e( '— No Change —', 'convertkit' ); ?></option>
+			<option value="0" data-preserve-on-refresh="1">
 				<?php esc_html_e( 'None', 'convertkit' ); ?>
 			</option>
 			<?php
-			foreach ( $convertkit_tags->get() as $convertkit_tag ) {
-				?>
-				<option value="<?php echo esc_attr( $convertkit_tag['id'] ); ?>"><?php echo esc_attr( $convertkit_tag['name'] ); ?></option>
-				<?php
+			if ( $convertkit_tags->exist() ) {
+				foreach ( $convertkit_tags->get() as $convertkit_tag ) {
+					?>
+					<option value="<?php echo esc_attr( $convertkit_tag['id'] ); ?>"><?php echo esc_attr( $convertkit_tag['name'] ); ?></option>
+					<?php
+				}
 			}
 			?>
 		</select>
+		<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Tags from ConvertKit account', 'convertkit' ); ?>" data-resource="tags" data-field="wp-convertkit-bulk-edit-tag">
+			<span class="dashicons dashicons-update"></span>
+		</button>
 	</label>
 	<?php wp_nonce_field( 'wp-convertkit-save-meta', 'wp-convertkit-save-meta-nonce' ); ?>
 </div>

--- a/views/backend/post/bulk-edit.php
+++ b/views/backend/post/bulk-edit.php
@@ -32,7 +32,7 @@
 			}
 			?>
 		</select>
-		<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Forms from ConvertKit account', 'convertkit' ); ?>" data-resource="forms" data-field="wp-convertkit-bulk-edit-form">
+		<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Forms from ConvertKit account', 'convertkit' ); ?>" data-resource="forms" data-field="#wp-convertkit-bulk-edit-form">
 			<span class="dashicons dashicons-update"></span>
 		</button>
 	</label>
@@ -62,7 +62,7 @@
 			}
 			?>
 		</select>
-		<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Tags from ConvertKit account', 'convertkit' ); ?>" data-resource="tags" data-field="wp-convertkit-bulk-edit-tag">
+		<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Tags from ConvertKit account', 'convertkit' ); ?>" data-resource="tags" data-field="#wp-convertkit-bulk-edit-tag">
 			<span class="dashicons dashicons-update"></span>
 		</button>
 	</label>

--- a/views/backend/post/meta-box.php
+++ b/views/backend/post/meta-box.php
@@ -15,20 +15,16 @@
 				<label for="wp-convertkit-form"><?php esc_html_e( 'Form', 'convertkit' ); ?></label>
 			</th>
 			<td>
-				<?php
-				if ( ! $convertkit_forms->exist() ) {
-					esc_html_e( 'No Forms exist in ConvertKit.', 'convertkit' );
-				} else {
-					?>
-					<div class="convertkit-select2-container">
-						<select name="wp-convertkit[form]" id="wp-convertkit-form" class="convertkit-select2">
-							<option value="-1"<?php selected( - 1, $convertkit_post->get_form() ); ?>>
-								<?php esc_html_e( 'Default', 'convertkit' ); ?>
-							</option>
-							<option value="0"<?php selected( 0, $convertkit_post->get_form() ); ?>>
-								<?php esc_html_e( 'None', 'convertkit' ); ?>
-							</option>
-							<?php
+				<div class="convertkit-select2-container">
+					<select name="wp-convertkit[form]" id="wp-convertkit-form" class="convertkit-select2">
+						<option value="-1"<?php selected( - 1, $convertkit_post->get_form() ); ?> data-preserve-on-refresh="1">
+							<?php esc_html_e( 'Default', 'convertkit' ); ?>
+						</option>
+						<option value="0"<?php selected( 0, $convertkit_post->get_form() ); ?> data-preserve-on-refresh="1">
+							<?php esc_html_e( 'None', 'convertkit' ); ?>
+						</option>
+						<?php
+						if ( $convertkit_forms->exist() ) {
 							foreach ( $convertkit_forms->get() as $form ) {
 								?>
 								<option value="<?php echo esc_attr( $form['id'] ); ?>"<?php selected( $form['id'], $convertkit_post->get_form() ); ?>>
@@ -36,26 +32,27 @@
 								</option>
 								<?php
 							}
-							?>
-						</select>
-						<p class="description">
-							<?php
-							printf(
-								/* translators: settings url */
-								__( '<code>Default</code>: Uses the form specified on the <a href="%s" target="_blank">settings page</a>.', 'convertkit' ), /* phpcs:ignore */
-								esc_attr( esc_url( $settings_link ) )
-							);
-							?>
-							<br />
-							<?php _e( '<code>None</code>: do not display a form.', 'convertkit' ); /* phpcs:ignore */ ?>
-							<br />
-							<?php esc_html_e( 'Any other option will display that form after the main content.', 'convertkit' ); ?>
-						</p>
-					</div>
-					<?php
-				}
-				?>
-
+						}
+						?>
+					</select>
+					<button class="wp-convertkit-refresh-resources" class="button button-secondary hide-if-no-js" title="<?php esc_attr_e( 'Refresh Forms from ConvertKit account', 'convertkit' ); ?>" data-resource="forms" data-field="#wp-convertkit-form">
+						<span class="dashicons dashicons-update"></span>
+					</button>
+					<p class="description">
+						<?php
+						printf(
+							/* translators: settings url */
+							__( '<code>Default</code>: Uses the form specified on the <a href="%s" target="_blank">settings page</a>.', 'convertkit' ), /* phpcs:ignore */
+							esc_attr( esc_url( $settings_link ) )
+						);
+						?>
+						<br />
+						<?php _e( '<code>None</code>: do not display a form.', 'convertkit' ); /* phpcs:ignore */ ?>
+						<br />
+						<?php esc_html_e( 'Any other option will display that form after the main content.', 'convertkit' ); ?>
+					</p>
+				</div>
+				
 				<p class="description">
 					<?php
 					echo sprintf(
@@ -77,17 +74,13 @@
 					<label for="wp-convertkit-landing_page"><?php esc_html_e( 'Landing Page', 'convertkit' ); ?></label>
 				</th>
 				<td>
-					<?php
-					if ( ! $convertkit_landing_pages->exist() ) {
-						esc_html_e( 'No Landing Pages exist in ConvertKit.', 'convertkit' );
-					} else {
-						?>
-						<div class="convertkit-select2-container">
-							<select name="wp-convertkit[landing_page]" id="wp-convertkit-landing_page" class="convertkit-select2">
-								<option <?php selected( '', $convertkit_post->get_landing_page() ); ?> value="0">
-									<?php esc_html_e( 'None', 'convertkit' ); ?>
-								</option>
-								<?php
+					<div class="convertkit-select2-container">
+						<select name="wp-convertkit[landing_page]" id="wp-convertkit-landing_page" class="convertkit-select2">
+							<option <?php selected( '', $convertkit_post->get_landing_page() ); ?> value="0" data-preserve-on-refresh="1">
+								<?php esc_html_e( 'None', 'convertkit' ); ?>
+							</option>
+							<?php
+							if ( $convertkit_landing_pages->exist() ) {
 								foreach ( $convertkit_landing_pages->get() as $landing_page ) {
 									if ( isset( $convertkit_landing_page['url'] ) ) {
 										?>
@@ -103,16 +96,17 @@
 										<?php
 									}
 								}
-								?>
-							</select>
-							<p class="description">
-								<?php esc_html_e( 'Select a landing page to make it appear in place of this page.', 'convertkit' ); ?>
-							</p>
-						</div>
-						<?php
-					}
-					?>
-
+							}
+							?>
+						</select>
+						<button class="wp-convertkit-refresh-resources" class="button button-secondary hide-if-no-js" title="<?php esc_attr_e( 'Refresh Landing Pages from ConvertKit account', 'convertkit' ); ?>" data-resource="landing_pages" data-field="wp-convertkit-landing_page">
+							<span class="dashicons dashicons-update"></span>
+						</button>
+						<p class="description">
+							<?php esc_html_e( 'Select a landing page to make it appear in place of this page.', 'convertkit' ); ?>
+						</p>
+					</div>
+					
 					<p class="description">
 						<?php
 						echo sprintf(
@@ -135,16 +129,12 @@
 			</th>
 			<td>
 				<div class="convertkit-select2-container">
-					<?php
-					if ( ! $convertkit_tags->exist() ) {
-						esc_html_e( 'No Tags exist in ConvertKit.', 'convertkit' );
-					} else {
-						?>
-						<select name="wp-convertkit[tag]" id="wp-convertkit-tag" class="convertkit-select2">
-							<option value="0"<?php selected( '', $convertkit_post->get_tag() ); ?>>
-								<?php esc_html_e( 'None', 'convertkit' ); ?>
-							</option>
-							<?php
+					<select name="wp-convertkit[tag]" id="wp-convertkit-tag" class="convertkit-select2">
+						<option value="0"<?php selected( '', $convertkit_post->get_tag() ); ?> data-preserve-on-refresh="1">
+							<?php esc_html_e( 'None', 'convertkit' ); ?>
+						</option>
+						<?php
+						if ( $convertkit_tags->exist() ) {
 							foreach ( $convertkit_tags->get() as $convertkit_tag ) {
 								?>
 								<option value="<?php echo esc_attr( $convertkit_tag['id'] ); ?>"<?php selected( $convertkit_tag['id'], $convertkit_post->get_tag() ); ?>>
@@ -152,11 +142,12 @@
 								</option>
 								<?php
 							}
-							?>
-						</select>
-						<?php
-					}
-					?>
+						}
+						?>
+					</select>
+					<button class="wp-convertkit-refresh-resources" class="button button-secondary hide-if-no-js" title="<?php esc_attr_e( 'Refresh Tags from ConvertKit account', 'convertkit' ); ?>" data-resource="tags" data-field="wp-convertkit-tag">
+						<span class="dashicons dashicons-update"></span>
+					</button>
 					<p class="description">
 						<?php esc_html_e( 'Select a tag to apply to visitors of this page who are subscribed.', 'convertkit' ); ?>
 						<br />

--- a/views/backend/post/meta-box.php
+++ b/views/backend/post/meta-box.php
@@ -52,7 +52,7 @@
 						<?php esc_html_e( 'Any other option will display that form after the main content.', 'convertkit' ); ?>
 					</p>
 				</div>
-				
+
 				<p class="description">
 					<?php
 					echo sprintf(
@@ -106,7 +106,7 @@
 							<?php esc_html_e( 'Select a landing page to make it appear in place of this page.', 'convertkit' ); ?>
 						</p>
 					</div>
-					
+
 					<p class="description">
 						<?php
 						echo sprintf(

--- a/views/backend/post/meta-box.php
+++ b/views/backend/post/meta-box.php
@@ -99,7 +99,7 @@
 							}
 							?>
 						</select>
-						<button class="wp-convertkit-refresh-resources" class="button button-secondary hide-if-no-js" title="<?php esc_attr_e( 'Refresh Landing Pages from ConvertKit account', 'convertkit' ); ?>" data-resource="landing_pages" data-field="wp-convertkit-landing_page">
+						<button class="wp-convertkit-refresh-resources" class="button button-secondary hide-if-no-js" title="<?php esc_attr_e( 'Refresh Landing Pages from ConvertKit account', 'convertkit' ); ?>" data-resource="landing_pages" data-field="#wp-convertkit-landing_page">
 							<span class="dashicons dashicons-update"></span>
 						</button>
 						<p class="description">
@@ -145,7 +145,7 @@
 						}
 						?>
 					</select>
-					<button class="wp-convertkit-refresh-resources" class="button button-secondary hide-if-no-js" title="<?php esc_attr_e( 'Refresh Tags from ConvertKit account', 'convertkit' ); ?>" data-resource="tags" data-field="wp-convertkit-tag">
+					<button class="wp-convertkit-refresh-resources" class="button button-secondary hide-if-no-js" title="<?php esc_attr_e( 'Refresh Tags from ConvertKit account', 'convertkit' ); ?>" data-resource="tags" data-field="#wp-convertkit-tag">
 						<span class="dashicons dashicons-update"></span>
 					</button>
 					<p class="description">

--- a/views/backend/post/quick-edit.php
+++ b/views/backend/post/quick-edit.php
@@ -11,34 +11,44 @@
 	<!-- Form -->
 	<label for="wp-convertkit-form">
 		<span class="title"><?php esc_html_e( 'Form', 'convertkit' ); ?></span>
-		<select name="wp-convertkit[form]" id="wp-convertkit-form" size="1">
-			<option value="-1"><?php esc_html_e( 'Default', 'convertkit' ); ?></option>
-			<option value="0"><?php esc_html_e( 'None', 'convertkit' ); ?></option>
+		<select name="wp-convertkit[form]" id="wp-convertkit-quick-edit-form" size="1">
+			<option value="-1" data-preserve-on-refresh="1"><?php esc_html_e( 'Default', 'convertkit' ); ?></option>
+			<option value="0" data-preserve-on-refresh="1"><?php esc_html_e( 'None', 'convertkit' ); ?></option>
 			<?php
-			foreach ( $convertkit_forms->get() as $form ) {
-				?>
-				<option value="<?php echo esc_attr( $form['id'] ); ?>"><?php echo esc_attr( $form['name'] ); ?></option>
-				<?php
+			if ( $convertkit_forms->exist() ) {
+				foreach ( $convertkit_forms->get() as $form ) {
+					?>
+					<option value="<?php echo esc_attr( $form['id'] ); ?>"><?php echo esc_attr( $form['name'] ); ?></option>
+					<?php
+				}
 			}
 			?>
 		</select>
+		<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Forms from ConvertKit account', 'convertkit' ); ?>" data-resource="forms" data-field="wp-convertkit-quick-edit-form">
+			<span class="dashicons dashicons-update"></span>
+		</button>
 	</label>
 
 	<!-- Tag -->
 	<label for="wp-convertkit-tag">
 		<span class="title"><?php esc_html_e( 'Tag', 'convertkit' ); ?></span>
-		<select name="wp-convertkit[tag]" id="wp-convertkit-tag" size="1">
-			<option value="0">
+		<select name="wp-convertkit[tag]" id="wp-convertkit-quick-edit-tag" size="1">
+			<option value="0" data-preserve-on-refresh="1">
 				<?php esc_html_e( 'None', 'convertkit' ); ?>
 			</option>
 			<?php
-			foreach ( $convertkit_tags->get() as $convertkit_tag ) {
-				?>
-				<option value="<?php echo esc_attr( $convertkit_tag['id'] ); ?>"><?php echo esc_attr( $convertkit_tag['name'] ); ?></option>
-				<?php
+			if ( $convertkit_tags->exist() ) {
+				foreach ( $convertkit_tags->get() as $convertkit_tag ) {
+					?>
+					<option value="<?php echo esc_attr( $convertkit_tag['id'] ); ?>"><?php echo esc_attr( $convertkit_tag['name'] ); ?></option>
+					<?php
+				}
 			}
 			?>
 		</select>
+		<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Tags from ConvertKit account', 'convertkit' ); ?>" data-resource="tags" data-field="wp-convertkit-quick-edit-tag">
+			<span class="dashicons dashicons-update"></span>
+		</button>
 	</label>
 	<?php wp_nonce_field( 'wp-convertkit-save-meta', 'wp-convertkit-save-meta-nonce' ); ?>
 </div>

--- a/views/backend/post/quick-edit.php
+++ b/views/backend/post/quick-edit.php
@@ -24,7 +24,7 @@
 			}
 			?>
 		</select>
-		<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Forms from ConvertKit account', 'convertkit' ); ?>" data-resource="forms" data-field="wp-convertkit-quick-edit-form">
+		<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Forms from ConvertKit account', 'convertkit' ); ?>" data-resource="forms" data-field="#wp-convertkit-quick-edit-form">
 			<span class="dashicons dashicons-update"></span>
 		</button>
 	</label>
@@ -46,7 +46,7 @@
 			}
 			?>
 		</select>
-		<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Tags from ConvertKit account', 'convertkit' ); ?>" data-resource="tags" data-field="wp-convertkit-quick-edit-tag">
+		<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Tags from ConvertKit account', 'convertkit' ); ?>" data-resource="tags" data-field="#wp-convertkit-quick-edit-tag">
 			<span class="dashicons dashicons-update"></span>
 		</button>
 	</label>

--- a/views/backend/term/fields.php
+++ b/views/backend/term/fields.php
@@ -29,7 +29,7 @@
 				}
 				?>
 			</select>
-			<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Forms from ConvertKit account', 'convertkit' ); ?>" data-resource="forms" data-field="wp-convertkit-form">
+			<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Forms from ConvertKit account', 'convertkit' ); ?>" data-resource="forms" data-field="#wp-convertkit-form">
 				<span class="dashicons dashicons-update"></span>
 			</button>
 			<p class="description">

--- a/views/backend/term/fields.php
+++ b/views/backend/term/fields.php
@@ -12,17 +12,13 @@
 		<label for="description"><?php esc_html_e( 'ConvertKit Form', 'convertkit' ); ?></label>
 	</th>
 	<td>
-		<?php
-		if ( ! $convertkit_forms->exist() ) {
-			esc_html_e( 'No Forms exist in ConvertKit.', 'convertkit' );
-		} else {
-			?>
-			<div class="convertkit-select2-container">
-				<select name="wp-convertkit[form]" id="wp-convertkit-form" class="convertkit-select2">
-					<option value="0"<?php selected( 0, $convertkit_term->get_form() ); ?>>
-						<?php esc_html_e( 'Default', 'convertkit' ); ?>
-					</option>
-					<?php
+		<div class="convertkit-select2-container">
+			<select name="wp-convertkit[form]" id="wp-convertkit-form" class="convertkit-select2">
+				<option value="0"<?php selected( 0, $convertkit_term->get_form() ); ?> data-preserve-on-refresh="1">
+					<?php esc_html_e( 'Default', 'convertkit' ); ?>
+				</option>
+				<?php
+				if ( $convertkit_forms->exist() ) {
 					foreach ( $convertkit_forms->get() as $convertkit_form ) {
 						?>
 						<option value="<?php echo esc_attr( $convertkit_form['id'] ); ?>"<?php selected( $convertkit_form['id'], $convertkit_term->get_form() ); ?>>
@@ -30,23 +26,26 @@
 						</option>
 						<?php
 					}
-					?>
-				</select>
-				<p class="description">
-					<?php _e( '<code>Default</code>: Display a form based on the Post\'s settings.', 'convertkit' ); /* phpcs:ignore */ ?>
-					<br />
-					<?php
-					echo sprintf(
-						/* translators: Taxonomy Name */
-						esc_html__( 'Any other option will display that form after the main content for Posts assigned to this %s.', 'convertkit' ),
-						'category'
-					);
-					?>
-				</p>
-			</div>
-			<?php
-			wp_nonce_field( 'wp-convertkit-save-meta', 'wp-convertkit-save-meta-nonce' );
-		}
+				}
+				?>
+			</select>
+			<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Forms from ConvertKit account', 'convertkit' ); ?>" data-resource="forms" data-field="wp-convertkit-form">
+				<span class="dashicons dashicons-update"></span>
+			</button>
+			<p class="description">
+				<?php _e( '<code>Default</code>: Display a form based on the Post\'s settings.', 'convertkit' ); /* phpcs:ignore */ ?>
+				<br />
+				<?php
+				echo sprintf(
+					/* translators: Taxonomy Name */
+					esc_html__( 'Any other option will display that form after the main content for Posts assigned to this %s.', 'convertkit' ),
+					'category'
+				);
+				?>
+			</p>
+		</div>
+		<?php
+		wp_nonce_field( 'wp-convertkit-save-meta', 'wp-convertkit-save-meta-nonce' );
 		?>
 	</td>
 </tr>

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -86,6 +86,7 @@ if ( is_admin() ) {
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-quick-edit.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-category.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-post.php';
+	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-refresh-resources.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-settings.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-tinymce.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-user.php';


### PR DESCRIPTION
## Summary

Adds buttons next to Form, Tag and Landing Page fields to refresh the cached forms/landing pages/tags from the API, across

- adding/editing Pages/Posts
![Screenshot 2022-07-14 at 16 17 19](https://user-images.githubusercontent.com/1462305/179017367-7368c4d4-8659-4aa6-ba97-454550d88084.png)

- quick/bulk editing Pages/Post
![Screenshot 2022-07-14 at 16 17 29](https://user-images.githubusercontent.com/1462305/179017403-75ab9200-be7d-47a0-a7c2-b3055ad5de85.png)

- editing Categories
![Screenshot 2022-07-14 at 16 17 49](https://user-images.githubusercontent.com/1462305/179017422-3289c940-8fd8-4071-9eeb-641e6b0e5898.png)

Video:
https://www.loom.com/share/5babb995c54349b69f74607e32c18369

This solves two issues:

1. Currently, only WordPress Administrators have access to forcing a refresh of resources by navigating to the `Settings > ConvertKit` screen.  WordPress Editors and Authors do not have access to this screen, which is standard WordPress behaviour - however, Editors and Authors in WordPress can create/edit Pages, Posts and Categories, and configure the per-Page/Post/Category settings for ConvertKit (such as defining a form or landing page to display).

2.  There can be confusion when a ConvertKit user (whether a WordPress Administrator or not) adds/edits/deletes a form/landing page/tag to their ConvertKit account, only to then not know how to reflect that change in WordPress.

There isn't a refresh button for Broadcasts, because:
- these are force refreshed when interacting with the Broadcasts shortcode or block when adding/editing a WordPress Page/Post,
- there is a [scheduled WordPress Cron](https://github.com/ConvertKit/convertkit-wordpress/blob/main/includes/cron-functions.php#L14) task that refreshes broadcasts hourly

## Testing

- `RefreshResourcesButtonCest`: Adds tests to confirm that the refresh buttons populate fields with forms/landing pages/tags.  To emulate a resource being added to a ConvertKit account, the test switches from API keys for an account with no resources to API keys for an account with resources.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)