### PR TITLE
Don't display Bulk Edit fields when no Pages/Posts

### DIFF
--- a/resources/backend/js/bulk-edit.js
+++ b/resources/backend/js/bulk-edit.js
@@ -17,13 +17,13 @@ jQuery( document ).ready(
 	function( $ ) {
 
 		// Move Bulk Edit fields from footer into the hidden bulk-edit table row,
-        // if a bulk-edit table row exists (it won't exist if searching returns no pages).
-        if ( $( 'tr#bulk-edit .inline-edit-wrapper fieldset.inline-edit-col-right' ).length > 0 ) {
-    		$( 'tr#bulk-edit .inline-edit-wrapper fieldset.inline-edit-col-right' ).first().append( $( '#convertkit-bulk-edit' ) );
+		// if a bulk-edit table row exists (it won't exist if searching returns no pages).
+		if ( $( 'tr#bulk-edit .inline-edit-wrapper fieldset.inline-edit-col-right' ).length > 0 ) {
+			$( 'tr#bulk-edit .inline-edit-wrapper fieldset.inline-edit-col-right' ).first().append( $( '#convertkit-bulk-edit' ) );
 
-    		// Show the Bulk Edit fields, as they are now contained in the inline-edit row which WordPress will show/hide as necessary.
-    		$( '#convertkit-bulk-edit' ).show();
-        }
+			// Show the Bulk Edit fields, as they are now contained in the inline-edit row which WordPress will show/hide as necessary.
+			$( '#convertkit-bulk-edit' ).show();
+		}
 
 	}
 );

--- a/resources/backend/js/bulk-edit.js
+++ b/resources/backend/js/bulk-edit.js
@@ -16,11 +16,14 @@
 jQuery( document ).ready(
 	function( $ ) {
 
-		// Move Bulk Edit fields from footer into the hidden bulk-edit table row.
-		$( 'tr#bulk-edit .inline-edit-wrapper fieldset.inline-edit-col-right' ).first().append( $( '#convertkit-bulk-edit' ) );
+		// Move Bulk Edit fields from footer into the hidden bulk-edit table row,
+        // if a bulk-edit table row exists (it won't exist if searching returns no pages).
+        if ( $( 'tr#bulk-edit .inline-edit-wrapper fieldset.inline-edit-col-right' ).length > 0 ) {
+    		$( 'tr#bulk-edit .inline-edit-wrapper fieldset.inline-edit-col-right' ).first().append( $( '#convertkit-bulk-edit' ) );
 
-		// Show the Bulk Edit fields, as they are now contained in the inline-edit row which WordPress will show/hide as necessary.
-		$( '#convertkit-bulk-edit' ).show();
+    		// Show the Bulk Edit fields, as they are now contained in the inline-edit row which WordPress will show/hide as necessary.
+    		$( '#convertkit-bulk-edit' ).show();
+        }
 
 	}
 );

--- a/tests/acceptance/forms/PageFormCest.php
+++ b/tests/acceptance/forms/PageFormCest.php
@@ -444,6 +444,23 @@ class PageFormCest
 	}
 
 	/**
+	 * Test that the Bulk Edit fields do not display when a search on a WP_List_Table
+	 * returns no results.
+	 * 
+	 * @since 	1.9.8.1
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testBulkEditFieldsHiddenWhenNoPagesFound(AcceptanceTester $I)
+	{
+		// Emulate the user searching for Pages with a query string that yields no results.
+		$I->amOnAdminPage('edit.php?post_type=page&s=nothing');
+
+		// Confirm that the Bulk Edit fields do not display.
+		$I->dontSeeElement('#convertkit-bulk-edit');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/acceptance/forms/PostFormCest.php
+++ b/tests/acceptance/forms/PostFormCest.php
@@ -546,6 +546,23 @@ class PostFormCest
 	}
 
 	/**
+	 * Test that the Bulk Edit fields do not display when a search on a WP_List_Table
+	 * returns no results.
+	 * 
+	 * @since 	1.9.8.1
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testBulkEditFieldsHiddenWhenNoPostsFound(AcceptanceTester $I)
+	{
+		// Emulate the user searching for Posts with a query string that yields no results.
+		$I->amOnAdminPage('edit.php?post_type=post&s=nothing');
+
+		// Confirm that the Bulk Edit fields do not display.
+		$I->dontSeeElement('#convertkit-bulk-edit');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/acceptance/integrations/WooCommerceProductFormCest.php
+++ b/tests/acceptance/integrations/WooCommerceProductFormCest.php
@@ -338,6 +338,23 @@ class WooCommerceProductFormCest
 	}
 
 	/**
+	 * Test that the Bulk Edit fields do not display when a search on a WP_List_Table
+	 * returns no results.
+	 * 
+	 * @since 	1.9.8.1
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testBulkEditFieldsHiddenWhenNoProductsFound(AcceptanceTester $I)
+	{
+		// Emulate the user searching for Products with a query string that yields no results.
+		$I->amOnAdminPage('edit.php?post_type=product&s=nothing');
+
+		// Confirm that the Bulk Edit fields do not display.
+		$I->dontSeeElement('#convertkit-bulk-edit');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.


### PR DESCRIPTION
## Summary

Fixes an issue in 1.9.8.0 where Bulk Edit fields would incorrectly display in the footer of the Pages/Posts table view when no Pages/Posts exist, or a search would return no results:
![Screenshot 2022-07-15 at 15 33 08](https://user-images.githubusercontent.com/1462305/179247187-0eb4c657-2e70-4db5-8018-b3e7011c8cf7.png)

## Testing

- `PageFormCest:testBulkEditFieldsHiddenWhenNoPagesFound`: Test that the Bulk Edit fields do not display when a search on a WP_List_Table returns no results.
- `PostFormCest:testBulkEditFieldsHiddenWhenNoPostsFound`: Test that the Bulk Edit fields do not display when a search on a WP_List_Table returns no results.
- `WooCommerceProductFormCest:testBulkEditFieldsHiddenWhenNoProductsFound`: Test that the Bulk Edit fields do not display when a search on a WP_List_Table returns no results.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)