### PR TITLE
Abstract `ck_subscriber_id` detection / cookie storage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "1.2.0"
+        "convertkit/convertkit-wordpress-libraries": "1.3.0.x-dev"
     },
     "require-dev": {
         "lucatume/wp-browser": "^3.0",

--- a/includes/blocks/class-convertkit-block-content.php
+++ b/includes/blocks/class-convertkit-block-content.php
@@ -203,11 +203,11 @@ class ConvertKit_Block_Content extends ConvertKit_Block {
 		}
 
 		// Bail if there is no subscriber ID from the cookie or request.
-		$subscriber = new ConvertKit_Subscriber();
+		$subscriber    = new ConvertKit_Subscriber();
 		$subscriber_id = $subscriber->get_subscriber_id();
 		if ( is_wp_error( $subscriber_id ) ) {
 			if ( $settings->debug_enabled() ) {
-				return '<!-- ConvertKit Custom Content: Subscriber ID Error: '. $subscriber_id->get_error_message() . ' -->';
+				return '<!-- ConvertKit Custom Content: Subscriber ID Error: ' . $subscriber_id->get_error_message() . ' -->';
 			}
 
 			return '';

--- a/includes/blocks/class-convertkit-block-content.php
+++ b/includes/blocks/class-convertkit-block-content.php
@@ -203,7 +203,15 @@ class ConvertKit_Block_Content extends ConvertKit_Block {
 		}
 
 		// Bail if there is no subscriber ID from the cookie or request.
-		$subscriber_id = WP_ConvertKit()->get_class( 'output' )->get_subscriber_id_from_request();
+		$subscriber = new ConvertKit_Subscriber();
+		$subscriber_id = $subscriber->get_subscriber_id();
+		if ( is_wp_error( $subscriber_id ) ) {
+			if ( $settings->debug_enabled() ) {
+				return '<!-- ConvertKit Custom Content: Subscriber ID Error: '. $subscriber_id->get_error_message() . ' -->';
+			}
+
+			return '';
+		}
 		if ( ! $subscriber_id ) {
 			if ( $settings->debug_enabled() ) {
 				return '<!-- ConvertKit Custom Content: Subscriber ID does not exist -->';

--- a/includes/class-convertkit-ajax.php
+++ b/includes/class-convertkit-ajax.php
@@ -32,7 +32,7 @@ class ConvertKit_AJAX {
 	}
 
 	/**
-	 * Stores the ConvertKit Subscriber's ID in the `ck_subscriber_id` cookie.
+	 * Stores the ConvertKit Subscriber's ID in a cookie.
 	 *
 	 * Typically performed when the user subscribes via a ConvertKit Form on the web site
 	 * that is set to "Send subscriber to thank you page", and the Plugin's JavaScript is not
@@ -56,37 +56,26 @@ class ConvertKit_AJAX {
 			wp_send_json_error( __( 'ConvertKit: Required parameter `subscriber_id` empty in AJAX request.', 'convertkit' ) );
 		}
 
-		// Bail if the API hasn't been configured.
-		$settings = new ConvertKit_Settings();
-		if ( ! $settings->has_api_key_and_secret() ) {
-			wp_send_json_error( __( 'ConvertKit: API Keys not defined in Plugin Settings.', 'convertkit' ) );
+		// Get subscriber ID.
+		$subscriber    = new ConvertKit_Subscriber();
+		$subscriber_id = $subscriber->validate_and_store_subscriber_id( $id );
+
+		// Bail if an error occured i.e. API hasn't been configured, subscriber ID does not exist in ConvertKit etc.
+		if ( is_wp_error( $subscriber_id ) ) {
+			wp_send_json_error( $subscriber_id->get_error_message() );
 		}
-
-		// Initialize the API.
-		$api = new ConvertKit_API( $settings->get_api_key(), $settings->get_api_secret(), $settings->debug_enabled() );
-
-		// Get subscriber by ID, to ensure they exist.
-		$subscriber = $api->get_subscriber_by_id( $id );
-
-		// Bail if no subscriber exists with the given subscriber ID.
-		if ( is_wp_error( $subscriber ) ) {
-			wp_send_json_error( $subscriber->get_error_message() );
-		}
-
-		// Store the subscriber ID as a cookie.
-		setcookie( 'ck_subscriber_id', $subscriber['id'], time() + ( 365 * DAY_IN_SECONDS ), '/' );
 
 		// Return the subscriber ID.
 		wp_send_json_success(
 			array(
-				'id' => $subscriber['id'],
+				'id' => $subscriber_id,
 			)
 		);
 
 	}
 
 	/**
-	 * Stores the ConvertKit Subscriber Email's ID in the `ck_subscriber_id` cookie.
+	 * Stores the ConvertKit Subscriber Email's ID in a cookie.
 	 *
 	 * Typically performed when the user subscribes via a ConvertKit Form on the web site
 	 * and the Plugin's JavaScript is not disabled, permitting convertkit.js to run.
@@ -114,30 +103,19 @@ class ConvertKit_AJAX {
 			wp_send_json_error( __( 'ConvertKit: Required parameter `email` is not an email address.', 'convertkit' ) );
 		}
 
-		// Bail if the API hasn't been configured.
-		$settings = new ConvertKit_Settings();
-		if ( ! $settings->has_api_key_and_secret() ) {
-			wp_send_json_error( __( 'ConvertKit: API Keys not defined in Plugin Settings.', 'convertkit' ) );
+		// Get subscriber ID.
+		$subscriber    = new ConvertKit_Subscriber();
+		$subscriber_id = $subscriber->validate_and_store_subscriber_email( $email );
+
+		// Bail if an error occured i.e. API hasn't been configured, subscriber ID does not exist in ConvertKit etc.
+		if ( is_wp_error( $subscriber_id ) ) {
+			wp_send_json_error( $subscriber_id->get_error_message() );
 		}
-
-		// Initialize the API.
-		$api = new ConvertKit_API( $settings->get_api_key(), $settings->get_api_secret(), $settings->debug_enabled() );
-
-		// Get subscriber by email address.
-		$subscriber = $api->get_subscriber_by_email( $email );
-
-		// Bail if no subscriber exists with the given email address.
-		if ( is_wp_error( $subscriber ) ) {
-			wp_send_json_error( $subscriber->get_error_message() );
-		}
-
-		// Store the subscriber ID as a cookie.
-		setcookie( 'ck_subscriber_id', $subscriber['id'], time() + ( 365 * DAY_IN_SECONDS ), '/' );
 
 		// Return the subscriber ID.
 		wp_send_json_success(
 			array(
-				'id' => $subscriber['id'],
+				'id' => $subscriber_id,
 			)
 		);
 
@@ -188,6 +166,10 @@ class ConvertKit_AJAX {
 		if ( is_wp_error( $subscriber ) ) {
 			wp_send_json_error( $subscriber->get_error_message() );
 		}
+
+		// Store the subscriber ID as a cookie.
+		$subscriber = new ConvertKit_Subscriber();
+		$subscriber->set( $subscriber_id );
 
 		// Tag the subscriber with the Post's tag.
 		$tag = $api->tag_subscribe( $tag_id, $subscriber['email_address'] );

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -385,8 +385,16 @@ class ConvertKit_Output {
 	 */
 	public function get_subscriber_id_from_request() {
 
-		$subscriber = new ConvertKit_Subscriber();
-		return $subscriber->get_subscriber_id();
+		// Use ConvertKit_Subscriber class to fetch and validate the subscriber ID.
+		$subscriber    = new ConvertKit_Subscriber();
+		$subscriber_id = $subscriber->get_subscriber_id();
+
+		// If an error occured, the subscriber ID in the request/cookie is not a valid subscriber.
+		if ( is_wp_error( $subscriber_id ) ) {
+			return 0;
+		}
+
+		return $subscriber_id;
 
 	}
 

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -385,20 +385,8 @@ class ConvertKit_Output {
 	 */
 	public function get_subscriber_id_from_request() {
 
-		// If the subscriber ID is included in the URL as a query parameter
-		// (i.e. 'Add subscriber_id parameter in email links' is enabled at https://app.convertkit.com/account_settings/advanced_settings,
-		// return it as the subscriber ID.
-		if ( isset( $_GET['ck_subscriber_id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			return (int) sanitize_text_field( $_GET['ck_subscriber_id'] ); // phpcs:ignore WordPress.Security.NonceVerification
-		}
-
-		// If the subscriber ID is stored as a cookie (i.e. the user subscribed via a form
-		// from this Plugin on this site, which sets this cookie), return it as the subscriber ID.
-		if ( isset( $_COOKIE['ck_subscriber_id'] ) ) {
-			return (int) sanitize_text_field( $_COOKIE['ck_subscriber_id'] );
-		}
-
-		return 0;
+		$subscriber = new ConvertKit_Subscriber();
+		return $subscriber->get_subscriber_id();
 
 	}
 

--- a/includes/class-convertkit-subscriber.php
+++ b/includes/class-convertkit-subscriber.php
@@ -29,7 +29,7 @@ class ConvertKit_Subscriber {
 	 *
 	 * @since   2.0.0
 	 *
-	 * @return  int|bool    Subscriber ID | false
+	 * @return  WP_Error|bool|int    Error | false | Subscriber ID
 	 */
 	public function get_subscriber_id() {
 

--- a/includes/class-convertkit-subscriber.php
+++ b/includes/class-convertkit-subscriber.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * ConvertKit Subscriber class.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Class to confirm a ConvertKit Subscriber ID exists, writing/reading
+ * it from cookie storage.
+ *
+ * @since   2.0.0
+ */
+class ConvertKit_Subscriber {
+
+	/**
+	 * Holds the key to check on requests and store as a cookie.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @var     string
+	 */
+	private $key = 'ck_subscriber_id';
+
+	/**
+	 * Gets the subscriber ID from either the request's `ck_subscriber_id` parameter,
+	 * or the existing `ck_subscriber_id` cookie.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return  int|bool    Subscriber ID | false
+	 */
+	public function get_subscriber_id() {
+
+		// If the subscriber ID is in the request URI, use it.
+		if ( isset( $_REQUEST[ $this->key ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			return $this->validate_and_store_subscriber_id( absint( $_REQUEST[ $this->key ] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+		}
+
+		// If the subscriber ID is in a cookie, return it.
+		// For performance, we don't check that the subscriber ID exists every time, otherwise this would
+		// call the API on every page load.
+		if ( isset( $_COOKIE[ $this->key ] ) ) {
+			return $this->get_subscriber_id_from_cookie();
+		}
+
+		// If here, no subscriber ID exists.
+		return false;
+
+	}
+
+	/**
+	 * Validates the given subscriber ID by querying the API to confirm
+	 * the subscriber exists before storing their ID in a cookie.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @param   int $subscriber_id  Possible Subscriber ID.
+	 * @return  WP_Error|int                    Error | Confirmed Subscriber ID
+	 */
+	public function validate_and_store_subscriber_id( $subscriber_id ) {
+
+		// Bail if the API hasn't been configured.
+		$settings = new ConvertKit_Settings();
+		if ( ! $settings->has_api_key_and_secret() ) {
+			return new WP_Error(
+				'convertkit_subscriber_get_subscriber_id_from_request_error',
+				__( 'API Key and Secret not configured in Plugin Settings.', 'convertkit' )
+			);
+		}
+
+		// Initialize the API.
+		$api = new ConvertKit_API( $settings->get_api_key(), $settings->get_api_secret(), $settings->debug_enabled() );
+
+		// Get subscriber by ID, to ensure they exist.
+		$subscriber = $api->get_subscriber_by_id( $subscriber_id );
+
+		// Bail if no subscriber exists with the given subscriber ID, or an error occured.
+		if ( is_wp_error( $subscriber ) ) {
+			// Delete the cookie.
+			$this->forget();
+
+			// Return error.
+			return $subscriber;
+		}
+
+		// Store the subscriber ID as a cookie.
+		$this->set( $subscriber['id'] );
+
+		// Return subscriber ID.
+		return absint( $subscriber['id'] );
+
+	}
+
+	/**
+	 * Validates the given subscriber email by querying the API to confirm
+	 * the subscriber exists before storing their ID in a cookie.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @param   string $subscriber_email   Possible Subscriber Email.
+	 * @return  WP_Error|int                        Error | Confirmed Subscriber ID
+	 */
+	public function validate_and_store_subscriber_email( $subscriber_email ) {
+
+		// Bail if the API hasn't been configured.
+		$settings = new ConvertKit_Settings();
+		if ( ! $settings->has_api_key_and_secret() ) {
+			return new WP_Error(
+				'convertkit_subscriber_get_subscriber_id_from_request_error',
+				__( 'API Key and Secret not configured in Plugin Settings.', 'convertkit' )
+			);
+		}
+
+		// Initialize the API.
+		$api = new ConvertKit_API( $settings->get_api_key(), $settings->get_api_secret(), $settings->debug_enabled() );
+
+		// Get subscriber by email, to ensure they exist.
+		$subscriber = $api->get_subscriber_by_email( $subscriber_email );
+
+		// Bail if no subscriber exists with the given subscriber ID, or an error occured.
+		if ( is_wp_error( $subscriber ) ) {
+			// Delete the cookie.
+			$this->forget();
+
+			// Return error.
+			return $subscriber;
+		}
+
+		// Store the subscriber ID as a cookie.
+		$this->set( $subscriber['id'] );
+
+		// Return subscriber ID.
+		return absint( $subscriber['id'] );
+
+	}
+
+	/**
+	 * Gets the subscriber ID from the `ck_subscriber_id` cookie.
+	 *
+	 * @since   2.0.0
+	 */
+	private function get_subscriber_id_from_cookie() {
+
+		return absint( $_COOKIE[ $this->key ] );
+
+	}
+
+	/**
+	 * Stores the given subscriber ID in the `ck_subscriber_id` cookie.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @param   int $subscriber_id  Subscriber ID.
+	 */
+	public function set( $subscriber_id ) {
+
+		setcookie( $this->key, (string) $subscriber_id, time() + ( 365 * DAY_IN_SECONDS ), '/' );
+
+	}
+
+	/**
+	 * Deletes the `ck_subscriber_id` cookie.
+	 *
+	 * @since   2.0.0
+	 */
+	public function forget() {
+
+		setcookie( $this->key, '', time() - ( 365 * DAY_IN_SECONDS ), '/' );
+
+	}
+
+}

--- a/tests/acceptance/tags/PageShortcodeCustomContentCest.php
+++ b/tests/acceptance/tags/PageShortcodeCustomContentCest.php
@@ -90,6 +90,9 @@ class PageShortcodeCustomContentCest
 			'post_content'	=> '[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]ConvertKitCustomContent[/convertkit_content]',
 		]);
 
+		// Prevent API rate limit from being hit in parallel tests.
+		$I->wait(2);
+
 		// Load the Page on the frontend site.
 		$I->amOnPage('/convertkit-custom-content-shortcode-valid-tag-param-and-invalid-subscriber-id');
 
@@ -124,6 +127,9 @@ class PageShortcodeCustomContentCest
 			'post_name' 	=> 'convertkit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id',
 			'post_content'	=> '[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]ConvertKitCustomContent[/convertkit_content]',
 		]);
+
+		// Prevent API rate limit from being hit in parallel tests.
+		$I->wait(2);
 
 		// Load the Page on the frontend site.
 		$I->amOnPage('/convertkit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id');

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -58,6 +58,7 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-resource-tags.
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-settings.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-setup.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-shortcodes.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-subscriber.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-term.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-user.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-widgets.php';


### PR DESCRIPTION
## Summary

Abstracts logic to check:
- if a URL request includes a `ck_subscriber_id` parameter (i.e. if clicking a link in a ConvertKit email where the ConvertKit account's `Add subscriber_id parameter in email links` setting is enabled), and/or 
- if a `ck_subscriber_id` cookie exists (having been set by a previous request above).

This subscriber ID is used for displaying [custom content](https://help.convertkit.com/en/articles/2502591-getting-started-the-wordpress-plugin#custom-content) (i.e. blocks of content that are only viewable to a subscriber that has a specific tag); but will later be used in the Restrict Content functionality, to provide an improved way to gate/restrict content by form, tag or product, with email link authentication.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)