### PR TITLE
Pass Site ID as integer to switch_to_blog()

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -33,7 +33,7 @@ function convertkit_plugin_activate( $network_wide ) {
 			)
 		);
 		foreach ( $sites as $site ) {
-			switch_to_blog( $site->blog_id );
+			switch_to_blog( (int) $site->blog_id );
 			$convertkit->get_class( 'setup' )->activate();
 			restore_current_blog();
 		}
@@ -90,7 +90,7 @@ function convertkit_plugin_deactivate( $network_wide ) {
 			)
 		);
 		foreach ( $sites as $site ) {
-			switch_to_blog( $site->blog_id );
+			switch_to_blog( (int) $site->blog_id );
 			$convertkit->get_class( 'setup' )->deactivate();
 			restore_current_blog();
 		}


### PR DESCRIPTION
## Summary

Passes the site ID as an integer instead of a string when calling `switch_to_blog()`, as detected in PHPStan for WordPress' [most recent update (1.1.3)](https://github.com/szepeviktor/phpstan-wordpress/releases/tag/v1.1.3), released today:
<img width="1121" alt="Screenshot 2022-09-22 at 11 17 15" src="https://user-images.githubusercontent.com/1462305/191800750-116ad838-692d-400a-ade0-26f72702fb18.png">

## Testing

Existing tests pass

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)