### PR TITLE
Display Notification on Refresh Resource error

### DIFF
--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -141,6 +141,11 @@ function convertKitRefreshResourcesOutputErrorNotice( message ) {
 		// Show a WordPress style error notice.
 		$( 'hr.wp-header-end' ).after( '<div id="message" class="error convertkit-error notice is-dismissible"><p>' + message + '</p></div>' );
 
+		// Notify WordPress that a new dismissible notification exists, triggering WordPress' makeNoticesDismissible() function,
+		// which adds a dismiss button and binds necessary events to hide the notification.
+		// We can't directly call makeNoticesDismissible(), as its minified function name will be different.
+		$( document ).trigger( 'wp-updates-notice-added' );
+
 	} )( jQuery );
 
 }

--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -43,6 +43,20 @@ jQuery( document ).ready(
 								console.log( response );
 							}
 
+							// Remove any existing error notices that might be displayed.
+							convertKitRefreshResourcesRemoveNotices();
+
+							// Show an error if the request wasn't successful.
+							if ( ! response.success ) {
+								// Show error notice.
+								convertKitRefreshResourcesOutputErrorNotice( response.data );
+
+								// Enable button.
+								$( button ).prop( 'disabled', false );
+
+								return;
+							}
+
 							// Get currently selected option.
 							var selectedOption = $( field ).val();
 
@@ -72,14 +86,22 @@ jQuery( document ).ready(
 
 							// Enable button.
 							$( button ).prop( 'disabled', false );
-
 						}
 					}
 				).fail(
-					function (response) {
+					function ( response ) {
 						if ( convertkit_admin_refresh_resources.debug ) {
 							console.log( response );
 						}
+
+						// Remove any existing error notices that might be displayed.
+						convertKitRefreshResourcesRemoveNotices();
+
+						// Show error notice.
+						convertKitRefreshResourcesOutputErrorNotice( 'ConvertKit: ' + response.status + ' ' + response.statusText );
+
+						// Enable button.
+						$( button ).prop( 'disabled', false );
 					}
 				);
 
@@ -88,3 +110,37 @@ jQuery( document ).ready(
 
 	}
 );
+
+/**
+ * Removes any existing ConvertKit WordPress style error notices.
+ *
+ * @since 	1.9.8.3
+ */
+function convertKitRefreshResourcesRemoveNotices() {
+
+	( function( $ ) {
+
+		$( 'div.convertkit-error' ).remove();
+
+	} )( jQuery );
+
+}
+
+/**
+ * Removes any existing ConvertKit WordPress style error notices, before outputting
+ * an error notice.
+ *
+ * @since 	1.9.8.3
+ *
+ * @param 	string 	message 	Error message to display.
+ */
+function convertKitRefreshResourcesOutputErrorNotice( message ) {
+
+	( function( $ ) {
+
+		// Show a WordPress style error notice.
+		$( 'hr.wp-header-end' ).after( '<div id="message" class="error convertkit-error notice is-dismissible"><p>' + message + '</p></div>' );
+
+	} )( jQuery );
+
+}

--- a/tests/acceptance/general/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/general/RefreshResourcesButtonCest.php
@@ -226,6 +226,11 @@ class RefreshResourcesButtonCest
 		// Confirm that an error notification is displayed on screen, with the expected error message.
 		$I->seeElementInDOM('div.convertkit-error');
 		$I->see('Authorization Failed: API Key not valid');
+
+		// Confirm that the notice is dismissible.
+		$I->click('div.convertkit-error button.notice-dismiss');
+		$I->wait(1);
+		$I->dontSeeElementInDOM('div.convertkit-error');
 	}
 
 	/**

--- a/tests/acceptance/general/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/general/RefreshResourcesButtonCest.php
@@ -190,6 +190,45 @@ class RefreshResourcesButtonCest
 	}
 
 	/**
+	 * Test that the refresh button triggers an error message when the AJAX request fails,
+	 * or the ConvertKit API returns an error.
+	 * 
+	 * @since 	1.9.8.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testRefreshResourcesErrorNotice(AcceptanceTester $I)
+	{
+		// Specify invalid API credentials, so that the AJAX request returns an error.
+		$I->haveOptionInDatabase('_wp_convertkit_settings', [
+			'api_key'    => 'fakeApiKey',
+			'api_secret' => 'fakeApiSecret',
+			'debug'      => 'on',
+			'no_scripts' => '',
+			'no_css'     => '',
+		]);
+
+		// Programmatically create a Page.
+		$pageID = $I->havePostInDatabase([
+			'post_type' 	=> 'page',
+			'post_title' 	=> 'ConvertKit: Page: Refresh Resources: Quick Edit',
+		]);
+
+		// Open Quick Edit form forthe Page in the Pages WP_List_Table.
+		$I->openQuickEdit($I, 'page', $pageID);
+
+		// Click the Forms refresh button.
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
+
+		// Confirm that an error notification is displayed on screen, with the expected error message.
+		$I->seeElementInDOM('div.convertkit-error');
+		$I->see('Authorization Failed: API Key not valid');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.


### PR DESCRIPTION
## Summary

Displays a dismissible WordPress style inline error message when the refresh button's request fails, rather than failing silently, [as suggested here](https://github.com/ConvertKit/convertkit-woocommerce/pull/109#pullrequestreview-1060182288):
![Screenshot 2022-08-08 at 15 31 27](https://user-images.githubusercontent.com/1462305/183442536-a83088f5-ca6e-4ea1-80fc-bb145783b84b.png)

As WordPress doesn't have a native toast-style notification API/function we can use, I've implemented it to follow how WordPress shows its notifications:
![Screenshot 2022-08-05 at 17 47 07](https://user-images.githubusercontent.com/1462305/183123990-44500c72-07a2-4229-8239-a04ea305f2a3.png)

If you think toast-style notifications would be better here, let me know.

## Testing

- `RefreshResourcesButtonCest:testRefreshResourcesErrorNotice`: Confirms that an error notification is displayed when clicking the refresh button, where the Plugin is configured with invalid API keys

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)
