### PR TITLE
ConvertKit 2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "1.3.0.x-dev"
+        "convertkit/convertkit-wordpress-libraries": "1.2.1"
     },
     "require-dev": {
         "lucatume/wp-browser": "^3.0",

--- a/includes/blocks/class-convertkit-block-product.php
+++ b/includes/blocks/class-convertkit-block-product.php
@@ -29,7 +29,6 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 
 		// Enqueue scripts and styles for this Gutenberg Block in the editor view.
 		add_action( 'convertkit_gutenberg_enqueue_scripts', array( $this, 'enqueue_scripts_editor' ) );
-		add_action( 'convertkit_gutenberg_enqueue_styles', array( $this, 'enqueue_styles_editor' ) );
 
 		// Enqueue scripts and styles for this Gutenberg Block in the editor and frontend views.
 		add_action( 'convertkit_gutenberg_enqueue_scripts_editor_and_frontend', array( $this, 'enqueue_scripts' ) );
@@ -45,17 +44,6 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 	public function enqueue_scripts_editor() {
 
 		wp_enqueue_script( 'convertkit-gutenberg-block-product', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/gutenberg-block-product.js', array( 'convertkit-gutenberg' ), CONVERTKIT_PLUGIN_VERSION, true );
-
-	}
-
-	/**
-	 * Enqueues styles for this Gutenberg Block in the editor view.
-	 *
-	 * @since   1.9.8.5
-	 */
-	public function enqueue_styles_editor() {
-
-		wp_enqueue_style( 'convertkit-gutenberg-block-product', CONVERTKIT_PLUGIN_URL . '/resources/backend/css/gutenberg-block-product.css', array( 'wp-edit-blocks' ), CONVERTKIT_PLUGIN_VERSION );
 
 	}
 

--- a/includes/class-convertkit-post-type-product.php
+++ b/includes/class-convertkit-post-type-product.php
@@ -8,9 +8,12 @@
 
 /**
  * Class to register the Product Custom Post Type, and store
- * Products in the Custom Post Type, permitting Gutenberg's
- * LinkControl to display ConvertKit Products as results
- * when searching for items to link text to.
+ * Products in the Custom Post Type, permitting both Gutenberg's
+ * LinkControl and Classic Editor link functionality to display
+ * ConvertKit Products as results when searching for items to link text to.
+ *
+ * Also adds data-commerce attributes to any links pointing to a ConvertKit
+ * Product URL.
  *
  * @since   2.0.0
  */

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: email marketing, email newsletter, newsletter, convertkit
 Requires at least: 5.0
 Tested up to: 6.0.2
 Requires PHP: 5.6.20
-Stable tag: 1.9.8.5
+Stable tag: 2.0.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -33,7 +33,7 @@ Sign up forms can be configured to:
 Embedding ConvertKit forms on your WordPress web site with the ConvertKit Plugin is quick and simple:
 
 - Choose a default form to be displayed below each individual Post Type (Pages, Posts and other public Post Types, such as WooCommerce Products)
-- Choose a specific form to be dispalyed below a specific Page, Post or custom post type
+- Choose a specific form to be displayed below a specific Page, Post or custom post type
 - Turn off form embedding at both site wide and/or individual Page/Post level
 
 For greater control, ConvertKit forms can be displayed in specific sections of your WordPress site's content, sidebars and footers by:
@@ -55,6 +55,10 @@ Embed existing email newsletters on your WordPress web site, ensuring visitors n
 
 - Using the ConvertKit Broadcasts block in Gutenberg
 - Using the `[convertkit_broadcasts]` shortcode in the Classic Editor
+
+= Sell Products =
+
+Embed buttons, or link text, to sell your ConvertKit Products in seconds - whether digital goods, paid newsletters, coaching and more.
 
 = Plugin Integrations =
 
@@ -112,6 +116,13 @@ Full Plugin documentation can be found [here](https://help.convertkit.com/en/art
 7. Track subscriber growth
 
 == Changelog ==
+
+### 2.0.0 2022-10-xx
+* Added: ConvertKit Products Block, to output a button linking to a ConvertKit Product or Tip Jar
+* Added: ConvertKit Products Shortcode, to output a button linking to a ConvertKit Product or Tip Jar
+* Added: Gutenberg: Option to link text or button to a ConvertKit Product or Tip Jar
+* Added: Classic Editor: Option to link text or button to a ConvertKit Product or Tip Jar
+* Added: Settings: Improved UI
 
 ### 1.9.8.5 2022-10-03
 * Added: Broadcasts: Shortcode: Options to specify background, text and link colors

--- a/readme.txt
+++ b/readme.txt
@@ -58,7 +58,7 @@ Embed existing email newsletters on your WordPress web site, ensuring visitors n
 
 = Sell Products =
 
-Embed buttons, or link text, to sell your ConvertKit Products in seconds - whether digital goods, paid newsletters, coaching and more.
+Embed buttons (or link text) to sell your ConvertKit Products in seconds - whether that's digital goods, paid newsletters, music, coaching and more.
 
 = Plugin Integrations =
 

--- a/readme.txt
+++ b/readme.txt
@@ -117,7 +117,7 @@ Full Plugin documentation can be found [here](https://help.convertkit.com/en/art
 
 == Changelog ==
 
-### 2.0.0 2022-10-xx
+### 2.0.0 2022-10-24
 * Added: ConvertKit Products Block, to output a button linking to a ConvertKit Product or Tip Jar
 * Added: ConvertKit Products Shortcode, to output a button linking to a ConvertKit Product or Tip Jar
 * Added: Gutenberg: Option to link text or button to a ConvertKit Product or Tip Jar

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -9,7 +9,7 @@
  * Plugin Name: ConvertKit
  * Plugin URI: https://convertkit.com/
  * Description: Quickly and easily integrate ConvertKit forms into your site.
- * Version: 1.9.8.5
+ * Version: 2.0.0
  * Author: ConvertKit
  * Author URI: https://convertkit.com/
  * Text Domain: convertkit
@@ -25,7 +25,7 @@ define( 'CONVERTKIT_PLUGIN_NAME', 'ConvertKit' ); // Used for user-agent in API 
 define( 'CONVERTKIT_PLUGIN_FILE', plugin_basename( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_PATH', __DIR__ );
-define( 'CONVERTKIT_PLUGIN_VERSION', '1.9.8.5' );
+define( 'CONVERTKIT_PLUGIN_VERSION', '2.0.0' );
 
 // Load shared classes, if they have not been included by another ConvertKit Plugin.
 if ( ! class_exists( 'ConvertKit_API' ) ) {


### PR DESCRIPTION
## Summary

Minor changes for the 2.0.0 Plugin release:
- Updated readme file to reflect changes and Products functionality
- Updated readme file and Plugin version to `2.0.0`
- Use WordPress Libraries `1.2.1`, which is now published
- Remove CSS include for non-existent file `gutenberg-block-product.css`

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)