### PR TITLE
Quicktags Modal Size and Position

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -113,6 +113,9 @@ Full Plugin documentation can be found [here](https://help.convertkit.com/en/art
 
 == Changelog ==
 
+### 1.9.8.4 2022-09-xx
+* Fix: Text Editor: Quicktag Buttons: Position and size modal window correctly to avoid scrollbars and whitespace
+
 ### 1.9.8.3 2022-08-19
 * Added: Settings: Tools: Use WordPress' Site Info to populate System Info section
 * Added: Refresh button: Show error notification when refreshing fails

--- a/resources/backend/css/quicktags.css
+++ b/resources/backend/css/quicktags.css
@@ -3,9 +3,12 @@
 	left: 50%;
 	top: 50%;
 	transform: translate(-50%, -50%);
-	background: red;
+	width: 500px;
 }
-.convertkit-quicktags-modal .media-modal .media-frame-title {
+.convertkit-quicktags-modal .media-modal .media-modal-content {
+	min-height: auto;
+}
+.convertkit-quicktags-modal .media-modal .media-modal-content .media-frame-title {
 	left: 0;
 	height: 30px;
 }

--- a/resources/backend/css/quicktags.css
+++ b/resources/backend/css/quicktags.css
@@ -1,5 +1,5 @@
 .convertkit-quicktags-modal .media-modal {
-	position: absolute;
+	position: fixed;
 	left: 50%;
 	top: 50%;
 	transform: translate(-50%, -50%);

--- a/resources/backend/js/quicktags.js
+++ b/resources/backend/js/quicktags.js
@@ -45,24 +45,19 @@ function convertKitQuickTagRegister( block ) {
 						// Show Modal.
 						convertKitQuickTagsModal.open();
 
-						// Resize Modal so it's not full screen.
-						$( 'div.convertkit-quicktags-modal div.media-modal.wp-core-ui' ).css(
-							{
-								width: ( block.modal.width ) + 'px',
-								height: ( block.modal.height + 20 ) + 'px' // Prevents a vertical scroll bar.
-							}
-						);
-
 						// Set Title.
 						$( '#convertkit-quicktags-modal .media-frame-title h1' ).text( block.title );
 
 						// Inject HTML into modal.
 						$( '#convertkit-quicktags-modal .media-frame-content' ).html( response );
 
-						// Resize HTML height so it fills the modal.
-						$( 'div.convertkit-quicktags-modal div.media-modal.wp-core-ui div.convertkit-vertical-tabbed-ui' ).css(
+						console.log( $( 'div.convertkit-quicktags-modal div.media-frame-title h1' ).outerHeight() );
+						console.log( $( 'div.convertkit-quicktags-modal form.convertkit-tinymce-popup' ).height() );
+
+						// Resize Modal height to prevent whitespace below form.
+						$( 'div.convertkit-quicktags-modal div.media-modal.wp-core-ui' ).css(
 							{
-								height: ( block.modal.height - 50 ) + 'px' // -50px is for the footer buttons.
+								height: ( $( 'div.convertkit-quicktags-modal div.media-frame-title h1' ).outerHeight() + $( 'div.convertkit-quicktags-modal form.convertkit-tinymce-popup' ).height() + 6 ) + 'px' // Prevents a vertical scroll bar.
 							}
 						);
 

--- a/resources/backend/js/quicktags.js
+++ b/resources/backend/js/quicktags.js
@@ -51,13 +51,10 @@ function convertKitQuickTagRegister( block ) {
 						// Inject HTML into modal.
 						$( '#convertkit-quicktags-modal .media-frame-content' ).html( response );
 
-						console.log( $( 'div.convertkit-quicktags-modal div.media-frame-title h1' ).outerHeight() );
-						console.log( $( 'div.convertkit-quicktags-modal form.convertkit-tinymce-popup' ).height() );
-
 						// Resize Modal height to prevent whitespace below form.
 						$( 'div.convertkit-quicktags-modal div.media-modal.wp-core-ui' ).css(
 							{
-								height: ( $( 'div.convertkit-quicktags-modal div.media-frame-title h1' ).outerHeight() + $( 'div.convertkit-quicktags-modal form.convertkit-tinymce-popup' ).height() + 6 ) + 'px' // Prevents a vertical scroll bar.
+								height: ( $( 'div.convertkit-quicktags-modal div.media-frame-title h1' ).outerHeight() + $( 'div.convertkit-quicktags-modal form.convertkit-tinymce-popup' ).height() + 6 ) + 'px' // Additional 6px prevents a vertical scroll bar.
 							}
 						);
 


### PR DESCRIPTION
## Summary

Fixes the size and position of the Quicktags modal, which is displayed when clicking a ConvertKit button in the Text editor.

Before:
![Screenshot 2022-09-01 at 17 06 00](https://user-images.githubusercontent.com/1462305/187961221-3c892414-ec47-451d-8e5d-15417e9766f0.png)

After:
![Screenshot 2022-09-01 at 17 05 50](https://user-images.githubusercontent.com/1462305/187961215-ca6e0736-87d5-4d9d-b77f-c45dc369705d.png)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)