### PR TITLE
Tests: PHP Versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         wp-versions: [ '6.0.3' ] #[ '5.6.7', '5.7.5', '5.8.3', '5.9' ]
-        php-versions: [ '7.2', '7.3', '7.4', '8.0' ] #[ '7.3', '7.4', '8.0', '8.1' ]
+        php-versions: [ '7.4', '8.0' ] #[ '7.3', '7.4', '8.0', '8.1' ]
         
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [

--- a/tests/acceptance/tags/PageShortcodeCustomContentCest.php
+++ b/tests/acceptance/tags/PageShortcodeCustomContentCest.php
@@ -90,9 +90,6 @@ class PageShortcodeCustomContentCest
 			'post_content'	=> '[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]ConvertKitCustomContent[/convertkit_content]',
 		]);
 
-		// Prevent API rate limit from being hit in parallel tests.
-		$I->wait(2);
-
 		// Load the Page on the frontend site.
 		$I->amOnPage('/convertkit-custom-content-shortcode-valid-tag-param-and-invalid-subscriber-id');
 
@@ -127,9 +124,6 @@ class PageShortcodeCustomContentCest
 			'post_name' 	=> 'convertkit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id',
 			'post_content'	=> '[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]ConvertKitCustomContent[/convertkit_content]',
 		]);
-
-		// Prevent API rate limit from being hit in parallel tests.
-		$I->wait(2);
 
 		// Load the Page on the frontend site.
 		$I->amOnPage('/convertkit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id');


### PR DESCRIPTION
## Summary

Run tests against [supported PHP versions](https://www.php.net/supported-versions.php) and resolves API rate limits triggering tests to fail, due to so many tests previously running in parallel.

Coding Standards tests continue to run against PHP 7.2 and 7.3, to confirm we are not introducing breaking changes i.e. functions only available in PHP 7.4+.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)