### PR TITLE
API and Caching for Products

### DIFF
--- a/admin/class-convertkit-admin-refresh-resources.php
+++ b/admin/class-convertkit-admin-refresh-resources.php
@@ -62,6 +62,11 @@ class ConvertKit_Admin_Refresh_Resources {
 				$results = $posts->refresh();
 				break;
 
+			case 'products':
+				$products = new ConvertKit_Resource_Products();
+				$results  = $products->refresh();
+				break;
+
 			default:
 				$results = new WP_Error(
 					'convertkit_admin_refresh_resources_error',

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -331,6 +331,9 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 			$posts = new ConvertKit_Resource_Posts();
 			$posts->refresh();
 
+			$products = new ConvertKit_Resource_Products();
+			$products->refresh();
+
 			$tags = new ConvertKit_Resource_Tags();
 			$tags->refresh();
 		}

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "1.0.0"
+        "convertkit/convertkit-wordpress-libraries": "1.1.0.x-dev"
     },
     "require-dev": {
         "lucatume/wp-browser": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "1.1.0.x-dev"
+        "convertkit/convertkit-wordpress-libraries": "1.1.0"
     },
     "require-dev": {
         "lucatume/wp-browser": "^3.0",

--- a/includes/class-convertkit-resource-products.php
+++ b/includes/class-convertkit-resource-products.php
@@ -10,7 +10,7 @@
  * Reads ConvertKit Products from the options table, and refreshes
  * ConvertKit Products data stored locally from the API.
  *
- * @since   1.9.8.5
+ * @since   2.0.0
  */
 class ConvertKit_Resource_Products extends ConvertKit_Resource {
 
@@ -31,9 +31,11 @@ class ConvertKit_Resource_Products extends ConvertKit_Resource {
 	/**
 	 * Constructor.
 	 *
-	 * @since   1.9.8.5
+	 * @since   2.0.0
+	 *
+	 * @param   bool|string $context    Context.
 	 */
-	public function __construct() {
+	public function __construct( $context = false ) {
 
 		// Initialize the API if the API Key and Secret have been defined in the Plugin Settings.
 		$settings = new ConvertKit_Settings();
@@ -41,7 +43,8 @@ class ConvertKit_Resource_Products extends ConvertKit_Resource {
 			$this->api = new ConvertKit_API(
 				$settings->get_api_key(),
 				$settings->get_api_secret(),
-				$settings->debug_enabled()
+				$settings->debug_enabled(),
+				$context
 			);
 		}
 
@@ -53,7 +56,7 @@ class ConvertKit_Resource_Products extends ConvertKit_Resource {
 	/**
 	 * Returns the commerce.js URL based on the account's ConvertKit Domain.
 	 *
-	 * @since   1.9.8.5
+	 * @since   2.0.0
 	 *
 	 * @return  bool|string     false (if no products) | URL.
 	 */
@@ -79,7 +82,7 @@ class ConvertKit_Resource_Products extends ConvertKit_Resource {
 	/**
 	 * Returns the HTML button markup for the given Product ID.
 	 *
-	 * @since   1.9.8.5
+	 * @since   2.0.0
 	 *
 	 * @param   int    $id             Product ID.
 	 * @param   string $button_text    Button Text.

--- a/includes/class-convertkit-resource-products.php
+++ b/includes/class-convertkit-resource-products.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * ConvertKit Products Resource class.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Reads ConvertKit Products from the options table, and refreshes
+ * ConvertKit Products data stored locally from the API.
+ *
+ * @since   1.9.8.5
+ */
+class ConvertKit_Resource_Products extends ConvertKit_Resource {
+
+	/**
+	 * Holds the Settings Key that stores site wide ConvertKit settings
+	 *
+	 * @var     string
+	 */
+	public $settings_name = 'convertkit_products';
+
+	/**
+	 * The type of resource
+	 *
+	 * @var     string
+	 */
+	public $type = 'products';
+
+	/**
+	 * Constructor.
+	 *
+	 * @since   1.9.8.5
+	 */
+	public function __construct() {
+
+		// Initialize the API if the API Key and Secret have been defined in the Plugin Settings.
+		$settings = new ConvertKit_Settings();
+		if ( $settings->has_api_key_and_secret() ) {
+			$this->api = new ConvertKit_API(
+				$settings->get_api_key(),
+				$settings->get_api_secret(),
+				$settings->debug_enabled()
+			);
+		}
+
+		// Call parent initialization function.
+		parent::init();
+
+	}
+
+	/**
+	 * Returns the commerce.js URL based on the account's ConvertKit Domain.
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @return  bool|string     false (if no products) | URL.
+	 */
+	public function get_commerce_js_url() {
+
+		// Bail if no Products exist in this resource.
+		if ( ! $this->exist() ) {
+			return false;
+		}
+
+		// Fetch the first Product.
+		$products = $this->get();
+		$product  = reset( $products );
+
+		// Parse the URL.
+		$parsed_url = wp_parse_url( $product['url'] );
+
+		// Return commerce.js URL.
+		return $parsed_url['scheme'] . '://' . $parsed_url['host'] . '/commerce.js';
+
+	}
+
+	/**
+	 * Returns the HTML button markup for the given Product ID.
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @param   int    $id             Product ID.
+	 * @param   string $button_text    Button Text.
+	 * @param   array  $css_classes    CSS classes to apply to link (typically included when using Gutenberg).
+	 * @param   array  $css_styles     CSS inline styles to apply to link (typically included when using Gutenberg).
+	 * @param   bool   $return_as_span If true, returns a <span> instead of <a>. Useful for the block editor so that the element is interactible.
+	 * @return  WP_Error|string         Button HTML
+	 */
+	public function get_html( $id, $button_text, $css_classes = array(), $css_styles = array(), $return_as_span = false ) {
+
+		// Cast ID to integer.
+		$id = absint( $id );
+
+		// Bail if the resources are a WP_Error.
+		if ( is_wp_error( $this->resources ) ) {
+			return $this->resources;
+		}
+
+		// Bail if the resource doesn't exist.
+		if ( ! isset( $this->resources[ $id ] ) ) {
+			return new WP_Error(
+				'convertkit_resource_products_get_html',
+				sprintf(
+					/* translators: ConvertKit Product ID */
+					__( 'ConvertKit Product ID %s does not exist on ConvertKit.', 'convertkit' ),
+					$id
+				)
+			);
+		}
+
+		// Build button HTML.
+		$html = '<div class="convertkit-product">';
+
+		if ( $return_as_span ) {
+			$html .= '<span';
+		} else {
+			$html .= '<a href="' . $this->resources[ $id ]['url'] . '"';
+		}
+
+		$html .= ' class="wp-block-button__link ' . esc_attr( implode( ' ', $css_classes ) ) . '" style="' . implode( ';', $css_styles ) . '" data-commerce>';
+		$html .= esc_html( $button_text );
+
+		if ( $return_as_span ) {
+			$html .= '</span>';
+		} else {
+			$html .= '</a>';
+		}
+
+		$html .= '</div>';
+
+		// Return.
+		return $html;
+
+	}
+
+}

--- a/tests/wpunit/ResourceProductsNoDataTest.php
+++ b/tests/wpunit/ResourceProductsNoDataTest.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Tests for the ConvertKit_Resource_Products class when no data is present in the API.
+ * 
+ * @since 	1.9.8.5
+ */
+class ResourceProductsNoDataTest extends \Codeception\TestCase\WPTestCase
+{
+	/**
+	 * @var \WpunitTester
+	 */
+	protected $tester;
+
+	/**
+	 * Holds the ConvertKit Settings class.
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @var 	ConvertKit_Settings
+	 */
+	private $settings;
+
+	/**
+	 * Holds the ConvertKit Resource class.
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @var 	ConvertKit_Resource_Products
+	 */
+	private $resource;
+
+	/**
+	 * Performs actions before each test.
+	 * 
+	 * @since 	1.9.8.5
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		// Activate Plugin.
+		activate_plugins('convertkit/wp-convertkit.php');
+
+		// Store API Key and Secret in Plugin's settings.
+		$this->settings = new ConvertKit_Settings();
+		update_option($this->settings::SETTINGS_NAME, [
+			'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+			'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+		]);
+
+		// Initialize the resource class we want to test.
+		$this->resource = new ConvertKit_Resource_Products();
+
+		// Confirm initialization didn't result in an error.
+		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
+	}
+
+	/**
+	 * Performs actions after each test.
+	 * 
+	 * @since 	1.9.6.9
+	 */
+	public function tearDown(): void
+	{
+		// Delete API Key, API Secret and Resources from Plugin's settings.
+		delete_option($this->settings::SETTINGS_NAME);
+		delete_option($this->resource->settings_name);
+		delete_option($this->resource->settings_name . '_last_queried');
+
+		// Destroy the resource class we tested.
+		unset($this->resource);
+
+		// Deactivate Plugin.
+		deactivate_plugins('convertkit/wp-convertkit.php');
+		
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that the refresh() function performs as expected, storing data in the options table.
+	 * 
+	 * @since 	1.9.8.5
+	 */
+	public function testRefresh()
+	{
+		// Confirm that the data is stored in the options table and includes some expected keys.
+		$result = $this->resource->refresh();
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
+	}
+
+	/**
+	 * Test that the expiry timestamp is set and returns the expected value.
+	 * 
+	 * @since 	1.9.8.5
+	 */
+	public function testExpiry()
+	{
+		// Define the expected expiry date based on the resource class' $cache_duration setting.
+		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+
+		// Fetch the actual expiry date set when the resource class was initialized.
+		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+
+		// Confirm both dates match.
+		$this->assertEquals($expectedExpiryDate, $expiryDate);
+	}
+
+	/**
+	 * Test that the get() function performs as expected.
+	 * 
+	 * @since 	1.9.8.5
+	 */
+	public function testGet()
+	{
+		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+		$result = $this->resource->get();
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
+	}
+
+	/**
+	 * Test that the count() function returns the number of resources.
+	 * 
+	 * @since 	1.9.7.6
+	 */
+	public function testCount()
+	{
+		$result = $this->resource->get();
+		$this->assertEquals($this->resource->count(), count($result));
+	}
+
+	/**
+	 * Test that the exist() function performs as expected.
+	 * 
+	 * @since 	1.9.8.5
+	 */
+	public function testExist()
+	{
+		// Confirm that the function returns true, because resources exist.
+		$result = $this->resource->exist();
+		$this->assertSame($result, false);
+	}
+}

--- a/tests/wpunit/ResourceProductsTest.php
+++ b/tests/wpunit/ResourceProductsTest.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Tests for the ConvertKit_Resource_Products class.
+ * 
+ * @since 	1.9.8.5
+ */
+class ResourceProductsTest extends \Codeception\TestCase\WPTestCase
+{
+	/**
+	 * @var \WpunitTester
+	 */
+	protected $tester;
+
+	/**
+	 * Holds the ConvertKit Settings class.
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @var 	ConvertKit_Settings
+	 */
+	private $settings;
+
+	/**
+	 * Holds the ConvertKit Resource class.
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @var 	ConvertKit_Resource_Products
+	 */
+	private $resource;
+
+	/**
+	 * Performs actions before each test.
+	 * 
+	 * @since 	1.9.8.5
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		// Activate Plugin.
+		activate_plugins('convertkit/wp-convertkit.php');
+
+		// Store API Key and Secret in Plugin's settings.
+		$this->settings = new ConvertKit_Settings();
+		update_option($this->settings::SETTINGS_NAME, [
+			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+		]);
+
+		// Initialize the resource class we want to test.
+		$this->resource = new ConvertKit_Resource_Products();
+
+		// Confirm initialization didn't result in an error.
+		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
+	}
+
+	/**
+	 * Performs actions after each test.
+	 * 
+	 * @since 	1.9.6.9
+	 */
+	public function tearDown(): void
+	{
+		// Delete API Key, API Secret and Resources from Plugin's settings.
+		delete_option($this->settings::SETTINGS_NAME);
+		delete_option($this->resource->settings_name);
+		delete_option($this->resource->settings_name . '_last_queried');
+
+		// Destroy the resource class we tested.
+		unset($this->resource);
+
+		// Deactivate Plugin.
+		deactivate_plugins('convertkit/wp-convertkit.php');
+		
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that the refresh() function performs as expected.
+	 * 
+	 * @since 	1.9.8.5
+	 */
+	public function testRefresh()
+	{
+		// Confirm that the data is stored in the options table and includes some expected keys.
+		$result = $this->resource->refresh();
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
+	}
+
+	/**
+	 * Test that the expiry timestamp is set and returns the expected value.
+	 * 
+	 * @since 	1.9.8.5
+	 */
+	public function testExpiry()
+	{
+		// Define the expected expiry date based on the resource class' $cache_duration setting.
+		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+
+		// Fetch the actual expiry date set when the resource class was initialized.
+		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+
+		// Confirm both dates match.
+		$this->assertEquals($expectedExpiryDate, $expiryDate);
+	}
+
+	/**
+	 * Test that the get() function performs as expected.
+	 * 
+	 * @since 	1.9.8.5
+	 */
+	public function testGet()
+	{
+		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+		$result = $this->resource->get();
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
+	}
+
+	/**
+	 * Test that the count() function returns the number of resources.
+	 * 
+	 * @since 	1.9.7.6
+	 */
+	public function testCount()
+	{
+		$result = $this->resource->get();
+		$this->assertEquals($this->resource->count(), count($result));
+	}
+
+	/**
+	 * Test that the exist() function performs as expected.
+	 * 
+	 * @since 	1.9.8.5
+	 */
+	public function testExist()
+	{
+		// Confirm that the function returns true, because resources exist.
+		$result = $this->resource->exist();
+		$this->assertSame($result, true);
+	}
+}

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -53,6 +53,7 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-preview-output
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-resource-forms.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-resource-landing-pages.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-resource-posts.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-resource-products.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-resource-tags.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-settings.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-setup.php';


### PR DESCRIPTION
## Summary

Utilises version [1.2.0 of the ConvertKit WordPress Libraries](https://github.com/ConvertKit/convertkit-wordpress-libraries/pull/2) to support fetching Products via the ConvertKit API and caching them in the Plugin.

Further PR's to follow for implementation of the Product button block and shortcode, which will build on this.

## Testing

- `ResourceProductsTest`: Tests that the `ConvertKit_Resource_Products` class works with the API
- `ResourceProductsNoDataTest`: Tess that the `ConvertKit_Resource_Products` class works with the API when the ConvertKit account contains no Products.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)