### PR TITLE
Broadcasts: Elementor: Support color options

### DIFF
--- a/includes/integrations/elementor/class-convertkit-elementor-widget.php
+++ b/includes/integrations/elementor/class-convertkit-elementor-widget.php
@@ -220,6 +220,18 @@ class ConvertKit_Elementor_Widget extends Elementor\Widget_Base {
 				);
 				break;
 
+			/**
+			 * Color Picker
+			 */
+			case 'color':
+				$control = array_merge(
+					$control,
+					array(
+						'type' => Elementor\Controls_Manager::COLOR,
+					)
+				);
+				break;
+
 			default:
 				$control = array_merge(
 					$control,

--- a/readme.txt
+++ b/readme.txt
@@ -115,6 +115,7 @@ Full Plugin documentation can be found [here](https://help.convertkit.com/en/art
 
 ### 1.9.8.5 2022-xx-xx
 * Added: Broadcasts: Shortcode: Options to specify background, text and link colors
+* Added: Broadcasts: Elementor: Options to specify background, text and link colors
 
 ### 1.9.8.4 2022-09-08
 * Added: Setup Wizard for new installations

--- a/tests/acceptance/integrations/ElementorBroadcastsCest.php
+++ b/tests/acceptance/integrations/ElementorBroadcastsCest.php
@@ -189,6 +189,58 @@ class ElementorBroadcastsCest
 	}
 
 	/**
+	 * Test the Broadcasts block's hex colors work when defined.
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testBroadcastsWidgetWithHexColorParameters(AcceptanceTester $I)
+	{
+		// Define colors.
+		$backgroundColor = '#ee1616';
+		$textColor = '#1212c0';
+		$linkColor = '#ffffff';
+
+		// Create Page with Broadcasts widget in Elementor.
+		$pageID = $this->_createPageWithBroadcastsWidget($I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Hex Colors', [
+			'date_format' 			=> 'F j, Y',
+			'limit' 				=> 1,
+			'paginate' 				=> 1,
+			'paginate_label_prev' 	=> 'Newer',
+			'paginate_label_next' 	=> 'Older',
+			'link_color'			=> $linkColor,
+			'background_color'		=> $backgroundColor,
+			'text_color'			=> $textColor,
+		]);
+
+		// Load Page.
+		$I->amOnPage('?p='.$pageID);
+
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible('body.page-template-default');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the block displays.
+		$I->seeBroadcastsOutput($I);
+
+		// Confirm that our stylesheet loaded.
+		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="'.$_ENV['TEST_SITE_WP_URL'].'/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
+
+		// Confirm that the chosen colors are applied as CSS styles.
+		$I->seeInSource('<div class="convertkit-broadcasts has-text-color has-background" style="color:'.$textColor.';background-color:'.$backgroundColor.'"');
+		$I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:'.$linkColor.'"');
+	
+		// Test pagination.
+		$I->testBroadcastsPagination($I, 'Older', 'Newer');
+
+		// Confirm that link styles are still applied to refreshed data.
+		$I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:'.$linkColor.'"');
+	}
+
+	/**
 	 * Create a Page in the database comprising of Elementor Page Builder data
 	 * containing a ConvertKit Form widget.
 	 * 


### PR DESCRIPTION
## Summary

This PR adds support for defining color options when using the Broadcasts widget in Elementor, utilizing Elementor's built in color picker

Before:
<img width="1476" alt="Screenshot 2022-09-20 at 11 04 24" src="https://user-images.githubusercontent.com/1462305/191312572-117f5d23-9792-47cd-aece-61fcbeea63fe.png">

After:
<img width="1476" alt="Screenshot 2022-09-20 at 11 04 44" src="https://user-images.githubusercontent.com/1462305/191312575-be64637c-9b1c-442c-9413-9ec4cdc190b2.png">

## Testing

- `ElementorBroadcastsCest:testBroadcastsWidgetWithHexColorParameters`: Tests that link, background and text colors are honored when configured in the Elementor Broadcast widget.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)