### PR TITLE
Determine if WP_Debug_Data class can be used for System Info

### DIFF
--- a/admin/section/class-convertkit-settings-tools.php
+++ b/admin/section/class-convertkit-settings-tools.php
@@ -121,11 +121,8 @@ class ConvertKit_Settings_Tools extends ConvertKit_Settings_Base {
 			return;
 		}
 
-		// Use WordPress' debug_data() function to get system info, matching how Tools > Site Health > Info works.
-		if ( ! class_exists( 'WP_Debug_Data' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/class-wp-debug-data.php';
-		}
-		$system_info = str_replace( '`', '', WP_Debug_Data::format( WP_Debug_Data::debug_data(), 'debug' ) );
+		// Get System Info.
+		$system_info = $this->get_system_info();
 
 		// Write contents to temporary file.
 		$tmpfile  = tmpfile();
@@ -293,14 +290,9 @@ class ConvertKit_Settings_Tools extends ConvertKit_Settings_Base {
 	 */
 	public function render() {
 
-		// Get Log.
-		$log = new ConvertKit_Log( CONVERTKIT_PLUGIN_PATH );
-
-		// Use WordPress' debug_data() function to get system info, matching how Tools > Site Health > Info works.
-		if ( ! class_exists( 'WP_Debug_Data' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/class-wp-debug-data.php';
-		}
-		$system_info = str_replace( '`', '', WP_Debug_Data::format( WP_Debug_Data::debug_data(), 'debug' ) );
+		// Get Log and System Info.
+		$log         = new ConvertKit_Log( CONVERTKIT_PLUGIN_PATH );
+		$system_info = $this->get_system_info();
 
 		// Define messages that might be displayed as a notification.
 		$messages = array(
@@ -328,9 +320,33 @@ class ConvertKit_Settings_Tools extends ConvertKit_Settings_Base {
 	 * Prints help info for this section
 	 */
 	public function print_section_info() {
+
 		?>
 		<p><?php esc_html_e( 'Tools to help you manage ConvertKit on your site.', 'convertkit' ); ?></p>
 		<?php
+
+	}
+
+	/**
+	 * Returns a string comprising of the WordPress system information, with Plugin information
+	 * prepended.
+	 *
+	 * @since   1.9.8.3
+	 */
+	private function get_system_info() {
+
+		// If we're using WordPress < 5.2, there's no WP_Debug_Data class to fetch system information from.
+		if ( version_compare( get_bloginfo( 'version' ), '5.2', '<' ) ) {
+			return __( 'WordPress 5.2 or higher is required for system information report.', 'convertkit' );
+		}
+
+		// Use WordPress' debug_data() function to get system info, matching how Tools > Site Health > Info works.
+		if ( ! class_exists( 'WP_Debug_Data' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/class-wp-debug-data.php';
+		}
+
+		return str_replace( '`', '', WP_Debug_Data::format( WP_Debug_Data::debug_data(), 'debug' ) );
+
 	}
 
 }


### PR DESCRIPTION
## Summary

Building on [this PR](https://github.com/ConvertKit/convertkit-wordpress/pull/348), checks if the user is running WordPress 5.2 or greater, which is required to make use of WordPress' WP_Debug_Data class for building out the System Info.

If the user is running WordPress 5.0 or 5.1, they'll instead see this message, both in the `Settings > ConvertKit > Tools` screen and if they click the `Download system info` button:
![Screenshot 2022-08-15 at 17 33 53](https://user-images.githubusercontent.com/1462305/184676504-261fd767-c139-47d5-9be2-bdbb6637dd65.png)

We could re-include the old method for building System Info to support WordPress 5.0 and 5.1, as our Plugin does list itself as supporting WordPress 5.0 or higher.  However, [WordPress' statistics](https://en-gb.wordpress.org/about/stats/) indicate only ~ 2.31% of sites are using 5.0 or 5.1, and I'd prefer not to include older libraries in our code, unless there's a strong case to do so.

There's also an option of bumping the minimum required WordPress version for the Plugin to 5.2, but given that the rest of the Plugin works with 5.0 and 5.1, I don't want to unnecessarily prevent site owners from installing or updating to future versions of the Plugin.  The above statistics are for WordPress in general, so I don't know how many of our ~ 40,000 active installations are on WordPress 5.0 or 5.1.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)