### PR TITLE
Shortcodes: Add support for multiple Visual/Text editors on edit screen

### DIFF
--- a/admin/class-convertkit-admin-tinymce.php
+++ b/admin/class-convertkit-admin-tinymce.php
@@ -49,6 +49,7 @@ class ConvertKit_Admin_TinyMCE {
 
 		// Get requested shortcode name.
 		$shortcode_name = sanitize_text_field( $_REQUEST['shortcode'] );
+		$editor_type    = sanitize_text_field( $_REQUEST['editor_type'] );
 
 		// If the shortcode is not registered, return a view in the modal to tell the user.
 		if ( ! isset( $shortcodes[ $shortcode_name ] ) ) {
@@ -82,7 +83,6 @@ class ConvertKit_Admin_TinyMCE {
 
 		// Enqueue Quicktag JS.
 		wp_enqueue_script( 'convertkit-admin-quicktags', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/quicktags.js', array( 'jquery', 'quicktags' ), CONVERTKIT_PLUGIN_VERSION, true );
-		wp_enqueue_script( 'convertkit-admin-modal', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/modal.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
 
 		// Make shortcodes available as convertkit_quicktags JS variable.
 		wp_localize_script( 'convertkit-admin-quicktags', 'convertkit_quicktags', $shortcodes );

--- a/readme.txt
+++ b/readme.txt
@@ -110,6 +110,10 @@ Full Plugin documentation can be found [here](https://help.convertkit.com/en/art
 
 == Changelog ==
 
+### 1.9.8.3 2022-08-xx
+* Fix: Classic Editor: Insert shortcode into active editor when multiple editor instances exist
+* Fix: Text Editor: Insert shortcode would not work when multiple editor instances exist
+
 ### 1.9.8.2 2022-08-04
 * Fix: API: Show error notification when API returns HTTP 500 and 502 errors, instead of showing PHP warnings
 * Fix: Bulk and Quick Edit: `for` label attribute now matches the field ID

--- a/resources/backend/js/modal.js
+++ b/resources/backend/js/modal.js
@@ -87,33 +87,27 @@ jQuery( document ).ready(
 					shortcode += '[/' + $( 'input[name="shortcode"]', $( form ) ).val() + ']';
 				}
 
-				/**
-				 * Finish building the link, and insert it, depending on whether we were initialized from
-				 * the Visual Editor or Text Editor.
-				 */
-				if ( typeof tinyMCE !== 'undefined' && tinyMCE.activeEditor && ! tinyMCE.activeEditor.isHidden() ) {
-					// Insert into editor.
-					tinyMCE.activeEditor.execCommand( 'mceReplaceContent', false, shortcode );
+				// Depending on the editor type, insert the shortcode.
+				switch ( $( 'input[name="editor_type"]', $( form ) ).val() ) {
+					case 'tinymce':
+						// Sanity check that a Visual editor exists and is active.
+						if ( typeof tinyMCE !== 'undefined' && tinyMCE.activeEditor && ! tinyMCE.activeEditor.isHidden() ) {
+							// Insert into editor.
+							tinyMCE.activeEditor.execCommand( 'mceReplaceContent', false, shortcode );
 
-					// Close modal.
-					tinyMCE.activeEditor.windowManager.close();
+							// Close modal.
+							tinyMCE.activeEditor.windowManager.close();
+						}
+						break;
 
-					// Done.
-					return;
+					case 'quicktags':
+						// Insert into editor.
+						QTags.insertContent( shortcode );
+
+						// Close modal.
+						convertKitQuickTagsModal.close();
+						break;
 				}
-
-				// Text Editor.
-				if ( typeof QTags !== 'undefined' ) {
-					// Insert into editor.
-					QTags.insertContent( shortcode );
-
-					// Close modal.
-					convertKitQuickTagsModal.close();
-
-					// Done.
-					return;
-				}
-
 			}
 		);
 

--- a/resources/backend/js/quicktags.js
+++ b/resources/backend/js/quicktags.js
@@ -34,9 +34,10 @@ function convertKitQuickTagRegister( block ) {
 				$.post(
 					ajaxurl,
 					{
-						'action': 	'convertkit_admin_tinymce_output_modal',
-						'nonce':  	convertkit_admin_tinymce.nonce,
-						'shortcode':block.name
+						'action': 		'convertkit_admin_tinymce_output_modal',
+						'nonce':  		convertkit_admin_tinymce.nonce,
+						'editor_type':  'quicktags',
+						'shortcode': 	block.name
 
 					},
 					function( response ) {

--- a/resources/backend/js/tinymce.js
+++ b/resources/backend/js/tinymce.js
@@ -56,6 +56,7 @@ function convertKitTinyMCERegisterPlugin( block ) {
 							{
 								'action': 		'convertkit_admin_tinymce_output_modal',
 								'nonce':  		convertkit_admin_tinymce.nonce,
+								'editor_type':  'tinymce',
 								'shortcode': 	block.name
 							},
 							function( response ) {

--- a/tests/_support/Helper/Acceptance/WPClassicEditor.php
+++ b/tests/_support/Helper/Acceptance/WPClassicEditor.php
@@ -44,7 +44,7 @@ class WPClassicEditor extends \Codeception\Module
 	public function addVisualEditorShortcode($I, $shortcodeName, $shortcodeProgrammaticName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false, $targetEditor = 'content')
 	{
 		// Click the Visual tab.
-		$I->scrollTo('input#title');
+		$I->scrollTo('h1.wp-heading-inline');
 		$I->click('button#'.$targetEditor.'-tmce');
 
 		// Click the TinyMCE Button for this shortcode.
@@ -103,7 +103,7 @@ class WPClassicEditor extends \Codeception\Module
 	public function addTextEditorShortcode($I, $shortcodeName, $shortcodeProgrammaticName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false, $targetEditor = 'content')
 	{
 		// Click the Text tab.
-		$I->scrollTo('input#title');
+		$I->scrollTo('h1.wp-heading-inline');
 		$I->click('button#'.$targetEditor.'-html');
 
 		// Click the QuickTags Button for this shortcode.

--- a/tests/_support/Helper/Acceptance/WPClassicEditor.php
+++ b/tests/_support/Helper/Acceptance/WPClassicEditor.php
@@ -43,6 +43,7 @@ class WPClassicEditor extends \Codeception\Module
 	public function addVisualEditorShortcode($I, $shortcodeName, $shortcodeProgrammaticName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false)
 	{
 		// Click the Visual tab.
+		$I->scrollTo('input#title');
 		$I->click('button#content-tmce');
 
 		// Click the TinyMCE Button for this shortcode.

--- a/tests/_support/Helper/Acceptance/WPClassicEditor.php
+++ b/tests/_support/Helper/Acceptance/WPClassicEditor.php
@@ -39,15 +39,16 @@ class WPClassicEditor extends \Codeception\Module
 	 * @param 	string 				$shortcodeProgrammaticName 	Programmatic Shortcode Name (e.g. 'convertkit-form').
 	 * @param 	bool|array 			$shortcodeConfiguration 	Shortcode Configuration (field => value key/value array).
 	 * @param 	bool|string 		$expectedShortcodeOutput 	Expected Shortcode Output (e.g. [convertkit_form form="12345"]).
+	 * @param 	string 				$targetEditor				Target TinyMCE editor instance.
 	 */
-	public function addVisualEditorShortcode($I, $shortcodeName, $shortcodeProgrammaticName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false)
+	public function addVisualEditorShortcode($I, $shortcodeName, $shortcodeProgrammaticName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false, $targetEditor = 'content')
 	{
 		// Click the Visual tab.
 		$I->scrollTo('input#title');
-		$I->click('button#content-tmce');
+		$I->click('button#'.$targetEditor.'-tmce');
 
 		// Click the TinyMCE Button for this shortcode.
-		$I->click('div.mce-container div[aria-label="'.$shortcodeName.'"] button');
+		$I->click('#wp-'.$targetEditor.'-editor-container div.mce-container div[aria-label="'.$shortcodeName.'"] button');
 
 		// Wait for the modal's contents to load.
 		$I->waitForElementVisible('#convertkit-modal-body input.button-primary');
@@ -78,7 +79,7 @@ class WPClassicEditor extends \Codeception\Module
 
 		// If the expected shortcode output is provided, check it exists in the Visual editor.
 		if ($expectedShortcodeOutput) {
-			$I->switchToIFrame('iframe#content_ifr');
+			$I->switchToIFrame('iframe#'.$targetEditor.'_ifr');
 			$I->seeInSource($expectedShortcodeOutput);
 			$I->switchToIFrame();
 		}
@@ -97,14 +98,16 @@ class WPClassicEditor extends \Codeception\Module
 	 * @param 	string 				$shortcodeProgrammaticName 	Programmatic Shortcode Name (e.g. 'convertkit-form').
 	 * @param 	bool|array 			$shortcodeConfiguration 	Shortcode Configuration (field => value key/value array).
 	 * @param 	bool|string 		$expectedShortcodeOutput 	Expected Shortcode Output (e.g. [convertkit_form form="12345"]).
+	 * @param 	string 				$targetEditor				ID of text editor instance.
 	 */
-	public function addTextEditorShortcode($I, $shortcodeName, $shortcodeProgrammaticName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false)
+	public function addTextEditorShortcode($I, $shortcodeName, $shortcodeProgrammaticName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false, $targetEditor = 'content')
 	{
 		// Click the Text tab.
-		$I->click('button#content-html');
+		$I->scrollTo('input#title');
+		$I->click('button#'.$targetEditor.'-html');
 
 		// Click the QuickTags Button for this shortcode.
-		$I->click('input#qt_content_'.$shortcodeProgrammaticName);
+		$I->click('input#qt_'.$targetEditor.'_'.$shortcodeProgrammaticName);
 
 		// Wait for the modal's contents to load.
 		$I->waitForElementVisible('#convertkit-quicktags-modal input.button-primary');
@@ -135,7 +138,7 @@ class WPClassicEditor extends \Codeception\Module
 
 		// If the expected shortcode output is provided, check it exists in the Text editor.
 		if ($expectedShortcodeOutput) {
-			$I->seeInField('textarea.wp-editor-area', $expectedShortcodeOutput);
+			$I->seeInField('textarea#'.$targetEditor, $expectedShortcodeOutput);
 		}
 	}
 

--- a/tests/acceptance/integrations/WooCommerceProductFormCest.php
+++ b/tests/acceptance/integrations/WooCommerceProductFormCest.php
@@ -136,6 +136,40 @@ class WooCommerceProductFormCest
 	}
 
 	/**
+	 * Test the [convertkit_form] shortcode is inserted in the Content editor for a WooCommerce Product,
+	 * and not the Excerpt editor.
+	 * 
+	 * @since 	1.9.8.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testAddNewProductUsingFormShortcodeInVisualEditor(AcceptanceTester $I)
+	{
+		// Add a Product using the Classic Editor.
+		$I->addClassicEditorPage($I, 'product', 'ConvertKit: Product: Form: Shortcode: Visual Editor');
+
+		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None', 'aria-owns');
+
+		// Add shortcode to Product, setting the Form setting to the value specified in the .env file.
+		$I->addVisualEditorShortcode(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+			],
+			'[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]'
+		);
+
+		// Publish and view the Product on the frontend site.
+		$I->publishAndViewClassicEditorPage($I);
+
+		// Confirm that the ConvertKit Form is displayed.
+		$I->seeElementInDOM('form[data-sv-form]');
+	}
+
+	/**
 	 * Test that the Default Form for Products displays when the Default option is chosen via
 	 * WordPress' Quick Edit functionality.
 	 * 

--- a/tests/acceptance/integrations/WooCommerceProductFormCest.php
+++ b/tests/acceptance/integrations/WooCommerceProductFormCest.php
@@ -136,8 +136,8 @@ class WooCommerceProductFormCest
 	}
 
 	/**
-	 * Test the [convertkit_form] shortcode is inserted in the Content editor for a WooCommerce Product,
-	 * and not the Excerpt editor.
+	 * Test the [convertkit_form] shortcode is inserted into the applicable Content or Excerpt Visual Editor
+	 * instances when adding a WooCommerce Product.
 	 * 
 	 * @since 	1.9.8.3
 	 * 
@@ -151,7 +151,8 @@ class WooCommerceProductFormCest
 		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None', 'aria-owns');
 
-		// Add shortcode to Product, setting the Form setting to the value specified in the .env file.
+		// Add shortcode to Excerpt (Product short description), setting the Form setting to the value specified in the .env file,
+		// and confirming that the expected shortcode is displayed in the Excerpt field.
 		$I->addVisualEditorShortcode(
 			$I,
 			'ConvertKit Form',
@@ -159,7 +160,70 @@ class WooCommerceProductFormCest
 			[
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
 			],
-			'[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]'
+			'[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]',
+			'excerpt' // The ID of the Product short description field.
+		);
+
+		// Add shortcode to Content, setting the Form setting to the value specified in the .env file,
+		// and confirming that the expected shortcode is displayed in the Excerpt field.
+		$I->addVisualEditorShortcode(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+			],
+			'[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]',
+			'content' // The ID of the Content field.
+		);
+
+		// Publish and view the Product on the frontend site.
+		$I->publishAndViewClassicEditorPage($I);
+
+		// Confirm that the ConvertKit Form is displayed.
+		$I->seeElementInDOM('form[data-sv-form]');
+	}
+
+	/**
+	 * Test the [convertkit_form] shortcode is inserted into the applicable Content or Excerpt Text Editor
+	 * instances when adding a WooCommerce Product.
+	 * 
+	 * @since 	1.9.8.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testAddNewProductUsingFormShortcodeInTextEditor(AcceptanceTester $I)
+	{
+		// Add a Product using the Classic Editor.
+		$I->addClassicEditorPage($I, 'product', 'ConvertKit: Product: Form: Shortcode: Text Editor');
+
+		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None', 'aria-owns');
+
+		// Add shortcode to Excerpt (Product short description), setting the Form setting to the value specified in the .env file,
+		// and confirming that the expected shortcode is displayed in the Excerpt field.		
+		$I->addTextEditorShortcode(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+			],
+			'[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]',
+			'excerpt' // The ID of the Product short description field.
+		);
+
+		// Add shortcode to Content, setting the Form setting to the value specified in the .env file,
+		// and confirming that the expected shortcode is displayed in the Excerpt field.
+		$I->addTextEditorShortcode(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+			],
+			'[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]',
+			'content' // The ID of the Content field.
 		);
 
 		// Publish and view the Product on the frontend site.

--- a/views/backend/tinymce/modal.php
+++ b/views/backend/tinymce/modal.php
@@ -23,6 +23,8 @@
 		</div>
 		<div class="right">
 			<input type="hidden" name="shortcode" value="convertkit_<?php echo esc_attr( $shortcode['name'] ); ?>" />
+			<input type="hidden" name="editor_type" value="<?php echo esc_attr( $editor_type ); // quicktags|tinymce. ?>" />
+			
 			<?php
 			if ( $shortcode['shortcode_include_closing_tag'] ) {
 				?>

--- a/views/backend/tinymce/modal.php
+++ b/views/backend/tinymce/modal.php
@@ -24,7 +24,7 @@
 		<div class="right">
 			<input type="hidden" name="shortcode" value="convertkit_<?php echo esc_attr( $shortcode['name'] ); ?>" />
 			<input type="hidden" name="editor_type" value="<?php echo esc_attr( $editor_type ); // quicktags|tinymce. ?>" />
-			
+
 			<?php
 			if ( $shortcode['shortcode_include_closing_tag'] ) {
 				?>


### PR DESCRIPTION
## Summary

When multiple Visual / Classic Editor instances exist on an edit screen (i.e. when adding/editing WooCommerce Products), two problems exist:

1. Text editor: buttons to insert ConvertKit shortcodes would not consistently work, resulting in the modal / modal background remaining stuck on screen:
![Screenshot_2022-08-11_at_14_36_45](https://user-images.githubusercontent.com/1462305/184146303-1260ed99-cf76-4a3a-be8d-0e10227a8bdd.png)

2. Visual editor: buttons would sometimes insert the shortcode into the non-active editor:
![Screenshot_2022-08-11_at_14_31_53](https://user-images.githubusercontent.com/1462305/184145331-880e82e7-294a-4d17-b7fa-d2818d05eec8.png)

This PR resolves by including an `editor_type`, so the `modal.js` script knows the state of the editor (visual or text), and can therefore consistently work, inserting the shortcode into the correct editor and closing the applicable modal window.

## Testing

- `WooCommerceProductFormCest:testAddNewProductUsingFormShortcodeInVisualEditor`: Test the [convertkit_form] shortcode is inserted into the correct Content or Excerpt Visual Editor instances when adding a WooCommerce Product.
- `WooCommerceProductFormCest:testAddNewProductUsingFormShortcodeInTextEditor`: Test the [convertkit_form] shortcode is inserted into the correct Content or Excerpt Text Editor instances when adding a WooCommerce Product.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)