### PR TITLE
Add Product button as an Elementor widget

### DIFF
--- a/includes/integrations/elementor/class-convertkit-elementor-widget-product.php
+++ b/includes/integrations/elementor/class-convertkit-elementor-widget-product.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Elementor Widget: ConvertKit Product.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Registers the ConvertKit Product Block as an Elementor Widget.
+ *
+ * @package ConvertKit
+ * @author  ConvertKit
+ */
+class ConvertKit_Elementor_Widget_Product extends ConvertKit_Elementor_Widget {
+
+	/**
+	 * The module's slug. Must be different from the block's name i.e. cannot be convertkit-product.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @var     string
+	 */
+	public $slug = 'convertkit-elementor-product';
+
+}

--- a/resources/backend/css/elementor.css
+++ b/resources/backend/css/elementor.css
@@ -10,3 +10,9 @@
 	background: url(../images/block-icon-broadcasts.svg) center no-repeat;
 	background-size: 24px 24px;
 }
+.eicon-convertkit-product {
+	width: 24px;
+	height: 24px;
+	background: url(../images/block-icon-product.svg) center no-repeat;
+	background-size: 24px 24px;
+}

--- a/tests/acceptance/general/PluginSetupWizardCest.php
+++ b/tests/acceptance/general/PluginSetupWizardCest.php
@@ -144,6 +144,9 @@ class PluginSetupWizardCest
 		// Confirm expected setup wizard screen is displayed.
 		$this->_seeExpectedSetupWizardScreen($I, 2, 'Connect your ConvertKit account');
 
+		// Wait to prevent API rate limit hit due to parallel tests.
+		$I->wait(2);
+
 		// Fill fields with invalid API Keys.
 		$I->fillField('api_key', $_ENV['CONVERTKIT_API_KEY']);
 		$I->fillField('api_secret', $_ENV['CONVERTKIT_API_SECRET']);

--- a/tests/acceptance/integrations/ElementorProductCest.php
+++ b/tests/acceptance/integrations/ElementorProductCest.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Tests for the ConvertKit Product Elementor Widget.
+ * 
+ * @since 	2.0.0
+ */
+class ElementorProductCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 * 
+	 * @since 	2.0.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'elementor');
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
+	}
+
+	/**
+	 * Test the Product widget is registered in Elementor.
+	 * 
+	 * @since 	2.0.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testProductWidgetIsRegistered(AcceptanceTester $I)
+	{
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Elementor: Registered');
+
+		// Click Edit with Elementor button.
+		$I->click('#elementor-switch-mode-button');
+
+		// When Elementor loads, search for the ConvertKit Product block.
+		$I->waitForElementVisible('#elementor-panel-elements-search-input');
+		$I->fillField('#elementor-panel-elements-search-input', 'ConvertKit Product');
+
+		// Confirm that the Product widget is displayed as an option.
+		$I->seeElementInDOM('#elementor-panel-elements .elementor-element');
+	}
+
+	/**
+	 * Test the Product block works when using valid parameters.
+	 * 
+	 * @since 	2.0.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testProductWidgetWithValidParameters(AcceptanceTester $I)
+	{
+		// Create Page with Product widget in Elementor.
+		$pageID = $this->_createPageWithProductWidget($I, 'ConvertKit: Page: Product: Elementor Widget: Valid Params', [
+			'product' => $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+			'text'	  => 'Buy my product',
+		]);
+
+		// Load Page.
+		$I->amOnPage('?p='.$pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the block displays.
+		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
+	}
+
+	/**
+	 * Test the Product block's hex colors work when defined.
+	 * 
+	 * @since 	2.0.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testProductWidgetWithHexColorParameters(AcceptanceTester $I)
+	{
+		// Define colors.
+		$backgroundColor = '#ee1616';
+		$textColor = '#1212c0';
+
+		// Create Page with Product widget in Elementor.
+		$pageID = $this->_createPageWithProductWidget($I, 'ConvertKit: Page: Product: Elementor Widget: Hex Colors', [
+			'product' 				=> $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+			'text'	  				=> 'Buy my product',
+			'background_color'		=> $backgroundColor,
+			'text_color'			=> $textColor,
+		]);
+
+		// Load Page.
+		$I->amOnPage('?p='.$pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the block displays.
+		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product', $textColor, $backgroundColor);
+	}
+
+	/**
+	 * Create a Page in the database comprising of Elementor Page Builder data
+	 * containing a ConvertKit Product widget.
+	 * 
+	 * Codeception's dragAndDrop() method doesn't support dropping an element into an iframe, which is
+	 * how Elementor works for adding widgets to a Page.
+	 * 
+	 * Therefore, we directly create a Page in the database, with Elementor's data structure
+	 * as if we added the Product widget to a Page edited in Elementor.
+	 * 
+	 * testProductWidgetIsRegistered() above is a sanity check that the Product Widget is registered
+	 * and available to users in Elementor.
+	 * 
+	 * @since 	2.0.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 			Tester.
+	 * @param 	string 				$title 		Page Title.
+	 * @param 	array 				$settings 	Widget settings.
+	 * @return 	int 							Page ID
+	 */
+	private function _createPageWithProductWidget(AcceptanceTester $I, $title, $settings)
+	{
+		return $I->havePostInDatabase([
+			'post_title'	=> $title,
+			'post_type'		=> 'page',
+			'post_status'	=> 'publish',
+			'meta_input' => [
+				// Elementor.
+				'_elementor_data' => [
+					0 => [
+						'id' => '39bb59d',
+						'elType' => 'section',
+						'settings' => [],
+						'elements' => [
+							[
+								'id' => 'b7e0e57',
+								'elType' => 'column',
+								'settings' => [
+									'_column_size' => 100,
+									'_inline_size' => null,
+								],
+								'elements' => [
+									[
+										'id' => 'a73a905',
+										'elType' => 'widget',
+										'settings' => $settings,
+										'widgetType' => 'convertkit-elementor-product',
+									],
+								],
+							],
+						],
+					],
+				],
+				'_elementor_version' => '3.6.1',
+				'_elementor_edit_mode' => 'builder',
+				'_elementor_template_type' => 'wp-page',
+
+				// Configure ConvertKit Plugin to not display a default Form,
+				// as we are testing for the Form in Elementor.
+				'_wp_convertkit_post_meta' => [
+					'form'         => '-1',
+					'landing_page' => '',
+					'tag'          => '',
+				],
+			],
+		]);
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 * 
+	 * @since 	2.0.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateThirdPartyPlugin($I, 'elementor');
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
+	}
+}


### PR DESCRIPTION
## Summary

Registers the Product button block as an Elementor widget:
https://www.loom.com/share/1ebd138e582c428fb61504d70ca8778b

## Testing

- `ElementorProductCest`: Tests for adding the Product button in Elementor

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)