### PR TITLE
Extend Refresh Resource error notifications for Gutenberg, Classic Editor and Edit Category

### DIFF
--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -17,7 +17,11 @@ jQuery( document ).ready(
 			'click',
 			function( e ) {
 
+				// Prevent default button behaviour.
 				e.preventDefault();
+
+				// Remove any existing error notices that might be displayed.
+				convertKitRefreshResourcesRemoveNotices();
 
 				// Fetch some DOM elements.
 				var button = this,
@@ -42,9 +46,6 @@ jQuery( document ).ready(
 							if ( convertkit_admin_refresh_resources.debug ) {
 								console.log( response );
 							}
-
-							// Remove any existing error notices that might be displayed.
-							convertKitRefreshResourcesRemoveNotices();
 
 							// Show an error if the request wasn't successful.
 							if ( ! response.success ) {
@@ -118,6 +119,14 @@ jQuery( document ).ready(
  */
 function convertKitRefreshResourcesRemoveNotices() {
 
+	// If we're editing a Page, Post or Custom Post Type in Gutenberg, use wp.data.dispatch to remove the error.
+	if ( typeof wp !== 'undefined' && typeof wp.blocks !== 'undefined' ) {
+		// Gutenberg Editor.
+		wp.data.dispatch( 'core/notices' ).removeNotice( 'convertkit-error' );
+		return;
+	}
+
+	// Classic Editor or WP_List_Table (Bulk/Quick edit).
 	( function( $ ) {
 
 		$( 'div.convertkit-error' ).remove();
@@ -136,6 +145,23 @@ function convertKitRefreshResourcesRemoveNotices() {
  */
 function convertKitRefreshResourcesOutputErrorNotice( message ) {
 
+	// Prefix the message with the Plugin name.
+	message = 'ConvertKit: ' + message;
+
+	// If we're editing a Page, Post or Custom Post Type in Gutenberg, use wp.data.dispatch to show the error.
+	if ( typeof wp !== 'undefined' && typeof wp.blocks !== 'undefined' ) {
+		// Gutenberg Editor.
+		wp.data.dispatch( 'core/notices' ).createErrorNotice(
+			message,
+			{
+				id: 'convertkit-error'
+			}
+		);
+
+		return;
+	}
+
+	// Classic Editor or WP_List_Table (Bulk/Quick edit).
 	( function( $ ) {
 
 		// Show a WordPress style error notice.

--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -126,7 +126,7 @@ function convertKitRefreshResourcesRemoveNotices() {
 		return;
 	}
 
-	// Classic Editor or WP_List_Table (Bulk/Quick edit).
+	// Classic Editor, WP_List_Table (Bulk/Quick edit) or Edit Term.
 	( function( $ ) {
 
 		$( 'div.convertkit-error' ).remove();
@@ -161,11 +161,17 @@ function convertKitRefreshResourcesOutputErrorNotice( message ) {
 		return;
 	}
 
-	// Classic Editor or WP_List_Table (Bulk/Quick edit).
+	// Classic Editor, WP_List_Table (Bulk/Quick edit) or Edit Term.
 	( function( $ ) {
 
-		// Show a WordPress style error notice.
-		$( 'hr.wp-header-end' ).after( '<div id="message" class="error convertkit-error notice is-dismissible"><p>' + message + '</p></div>' );
+		var notice = '<div id="message" class="error convertkit-error notice is-dismissible"><p>' + message + '</p></div>';
+
+		// Append the WordPress style error notice, depending on the screen.
+		if ( $( 'hr.wp-header-end' ).length > 0 ) {
+			$( 'hr.wp-header-end' ).after( notice );
+		} else if ( $( '#ajax-response' ).length > 0 ) {
+			$( '#ajax-response' ).after( notice );
+		}
 
 		// Notify WordPress that a new dismissible notification exists, triggering WordPress' makeNoticesDismissible() function,
 		// which adds a dismiss button and binds necessary events to hide the notification.

--- a/tests/acceptance/general/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/general/RefreshResourcesButtonCest.php
@@ -191,13 +191,93 @@ class RefreshResourcesButtonCest
 
 	/**
 	 * Test that the refresh button triggers an error message when the AJAX request fails,
-	 * or the ConvertKit API returns an error.
+	 * or the ConvertKit API returns an error, when adding a Page using the Gutenberg editor.
 	 * 
 	 * @since 	1.9.8.3
 	 * 
 	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testRefreshResourcesErrorNotice(AcceptanceTester $I)
+	public function testRefreshResourcesErrorNoticeOnPage(AcceptanceTester $I)
+	{
+		// Navigate to Pages > Add New
+		$I->amOnAdminPage('post-new.php?post_type=page');
+
+		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
+		$I->maybeCloseGutenbergWelcomeModal($I);
+
+		// Specify invalid API credentials, so that the AJAX request returns an error.
+		$I->haveOptionInDatabase('_wp_convertkit_settings', [
+			'api_key'    => 'fakeApiKey',
+			'api_secret' => 'fakeApiSecret',
+			'debug'      => 'on',
+			'no_scripts' => '',
+			'no_css'     => '',
+		]);
+
+		// Click the Forms refresh button.
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
+
+		// Confirm that an error notification is displayed on screen, with the expected error message.
+
+		$I->seeElementInDOM('div.components-notice-list div.is-error');
+		$I->see('Authorization Failed: API Key not valid');
+
+		// Confirm that the notice is dismissible.
+		$I->click('div.components-notice-list div.is-error button.components-notice__dismiss');
+		$I->wait(1);
+		$I->dontSeeElementInDOM('div.components-notice-list div.is-error');
+	}
+
+	/**
+	 * Test that the refresh button triggers an error message when the AJAX request fails,
+	 * or the ConvertKit API returns an error, when adding a Page using the Classic Editor.
+	 * 
+	 * @since 	1.9.8.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testRefreshResourcesErrorNoticeOnPageClassicEditor(AcceptanceTester $I)
+	{
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Refresh Resources: Classic Editor' );
+
+		// Specify invalid API credentials, so that the AJAX request returns an error.
+		$I->haveOptionInDatabase('_wp_convertkit_settings', [
+			'api_key'    => 'fakeApiKey',
+			'api_secret' => 'fakeApiSecret',
+			'debug'      => 'on',
+			'no_scripts' => '',
+			'no_css'     => '',
+		]);
+
+		// Click the Forms refresh button.
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
+
+		// Confirm that an error notification is displayed on screen, with the expected error message.
+		$I->seeElementInDOM('div.convertkit-error');
+		$I->see('Authorization Failed: API Key not valid');
+
+		// Confirm that the notice is dismissible.
+		$I->click('div.convertkit-error button.notice-dismiss');
+		$I->wait(1);
+		$I->dontSeeElementInDOM('div.convertkit-error');
+	}
+
+	/**
+	 * Test that the refresh button triggers an error message when the AJAX request fails,
+	 * or the ConvertKit API returns an error, when using the Quick Edit functionality.
+	 * 
+	 * @since 	1.9.8.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testRefreshResourcesErrorNoticeOnQuickEdit(AcceptanceTester $I)
 	{
 		// Specify invalid API credentials, so that the AJAX request returns an error.
 		$I->haveOptionInDatabase('_wp_convertkit_settings', [
@@ -234,6 +314,98 @@ class RefreshResourcesButtonCest
 	}
 
 	/**
+	 * Test that the refresh button triggers an error message when the AJAX request fails,
+	 * or the ConvertKit API returns an error, when using the Bulk Edit functionality.
+	 * 
+	 * @since 	1.9.8.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testRefreshResourcesErrorNoticeOnBulkEdit(AcceptanceTester $I)
+	{
+		// Specify invalid API credentials, so that the AJAX request returns an error.
+		$I->haveOptionInDatabase('_wp_convertkit_settings', [
+			'api_key'    => 'fakeApiKey',
+			'api_secret' => 'fakeApiSecret',
+			'debug'      => 'on',
+			'no_scripts' => '',
+			'no_css'     => '',
+		]);
+
+		// Programmatically create two Pages.
+		$pageIDs = array(
+			$I->havePostInDatabase([
+				'post_type' 	=> 'page',
+				'post_title' 	=> 'ConvertKit: Page: Refresh Resources: Bulk Edit #1',
+			]),
+			$I->havePostInDatabase([
+				'post_type' 	=> 'page',
+				'post_title' 	=> 'ConvertKit: Page: Refresh Resources: Bulk Edit #2',
+			])
+		);
+
+		// Open Bulk Edit form for the Pages in the Pages WP_List_Table.
+		$I->openBulkEdit($I, 'page', $pageIDs);
+
+		// Click the Forms refresh button.
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
+
+		// Confirm that an error notification is displayed on screen, with the expected error message.
+		$I->seeElementInDOM('div.convertkit-error');
+		$I->see('Authorization Failed: API Key not valid');
+
+		// Confirm that the notice is dismissible.
+		$I->click('div.convertkit-error button.notice-dismiss');
+		$I->wait(1);
+		$I->dontSeeElementInDOM('div.convertkit-error');
+	}
+
+	/**
+	 * Test that the refresh button triggers an error message when the AJAX request fails,
+	 * or the ConvertKit API returns an error, when editing a Category.
+	 * 
+	 * @since 	1.9.8.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testRefreshResourcesErrorNoticeOnCategory(AcceptanceTester $I)
+	{
+		// Specify invalid API credentials, so that the AJAX request returns an error.
+		$I->haveOptionInDatabase('_wp_convertkit_settings', [
+			'api_key'    => 'fakeApiKey',
+			'api_secret' => 'fakeApiSecret',
+			'debug'      => 'on',
+			'no_scripts' => '',
+			'no_css'     => '',
+		]);
+
+		// Create Category.
+		$termID = $I->haveTermInDatabase( 'ConvertKit Refresh Resources', 'category' );
+		$termID = $termID[0];
+
+		// Edit the Term.
+		$I->amOnAdminPage('term.php?taxonomy=category&tag_ID=' . $termID);
+
+		// Click the Forms refresh button.
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
+
+		// Confirm that an error notification is displayed on screen, with the expected error message.
+		$I->seeElementInDOM('div.convertkit-error');
+		$I->see('Authorization Failed: API Key not valid');
+
+		// Confirm that the notice is dismissible.
+		$I->click('div.convertkit-error button.notice-dismiss');
+		$I->wait(1);
+		$I->dontSeeElementInDOM('div.convertkit-error');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
@@ -244,6 +416,7 @@ class RefreshResourcesButtonCest
 	 */
 	public function _passed(AcceptanceTester $I)
 	{
+		$I->deactivateThirdPartyPlugin($I, 'classic-editor');
 		$I->deactivateConvertKitPlugin($I);
 		$I->resetConvertKitPlugin($I);
 	}


### PR DESCRIPTION
## Summary

Extends work done on the [error notification for refresh resources](https://github.com/ConvertKit/convertkit-wordpress/pull/344), to include coverage for displaying an error notification when refreshing resource call returns an error across:
- Adding/editing a Page, Post or Custom Post Type in the Gutenberg editor
![Screenshot 2022-08-15 at 16 25 03](https://user-images.githubusercontent.com/1462305/184664744-4b8246d2-0f3c-4d91-8af0-1d95c77f1b18.png)

- Adding/editing a Page, Post or Custom Post Type in the Classic Editor
![Screenshot 2022-08-15 at 16 25 52](https://user-images.githubusercontent.com/1462305/184664861-2eea24e8-81d3-4105-b816-f125894645f0.png)

- Editing a Category
![Screenshot 2022-08-15 at 16 24 46](https://user-images.githubusercontent.com/1462305/184664730-e757fe5d-86de-437c-9498-6874f8f20447.png)


## Testing

- `RefreshResourcesButtonCest:testRefreshResourcesErrorNoticeOnPage`: Tests that a dismissible error notification is displayed when adding/editing a Page in Gutenberg, and the refresh resource button returns an error
- `RefreshResourcesButtonCest:testRefreshResourcesErrorNoticeOnPageClassicEditor`: Tests that a dismissible error notification is displayed when adding/editing a Page in the Classic Editor, and the refresh resource button returns an error
- `RefreshResourcesButtonCest:testRefreshResourcesErrorNoticeOnCategory`: Tests that a dismissible error notification is displayed when editing a Category, and the refresh resource button returns an error


## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)