### PR TITLE
Tests: Improve reliability of tests for Broadcasts and WooCommerce

### DIFF
--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -334,7 +334,8 @@ class Plugin extends \Codeception\Module
 		$secondBroadcast = current(array_slice($broadcasts, 1, 1));
 
 		// Confirm that the expected Broadcast name is displayed and links to the expected URL, with UTM parameters.
-		$I->seeInSource('<a href="'.$secondBroadcast['url'].'?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener">'.$secondBroadcast['title'].'</a>');
+		$I->seeInSource('<a href="'.$secondBroadcast['url'].'?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener"');
+		$I->seeInSource($secondBroadcast['title']);
 
 		// Click the Newer Posts link.
 		$I->click('li.convertkit-broadcasts-pagination-prev a');
@@ -347,7 +348,8 @@ class Plugin extends \Codeception\Module
 		$I->seeBroadcastsOutput($I, 1, false, $nextLabel);
 
 		// Confirm that the expected Broadcast name is displayed and links to the expected URL, with UTM parameters.
-		$I->seeInSource('<a href="'.$firstBroadcast['url'].'?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener">'.$firstBroadcast['title'].'</a>');
+		$I->seeInSource('<a href="'.$firstBroadcast['url'].'?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener"');
+		$I->seeInSource($firstBroadcast['title']);
 	}
 
 	/**

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -303,6 +303,16 @@ class Plugin extends \Codeception\Module
 		}
 	}
 
+	/**
+	 * Tests that the Broadcasts pagination works, and that the expected Broadcast
+	 * is displayed after using previous and next links.
+	 * 
+	 * @since 	2.0.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 						Tester.
+	 * @param 	string 				$previousLabel 			Previous / Newer Broadcasts Label.
+	 * @param 	string 				$nextLabel 				Next / Older Broadcasts Label.
+	 */
 	public function testBroadcastsPagination($I, $previousLabel, $nextLabel)
 	{
 		// Confirm that the block displays one broadcast with a pagination link to older broadcasts.
@@ -318,8 +328,13 @@ class Plugin extends \Codeception\Module
 		// Confirm that the block displays one broadcast with a pagination link to newer broadcasts.
 		$I->seeBroadcastsOutput($I, 1, $previousLabel, false);
 
-		// Confirm that the expected Broadcast name is displayed.
-		$I->seeInSource('Broadcast 2');
+		// Fetch Broadcasts from the resource, to determine the name of the most recent two broadcasts.
+		$broadcasts = $I->grabOptionFromDatabase('convertkit_posts');
+		$firstBroadcast = current(array_slice($broadcasts, 0, 1));
+		$secondBroadcast = current(array_slice($broadcasts, 1, 1));
+
+		// Confirm that the expected Broadcast name is displayed and links to the expected URL, with UTM parameters.
+		$I->seeInSource('<a href="'.$secondBroadcast['url'].'?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener">'.$secondBroadcast['title'].'</a>');
 
 		// Click the Newer Posts link.
 		$I->click('li.convertkit-broadcasts-pagination-prev a');
@@ -331,8 +346,8 @@ class Plugin extends \Codeception\Module
 		// Confirm that the block displays one broadcast with a pagination link to older broadcasts.
 		$I->seeBroadcastsOutput($I, 1, false, $nextLabel);
 
-		// Confirm that the expected Broadcast name is displayed.
-		$I->seeInSource('Paid Subscriber Broadcast');
+		// Confirm that the expected Broadcast name is displayed and links to the expected URL, with UTM parameters.
+		$I->seeInSource('<a href="'.$firstBroadcast['url'].'?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener">'.$firstBroadcast['title'].'</a>');
 	}
 
 	/**

--- a/tests/_support/Helper/Acceptance/WPClassicEditor.php
+++ b/tests/_support/Helper/Acceptance/WPClassicEditor.php
@@ -43,8 +43,17 @@ class WPClassicEditor extends \Codeception\Module
 	 */
 	public function addVisualEditorShortcode($I, $shortcodeName, $shortcodeProgrammaticName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false, $targetEditor = 'content')
 	{
-		// Click the Visual tab.
-		$I->scrollTo('h1.wp-heading-inline');
+		// Scroll to the applicable TinyMCE editor.
+		switch($targetEditor) {
+			case 'excerpt':
+				$I->scrollTo('#postexcerpt');
+				break;
+			default:
+				$I->scrollTo('h1.wp-heading-inline');
+				break;
+		}
+
+		// Click the Visual tab on the applicable TinyMCE editor.
 		$I->click('button#'.$targetEditor.'-tmce');
 
 		// Click the TinyMCE Button for this shortcode.

--- a/tests/_support/Helper/Acceptance/WPClassicEditor.php
+++ b/tests/_support/Helper/Acceptance/WPClassicEditor.php
@@ -112,8 +112,18 @@ class WPClassicEditor extends \Codeception\Module
 	 */
 	public function addTextEditorShortcode($I, $shortcodeName, $shortcodeProgrammaticName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false, $targetEditor = 'content')
 	{
+		// Scroll to the applicable TinyMCE editor.
+		switch($targetEditor) {
+			case 'excerpt':
+				$I->scrollTo('#postexcerpt');
+				$I->click('#postexcerpt button.handlediv');
+				break;
+			default:
+				$I->scrollTo('h1.wp-heading-inline');
+				break;
+		}
+
 		// Click the Text tab.
-		$I->scrollTo('h1.wp-heading-inline');
 		$I->click('button#'.$targetEditor.'-html');
 
 		// Click the QuickTags Button for this shortcode.

--- a/tests/_support/Helper/Acceptance/WPClassicEditor.php
+++ b/tests/_support/Helper/Acceptance/WPClassicEditor.php
@@ -47,6 +47,7 @@ class WPClassicEditor extends \Codeception\Module
 		switch($targetEditor) {
 			case 'excerpt':
 				$I->scrollTo('#postexcerpt');
+				$I->click('#postexcerpt button.handlediv');
 				break;
 			default:
 				$I->scrollTo('h1.wp-heading-inline');


### PR DESCRIPTION
## Summary

**Broadcasts**

Broadcast tests that use the `testBroadcastsPagination()` helper now read the cached resource to determine the first two Broadcasts that should be displayed when testing previous / next pagination.

Previously, the Broadcast name was hard coded into the test, which doesn’t make sense when Broadcasts might be added to the ConvertKit account in the future.

Additional checks have been added to confirm the correct Broadcast URL and UTM parameters are output.

**WooCommerce**

Updates the `addVisualEditorShortcode()` and `addTextEditorShortcode()` test helpers to correctly navigate to, and open, the applicable UI element, prior to performing steps.  This is due to WooCommerce 7.0 changing the default behaviour of the `Product short description` meta box being closed, not open. 

## Testing

- Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)