### PR TITLE
Broadcasts: Shortcode: Support color options

### DIFF
--- a/admin/class-convertkit-admin-tinymce.php
+++ b/admin/class-convertkit-admin-tinymce.php
@@ -99,6 +99,10 @@ class ConvertKit_Admin_TinyMCE {
 		// Enqueue Quicktag CSS.
 		wp_enqueue_style( 'convertkit-admin-quicktags', CONVERTKIT_PLUGIN_URL . 'resources/backend/css/quicktags.css', array(), CONVERTKIT_PLUGIN_VERSION );
 
+		// Enqueue WordPress JS and CSS.
+		wp_enqueue_script( 'wp-color-picker' );
+		wp_enqueue_style( 'wp-color-picker' );
+
 		// Output Backbone View Template.
 		add_action( 'wp_print_footer_scripts', array( $this, 'output_quicktags_modal' ) );
 		add_action( 'admin_print_footer_scripts', array( $this, 'output_quicktags_modal' ) );

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "1.0.0"
+        "convertkit/convertkit-wordpress-libraries": "1.1.0"
     },
     "require-dev": {
         "lucatume/wp-browser": "^3.0",

--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -254,6 +254,21 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 				'type'        => 'text',
 				'description' => __( 'The label to display for the link to older broadcasts.', 'convertkit' ),
 			),
+
+			// These fields will only display on the shortcode, and are deliberately not registered in get_attributes(),
+			// because Gutenberg will register its own color pickers for link, background and text.
+			'link_color' => array(
+				'label'       => __( 'Link color', 'convertkit' ),
+				'type'        => 'color',
+			),
+			'background_color' => array(
+				'label'       => __( 'Background color', 'convertkit' ),
+				'type'        => 'color',
+			),
+			'text_color' => array(
+				'label'       => __( 'Text color', 'convertkit' ),
+				'type'        => 'color',
+			),
 		);
 
 	}
@@ -281,6 +296,9 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 					'paginate',
 					'paginate_label_prev',
 					'paginate_label_next',
+					'link_color',
+					'background_color',
+					'text_color',
 				),
 			),
 		);
@@ -302,6 +320,9 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 			'paginate'            => false,
 			'paginate_label_prev' => __( 'Previous', 'convertkit' ),
 			'paginate_label_next' => __( 'Next', 'convertkit' ),
+			'link_color'		  => '',
+			'background_color'	  => '',
+			'text_color'		  => '',
 
 			// Built-in Gutenberg block attributes.
 			'style'               => '',
@@ -386,6 +407,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 			'paginate'            => absint( $_REQUEST['paginate'] ),
 			'paginate_label_next' => sanitize_text_field( $_REQUEST['paginate_label_next'] ),
 			'paginate_label_prev' => sanitize_text_field( $_REQUEST['paginate_label_prev'] ),
+			'link_color'		  => sanitize_text_field( $_REQUEST['link_color'] ),
 		);
 
 		// Parse attributes, defining fallback defaults if required
@@ -461,7 +483,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 			// Add broadcast as list item.
 			$html .= '<li class="convertkit-broadcast">
 				<time datetime="' . date_i18n( 'Y-m-d', $date_timestamp ) . '">' . date_i18n( $atts['date_format'], $date_timestamp ) . '</time>
-				<a href="' . $url . '" target="_blank" rel="nofollow noopener">' . $broadcast['title'] . '</a>
+				<a href="' . $url . '" target="_blank" rel="nofollow noopener"' . $this->get_link_style_tag( $atts ) . '>' . $broadcast['title'] . '</a>
 			</li>';
 		}
 
@@ -516,7 +538,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 	 */
 	private function get_pagination_link_prev_html( $atts, $nonce ) {
 
-		return '<a href="' . esc_attr( $this->get_pagination_link( $atts['page'] - 1, $nonce ) ) . '" title="' . esc_attr( $atts['paginate_label_prev'] ) . '" data-page="' . esc_attr( (string) ( $atts['page'] - 1 ) ) . '" data-nonce="' . esc_attr( $nonce ) . '">
+		return '<a href="' . esc_attr( $this->get_pagination_link( $atts['page'] - 1, $nonce ) ) . '" title="' . esc_attr( $atts['paginate_label_prev'] ) . '" data-page="' . esc_attr( (string) ( $atts['page'] - 1 ) ) . '" data-nonce="' . esc_attr( $nonce ) . '"' . $this->get_link_style_tag( $atts ) . '>
 			' . esc_attr( $atts['paginate_label_prev'] ) . '
 		</a>';
 
@@ -534,7 +556,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 	 */
 	private function get_pagination_link_next_html( $atts, $nonce ) {
 
-		return '<a href="' . esc_attr( $this->get_pagination_link( $atts['page'] + 1, $nonce ) ) . '" title="' . esc_attr( $atts['paginate_label_next'] ) . '" data-page="' . esc_attr( (string) ( $atts['page'] + 1 ) ) . '" data-nonce="' . esc_attr( $nonce ) . '">
+		return '<a href="' . esc_attr( $this->get_pagination_link( $atts['page'] + 1, $nonce ) ) . '" title="' . esc_attr( $atts['paginate_label_next'] ) . '" data-page="' . esc_attr( (string) ( $atts['page'] + 1 ) ) . '" data-nonce="' . esc_attr( $nonce ) . '"' . $this->get_link_style_tag( $atts ) . '>
 			' . esc_attr( $atts['paginate_label_next'] ) . '
 		</a>';
 
@@ -601,6 +623,31 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 
 		// Return requested page number.
 		return absint( $_REQUEST['convertkit-broadcasts-page'] );
+
+	}
+
+	/**
+	 * If a link_color attribute exists in the given array of attributes, we're rendering a shortcode, and therefore
+	 * need to include inline styling for links.
+	 *
+	 * The Gutenberg block doesn't need this, because WordPress generates its own inline styles when a link color is selected.
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	array 	$atts 	Block attributes.
+	 * @return 	string 			style attribute (blank string if no styles need to be applied)
+	 */
+	private function get_link_style_tag( $atts ) {
+
+		if ( ! isset( $atts['link_color'] ) ) {
+			return '';
+		}
+
+		if ( empty( $atts['link_color'] ) ) {
+			return '';
+		}
+
+		return ' style="color:' . $atts['link_color'] . '"';
 
 	}
 

--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -115,7 +115,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 			// Shortcode: TinyMCE / QuickTags Modal Width and Height.
 			'modal'                         => array(
 				'width'  => 500,
-				'height' => 405,
+				'height' => 580,
 			),
 
 			// Shortcode: Include a closing [/shortcode] tag when using TinyMCE or QuickTag Modals.

--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -257,17 +257,17 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 
 			// These fields will only display on the shortcode, and are deliberately not registered in get_attributes(),
 			// because Gutenberg will register its own color pickers for link, background and text.
-			'link_color' => array(
-				'label'       => __( 'Link color', 'convertkit' ),
-				'type'        => 'color',
+			'link_color'          => array(
+				'label' => __( 'Link color', 'convertkit' ),
+				'type'  => 'color',
 			),
-			'background_color' => array(
-				'label'       => __( 'Background color', 'convertkit' ),
-				'type'        => 'color',
+			'background_color'    => array(
+				'label' => __( 'Background color', 'convertkit' ),
+				'type'  => 'color',
 			),
-			'text_color' => array(
-				'label'       => __( 'Text color', 'convertkit' ),
-				'type'        => 'color',
+			'text_color'          => array(
+				'label' => __( 'Text color', 'convertkit' ),
+				'type'  => 'color',
 			),
 		);
 
@@ -320,9 +320,9 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 			'paginate'            => false,
 			'paginate_label_prev' => __( 'Previous', 'convertkit' ),
 			'paginate_label_next' => __( 'Next', 'convertkit' ),
-			'link_color'		  => '',
-			'background_color'	  => '',
-			'text_color'		  => '',
+			'link_color'          => '',
+			'background_color'    => '',
+			'text_color'          => '',
 
 			// Built-in Gutenberg block attributes.
 			'style'               => '',
@@ -407,7 +407,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 			'paginate'            => absint( $_REQUEST['paginate'] ),
 			'paginate_label_next' => sanitize_text_field( $_REQUEST['paginate_label_next'] ),
 			'paginate_label_prev' => sanitize_text_field( $_REQUEST['paginate_label_prev'] ),
-			'link_color'		  => sanitize_text_field( $_REQUEST['link_color'] ),
+			'link_color'          => sanitize_text_field( $_REQUEST['link_color'] ),
 		);
 
 		// Parse attributes, defining fallback defaults if required
@@ -631,11 +631,11 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 	 * need to include inline styling for links.
 	 *
 	 * The Gutenberg block doesn't need this, because WordPress generates its own inline styles when a link color is selected.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	array 	$atts 	Block attributes.
-	 * @return 	string 			style attribute (blank string if no styles need to be applied)
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @param   array $atts   Block attributes.
+	 * @return  string          style attribute (blank string if no styles need to be applied)
 	 */
 	private function get_link_style_tag( $atts ) {
 

--- a/includes/blocks/class-convertkit-block.php
+++ b/includes/blocks/class-convertkit-block.php
@@ -186,7 +186,7 @@ class ConvertKit_Block {
 
 		// Fetch attribute definitions.
 		$atts_definitions = $this->get_attributes();
-
+		
 		// Iterate through attributes, casting them based on their attribute definition.
 		foreach ( $atts as $att => $value ) {
 			// Skip if no definition exists for this attribute.
@@ -229,6 +229,13 @@ class ConvertKit_Block {
 			$atts['_css_styles']['color'] = 'color:' . $atts['style']['color']['text'];
 		}
 
+		// If the shortcode supports a text color, and a custom hex color was selected, add it to the
+		// array of CSS inline styles.
+		if ( isset( $atts['text_color'] ) && ! empty( $atts['text_color'] ) ) {
+			$atts['_css_classes'][]       = 'has-text-color';
+			$atts['_css_styles']['color'] = 'color:' . $atts['text_color'];
+		}
+
 		// If the block supports a background color, and a preset color was selected, add it to the
 		// array of CSS classes.
 		if ( $atts['backgroundColor'] ) {
@@ -241,6 +248,13 @@ class ConvertKit_Block {
 		if ( isset( $atts['style']['color'] ) && isset( $atts['style']['color']['background'] ) ) {
 			$atts['_css_classes'][]            = 'has-background';
 			$atts['_css_styles']['background'] = 'background-color:' . $atts['style']['color']['background'];
+		}
+
+		// If the shortcode supports a background color, and a custom hex color was selected, add it to the
+		// array of CSS inline styles.
+		if ( isset( $atts['background_color'] ) && ! empty( $atts['background_color'] ) ) {
+			$atts['_css_classes'][]       = 'has-background';
+			$atts['_css_styles']['background'] = 'background-color:' . $atts['background_color'];
 		}
 
 		// Remove some unused attributes, now they're declared above.

--- a/includes/blocks/class-convertkit-block.php
+++ b/includes/blocks/class-convertkit-block.php
@@ -186,7 +186,7 @@ class ConvertKit_Block {
 
 		// Fetch attribute definitions.
 		$atts_definitions = $this->get_attributes();
-		
+
 		// Iterate through attributes, casting them based on their attribute definition.
 		foreach ( $atts as $att => $value ) {
 			// Skip if no definition exists for this attribute.
@@ -253,7 +253,7 @@ class ConvertKit_Block {
 		// If the shortcode supports a background color, and a custom hex color was selected, add it to the
 		// array of CSS inline styles.
 		if ( isset( $atts['background_color'] ) && ! empty( $atts['background_color'] ) ) {
-			$atts['_css_classes'][]       = 'has-background';
+			$atts['_css_classes'][]            = 'has-background';
 			$atts['_css_styles']['background'] = 'background-color:' . $atts['background_color'];
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -113,6 +113,9 @@ Full Plugin documentation can be found [here](https://help.convertkit.com/en/art
 
 == Changelog ==
 
+### 1.9.8.5 2022-xx-xx
+* Added: Broadcasts: Shortcode: Options to specify background, text and link colors
+
 ### 1.9.8.4 2022-09-08
 * Added: Setup Wizard for new installations
 * Fix: Text Editor: Quicktag Buttons: Position and size modal window correctly to avoid scrollbars and whitespace

--- a/resources/backend/css/tinymce.css
+++ b/resources/backend/css/tinymce.css
@@ -47,3 +47,6 @@
 .convertkit-option p {
 	white-space: normal;
 }
+.convertkit-option .wp-picker-container .wp-color-result.button {
+	padding-right: 10px;
+}

--- a/resources/backend/css/tinymce.css
+++ b/resources/backend/css/tinymce.css
@@ -47,6 +47,19 @@
 .convertkit-option p {
 	white-space: normal;
 }
-.convertkit-option .wp-picker-container .wp-color-result.button {
-	padding-right: 10px;
+
+/**
+ * Ensures consistent styling applied to 'Select color' button
+ * provided by WordPress' color picker across TinyMCE and QuickTag modals
+ */
+.convertkit-option .wp-color-result-text {
+	background: #f6f7f7;
+    border-radius: 0 2px 2px 0;
+    border-left: 1px solid #c3c4c7;
+    color: #50575e;
+    display: block;
+    line-height: 2.54545455;
+    padding: 0 6px;
+    font-size: 11px;
+    text-align: center;
 }

--- a/resources/backend/css/tinymce.css
+++ b/resources/backend/css/tinymce.css
@@ -54,12 +54,12 @@
  */
 .convertkit-option .wp-color-result-text {
 	background: #f6f7f7;
-    border-radius: 0 2px 2px 0;
-    border-left: 1px solid #c3c4c7;
-    color: #50575e;
-    display: block;
-    line-height: 2.54545455;
-    padding: 0 6px;
-    font-size: 11px;
-    text-align: center;
+	border-radius: 0 2px 2px 0;
+	border-left: 1px solid #c3c4c7;
+	color: #50575e;
+	display: block;
+	line-height: 2.54545455;
+	padding: 0 6px;
+	font-size: 11px;
+	text-align: center;
 }

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -116,6 +116,13 @@ function convertKitGutenbergRegisterBlock( block ) {
 							const attribute = block.panels[ panel ].fields[ i ], // e.g. 'term'.
 									field   = block.fields[ attribute ]; // field array.
 
+							// If this field doesn't exist as an attribute in the block's get_attributes(),
+							// this is a non-Gutenberg field (such as a color picker for shortcodes),
+							// which should be ignored.
+							if ( typeof props.attributes[ attribute ] === 'undefined' ) {
+								continue;
+							}
+
 							var fieldElement; // Holds the field element (select, textarea, text etc).
 
 							// Define Field's Properties.

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -119,7 +119,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 							// If this field doesn't exist as an attribute in the block's get_attributes(),
 							// this is a non-Gutenberg field (such as a color picker for shortcodes),
 							// which should be ignored.
-							if ( typeof props.attributes[ attribute ] === 'undefined' ) {
+							if ( typeof block.attributes[ attribute ] === 'undefined' ) {
 								continue;
 							}
 

--- a/resources/backend/js/quicktags.js
+++ b/resources/backend/js/quicktags.js
@@ -51,6 +51,9 @@ function convertKitQuickTagRegister( block ) {
 						// Inject HTML into modal.
 						$( '#convertkit-quicktags-modal .media-frame-content' ).html( response );
 
+						// Initialize color pickers.
+						$( '.convertkit-color-picker' ).wpColorPicker();
+
 						// Resize Modal height to prevent whitespace below form.
 						$( 'div.convertkit-quicktags-modal div.media-modal.wp-core-ui' ).css(
 							{

--- a/resources/backend/js/tinymce.js
+++ b/resources/backend/js/tinymce.js
@@ -64,6 +64,9 @@ function convertKitTinyMCERegisterPlugin( block ) {
 								// Inject HTML into modal.
 								$( '#convertkit-modal-body-body' ).html( response );
 
+								// Initialize color pickers.
+								$( '.convertkit-color-picker' ).wpColorPicker();
+
 							}
 						);
 

--- a/resources/frontend/js/broadcasts.js
+++ b/resources/frontend/js/broadcasts.js
@@ -28,6 +28,7 @@ jQuery( document ).ready(
 						paginate: $( blockContainer ).data( 'paginate' ),
 						paginate_label_prev: $( blockContainer ).data( 'paginate-label-prev' ),
 						paginate_label_next: $( blockContainer ).data( 'paginate-label-next' ),
+						link_color: $( blockContainer ).data( 'link-color' ),
 
 						page: $( this ).data( 'page' ), // Page is supplied as a data- attribute on the link clicked, not the container.
 						nonce: $( this ).data( 'nonce' ) // Nonce is supplied as a data- attribute on the link clicked, not the container.

--- a/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
@@ -196,6 +196,56 @@ class PageShortcodeBroadcastsCest
 	}
 
 	/**
+	 * Test the [convertkit_broadcasts] shortcode hex colors works when chosen,
+	 * using the Classic Editor (TinyMCE / Visual).
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testBroadcastsShortcodeInVisualEditorWithHexColorParameters(AcceptanceTester $I)
+	{
+		// Define colors.
+		$backgroundColor = '#ee1616';
+		$textColor = '#1212c0';
+		$linkColor = '#ffffff';
+
+		// It's tricky to interact with WordPress's color picker, so we programmatically create the Page
+		// instead to then confirm the color settings apply on the output.
+		// We don't need to test the color picker itself, as it's a WordPress supplied component, and our
+		// other Acceptance tests confirm that the shortcode can be added in the Classic Editor.
+		$I->havePageInDatabase([
+			'post_name' 	=> 'convertkit-page-broadcasts-shortcode-hex-color-params',
+			'post_content' 	=> '[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older" link_color="'.$linkColor.'" background_color="'.$backgroundColor.'" text_color="'.$textColor.'"]'
+		]);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/convertkit-page-broadcasts-shortcode-hex-color-params');
+
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible('body.page-template-default');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the block displays.
+		$I->seeBroadcastsOutput($I);
+
+		// Confirm that our stylesheet loaded.
+		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="'.$_ENV['TEST_SITE_WP_URL'].'/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
+
+		// Confirm that the chosen colors are applied as CSS styles.
+		$I->seeInSource('<div class="convertkit-broadcasts has-text-color has-background" style="color:'.$textColor.';background-color:'.$backgroundColor.'"');
+		$I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:'.$linkColor.'"');
+	
+		// Test pagination.
+		$I->testBroadcastsPagination($I, 'Older', 'Newer');
+
+		// Confirm that link styles are still applied to refreshed data.
+		$I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:'.$linkColor.'"');
+	}
+
+	/**
 	 * Test the [convertkit_broadcasts] shortcode works when using the default parameters,
 	 * using the Text Editor.
 	 * 

--- a/views/backend/tinymce/modal-field.php
+++ b/views/backend/tinymce/modal-field.php
@@ -28,7 +28,6 @@ switch ( $field['type'] ) {
 	 * Text
 	 */
 	case 'text':
-	case 'text_multiple':
 		?>
 		<input type="text" 
 				id="tinymce_modal_<?php echo esc_attr( $field_name ); ?>"
@@ -36,7 +35,7 @@ switch ( $field['type'] ) {
 				value="<?php echo esc_attr( isset( $shortcode['attributes'][ $field_name ]['default'] ) ? $shortcode['attributes'][ $field_name ]['default'] : '' ); ?>" 
 				<?php echo $data_attributes; // phpcs:ignore ?>
 				placeholder="<?php echo esc_attr( isset( $field['placeholder'] ) ? $field['placeholder'] : '' ); ?>"
-				class="widefat <?php echo esc_attr( isset( $field['class'] ) ? $field['class'] : '' ); ?>" />
+				class="widefat" />
 		<?php
 		break;
 
@@ -53,7 +52,7 @@ switch ( $field['type'] ) {
 				min="<?php echo esc_attr( $field['min'] ); ?>" 
 				max="<?php echo esc_attr( $field['max'] ); ?>" 
 				step="<?php echo esc_attr( $field['step'] ); ?>"
-				class="widefat <?php echo esc_attr( isset( $field['class'] ) ? $field['class'] : '' ); ?>" />
+				class="widefat" />
 		<?php
 		break;
 
@@ -66,7 +65,7 @@ switch ( $field['type'] ) {
 				id="tinymce_modal_<?php echo esc_attr( $field_name ); ?>"
 				<?php echo $data_attributes; // phpcs:ignore ?>
 				size="1"
-				class="widefat <?php echo esc_attr( isset( $field['class'] ) ? $field['class'] : '' ); ?>">
+				class="widefat">
 			<?php
 			$field['default_value'] = ( isset( $shortcode['attributes'][ $field_name ]['default'] ) ? $shortcode['attributes'][ $field_name ]['default'] : '' );
 			foreach ( $field['values'] as $value => $label ) {
@@ -82,33 +81,6 @@ switch ( $field['type'] ) {
 		break;
 
 	/**
-	 * Multiple Select
-	 */
-	case 'select_multiple':
-		?>
-		<select name="<?php echo esc_attr( $field_name ); ?>[]"
-				id="tinymce_modal_<?php echo esc_attr( $field_name ); ?>"
-				<?php echo $data_attributes; // phpcs:ignore ?>
-				size="1"
-				multiple="multiple"
-				class="widefat <?php echo esc_attr( isset( $field['class'] ) ? $field['class'] : '' ); ?>">
-			<?php
-			$field['default_value'] = ( isset( $shortcode['attributes'][ $field_name ]['default'] ) ? $shortcode['attributes'][ $field_name ]['default'] : '' );
-			if ( isset( $field['values'] ) && is_array( $field['values'] ) && count( $field['values'] ) > 0 ) {
-				foreach ( $field['values'] as $value => $label ) {
-					?>
-					<option value="<?php echo esc_attr( $value ); ?>"<?php selected( $field['default_value'], $value ); ?>>
-						<?php echo esc_attr( $label ); ?>
-					</option>
-					<?php
-				}
-			}
-			?>
-		</select>
-		<?php
-		break;
-
-	/**
 	 * Toggle
 	 */
 	case 'toggle':
@@ -117,13 +89,28 @@ switch ( $field['type'] ) {
 				id="tinymce_modal_<?php echo esc_attr( $field_name ); ?>"
 				<?php echo $data_attributes; // phpcs:ignore ?>
 				size="1"
-				class="widefat <?php echo esc_attr( isset( $field['class'] ) ? $field['class'] : '' ); ?>">
+				class="widefat">
 			<?php
 			$field['default_value'] = ( isset( $shortcode['attributes'][ $field_name ]['default'] ) ? $shortcode['attributes'][ $field_name ]['default'] : '' );
 			?>
 			<option value="0"<?php selected( $field['default_value'], 0 ); ?>><?php esc_html_e( 'No', 'convertkit' ); ?></option>
 			<option value="1"<?php selected( $field['default_value'], 1 ); ?>><?php esc_html_e( 'Yes', 'convertkit' ); ?></option>
 		</select>
+		<?php
+		break;
+
+	/**
+	 * Color Picker
+	 */
+	case 'color':
+		?>
+		<input type="text" 
+				id="tinymce_modal_<?php echo esc_attr( $field_name ); ?>"
+				name="<?php echo esc_attr( $field_name ); ?>"
+				value="<?php echo esc_attr( isset( $shortcode['attributes'][ $field_name ]['default'] ) ? $shortcode['attributes'][ $field_name ]['default'] : '' ); ?>" 
+				<?php echo $data_attributes; // phpcs:ignore ?>
+				placeholder="<?php echo esc_attr( isset( $field['placeholder'] ) ? $field['placeholder'] : '' ); ?>"
+				class="widefat convertkit-color-picker" />
 		<?php
 		break;
 }


### PR DESCRIPTION
## Summary

When using the Broadcasts block in Gutenberg, native options are displayed to define the block's background, text and link colors:
<img width="1182" alt="Screenshot 2022-09-19 at 14 35 55" src="https://user-images.githubusercontent.com/1462305/191100990-10be0107-8110-4a29-b16f-418b0a5812ee.png">

This PR adds support for defining color options when using the Broadcasts shortcode (i.e. for users not using Gutenberg), utilizing WordPress' built in color picker:
<img width="1160" alt="Screenshot 2022-09-19 at 14 37 49" src="https://user-images.githubusercontent.com/1462305/191101278-78a01730-2187-4b16-913c-8098c906a620.png">
<img width="860" alt="Screenshot 2022-09-19 at 14 38 15" src="https://user-images.githubusercontent.com/1462305/191101279-838dde94-7f0e-4259-a59e-46351ccc7943.png">
<img width="1070" alt="Screenshot 2022-09-19 at 14 38 21" src="https://user-images.githubusercontent.com/1462305/191101281-d8eef963-b6eb-4af4-a6bd-50e8b527b027.png">

## Testing

- `PageShortcodeBroadcastsCest:testBroadcastsShortcodeInVisualEditorWithHexColorParameters`: Test that color parameters are honored when defined.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)