### PR TITLE
Setup Wizard for Plugin

### DIFF
--- a/admin/class-convertkit-admin-setup-wizard.php
+++ b/admin/class-convertkit-admin-setup-wizard.php
@@ -155,9 +155,10 @@ class ConvertKit_Admin_Setup_Wizard {
 			return;
 		}
 
-		// Bail if the user doesn't have the required capability to access this setup wizard.
+		// Redirect back to the Dashboard if the user doesn't have the required capability to access this setup wizard.
 		if ( ! $this->user_has_access() ) {
-			return;
+			wp_safe_redirect( admin_url( 'index.php' ) );
+			exit;
 		}
 
 		// Define current screen, so that calls to get_current_screen() tell Plugins which screen is loaded.

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php
@@ -234,14 +234,16 @@ class ConvertKit_Admin_Setup_Wizard_Plugin extends ConvertKit_Admin_Setup_Wizard
 
 				// If no Forms exist in ConvertKit, change the next button label and make it a link to reload
 				// the screen.
-				$this->steps[3]['next_button']['label'] = __( 'I\'ve created a form in ConvertKit', 'convertkit' );
-				$this->steps[3]['next_button']['link']  = add_query_arg(
-					array(
-						'page' => $this->page_name,
-						'step' => 3,
-					),
-					admin_url( 'index.php' )
-				);
+				if ( ! $this->forms->exist() ) {
+					$this->steps[3]['next_button']['label'] = __( 'I\'ve created a form in ConvertKit', 'convertkit' );
+					$this->steps[3]['next_button']['link']  = add_query_arg(
+						array(
+							'page' => $this->page_name,
+							'step' => 3,
+						),
+						admin_url( 'index.php' )
+					);
+				}
 
 				// Fetch a Post and a Page, appending the preview nonce to their URLs.
 				$this->preview_nonce = wp_create_nonce( 'convertkit-preview-form' );

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php
@@ -139,6 +139,11 @@ class ConvertKit_Admin_Setup_Wizard_Plugin extends ConvertKit_Admin_Setup_Wizard
 		// Delete the transient, so we don't redirect again.
 		delete_transient( $this->page_name );
 
+		// Bail if the user doesn't have access.
+		if ( ! $this->user_has_access() ) {
+			return;
+		}
+
 		// Check if any settings exist.
 		// If they do, the Plugin has already been setup, so no need to show the setup screen.
 		$settings = new ConvertKit_Settings();

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php
@@ -1,0 +1,288 @@
+<?php
+/**
+ * ConvertKit Admin Setup Wizard class.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Provides a UI for setting up the ConvertKit Plugin when activated for the
+ * first time.
+ *
+ * If the Plugin has previously been configured (i.e. settings exist in the database),
+ * this UI isn't triggered on activation.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+class ConvertKit_Admin_Setup_Wizard_Plugin extends ConvertKit_Admin_Setup_Wizard {
+
+	/**
+	 * Holds the ConvertKit Forms resource class.
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @var     bool|ConvertKit_Resource_Forms
+	 */
+	public $forms = false;
+
+	/**
+	 * Holds the ConvertKit Settings class.
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @var     bool|ConvertKit_Settings
+	 */
+	public $settings = false;
+
+	/**
+	 * Holds the nonce for validating a frontend preview request.
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @var     bool|string
+	 */
+	public $preview_nonce = false;
+
+	/**
+	 * Holds the URL to the most recent WordPress Post, used when previewing a Form below a Post
+	 * on the frontend site.
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @var     bool|string
+	 */
+	public $preview_post_url = false;
+
+	/**
+	 * Holds the URL to the most recent WordPress Page, used when previewing a Form below a Page
+	 * on the frontend site.
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @var     bool|string
+	 */
+	public $preview_page_url = false;
+
+	/**
+	 * The programmatic name for this wizard.
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @var     string
+	 */
+	public $page_name = 'convertkit-setup';
+
+	/**
+	 * The URL to take the user to when they click the Exit link.
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @var     string
+	 */
+	public $exit_url = 'options-general.php?page=_wp_convertkit_settings';
+
+	/**
+	 * Registers action and filter hooks.
+	 *
+	 * @since   1.9.8.5
+	 */
+	public function __construct() {
+
+		// Define details for each step in the setup process.
+		$this->steps = array(
+			1 => array(
+				'name' => __( 'Setup', 'convertkit' ),
+			),
+			2 => array(
+				'name'        => __( 'Connect Account', 'convertkit' ),
+				'next_button' => array(
+					'label' => __( 'Connect', 'convertkit' ),
+				),
+			),
+			3 => array(
+				'name'        => __( 'Form Configuration', 'convertkit' ),
+				'next_button' => array(
+					'label' => __( 'Finish Setup', 'convertkit' ),
+				),
+			),
+			4 => array(
+				'name' => __( 'Done', 'convertkit' ),
+			),
+		);
+
+		add_action( 'admin_init', array( $this, 'maybe_redirect_to_setup_screen' ), 9999 );
+		add_action( 'convertkit_admin_setup_wizard_process_form_convertkit-setup', array( $this, 'process_form' ) );
+		add_action( 'convertkit_admin_setup_wizard_load_screen_data_convertkit-setup', array( $this, 'load_screen_data' ) );
+
+		// Call parent class constructor.
+		parent::__construct();
+
+	}
+
+	/**
+	 * Redirects to the setup screen if a transient was created on Plugin activation,
+	 * and the Plugin has no API Key and Secret configured.
+	 *
+	 * @since   1.9.8.5
+	 */
+	public function maybe_redirect_to_setup_screen() {
+
+		// If no transient was set by the Plugin's activation routine, don't redirect to the setup screen.
+		// This transient will only exist for 30 seconds by design, so we don't hijack a later WordPress
+		// Admin screen request.
+		if ( ! get_transient( $this->page_name ) ) {
+			return;
+		}
+
+		// Delete the transient, so we don't redirect again.
+		delete_transient( $this->page_name );
+
+		// Check if any settings exist.
+		// If they do, the Plugin has already been setup, so no need to show the setup screen.
+		$settings = new ConvertKit_Settings();
+		if ( $settings->has_api_key_and_secret() ) {
+			return;
+		}
+
+		// Show the setup screen.
+		wp_safe_redirect( admin_url( 'index.php?page=' . $this->page_name ) );
+		exit;
+
+	}
+
+	/**
+	 * Process posted data from the submitted form.
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @param   int $step   Current step.
+	 */
+	public function process_form( $step ) {
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing
+		// Nonce verification has been performed in ConvertKit_Admin_Setup_Wizard:process_form(), prior to calling this function.
+
+		// Depending on the step, process the form data.
+		switch ( $step ) {
+			case 3:
+				// Check that the API Key and Secret work.
+				$api_key    = sanitize_text_field( wp_unslash( $_POST['api_key'] ) );
+				$api_secret = sanitize_text_field( wp_unslash( $_POST['api_secret'] ) );
+
+				$api    = new ConvertKit_API( $api_key, $api_secret );
+				$result = $api->account();
+
+				// Show an error message if Account Details could not be fetched e.g. API credentials supplied are invalid.
+				if ( is_wp_error( $result ) ) {
+					// Decrement the step.
+					$this->step  = ( $this->step - 1 );
+					$this->error = $result->get_error_message();
+					return;
+				}
+
+				// If here, API credentials are valid.
+				// Save them.
+				$settings = new ConvertKit_Settings();
+				$settings->save(
+					array(
+						'api_key'    => $api_key,
+						'api_secret' => $api_secret,
+					)
+				);
+				break;
+
+			case 4:
+				// Save Default Page and Post Form settings.
+				$settings = new ConvertKit_Settings();
+				$settings->save(
+					array(
+						'post_form' => sanitize_text_field( $_POST['post_form'] ),
+						'page_form' => sanitize_text_field( $_POST['page_form'] ),
+					)
+				);
+				break;
+		}
+
+		// phpcs:enable
+
+	}
+
+	/**
+	 * Load any data into class variables for the given setup wizard name and current step.
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @param   int $step   Current step.
+	 */
+	public function load_screen_data( $step ) {
+
+		switch ( $step ) {
+			case 2:
+				// Load settings class.
+				$this->settings = new ConvertKit_Settings();
+				break;
+
+			case 3:
+				// Re-load settings class now that the API Key and Secret has been defined.
+				$this->settings = new ConvertKit_Settings();
+
+				// Fetch Forms.
+				$this->forms = new ConvertKit_Resource_Forms();
+				$this->forms->refresh();
+
+				// Fetch a Post and a Page, appending the preview nonce to their URLs.
+				$this->preview_nonce = wp_create_nonce( 'convertkit-preview-form' );
+
+				$this->preview_post_url = add_query_arg(
+					array(
+						'convertkit-preview-nonce' => $this->preview_nonce,
+					),
+					get_permalink( $this->get_most_recent( 'post' ) )
+				);
+
+				$this->preview_page_url = add_query_arg(
+					array(
+						'convertkit-preview-nonce' => $this->preview_nonce,
+					),
+					get_permalink( $this->get_most_recent( 'page' ) )
+				);
+				break;
+		}
+
+	}
+
+	/**
+	 * Returns the most recent published Post ID.
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @param   string $post_type  Post Type.
+	 * @return  false|int           Post ID
+	 */
+	private function get_most_recent( $post_type = 'post' ) {
+
+		// Run query.
+		$query = new WP_Query(
+			array(
+				'post_type'      => $post_type,
+				'post_status'    => 'publish',
+				'posts_per_page' => 1,
+				'orderby'        => 'date',
+				'order'          => 'DESC',
+				'fields'         => 'ids',
+			)
+		);
+
+		// Return false if no Posts exist for the given type.
+		if ( empty( $query->posts ) ) {
+			return false;
+		}
+
+		// Return the Post ID.
+		return $query->posts[0];
+
+	}
+
+}

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php
@@ -232,8 +232,16 @@ class ConvertKit_Admin_Setup_Wizard_Plugin extends ConvertKit_Admin_Setup_Wizard
 				$this->forms = new ConvertKit_Resource_Forms();
 				$this->forms->refresh();
 
-				// If no Forms exist in ConvertKit, change the next button label.
+				// If no Forms exist in ConvertKit, change the next button label and make it a link to reload
+				// the screen.
 				$this->steps[3]['next_button']['label'] = __( 'I\'ve created a form in ConvertKit', 'convertkit' );
+				$this->steps[3]['next_button']['link']  = add_query_arg(
+					array(
+						'page' => $this->page_name,
+						'step' => 3,
+					),
+					admin_url( 'index.php' )
+				);
 
 				// Fetch a Post and a Page, appending the preview nonce to their URLs.
 				$this->preview_nonce = wp_create_nonce( 'convertkit-preview-form' );

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php
@@ -232,6 +232,9 @@ class ConvertKit_Admin_Setup_Wizard_Plugin extends ConvertKit_Admin_Setup_Wizard
 				$this->forms = new ConvertKit_Resource_Forms();
 				$this->forms->refresh();
 
+				// If no Forms exist in ConvertKit, change the next button label.
+				$this->steps[3]['next_button']['label'] = __( 'I\'ve created a form in ConvertKit', 'convertkit' );
+
 				// Fetch a Post and a Page, appending the preview nonce to their URLs.
 				$this->preview_nonce = wp_create_nonce( 'convertkit-preview-form' );
 

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php
@@ -253,19 +253,25 @@ class ConvertKit_Admin_Setup_Wizard_Plugin extends ConvertKit_Admin_Setup_Wizard
 				// Fetch a Post and a Page, appending the preview nonce to their URLs.
 				$this->preview_nonce = wp_create_nonce( 'convertkit-preview-form' );
 
-				$this->preview_post_url = add_query_arg(
-					array(
-						'convertkit-preview-nonce' => $this->preview_nonce,
-					),
-					get_permalink( $this->get_most_recent( 'post' ) )
-				);
+				$post_id = $this->get_most_recent( 'post' );
+				if ( $post_id ) {
+					$this->preview_post_url = add_query_arg(
+						array(
+							'convertkit-preview-nonce' => $this->preview_nonce,
+						),
+						get_permalink( $post_id )
+					);
+				}
 
-				$this->preview_page_url = add_query_arg(
-					array(
-						'convertkit-preview-nonce' => $this->preview_nonce,
-					),
-					get_permalink( $this->get_most_recent( 'page' ) )
-				);
+				$page_id = $this->get_most_recent( 'page' );
+				if ( $page_id ) {
+					$this->preview_page_url = add_query_arg(
+						array(
+							'convertkit-preview-nonce' => $this->preview_nonce,
+						),
+						get_permalink( $page_id )
+					);
+				}
 				break;
 		}
 

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -64,14 +64,15 @@ class WP_ConvertKit {
 			return;
 		}
 
-		$this->classes['admin_bulk_edit']         = new ConvertKit_Admin_Bulk_Edit();
-		$this->classes['admin_category']          = new ConvertKit_Admin_Category();
-		$this->classes['admin_post']              = new ConvertKit_Admin_Post();
-		$this->classes['admin_quick_edit']        = new ConvertKit_Admin_Quick_Edit();
-		$this->classes['admin_refresh_resources'] = new ConvertKit_Admin_Refresh_Resources();
-		$this->classes['admin_settings']          = new ConvertKit_Admin_Settings();
-		$this->classes['admin_tinymce']           = new ConvertKit_Admin_TinyMCE();
-		$this->classes['admin_user']              = new ConvertKit_Admin_User();
+		$this->classes['admin_bulk_edit']           = new ConvertKit_Admin_Bulk_Edit();
+		$this->classes['admin_category']            = new ConvertKit_Admin_Category();
+		$this->classes['admin_post']                = new ConvertKit_Admin_Post();
+		$this->classes['admin_quick_edit']          = new ConvertKit_Admin_Quick_Edit();
+		$this->classes['admin_refresh_resources']   = new ConvertKit_Admin_Refresh_Resources();
+		$this->classes['admin_settings']            = new ConvertKit_Admin_Settings();
+		$this->classes['admin_setup_wizard_plugin'] = new ConvertKit_Admin_Setup_Wizard_Plugin();
+		$this->classes['admin_tinymce']             = new ConvertKit_Admin_TinyMCE();
+		$this->classes['admin_user']                = new ConvertKit_Admin_User();
 
 		/**
 		 * Initialize integration classes for the WordPress Administration interface.
@@ -136,7 +137,8 @@ class WP_ConvertKit {
 			return;
 		}
 
-		$this->classes['output'] = new ConvertKit_Output();
+		$this->classes['output']              = new ConvertKit_Output();
+		$this->classes['setup_wizard_plugin'] = new ConvertKit_Setup_Wizard_Plugin();
 
 		/**
 		 * Initialize integration classes for the frontend web site.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -22,6 +22,9 @@ function convertkit_plugin_activate( $network_wide ) {
 	if ( ! is_multisite() || ! $network_wide ) {
 		// Single Site activation.
 		$convertkit->get_class( 'setup' )->activate();
+
+		// Set a transient for 30 seconds to redirect to the setup screen on activation.
+		set_transient( 'convertkit-setup', true, 30 );
 	} else {
 		// Multisite network wide activation.
 		$sites = get_sites(

--- a/includes/setup-wizard/class-convertkit-setup-wizard-plugin.php
+++ b/includes/setup-wizard/class-convertkit-setup-wizard-plugin.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * ConvertKit Setup Wizard Plugin class.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Handles previewing a supplied Form ID in the URL when viewing a Page or Post,
+ * when the user clicks a preview link in the Plugin Setup Wizard.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+class ConvertKit_Setup_Wizard_Plugin {
+
+	/**
+	 * Registers action and filter hooks.
+	 *
+	 * @since   1.9.8.5
+	 */
+	public function __construct() {
+
+		add_filter( 'convertkit_output_append_form_to_content_form_id', array( $this, 'preview_form' ), 99999 );
+
+	}
+
+	/**
+	 * Changes the form to display for the given Post ID if the request is
+	 * from a logged in user who has clicked a preview link in the Plugin Setup Wizard.
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @param   int $form_id    ConvertKit Form ID.
+	 * @return  int                 ConvertKit Form ID
+	 */
+	public function preview_form( $form_id ) {
+
+		// Bail if the user isn't logged in.
+		if ( ! is_user_logged_in() ) {
+			return $form_id;
+		}
+
+		// Bail if no nonce field exists.
+		if ( ! isset( $_REQUEST['convertkit-preview-nonce'] ) ) {
+			return $form_id;
+		}
+
+		// Bail if the nonce verification fails.
+		if ( ! wp_verify_nonce( sanitize_key( wp_unslash( $_REQUEST['convertkit-preview-nonce'] ) ), 'convertkit-preview-form' ) ) {
+			return $form_id;
+		}
+
+		// Determine the form to preview.
+		$preview_form_id = (int) ( isset( $_REQUEST['convertkit_form_id'] ) ? sanitize_text_field( $_REQUEST['convertkit_form_id'] ) : 0 );
+
+		// Return.
+		return $preview_form_id;
+
+	}
+
+}

--- a/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
+++ b/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
@@ -26,6 +26,10 @@ class ThirdPartyPlugin extends \Codeception\Module
 		// Activate the Plugin.
 		$I->activatePlugin($name);
 
+		// Go to the Plugins screen again; this prevents any Plugin that loads a wizard-style screen from
+		// causing seePluginActivated() to fail.
+		$I->amOnPluginsPage();
+
 		// Check that the Plugin activated successfully.
 		$I->seePluginActivated($name);
 

--- a/tests/acceptance/general/PluginSetupWizardCest.php
+++ b/tests/acceptance/general/PluginSetupWizardCest.php
@@ -329,9 +329,34 @@ class PluginSetupWizardCest
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-posts-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
 	}
 
+	/**
+	 * Test that the Setup Wizard > Form Configuration screen does not display preview links
+	 * when no Pages and Posts exist in WordPress.
+	 *
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
 	public function testSetupWizardFormConfigurationScreenWhenNoPostsOrPagesExist(AcceptanceTester $I)
 	{
+		// Activate Plugin.
+		$this->_activatePlugin($I);
 
+		// Define Plugin settings.
+		$I->haveOptionInDatabase('_wp_convertkit_settings', [
+			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+		]);
+
+		// Load Step 3/4.
+		$I->amOnAdminPage('index.php?page=convertkit-setup&step=3');
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen($I, 3, 'Display an email capture form');
+
+		// Confirm no Page or Post preview links exist, because there are no Pages or Posts in WordPress.
+		$I->dontSeeElementInDOM('a#convertkit-preview-form-post');
+		$I->dontSeeElementInDOM('a#convertkit-preview-form-page');
 	}
 
 	/**

--- a/tests/acceptance/general/PluginSetupWizardCest.php
+++ b/tests/acceptance/general/PluginSetupWizardCest.php
@@ -300,7 +300,7 @@ class PluginSetupWizardCest
 		$this->_seeExpectedSetupWizardScreen($I, 3, 'Create your first ConvertKit Form');
 
 		// Confirm button link to create a form on ConvertKit is correct.
-		$I->seeInSource('<a href="https://app.convertkit.com/forms/new?format=inline" target="_blank" class="button button-primary">Create form</a>');
+		$I->seeInSource('<a href="https://app.convertkit.com/forms/new?format=inline"');
 
 		// Define Plugin settings with a ConvertKit account containing forms,
 		// as if we created a form in ConvertKit.

--- a/tests/acceptance/general/PluginSetupWizardCest.php
+++ b/tests/acceptance/general/PluginSetupWizardCest.php
@@ -15,7 +15,7 @@ class PluginSetupWizardCest
 		$this->_activatePlugin($I);
 
 		// Confirm setup wizard is displayed.
-
+		$I->see('Welcome to the ConvertKit Setup Wizard');
 	}
 
 	/**
@@ -41,64 +41,224 @@ class PluginSetupWizardCest
 		$this->_activatePlugin($I);
 
 		// Confirm setup wizard does not display.
-
+		$I->dontSee('Welcome to the ConvertKit Setup Wizard');
 	}
 
 	/**
-	 * Tests each screen on the Setup Wizard, covering:
-	 * - expected buttons and text are displayed,
-	 * - buttons link to expected locations,
-	 * - completed steps are marked as completed,
-	 * - next / back buttons are / are not displayed as necessary,
-	 * - configuration or misconfiguration results in expected outcomes.
+	 * Test that the Setup Wizard exit link works.
 	 * 
 	 * @since 	1.9.8.5
 	 * 
 	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testSetupWizardScreens(AcceptanceTester $I)
+	public function testSetupWizardExitLink(AcceptanceTester $I)
 	{
-		/**
-		 * Setup
-		 */
-		// Test Register and Connect buttons.
+		// Activate Plugin.
+		$this->_activatePlugin($I);
 
-		// Test Exit wizard link.
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
 
-		/**
-		 * Connect Account
-		 */
-		// Confirm expected buttons display.
+		// Click Exit wizard link.
+		$I->click('Exit wizard');
 
-		// Confirm Exit wizard link displays.
+		// Confirm exit.
+		$I->acceptPopup();
 
-		// Check click here links work.
+		// Confirm Plugin settings screen loaded.
+		$I->seeInCurrentUrl('options-general.php?page=_wp_convertkit_settings');
 
-		// Test invalid API credentials.
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+	}
 
-		// Test valid API credentials.
+	/**
+	 * Test that the Setup Wizard > Setup > Register button works.
+	 *
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testSetupWizardSetupScreenRegisterButton(AcceptanceTester $I)
+	{
+		// Activate Plugin.
+		$this->_activatePlugin($I);
 
-		/**
-		 * Form Configuration
-		 */
-		// Confirm expected buttons display.
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
 
-		// Confirm Exit wizard link displays.
+		// Test Register button opens a new tab.
+		$I->click('Register');
+		$I->wait(2); // Required, otherwise switchToNextTab fails.
+		$I->switchToNextTab();
+		$I->seeInCurrentUrl('users/signup?utm_source=wordpress&utm_content=convertkit');
 
-		// Select a Form for Posts, and confirm the preview link displays the selected Form.
+		// Close newly opened tab from above button.
+		$I->closeTab();
 
-		// Select a Form for Pages, and confirm the preview link displays the selected Form.
-		
-		/**
-		 * Done
-		 */
-		// Confirm no next / back buttons display.
+		// Confirm that the original tab is now displaying the Connect Account screen.
+		$this->_seeExpectedSetupWizardScreen($I, 2, 'Connect your ConvertKit account');
+	}
 
-		// Confirm expected Dashboard and Plugin Settings buttons displayed.
+	/**
+	 * Test that the Setup Wizard > Setup > Connect button works.
+	 *
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testSetupWizardSetupScreenConnectButton(AcceptanceTester $I)
+	{
+		// Activate Plugin.
+		$this->_activatePlugin($I);
 
-		// Check settings stored in database.
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
 
-			
+		// Test Connect button
+		$I->click('Connect');
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen($I, 2, 'Connect your ConvertKit account');
+	}
+
+	/**
+	 * Test that the Setup Wizard > Connect Account screen works as expected when valid API credentials
+	 * are specified.
+	 *
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testSetupWizardConnectAccountScreen(AcceptanceTester $I)
+	{
+		// Activate Plugin.
+		$this->_activatePlugin($I);
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
+
+		// Test Connect button
+		$I->click('Connect');
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen($I, 2, 'Connect your ConvertKit account');
+
+		// Fill fields with invalid API Keys.
+		$I->fillField('api_key', $_ENV['CONVERTKIT_API_KEY']);
+		$I->fillField('api_secret', $_ENV['CONVERTKIT_API_SECRET']);
+
+		// Click Connect button.
+		$I->click('Connect');
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen($I, 3, 'Display an email capture form');
+	}
+
+	/**
+	 * Test that the Setup Wizard > Connect Account screen works as expected when invalid API credentials
+	 * are specified.
+	 *
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testSetupWizardConnectAccountScreenWithInvalidAPICredentials(AcceptanceTester $I)
+	{
+		// Activate Plugin.
+		$this->_activatePlugin($I);
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
+
+		// Test Connect button
+		$I->click('Connect');
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen($I, 2, 'Connect your ConvertKit account');
+
+		// Fill fields with invalid API Keys.
+		$I->fillField('api_key', 'fakeApiKey');
+		$I->fillField('api_secret', 'fakeApiSecret');
+
+		// Click Connect button.
+		$I->click('Connect');
+
+		// Confirm expected setup wizard screen is still displayed.
+		$this->_seeExpectedSetupWizardScreen($I, 2, 'Connect your ConvertKit account');
+
+		// Confirm error notification is displayed.
+		$I->seeElement('div.notice.notice-error.is-dismissible');
+
+		// Dismiss notification.
+		$I->click('div.notice-error button.notice-dismiss');
+
+		// Confirm notification no longer displayed.
+		$I->wait(1);
+		$I->dontSeeElement('div.notice.notice-error.is-dismissible');
+	}
+
+	/**
+	 * Test that the Setup Wizard > Form Configuration screen works as expected.
+	 *
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testSetupWizardFormConfigurationScreen(AcceptanceTester $I)
+	{
+		// Activate Plugin.
+		$this->_activatePlugin($I);
+
+		// Define Plugin settings.
+		$I->haveOptionInDatabase('_wp_convertkit_settings', [
+			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+		]);
+
+		// Load Step 3/4.
+		$I->amOnAdminPage('index.php?page=convertkit-setup&step=3');
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen($I, 3, 'Display an email capture form');
+
+		// Select a Post Form.
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-posts-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+
+		// Open preview.
+		$I->click('a#convertkit-preview-form-post');
+		$I->wait(2); // Required, otherwise switchToNextTab fails.
+
+		// Switch to newly opened tab.
+		$I->switchToNextTab();
+
+		// Confirm expected Form is displayed.
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+
+		// Close newly opened tab.
+		$I->closeTab();
+
+		// Select a Page Form.
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-page-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+
+		// Open preview.
+		$I->click('a#convertkit-preview-form-page');
+		$I->wait(2); // Required, otherwise switchToNextTab fails.
+
+		// Switch to newly opened tab.
+		$I->switchToNextTab();
+
+		// Confirm expected Form is displayed.
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+
+		// Close newly opened tab.
+		$I->closeTab();
+
+		// Click Finish Setup button.
+		$I->click('Finish Setup');
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen($I, 4, 'Setup complete');
 	}
 
 	/**
@@ -116,7 +276,41 @@ class PluginSetupWizardCest
 	{
 		$I->loginAsAdmin();
 		$I->amOnPluginsPage();
-		$I->activatePlugin($name);
+		$I->activatePlugin('convertkit');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+	}
+
+	/**
+	 * Runs tests on a Setup Wizard screen, to confirm that the expected step, title and buttons
+	 * are displayed.
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 		Tester
+	 * @param 	int 				$step 	Current step
+	 * @param 	string 				$title 	Expected title
+	 */
+	private function _seeExpectedSetupWizardScreen(AcceptanceTester $I, $step, $title)
+	{
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm expected setup wizard screen loaded.
+		$I->seeInCurrentUrl('index.php?page=convertkit-setup');
+		
+		// Confirm expected title is displayed.
+		$I->see($title);
+
+		// Confirm current and previous steps are highlighted as 'done'.
+		// @TODO.
+
+		// Confirm Step text is correct.
+		$I->see('Step '.$step.' of 4');
+
+		// Depending on the step, confirm previous/next buttons exist with expected links.
+		// @TODO.
 	}
 
 	/**

--- a/tests/acceptance/general/PluginSetupWizardCest.php
+++ b/tests/acceptance/general/PluginSetupWizardCest.php
@@ -297,7 +297,7 @@ class PluginSetupWizardCest
 		$I->amOnAdminPage('index.php?page=convertkit-setup&step=3');
 
 		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen($I, 3, 'Create your first ConvertKit Form');
+		$this->_seeExpectedSetupWizardScreen($I, 3, 'Create your first ConvertKit Form', true);
 
 		// Confirm button link to create a form on ConvertKit is correct.
 		$I->seeInSource('<a href="https://app.convertkit.com/forms/new?format=inline"');
@@ -349,8 +349,9 @@ class PluginSetupWizardCest
 	 * @param 	AcceptanceTester 	$I 		Tester
 	 * @param 	int 				$step 	Current step
 	 * @param 	string 				$title 	Expected title
+	 * @param 	bool 				$nextButtonIsLink 	Check that next button is a link (false = must be a <button> element).
 	 */
-	private function _seeExpectedSetupWizardScreen(AcceptanceTester $I, $step, $title)
+	private function _seeExpectedSetupWizardScreen(AcceptanceTester $I, $step, $title, $nextButtonIsLink = false)
 	{
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -362,13 +363,42 @@ class PluginSetupWizardCest
 		$I->see($title);
 
 		// Confirm current and previous steps are highlighted as 'done'.
-		// @TODO.
+		for ($stepCount = 1; $stepCount <= $step; $stepCount++) {
+			$I->seeElement('li.step-'.$stepCount.'.done');
+		}
 
 		// Confirm Step text is correct.
 		$I->see('Step '.$step.' of 4');
 
-		// Depending on the step, confirm previous/next buttons exist with expected links.
-		// @TODO.
+		// Depending on the step, confirm previous/next buttons exist / do not exist.
+		switch ($step) {
+			/**
+			 * First and last step should not display any footer buttons.
+			 */
+			case 1:
+			case 4:
+				$I->dontSeeElementInDOM('#convertkit-setup-wizard-footer div.left a.button');
+				$I->dontSeeElementInDOM('#convertkit-setup-wizard-footer div.right button');
+				$I->dontSeeElementInDOM('#convertkit-setup-wizard-footer div.right a.button');
+				break;
+
+			/**
+			 * Middle steps should always display footer buttons.
+			 */
+			case 2:
+			case 3:
+				$I->seeElementInDOM('#convertkit-setup-wizard-footer div.left a.button');
+
+				if ($nextButtonIsLink) {
+					// Next button must be a link.
+					$I->seeElementInDOM('#convertkit-setup-wizard-footer div.right a.button');
+				} else {
+					// Next button must be a <button> element to submit form.
+					$I->seeElementInDOM('#convertkit-setup-wizard-footer div.right button');	
+				}
+				break;
+
+		}
 	}
 
 	/**

--- a/tests/acceptance/general/PluginSetupWizardCest.php
+++ b/tests/acceptance/general/PluginSetupWizardCest.php
@@ -1,0 +1,136 @@
+<?php
+
+class PluginSetupWizardCest
+{
+	/**
+	 * Test that the Setup Wizard displays when the Plugin is activated.
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testSetupWizardDisplays(AcceptanceTester $I)
+	{
+		// Activate Plugin.
+		$this->_activatePlugin($I);
+
+		// Confirm setup wizard is displayed.
+
+	}
+
+	/**
+	 * Test that the Setup Wizard displays when the Plugin is activated on a site
+	 * where the Plugin has previously been activated and configured with API Keys.
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testSetupWizardDoesNotDisplayWhenConfigured(AcceptanceTester $I)
+	{
+		// Define Plugin settings as if the Plugin were previously activated and configured.
+		$I->haveOptionInDatabase('_wp_convertkit_settings', [
+			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+			'debug'      => 'on',
+			'no_scripts' => '',
+			'no_css'     => '',
+		]);
+
+		// Activate Plugin.
+		$this->_activatePlugin($I);
+
+		// Confirm setup wizard does not display.
+
+	}
+
+	/**
+	 * Tests each screen on the Setup Wizard, covering:
+	 * - expected buttons and text are displayed,
+	 * - buttons link to expected locations,
+	 * - completed steps are marked as completed,
+	 * - next / back buttons are / are not displayed as necessary,
+	 * - configuration or misconfiguration results in expected outcomes.
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testSetupWizardScreens(AcceptanceTester $I)
+	{
+		/**
+		 * Setup
+		 */
+		// Test Register and Connect buttons.
+
+		// Test Exit wizard link.
+
+		/**
+		 * Connect Account
+		 */
+		// Confirm expected buttons display.
+
+		// Confirm Exit wizard link displays.
+
+		// Check click here links work.
+
+		// Test invalid API credentials.
+
+		// Test valid API credentials.
+
+		/**
+		 * Form Configuration
+		 */
+		// Confirm expected buttons display.
+
+		// Confirm Exit wizard link displays.
+
+		// Select a Form for Posts, and confirm the preview link displays the selected Form.
+
+		// Select a Form for Pages, and confirm the preview link displays the selected Form.
+		
+		/**
+		 * Done
+		 */
+		// Confirm no next / back buttons display.
+
+		// Confirm expected Dashboard and Plugin Settings buttons displayed.
+
+		// Check settings stored in database.
+
+			
+	}
+
+	/**
+	 * Activate the Plugin, without checking it is activated, so that its Setup Wizard
+	 * screen loads.
+	 * 
+	 * This differs from the activateConvertKitPlugin() method, which will ignore a Setup Wizard
+	 * screen by reloading the Plugins screen to confirm a Plugin's activation.
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	private function _activatePlugin(AcceptanceTester $I)
+	{
+		$I->loginAsAdmin();
+		$I->amOnPluginsPage();
+		$I->activatePlugin($name);
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
+	}
+}

--- a/tests/acceptance/general/PluginSetupWizardCest.php
+++ b/tests/acceptance/general/PluginSetupWizardCest.php
@@ -216,6 +216,18 @@ class PluginSetupWizardCest
 			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
 		]);
 
+		// Create a Page and a Post, so that preview links display.
+		$I->havePostInDatabase([
+			'post_title'	=> 'ConvertKit: Setup Wizard: Page',
+			'post_type'		=> 'page',
+			'post_status'	=> 'publish',
+		]);
+		$I->havePostInDatabase([
+			'post_title'	=> 'ConvertKit: Setup Wizard: Post',
+			'post_type'		=> 'post',
+			'post_status'	=> 'publish',
+		]);
+
 		// Load Step 3/4.
 		$I->amOnAdminPage('index.php?page=convertkit-setup&step=3');
 
@@ -233,8 +245,7 @@ class PluginSetupWizardCest
 		$I->switchToNextTab();
 
 		// Confirm expected Form is displayed.
-		// @TODO This fails.
-		//$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 
 		// Close newly opened tab.
 		$I->closeTab();
@@ -250,8 +261,7 @@ class PluginSetupWizardCest
 		$I->switchToNextTab();
 
 		// Confirm expected Form is displayed.
-		// @TODO This fails.
-		//$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 
 		// Close newly opened tab.
 		$I->closeTab();
@@ -317,6 +327,11 @@ class PluginSetupWizardCest
 
 		// Confirm we can select a Post Form.
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-posts-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+	}
+
+	public function testSetupWizardFormConfigurationScreenWhenNoPostsOrPagesExist(AcceptanceTester $I)
+	{
+
 	}
 
 	/**

--- a/views/backend/setup-wizard/convertkit-setup/content-1.php
+++ b/views/backend/setup-wizard/convertkit-setup/content-1.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Outputs the content for the Plugin Setup Wizard > Setup step.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+?>
+
+<h1><?php esc_html_e( 'Welcome to the ConvertKit Setup Wizard', 'convertkit' ); ?></h1>
+<p>
+	<?php esc_html_e( 'This setup wizard will guide you through adding your first ConvertKit email marketing capture form to your site and begin capturing leads and subscribers.', 'convertkit' ); ?>
+</p>
+
+<div class="convertkit-setup-wizard-grid">
+	<div>
+		<h2><?php esc_html_e( 'I don\'t have a ConvertKit account.', 'convertkit' ); ?></h2>
+		<a href="<?php echo esc_attr( convertkit_get_registration_url() ); ?>" class="button button-primary convertkit-redirect" data-convertkit-redirect-url="<?php echo esc_attr( $this->next_step_url ); ?>" target="_blank">
+			<?php esc_html_e( 'Register', 'convertkit' ); ?>
+		</a>
+		<span class="description"><?php esc_html_e( 'Sign up to ConvertKit and register your account. It\'s free.', 'convertkit' ); ?></span>
+	</div>
+
+	<div>
+		<h2><?php esc_html_e( 'I have a ConvertKit account.', 'convertkit' ); ?></h2>
+		<a href="<?php echo esc_attr( $this->next_step_url ); ?>" class="button button-primary">
+			<?php esc_html_e( 'Connect', 'convertkit' ); ?>
+		</a>
+		<span class="description"><?php esc_html_e( 'Great! Click the Connect button to get started.', 'convertkit' ); ?></span>
+	</div>
+</div>

--- a/views/backend/setup-wizard/convertkit-setup/content-2.php
+++ b/views/backend/setup-wizard/convertkit-setup/content-2.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Outputs the content for the Plugin Setup Wizard > Connect Account step.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+?>
+
+<h1><?php esc_html_e( 'Connect your ConvertKit account', 'convertkit' ); ?></h1>
+<p>
+	<?php
+	esc_html_e( 'To connect this Plugin to your ConvertKit account, we need your API Key and Secret.', 'convertkit' );
+	?>
+</p>
+
+<hr />
+
+<div>
+	<label for="api_key">
+		<?php esc_html_e( 'Enter your ConvertKit API Key', 'convertkit' ); ?>
+	</label>
+	<input type="text" name="api_key" id="api_key" value="<?php echo esc_attr( $this->settings->get_api_key() ); ?>" class="widefat" placeholder="<?php esc_attr_e( 'Click the link below, copy the API Key, and paste it here.', 'convertkit' ); ?>" required />
+	<p class="description">
+		<?php
+		echo sprintf(
+			/* translators: %1$s: Link to ConvertKit Account */
+			esc_html__( '%1$s, and enter it in the above field.', 'convertkit' ),
+			'<a href="' . esc_url( convertkit_get_api_key_url() ) . '" target="_blank">' . esc_html__( 'Click here to get your ConvertKit API Key', 'convertkit' ) . '</a>'
+		);
+		?>
+	</p>
+</div>
+
+<div>
+	<label for="api_secret">
+		<?php esc_html_e( 'Enter your ConvertKit API Secret', 'convertkit' ); ?>
+	</label>
+	<input type="text" name="api_secret" id="api_secret" value="<?php echo esc_attr( $this->settings->get_api_secret() ); ?>" class="widefat" placeholder="<?php esc_attr_e( 'Click the link below, copy the API Secret, and paste it here.', 'convertkit' ); ?>" required />
+	<p class="description">
+		<?php
+		echo sprintf(
+			/* translators: %1$s: Link to ConvertKit Account */
+			esc_html__( '%1$s, and enter it in the above field.', 'convertkit' ),
+			'<a href="' . esc_url( convertkit_get_api_key_url() ) . '" target="_blank">' . esc_html__( 'Click here to get your ConvertKit API Secret', 'convertkit' ) . '</a>'
+		);
+		?>
+	</p>
+</div>
+
+

--- a/views/backend/setup-wizard/convertkit-setup/content-3.php
+++ b/views/backend/setup-wizard/convertkit-setup/content-3.php
@@ -49,7 +49,7 @@ if ( ! $this->forms->exist() ) {
 		</label>
 		<select name="post_form" id="wp-convertkit-form-posts" class="convertkit-select2 convertkit-update-link widefat" data-target="#convertkit-preview-form-post" data-link="<?php echo esc_attr( $this->preview_post_url ); ?>&convertkit_form_id=">
 			<option value="0">
-				<?php esc_html_e( 'Don\'t display an email subscription form on Posts.', 'convertkit' ); ?>
+				<?php esc_html_e( 'Don\'t display an email subscription form on posts.', 'convertkit' ); ?>
 			</option>	
 			<?php
 			foreach ( $this->forms->get() as $form ) {
@@ -64,12 +64,16 @@ if ( ! $this->forms->exist() ) {
 
 		<p class="description">
 			<?php
-			echo sprintf(
-				'%s %s %s',
-				esc_html__( 'Select a form above.', 'convertkit' ),
-				'<a href="' . esc_attr( $this->preview_post_url ) . '" id="convertkit-preview-form-post" target="_blank">' . esc_html__( 'Click here', 'convertkit' ) . '</a>',
-				esc_html__( 'to preview how this will look on individual Posts.', 'convertkit' )
-			);
+			if ( $this->preview_post_url ) {
+				echo sprintf(
+					'%s %s %s',
+					esc_html__( 'Select a form above.', 'convertkit' ),
+					'<a href="' . esc_attr( $this->preview_post_url ) . '" id="convertkit-preview-form-post" target="_blank">' . esc_html__( 'Click here', 'convertkit' ) . '</a>',
+					esc_html__( 'to preview how this will look on individual posts.', 'convertkit' )
+				);
+			} else {
+				esc_html_e( 'Select a form above.', 'convertkit' );
+			}
 			?>
 		</p>
 	</div>
@@ -80,7 +84,7 @@ if ( ! $this->forms->exist() ) {
 		</label>
 		<select name="page_form" id="wp-convertkit-form-pages" class="convertkit-select2 convertkit-update-link widefat" data-target="#convertkit-preview-form-page" data-link="<?php echo esc_attr( $this->preview_page_url ); ?>&convertkit_form_id=">	
 			<option value="0">
-				<?php esc_html_e( 'Don\'t display an email subscription form on Pages.', 'convertkit' ); ?>
+				<?php esc_html_e( 'Don\'t display an email subscription form on pages.', 'convertkit' ); ?>
 			</option>
 			<?php
 			foreach ( $this->forms->get() as $form ) {
@@ -95,12 +99,16 @@ if ( ! $this->forms->exist() ) {
 
 		<p class="description">
 			<?php
-			echo sprintf(
-				'%s %s %s',
-				esc_html__( 'Select a form above.', 'convertkit' ),
-				'<a href="' . esc_attr( $this->preview_page_url ) . '" id="convertkit-preview-form-page" target="_blank">' . esc_html__( 'Click here', 'convertkit' ) . '</a>',
-				esc_html__( 'to preview how this will look on individual Pages.', 'convertkit' )
-			);
+			if ( $this->preview_page_url ) {
+				echo sprintf(
+					'%s %s %s',
+					esc_html__( 'Select a form above.', 'convertkit' ),
+					'<a href="' . esc_attr( $this->preview_page_url ) . '" id="convertkit-preview-form-page" target="_blank">' . esc_html__( 'Click here', 'convertkit' ) . '</a>',
+					esc_html__( 'to preview how this will look on individual pages.', 'convertkit' )
+				);
+			} else {
+				esc_html_e( 'Select a form above.', 'convertkit' );
+			}
 			?>
 		</p>
 	</div>

--- a/views/backend/setup-wizard/convertkit-setup/content-3.php
+++ b/views/backend/setup-wizard/convertkit-setup/content-3.php
@@ -30,10 +30,6 @@ if ( ! $this->forms->exist() ) {
 	<div>
 		<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/_RmI6vQhGu8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 	</div>
-
-	<a href="<?php echo esc_attr( $this->current_step_url ); ?>" class="button button-primary">
-		<?php esc_html_e( 'I\'ve created a form in ConvertKit.', 'convertkit' ); ?>
-	</a>
 	<?php
 } else {
 	// Show options to configure Form to display on Posts and Pages.

--- a/views/backend/setup-wizard/convertkit-setup/content-3.php
+++ b/views/backend/setup-wizard/convertkit-setup/content-3.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Outputs the content for the Plugin Setup Wizard > Form Configuration step.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+// If no Forms exist on the ConvertKit account, show the user how to add a Form to ConvertKit,
+// with an option to refresh this page so that they can then select the Form to be displayed on e.g. Posts.
+if ( ! $this->forms->exist() ) {
+	?>
+	<h1><?php esc_html_e( 'Create your first ConvertKit Form', 'convertkit' ); ?></h1>
+	<p>
+		<?php
+		esc_html_e( 'To capture email leads, you first need to create a form in ConvertKit. Click the button below to get started.', 'convertkit' );
+		?>
+	</p>
+
+	<a href="https://app.convertkit.com/forms/new?format=inline" target="_blank" class="button button-primary">
+		<?php esc_html_e( 'Create form', 'convertkit' ); ?>
+	</a>
+
+	<p>
+		<?php
+		esc_html_e( 'Not sure how to do this? Follow the video below.', 'convertkit' );
+		?>
+	</p>
+
+	<div>
+		<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/_RmI6vQhGu8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+	</div>
+
+	<a href="<?php echo esc_attr( $this->current_step_url ); ?>" class="button button-primary">
+		<?php esc_html_e( 'I\'ve created a form in ConvertKit.', 'convertkit' ); ?>
+	</a>
+	<?php
+} else {
+	// Show options to configure Form to display on Posts and Pages.
+	?>
+	<h1><?php esc_html_e( 'Display an email capture form', 'convertkit' ); ?></h1>
+	<p>
+		<?php
+		esc_html_e( 'To capture email leads, you need to display a ConvertKit form on your site, using the options below.', 'convertkit' );
+		?>
+	</p>
+
+	<hr />
+
+	<div>
+		<label for="wp-convertkit-form-posts">
+			<?php esc_html_e( 'Which form would you like to display on individual blog posts?', 'convertkit' ); ?>
+		</label>
+		<select name="post_form" id="wp-convertkit-form-posts" class="convertkit-select2 convertkit-update-link widefat" data-target="#convertkit-preview-form-post" data-link="<?php echo esc_attr( $this->preview_post_url ); ?>&convertkit_form_id=">
+			<option value="0">
+				<?php esc_html_e( 'Don\'t display an email subscription form on Posts.', 'convertkit' ); ?>
+			</option>	
+			<?php
+			foreach ( $this->forms->get() as $form ) {
+				?>
+				<option value="<?php echo esc_attr( $form['id'] ); ?>"<?php selected( $this->settings->get_default_form( 'post' ), $form['id'] ); ?>>
+					<?php echo esc_attr( $form['name'] ); ?>
+				</option>
+				<?php
+			}
+			?>
+		</select>
+
+		<p class="description">
+			<?php
+			echo sprintf(
+				'%s %s %s',
+				esc_html__( 'Select a form above.', 'convertkit' ),
+				'<a href="' . esc_attr( $this->preview_post_url ) . '" id="convertkit-preview-form-post" target="_blank">' . esc_html__( 'Click here', 'convertkit' ) . '</a>',
+				esc_html__( 'to preview how this will look on individual Posts.', 'convertkit' )
+			);
+			?>
+		</p>
+	</div>
+
+	<div>
+		<label for="wp-convertkit-form-pages">
+			<?php esc_html_e( 'Which form would you like to display on Pages?', 'convertkit' ); ?>
+		</label>
+		<select name="page_form" id="wp-convertkit-form-pages" class="convertkit-select2 convertkit-update-link widefat" data-target="#convertkit-preview-form-page" data-link="<?php echo esc_attr( $this->preview_page_url ); ?>&convertkit_form_id=">	
+			<option value="0">
+				<?php esc_html_e( 'Don\'t display an email subscription form on Pages.', 'convertkit' ); ?>
+			</option>
+			<?php
+			foreach ( $this->forms->get() as $form ) {
+				?>
+				<option value="<?php echo esc_attr( $form['id'] ); ?>"<?php selected( $this->settings->get_default_form( 'page' ), $form['id'] ); ?>>
+					<?php echo esc_attr( $form['name'] ); ?>
+				</option>
+				<?php
+			}
+			?>
+		</select>
+
+		<p class="description">
+			<?php
+			echo sprintf(
+				'%s %s %s',
+				esc_html__( 'Select a form above.', 'convertkit' ),
+				'<a href="' . esc_attr( $this->preview_page_url ) . '" id="convertkit-preview-form-page" target="_blank">' . esc_html__( 'Click here', 'convertkit' ) . '</a>',
+				esc_html__( 'to preview how this will look on individual Pages.', 'convertkit' )
+			);
+			?>
+		</p>
+	</div>
+	<?php
+}

--- a/views/backend/setup-wizard/convertkit-setup/content-4.php
+++ b/views/backend/setup-wizard/convertkit-setup/content-4.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Outputs the content for the Plugin Setup Wizard > Done step.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+?>
+
+<h1><?php esc_html_e( 'Setup complete', 'convertkit' ); ?></h1>
+<p>
+	<?php esc_html_e( 'The ConvertKit for WordPress Plugin setup is complete.', 'convertkit' ); ?>
+</p>
+
+<div class="convertkit-setup-wizard-grid">
+	<div>
+		<a href="<?php echo esc_attr( admin_url( 'index.php' ) ); ?>" class="button button-primary">
+			<?php esc_html_e( 'Dashboard', 'convertkit' ); ?>
+		</a>
+		<span class="description"><?php esc_html_e( 'Exit the wizard and load the WordPress Dashboard screen.', 'convertkit' ); ?></span>
+	</div>
+
+	<div>
+		<a href="<?php echo esc_attr( convertkit_get_settings_link() ); ?>" class="button button-primary">
+			<?php esc_html_e( 'Plugin Settings', 'convertkit' ); ?>
+		</a>
+		<span class="description"><?php esc_html_e( 'Exit the wizard and load the Plugin\'s settings screen.', 'convertkit' ); ?></span>
+	</div>
+</div>

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -72,6 +72,9 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/contactform7/class
 // Elementor Integration.
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/elementor/class-convertkit-elementor.php';
 
+// Setup Wizards.
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/setup-wizard/class-convertkit-setup-wizard-plugin.php';
+
 // WishList Member Integration.
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/wishlist/class-convertkit-wishlist.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/wishlist/class-convertkit-wishlist-settings.php';
@@ -94,6 +97,7 @@ if ( is_admin() ) {
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-settings-base.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-settings-general.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/section/class-convertkit-settings-tools.php';
+	require_once CONVERTKIT_PLUGIN_PATH . '/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php';
 
 	// Contact Form 7 Integration.
 	require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php';


### PR DESCRIPTION
## Summary

Provides a setup wizard to configure the Plugin for the first time when the Plugin is activated and no settings exist.

The wizard will only display when:
- the WordPress user has permissions to activate plugins,
- the Plugin isn't activated on a multisite installation (there are complications with taking over the WordPress Admin UI on multisite),
- no existing API key and secret exist in the Plugin (i.e. if the Plugin was previously activated and configured on the same site, the wizard won't display) 

Videos:
- Linking a ConvertKit account:
https://www.loom.com/share/97c5939ad49f465cb77ff5953ba27188

- Linking a ConvertKit account that has no forms:
https://www.loom.com/share/684ef276f013411e92af11c1e040baeb

## Testing

- `PluginSetupWizardCest`: Tests that the setup wizard displays when expected, and each screen works.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)