### PR TITLE
API: Handle 500 and 502 HTTP errors

### DIFF
--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -69,9 +69,9 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function test429RateLimitHit()
 	{
-		// Force WordPress HTTP classes and functions to return a 502 error.
+		// Force WordPress HTTP classes and functions to return a 429 error.
 		$this->mockResponses( 429, 'Rate limit hit.' );
-		$result = $this->api->account(); // The API function we use doesn't matter, as mockResponse forces a 502 error.
+		$result = $this->api->account(); // The API function we use doesn't matter, as mockResponse forces a 429 error.
 		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
 		$this->assertEquals($result->get_error_message(), 'ConvertKit API Error: Rate limit hit.');
@@ -84,9 +84,9 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function test500InternalServerError()
 	{
-		// Force WordPress HTTP classes and functions to return a 502 error.
+		// Force WordPress HTTP classes and functions to return a 500 error.
 		$this->mockResponses( 500, 'Internal server error.' );
-		$result = $this->api->account(); // The API function we use doesn't matter, as mockResponse forces a 502 error.
+		$result = $this->api->account(); // The API function we use doesn't matter, as mockResponse forces a 500 error.
 		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
 		$this->assertEquals($result->get_error_message(), 'ConvertKit API Error: Internal server error.');


### PR DESCRIPTION
## Summary

Handles 500 and 502 HTTP errors by returning a WP_Error object, which is then output as a notice in the Plugin's settings screen:
![Screenshot 2022-08-01 at 17 09 27](https://user-images.githubusercontent.com/1462305/182198827-73155a8d-5016-4796-82d2-53c522b2910d.png)

Previously, a PHP warning would be displayed if a 500 or 502 error was hit, as the response data would be `null`:
![Screenshot 2022-08-01 at 17 07 05](https://user-images.githubusercontent.com/1462305/182198843-0a0f79fb-e23b-4278-bedf-2f4d1e9d6790.png)

429 errors are already handled; 401, 422 and other errors are not handled by this PR, as they return a verbose error message in the body, which the API class checks for and handles.

## Testing

- `APITest:test429RateLimitHit`: Tests that a 429 rate limit reached HTTP response code from the API class is returned as a WP_Error with the expected error message.
- `APITest:test500RateLimitHit`: Tests that a 500 internal server error HTTP response code from the API class is returned as a WP_Error with the expected error message.
- `APITest:test502RateLimitHit`: Tests that a 502 bad gateway HTTP response code from the API class is returned as a WP_Error with the expected error message.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)