### PR TITLE
Tests: Deactivate Contact Form 7 Plugin after test completion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,6 @@ jobs:
       DB_PASS: root
       DB_HOST: localhost
       INSTALL_PLUGINS: "classic-editor contact-form-7 disable-welcome-messages-and-tips elementor woocommerce wordpress-seo" # Don't include this repository's Plugin here.
-      ACTIVATE_PLUGINS: "disable-welcome-messages-and-tips wordpress-seo" # Installed Plugins that should be activated prior to any tests
       CONVERTKIT_API_KEY: ${{ secrets.CONVERTKIT_API_KEY }} # ConvertKit API Key, stored in the repository's Settings > Secrets
       CONVERTKIT_API_SECRET: ${{ secrets.CONVERTKIT_API_SECRET }} # ConvertKit API Secret, stored in the repository's Settings > Secrets
       CONVERTKIT_API_KEY_NO_DATA: ${{ secrets.CONVERTKIT_API_KEY_NO_DATA }} # ConvertKit API Key for ConvertKit account with no data, stored in the repository's Settings > Secrets
@@ -107,16 +106,11 @@ jobs:
         working-directory: ${{ env.ROOT_DIR }}
         run: wp-cli plugin install ${{ env.INSTALL_PLUGINS }}
 
-      # env.ACTIVATE_PLUGINS is a list of Plugin slugs, space separated e.g. contact-form-7 woocommerce.
-      - name: Activate Free Third Party WordPress Plugins
-        working-directory: ${{ env.ROOT_DIR }}
-        run: wp-cli plugin activate ${{ env.ACTIVATE_PLUGINS }}
-
       # These should be stored as a separated list of URLs in the repository Settings > Secrets > Repository Secret > CONVERTKIT_PAID_PLUGIN_URLS.
       # We cannot include the URLs in this file, as they're not Plugins we are permitted to distribute.
-      - name: Install and Activate Paid Third Party WordPress Plugins
+      - name: Install Paid Third Party WordPress Plugins
         working-directory: ${{ env.ROOT_DIR }}
-        run: wp-cli plugin install ${{ secrets.CONVERTKIT_PAID_PLUGIN_URLS }} --activate
+        run: wp-cli plugin install ${{ secrets.CONVERTKIT_PAID_PLUGIN_URLS }}
       
       # WP_DEBUG = true is required so any WordPress / PHP errors are output and caught by tests.
       # FS_METHOD = direct is required for WP_Filesystem to operate without suppressed PHP fopen() errors that trip up tests.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,12 @@ jobs:
         
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
+          'acceptance/broadcasts',
+          'acceptance/forms',
+          'acceptance/general',
           'acceptance/integrations',
+          'acceptance/landing-pages',
+          'acceptance/tags'
         ]
 
     # Steps to install, configure and run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,12 +48,7 @@ jobs:
         
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
-          'acceptance/broadcasts',
-          'acceptance/forms',
-          'acceptance/general',
           'acceptance/integrations',
-          'acceptance/landing-pages',
-          'acceptance/tags'
         ]
 
     # Steps to install, configure and run tests

--- a/tests/acceptance/integrations/ContactForm7FormCest.php
+++ b/tests/acceptance/integrations/ContactForm7FormCest.php
@@ -122,7 +122,7 @@ class ContactForm7FormCest
 	 */
 	public function _passed(AcceptanceTester $I)
 	{
-		//$I->deactivateThirdPartyPlugin($I, 'contact-form-7');
+		$I->deactivateThirdPartyPlugin($I, 'contact-form-7');
 		$I->deactivateConvertKitPlugin($I);
 		$I->resetConvertKitPlugin($I);
 	}

--- a/tests/acceptance/integrations/ContactForm7FormCest.php
+++ b/tests/acceptance/integrations/ContactForm7FormCest.php
@@ -122,8 +122,13 @@ class ContactForm7FormCest
 	 */
 	public function _passed(AcceptanceTester $I)
 	{
-		$I->deactivateThirdPartyPlugin($I, 'contact-form-7');
 		$I->deactivateConvertKitPlugin($I);
 		$I->resetConvertKitPlugin($I);
+
+		// We don't use deactivateThirdPartyPlugin(), as this checks for PHP warnings/errors.
+		// Contact Form 7 throws a warning on deactivation related to WordPress capabilities,
+		// which is outside of our control and would result in the test not completing. 
+		$I->amOnPluginsPage();
+		$I->deactivatePlugin('contact-form-7');
 	}
 }


### PR DESCRIPTION
## Summary

Reinstates deactivating the Contact Form 7 Plugin after running integration tests.

Deactivation was [previously disabled](https://github.com/ConvertKit/convertkit-wordpress/pull/338#discussion_r922173296) as it resulted in errors.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)