### PR TITLE
Tests: Apply Coding Standards

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -116,10 +116,15 @@ jobs:
         working-directory: ${{ env.PLUGIN_DIR }}
         run: composer dump-autoload
 
-      # Run WordPress Coding Standards tests.
-      - name: Run WordPress Coding Standards Tests
+      # Run PSR-12 Coding Standards on Tests.
+      - name: Run PSR-12 Coding Standards on Tests
         working-directory: ${{ env.PLUGIN_DIR }}
-        run: php vendor/bin/phpcs ./ -v -s
+        run: php vendor/bin/phpcs ./tests --standard=phpcs.tests.xml -v -s
+
+      # Run WordPress Coding Standards.
+      - name: Run WordPress Coding Standards
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: php vendor/bin/phpcs ./ --standard=phpcs.xml -v -s
 
       # Run PHPStan for static analysis.
       - name: Run PHPStan Static Analysis

--- a/TESTING.md
+++ b/TESTING.md
@@ -411,18 +411,23 @@ Any errors should be corrected by making applicable code or test changes.
 [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) checks that all Plugin code meets the 
 [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/).
 
-In the Plugin's directory, run the following command to run PHP_CodeSniffer, which will check the code meets WordPress' Coding Standards:
+In the Plugin's directory, run the following command to run PHP_CodeSniffer, which will check the code meets WordPress' Coding Standards
+as defined in the `phpcs.xml` configuration:
 
 ```bash
-vendor/bin/phpcs ./ -v -s
+vendor/bin/phpcs ./ --standard=phpcs.xml -v -s
 ```
 
-`-v` produces verbose output, and `-s` specifies the precise rule that failed:
+`--standard=phpcs.tests.xml` tells PHP CodeSniffer to use the Coding Standards rules / configuration defined in `phpcs.tests.xml`.
+These differ slightly from WordPress' Coding Standards, to ensure that writing tests isn't a laborious task, whilst maintaing consistency
+in test coding style. 
+`-v` produces verbose output
+`-s` specifies the precise rule that failed
 ![Coding Standards Screenshot](/.github/docs/coding-standards-error.png?raw=true)
 
 Any errors should be corrected by either:
 - making applicable code changes
-- (Experimental) running `vendor/bin/phpcbf ./ -v` to automatically fix coding standards
+- (Experimental) running `vendor/bin/phpcbf ./ --standard=phpcs.xml -v -s` to automatically fix coding standards
 
 Need to change the PHP or WordPress coding standard rules applied?  Either:
 - ignore a rule in the affected code, by adding `phpcs:ignore {rule}`, where {rule} is the given rule that failed in the above output.
@@ -450,6 +455,31 @@ vendor/bin/phpstan --memory-limit=1G
 Any errors should be corrected by making applicable code changes.
 
 False positives [can be excluded by configuring](https://phpstan.org/user-guide/ignoring-errors) the `phpstan.neon` file.
+
+## Run PHP CodeSniffer for Tests
+
+In the Plugin's directory, run the following command to run PHP_CodeSniffer, which will check the code meets Coding Standards
+as defined in the `phpcs.tests.xml` configuration:
+
+```bash
+vendor/bin/phpcs ./tests --standard=phpcs.tests.xml -v -s 
+```
+
+`--standard=phpcs.tests.xml` tells PHP CodeSniffer to use the Coding Standards rules / configuration defined in `phpcs.tests.xml`.
+These differ slightly from WordPress' Coding Standards, to ensure that writing tests isn't a laborious task, whilst maintaing consistency
+in test coding style. 
+`-v` produces verbose output
+`-s` specifies the precise rule that failed
+
+Any errors should be corrected by either:
+- making applicable code changes
+- (Experimental) running `vendor/bin/phpcbf ./tests --standard=phpcs.tests.xml -v -s ` to automatically fix coding standards
+
+Need to change the PHP or WordPress coding standard rules applied?  Either:
+- ignore a rule in the affected code, by adding `phpcs:ignore {rule}`, where {rule} is the given rule that failed in the above output.
+- edit the [phpcs.tests.xml](phpcs.tests.xml) file.
+
+**Rules can be ignored with caution**, but it's essential that rules relating to coding style and inline code commenting / docblocks remain.
 
 ## Next Steps
 

--- a/phpcs.tests.xml
+++ b/phpcs.tests.xml
@@ -2,7 +2,7 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP_CodeSniffer" xsi:noNamespaceSchemaLocation="phpcs.xsd">
     <description>Coding Standards for Tests</description>
 
-    <!-- Use the PEAR standard, with some exclusions -->
+    <!-- Use the PEAR standard to ensure standardization of tests code and formatting, with some exclusions so writing tests isn't burdensome -->
     <rule ref="PEAR">
         <exclude name="PEAR.NamingConventions.ValidFunctionName"/>
         <exclude name="PEAR.NamingConventions.ValidVariableName"/>
@@ -12,7 +12,10 @@
         <exclude name="PEAR.Commenting.FileComment.MissingPackageTag"/>
         <exclude name="PEAR.Commenting.FileComment.MissingLinkTag"/>
         <exclude name="PEAR.Commenting.FileComment.MissingVersion"/>
+        <exclude name="PEAR.Commenting.FunctionComment.MissingReturn"/>
 
+        <exclude name="Generic.Commenting.DocComment.NonParamGroup"/>
+        <exclude name="Generic.Commenting.DocComment.ParamNotFirst"/>
         <exclude name="Generic.Files.LineLength"/>
         <exclude name="Generic.WhiteSpace.DisallowTabIndent.TabsUsed"/>
     </rule>

--- a/phpcs.tests.xml
+++ b/phpcs.tests.xml
@@ -7,23 +7,42 @@
         <!-- Don't use yoda conditions -->
         <exclude name="WordPress.PHP.YodaConditions" />
 
-        <!-- Codeception uses camelCase for variable names -->
-        <exclude name="WordPress.NamingConventions.ValidVariableName" />
-
-        <!-- We might use some datetime functions for tests -->
-        <exclude name="WordPress.DateTime.RestrictedFunctions" />
-
-        <!-- Filenames for tests are different in Codeception -->
+        <!-- Exclude WordPress rules so we follow Codeception's formatting -->
+        <exclude name="WordPress.NamingConventions" />
         <exclude name="WordPress.Files.FileName" />
 
-        <!-- Exclude WordPress naming conventions, as Codeception has its own rules -->
-        <exclude name="WordPress.NamingConventions" />
+        <!-- Exclude rules for function parameter spacing and newlines -->
+        <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterOpenParenthesis" />
+        <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.ExtraSpaceAfterCloseParenthesis" />
+        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterOpen" />
+        <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceBeforeCloseParenthesis" />
+        <exclude name="Generic.Classes.OpeningBraceSameLine.BraceOnNewLine" />
+        <exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie.BraceOnNewLine" />
+        <exclude name="PEAR.Functions.FunctionCallSignature.SpaceBeforeOpenBracket" />
+        <exclude name="PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket" />
+        <exclude name="PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket" />
+
+        <!-- _before() and _passed() must use underscores -->
+        <exclude name="PSR2.Methods.MethodDeclaration.Underscore" />
+
+        <!-- Make arrays more modern -->
+        <exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
+        
+        <!-- We might use some datetime functions for tests -->
+        <exclude name="WordPress.DateTime.RestrictedFunctions" />
 
         <!-- Handles false positives where Coding Standards thinks we did something wrong when we're just checking for e.g. a stylesheet -->
         <exclude name="WordPress.WP.EnqueuedResources" />
         <exclude name="WordPress.PHP.DiscouragedPHPFunctions" />
-
-        <!-- Codeception requires _before() and _passed() methods start with an underscore -->
-        <exclude name="PSR2.Methods.MethodDeclaration.Underscore" />
     </rule>
+
+    <!-- Check that code is documented to WordPress Standards. -->
+    <rule ref="WordPress-Docs">
+        <!-- File document level comments are useless for tests; we know what a test suite does -->
+        <exclude name="Squiz.Commenting.FileComment.Missing" />
+    </rule>
+
+    <!-- Add in some extra rules from other standards. -->
+    <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
+    <rule ref="Generic.Commenting.Todo"/>
 </ruleset>

--- a/phpcs.tests.xml
+++ b/phpcs.tests.xml
@@ -34,6 +34,7 @@
         <!-- Handles false positives where Coding Standards thinks we did something wrong when we're just checking for e.g. a stylesheet -->
         <exclude name="WordPress.WP.EnqueuedResources" />
         <exclude name="WordPress.PHP.DiscouragedPHPFunctions" />
+        <exclude name="WordPress.WP.CapitalPDangit.Misspelled" />
     </rule>
 
     <!-- Check that code is documented to WordPress Standards. -->

--- a/phpcs.tests.xml
+++ b/phpcs.tests.xml
@@ -2,21 +2,28 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP_CodeSniffer" xsi:noNamespaceSchemaLocation="phpcs.xsd">
     <description>Coding Standards for Tests</description>
 
-    <!-- Use the PEAR standard to ensure standardization of tests code and formatting, with some exclusions so writing tests isn't burdensome -->
-    <rule ref="PEAR">
-        <exclude name="PEAR.NamingConventions.ValidFunctionName"/>
-        <exclude name="PEAR.NamingConventions.ValidVariableName"/>
-        <exclude name="PEAR.Commenting.ClassComment"/>
-        <exclude name="PEAR.Commenting.FileComment.Missing"/>
-        <exclude name="PEAR.Commenting.FileComment.MissingCategoryTag"/>
-        <exclude name="PEAR.Commenting.FileComment.MissingPackageTag"/>
-        <exclude name="PEAR.Commenting.FileComment.MissingLinkTag"/>
-        <exclude name="PEAR.Commenting.FileComment.MissingVersion"/>
-        <exclude name="PEAR.Commenting.FunctionComment.MissingReturn"/>
+    <!-- Check that code meets WordPress-Extra standards. -->
+    <rule ref="WordPress-Extra">
+        <!-- Don't use yoda conditions -->
+        <exclude name="WordPress.PHP.YodaConditions" />
 
-        <exclude name="Generic.Commenting.DocComment.NonParamGroup"/>
-        <exclude name="Generic.Commenting.DocComment.ParamNotFirst"/>
-        <exclude name="Generic.Files.LineLength"/>
-        <exclude name="Generic.WhiteSpace.DisallowTabIndent.TabsUsed"/>
+        <!-- Codeception uses camelCase for variable names -->
+        <exclude name="WordPress.NamingConventions.ValidVariableName" />
+
+        <!-- We might use some datetime functions for tests -->
+        <exclude name="WordPress.DateTime.RestrictedFunctions" />
+
+        <!-- Filenames for tests are different in Codeception -->
+        <exclude name="WordPress.Files.FileName" />
+
+        <!-- Exclude WordPress naming conventions, as Codeception has its own rules -->
+        <exclude name="WordPress.NamingConventions" />
+
+        <!-- Handles false positives where Coding Standards thinks we did something wrong when we're just checking for e.g. a stylesheet -->
+        <exclude name="WordPress.WP.EnqueuedResources" />
+        <exclude name="WordPress.PHP.DiscouragedPHPFunctions" />
+
+        <!-- Codeception requires _before() and _passed() methods start with an underscore -->
+        <exclude name="PSR2.Methods.MethodDeclaration.Underscore" />
     </rule>
 </ruleset>

--- a/phpcs.tests.xml
+++ b/phpcs.tests.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP_CodeSniffer" xsi:noNamespaceSchemaLocation="phpcs.xsd">
+    <description>Coding Standards for Tests</description>
+
+    <!-- Use the PEAR standard, with some exclusions -->
+    <rule ref="PEAR">
+        <exclude name="PEAR.NamingConventions.ValidFunctionName"/>
+        <exclude name="PEAR.NamingConventions.ValidVariableName"/>
+        <exclude name="PEAR.Commenting.ClassComment"/>
+        <exclude name="PEAR.Commenting.FileComment.Missing"/>
+        <exclude name="PEAR.Commenting.FileComment.MissingCategoryTag"/>
+        <exclude name="PEAR.Commenting.FileComment.MissingPackageTag"/>
+        <exclude name="PEAR.Commenting.FileComment.MissingLinkTag"/>
+        <exclude name="PEAR.Commenting.FileComment.MissingVersion"/>
+
+        <exclude name="Generic.Files.LineLength"/>
+        <exclude name="Generic.WhiteSpace.DisallowTabIndent.TabsUsed"/>
+    </rule>
+</ruleset>

--- a/phpcs.tests.xml
+++ b/phpcs.tests.xml
@@ -7,11 +7,11 @@
         <!-- Don't use yoda conditions -->
         <exclude name="WordPress.PHP.YodaConditions" />
 
-        <!-- Exclude WordPress rules so we follow Codeception's formatting -->
+        <!-- File and variable naming conventions in Codeception differ from WordPress -->
         <exclude name="WordPress.NamingConventions" />
         <exclude name="WordPress.Files.FileName" />
 
-        <!-- Exclude rules for function parameter spacing and newlines -->
+        <!-- Class and function braces and spacing in Codeceptoin differs from WordPress -->
         <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterOpenParenthesis" />
         <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.ExtraSpaceAfterCloseParenthesis" />
         <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterOpen" />
@@ -22,10 +22,10 @@
         <exclude name="PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket" />
         <exclude name="PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket" />
 
-        <!-- _before() and _passed() must use underscores -->
+        <!-- _before() and _passed() must use underscores in Codeception -->
         <exclude name="PSR2.Methods.MethodDeclaration.Underscore" />
 
-        <!-- Make arrays more modern -->
+        <!-- Permit [] instead of array() -->
         <exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
         
         <!-- We might use some datetime functions for tests -->

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -17,11 +17,11 @@
  *
  * @SuppressWarnings(PHPMD)
  */
-class AcceptanceTester extends \Codeception\Actor
-{
-    use _generated\AcceptanceTesterActions;
+class AcceptanceTester extends \Codeception\Actor {
 
-    /**
-     * Define custom actions here
-     */
+	use _generated\AcceptanceTesterActions;
+
+	/**
+	 * Define custom actions here
+	 */
 }

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -3,6 +3,7 @@
 
 /**
  * Inherited Methods
+ *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)
@@ -15,12 +16,12 @@
  * @method void pause()
  *
  * @SuppressWarnings(PHPMD)
-*/
+ */
 class AcceptanceTester extends \Codeception\Actor
 {
-	use _generated\AcceptanceTesterActions;
+    use _generated\AcceptanceTesterActions;
 
-	/**
-	 * Define custom actions here
-	 */
+    /**
+     * Define custom actions here
+     */
 }

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -3,6 +3,7 @@
 
 /**
  * Inherited Methods
+ *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)
@@ -15,7 +16,7 @@
  * @method void pause()
  *
  * @SuppressWarnings(PHPMD)
-*/
+ */
 class AcceptanceTester extends \Codeception\Actor
 {
 	use _generated\AcceptanceTesterActions;

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -3,7 +3,6 @@
 
 /**
  * Inherited Methods
- *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)
@@ -16,9 +15,9 @@
  * @method void pause()
  *
  * @SuppressWarnings(PHPMD)
- */
-class AcceptanceTester extends \Codeception\Actor {
-
+*/
+class AcceptanceTester extends \Codeception\Actor
+{
 	use _generated\AcceptanceTesterActions;
 
 	/**

--- a/tests/_support/FunctionalTester.php
+++ b/tests/_support/FunctionalTester.php
@@ -17,11 +17,11 @@
  *
  * @SuppressWarnings(PHPMD)
  */
-class FunctionalTester extends \Codeception\Actor
-{
-    use _generated\FunctionalTesterActions;
+class FunctionalTester extends \Codeception\Actor {
 
-    /**
-     * Define custom actions here
-     */
+	use _generated\FunctionalTesterActions;
+
+	/**
+	 * Define custom actions here
+	 */
 }

--- a/tests/_support/FunctionalTester.php
+++ b/tests/_support/FunctionalTester.php
@@ -3,7 +3,6 @@
 
 /**
  * Inherited Methods
- *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)
@@ -16,9 +15,9 @@
  * @method void pause()
  *
  * @SuppressWarnings(PHPMD)
- */
-class FunctionalTester extends \Codeception\Actor {
-
+*/
+class FunctionalTester extends \Codeception\Actor
+{
 	use _generated\FunctionalTesterActions;
 
 	/**

--- a/tests/_support/FunctionalTester.php
+++ b/tests/_support/FunctionalTester.php
@@ -3,6 +3,7 @@
 
 /**
  * Inherited Methods
+ *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)
@@ -15,12 +16,12 @@
  * @method void pause()
  *
  * @SuppressWarnings(PHPMD)
-*/
+ */
 class FunctionalTester extends \Codeception\Actor
 {
-	use _generated\FunctionalTesterActions;
+    use _generated\FunctionalTesterActions;
 
-	/**
-	 * Define custom actions here
-	 */
+    /**
+     * Define custom actions here
+     */
 }

--- a/tests/_support/FunctionalTester.php
+++ b/tests/_support/FunctionalTester.php
@@ -3,6 +3,7 @@
 
 /**
  * Inherited Methods
+ *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)
@@ -15,7 +16,7 @@
  * @method void pause()
  *
  * @SuppressWarnings(PHPMD)
-*/
+ */
 class FunctionalTester extends \Codeception\Actor
 {
 	use _generated\FunctionalTesterActions;

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -1,15 +1,16 @@
 <?php
 namespace Helper;
 
-// For readibility and portability of helpers between Plugins,
-// Acceptance helpers which work with specific WordPress / API
-// functionality (such as Gutenberg, Plugin config or the API)
-// can be found in the `Acceptance` subfolder.
-// If adding a new Helper to the `Acceptance` subfolder, remember
-// to load it through the `acceptance.suite.yml` file.
-
-// Helper functions placed here should be very generic
-
+/**
+ * For readibility and portability of helpers between Plugins,
+ * Acceptance helpers which work with specific WordPress / API
+ * functionality (such as Gutenberg, Plugin config or the API)
+ * can be found in the `Acceptance` subfolder.
+ * If adding a new Helper to the `Acceptance` subfolder, remember
+ * to load it through the `acceptance.suite.yml` file.
+ *
+ * Helper functions placed here should be very generic.
+ */
 class Acceptance extends \Codeception\Module
 {
 	/**

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -12,7 +12,7 @@ namespace Helper;
 
 class Acceptance extends \Codeception\Module
 {
-	/**
-	 * Define custom actions here
-	 */
+    /**
+     * Define custom actions here
+     */
 }

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -10,9 +10,9 @@ namespace Helper;
 
 // Helper functions placed here should be very generic
 
-class Acceptance extends \Codeception\Module
-{
-    /**
-     * Define custom actions here
-     */
+class Acceptance extends \Codeception\Module {
+
+	/**
+	 * Define custom actions here
+	 */
 }

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -10,8 +10,8 @@ namespace Helper;
 
 // Helper functions placed here should be very generic
 
-class Acceptance extends \Codeception\Module {
-
+class Acceptance extends \Codeception\Module
+{
 	/**
 	 * Define custom actions here
 	 */

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -5,97 +5,102 @@ namespace Helper\Acceptance;
 // would be used across multiple tests.
 // These are then available in $I->{yourFunctionName}
 
-class ConvertKitAPI extends \Codeception\Module
-{
-    /**
-     * Check the given email address exists as a subscriber.
-     * 
-     * @param AcceptanceTester $I            AcceptanceTester
-     * @param string           $emailAddress Email Address
-     */     
-    public function apiCheckSubscriberExists($I, $emailAddress)
-    {
-        // Run request.
-        $results = $this->apiRequest(
-            'subscribers', 'GET', [
-            'email_address' => $emailAddress,
-            ]
-        );
+class ConvertKitAPI extends \Codeception\Module {
 
-        // Check at least one subscriber was returned and it matches the email address.
-        $I->assertGreaterThan(0, $results['total_subscribers']);
-        $I->assertEquals($emailAddress, $results['subscribers'][0]['email_address']);
-    }
+	/**
+	 * Check the given email address exists as a subscriber.
+	 *
+	 * @param AcceptanceTester $I            AcceptanceTester
+	 * @param string           $emailAddress Email Address
+	 */
+	public function apiCheckSubscriberExists( $I, $emailAddress ) {
+		// Run request.
+		$results = $this->apiRequest(
+			'subscribers',
+			'GET',
+			array(
+				'email_address' => $emailAddress,
+			)
+		);
 
-    /**
-     * Check the given email address does not exists as a subscriber.
-     * 
-     * @param AcceptanceTester $I            AcceptanceTester
-     * @param string           $emailAddress Email Address
-     */     
-    public function apiCheckSubscriberDoesNotExist($I, $emailAddress)
-    {
-        // Run request.
-        $results = $this->apiRequest(
-            'subscribers', 'GET', [
-            'email_address' => $emailAddress,
-            ]
-        );
+		// Check at least one subscriber was returned and it matches the email address.
+		$I->assertGreaterThan( 0, $results['total_subscribers'] );
+		$I->assertEquals( $emailAddress, $results['subscribers'][0]['email_address'] );
+	}
 
-        // Check no subscribers are returned by this request.
-        $I->assertEquals(0, $results['total_subscribers']);
-    }
+	/**
+	 * Check the given email address does not exists as a subscriber.
+	 *
+	 * @param AcceptanceTester $I            AcceptanceTester
+	 * @param string           $emailAddress Email Address
+	 */
+	public function apiCheckSubscriberDoesNotExist( $I, $emailAddress ) {
+		// Run request.
+		$results = $this->apiRequest(
+			'subscribers',
+			'GET',
+			array(
+				'email_address' => $emailAddress,
+			)
+		);
 
-    /**
-     * Unsubscribes the given email address. Useful for clearing the API
-     * between tests.
-     * 
-     * @param string $emailAddress Email Address
-     */     
-    public function apiUnsubscribe($emailAddress)
-    {
-        // Run request.
-        $this->apiRequest(
-            'unsubscribe', 'PUT', [
-            'email' => $emailAddress,
-            ]
-        );
-    }
+		// Check no subscribers are returned by this request.
+		$I->assertEquals( 0, $results['total_subscribers'] );
+	}
 
-    /**
-     * Sends a request to the ConvertKit API, typically used to read an endpoint to confirm
-     * that data in an Acceptance Test was added/edited/deleted successfully.
-     * 
-     * @param string $endpoint Endpoint
-     * @param string $method   Method (GET|POST|PUT)
-     * @param array  $params   Endpoint Parameters
-     */
-    public function apiRequest($endpoint, $method = 'GET', $params = array())
-    {
-        // Build query parameters.
-        $params = array_merge(
-            $params, [
-            'api_key' => $_ENV['CONVERTKIT_API_KEY'],
-            'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-            ]
-        );
+	/**
+	 * Unsubscribes the given email address. Useful for clearing the API
+	 * between tests.
+	 *
+	 * @param string $emailAddress Email Address
+	 */
+	public function apiUnsubscribe( $emailAddress ) {
+		// Run request.
+		$this->apiRequest(
+			'unsubscribe',
+			'PUT',
+			array(
+				'email' => $emailAddress,
+			)
+		);
+	}
 
-        // Send request.
-        try {
-            $client = new \GuzzleHttp\Client();
-            $result = $client->request(
-                $method, 'https://api.convertkit.com/v3/' . $endpoint . '?' . http_build_query($params), [
-                'headers' => [
-                'Accept-Encoding' => 'gzip',
-                'timeout'         => 5,
-                ],
-                ]
-            );
+	/**
+	 * Sends a request to the ConvertKit API, typically used to read an endpoint to confirm
+	 * that data in an Acceptance Test was added/edited/deleted successfully.
+	 *
+	 * @param string $endpoint Endpoint
+	 * @param string $method   Method (GET|POST|PUT)
+	 * @param array  $params   Endpoint Parameters
+	 */
+	public function apiRequest( $endpoint, $method = 'GET', $params = array() ) {
+		// Build query parameters.
+		$params = array_merge(
+			$params,
+			array(
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+			)
+		);
 
-            // Return JSON decoded response.
-            return json_decode($result->getBody()->getContents(), true);
-        } catch(\GuzzleHttp\Exception\ClientException $e) {
-            return [];
-        }
-    }
+		// Send request.
+		try {
+			$client = new \GuzzleHttp\Client();
+			$result = $client->request(
+				$method,
+				'https://api.convertkit.com/v3/' . $endpoint . '?' . http_build_query( $params ),
+				array(
+					'headers' => array(
+						'Accept-Encoding' => 'gzip',
+						'timeout'         => 5,
+					),
+				)
+			);
+
+			// Return JSON decoded response.
+			return json_decode( $result->getBody()->getContents(), true );
+		} catch ( \GuzzleHttp\Exception\ClientException $e ) {
+			return array();
+		}
+	}
 }

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -9,16 +9,20 @@ class ConvertKitAPI extends \Codeception\Module
 {
 	/**
 	 * Check the given email address exists as a subscriber.
-	 * 
-	 * @param 	AcceptanceTester $I 			AcceptanceTester
-	 * @param 	string 			$emailAddress 	Email Address
-	 */ 	
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester.
+	 * @param   string           $emailAddress   Email Address
+	 */
 	public function apiCheckSubscriberExists($I, $emailAddress)
 	{
 		// Run request.
-		$results = $this->apiRequest('subscribers', 'GET', [
-			'email_address' => $emailAddress,
-		]);
+		$results = $this->apiRequest(
+			'subscribers',
+			'GET',
+			[
+				'email_address' => $emailAddress,
+			]
+		);
 
 		// Check at least one subscriber was returned and it matches the email address.
 		$I->assertGreaterThan(0, $results['total_subscribers']);
@@ -27,16 +31,20 @@ class ConvertKitAPI extends \Codeception\Module
 
 	/**
 	 * Check the given email address does not exists as a subscriber.
-	 * 
-	 * @param 	AcceptanceTester $I 			AcceptanceTester
-	 * @param 	string 			$emailAddress 	Email Address
-	 */ 	
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester.
+	 * @param   string           $emailAddress   Email Address
+	 */
 	public function apiCheckSubscriberDoesNotExist($I, $emailAddress)
 	{
 		// Run request.
-		$results = $this->apiRequest('subscribers', 'GET', [
-			'email_address' => $emailAddress,
-		]);
+		$results = $this->apiRequest(
+			'subscribers',
+			'GET',
+			[
+				'email_address' => $emailAddress,
+			]
+		);
 
 		// Check no subscribers are returned by this request.
 		$I->assertEquals(0, $results['total_subscribers']);
@@ -45,46 +53,57 @@ class ConvertKitAPI extends \Codeception\Module
 	/**
 	 * Unsubscribes the given email address. Useful for clearing the API
 	 * between tests.
-	 * 
-	 * @param 	string 			$emailAddress 	Email Address
-	 */ 	
+	 *
+	 * @param   string $emailAddress   Email Address
+	 */
 	public function apiUnsubscribe($emailAddress)
 	{
 		// Run request.
-		$this->apiRequest('unsubscribe', 'PUT', [
-			'email' => $emailAddress,
-		]);
+		$this->apiRequest(
+			'unsubscribe',
+			'PUT',
+			[
+				'email' => $emailAddress,
+			]
+		);
 	}
 
 	/**
 	 * Sends a request to the ConvertKit API, typically used to read an endpoint to confirm
 	 * that data in an Acceptance Test was added/edited/deleted successfully.
-	 * 
-	 * @param 	string 	$endpoint 	Endpoint
-	 * @param 	string 	$method 	Method (GET|POST|PUT)
-	 * @param 	array 	$params 	Endpoint Parameters
+	 *
+	 * @param   string $endpoint   Endpoint
+	 * @param   string $method     Method (GET|POST|PUT)
+	 * @param   array  $params     Endpoint Parameters
 	 */
 	public function apiRequest($endpoint, $method = 'GET', $params = array())
 	{
 		// Build query parameters.
-		$params = array_merge($params, [
-			'api_key' => $_ENV['CONVERTKIT_API_KEY'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-		]);
+		$params = array_merge(
+			$params,
+			[
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+			]
+		);
 
 		// Send request.
 		try {
 			$client = new \GuzzleHttp\Client();
-			$result = $client->request($method, 'https://api.convertkit.com/v3/' . $endpoint . '?' . http_build_query($params), [
-				'headers' => [
-					'Accept-Encoding' => 'gzip',
-					'timeout'         => 5,
-				],
-			]);
+			$result = $client->request(
+				$method,
+				'https://api.convertkit.com/v3/' . $endpoint . '?' . http_build_query($params),
+				[
+					'headers' => [
+						'Accept-Encoding' => 'gzip',
+						'timeout'         => 5,
+					],
+				]
+			);
 
 			// Return JSON decoded response.
 			return json_decode($result->getBody()->getContents(), true);
-		} catch(\GuzzleHttp\Exception\ClientException $e) {
+		} catch (\GuzzleHttp\Exception\ClientException $e) {
 			return [];
 		}
 	}

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -5,102 +5,87 @@ namespace Helper\Acceptance;
 // would be used across multiple tests.
 // These are then available in $I->{yourFunctionName}
 
-class ConvertKitAPI extends \Codeception\Module {
-
+class ConvertKitAPI extends \Codeception\Module
+{
 	/**
 	 * Check the given email address exists as a subscriber.
-	 *
-	 * @param AcceptanceTester $I            AcceptanceTester
-	 * @param string           $emailAddress Email Address
-	 */
-	public function apiCheckSubscriberExists( $I, $emailAddress ) {
+	 * 
+	 * @param 	AcceptanceTester $I 			AcceptanceTester
+	 * @param 	string 			$emailAddress 	Email Address
+	 */ 	
+	public function apiCheckSubscriberExists($I, $emailAddress)
+	{
 		// Run request.
-		$results = $this->apiRequest(
-			'subscribers',
-			'GET',
-			array(
-				'email_address' => $emailAddress,
-			)
-		);
+		$results = $this->apiRequest('subscribers', 'GET', [
+			'email_address' => $emailAddress,
+		]);
 
 		// Check at least one subscriber was returned and it matches the email address.
-		$I->assertGreaterThan( 0, $results['total_subscribers'] );
-		$I->assertEquals( $emailAddress, $results['subscribers'][0]['email_address'] );
+		$I->assertGreaterThan(0, $results['total_subscribers']);
+		$I->assertEquals($emailAddress, $results['subscribers'][0]['email_address']);
 	}
 
 	/**
 	 * Check the given email address does not exists as a subscriber.
-	 *
-	 * @param AcceptanceTester $I            AcceptanceTester
-	 * @param string           $emailAddress Email Address
-	 */
-	public function apiCheckSubscriberDoesNotExist( $I, $emailAddress ) {
+	 * 
+	 * @param 	AcceptanceTester $I 			AcceptanceTester
+	 * @param 	string 			$emailAddress 	Email Address
+	 */ 	
+	public function apiCheckSubscriberDoesNotExist($I, $emailAddress)
+	{
 		// Run request.
-		$results = $this->apiRequest(
-			'subscribers',
-			'GET',
-			array(
-				'email_address' => $emailAddress,
-			)
-		);
+		$results = $this->apiRequest('subscribers', 'GET', [
+			'email_address' => $emailAddress,
+		]);
 
 		// Check no subscribers are returned by this request.
-		$I->assertEquals( 0, $results['total_subscribers'] );
+		$I->assertEquals(0, $results['total_subscribers']);
 	}
 
 	/**
 	 * Unsubscribes the given email address. Useful for clearing the API
 	 * between tests.
-	 *
-	 * @param string $emailAddress Email Address
-	 */
-	public function apiUnsubscribe( $emailAddress ) {
+	 * 
+	 * @param 	string 			$emailAddress 	Email Address
+	 */ 	
+	public function apiUnsubscribe($emailAddress)
+	{
 		// Run request.
-		$this->apiRequest(
-			'unsubscribe',
-			'PUT',
-			array(
-				'email' => $emailAddress,
-			)
-		);
+		$this->apiRequest('unsubscribe', 'PUT', [
+			'email' => $emailAddress,
+		]);
 	}
 
 	/**
 	 * Sends a request to the ConvertKit API, typically used to read an endpoint to confirm
 	 * that data in an Acceptance Test was added/edited/deleted successfully.
-	 *
-	 * @param string $endpoint Endpoint
-	 * @param string $method   Method (GET|POST|PUT)
-	 * @param array  $params   Endpoint Parameters
+	 * 
+	 * @param 	string 	$endpoint 	Endpoint
+	 * @param 	string 	$method 	Method (GET|POST|PUT)
+	 * @param 	array 	$params 	Endpoint Parameters
 	 */
-	public function apiRequest( $endpoint, $method = 'GET', $params = array() ) {
+	public function apiRequest($endpoint, $method = 'GET', $params = array())
+	{
 		// Build query parameters.
-		$params = array_merge(
-			$params,
-			array(
-				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-			)
-		);
+		$params = array_merge($params, [
+			'api_key' => $_ENV['CONVERTKIT_API_KEY'],
+			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+		]);
 
 		// Send request.
 		try {
 			$client = new \GuzzleHttp\Client();
-			$result = $client->request(
-				$method,
-				'https://api.convertkit.com/v3/' . $endpoint . '?' . http_build_query( $params ),
-				array(
-					'headers' => array(
-						'Accept-Encoding' => 'gzip',
-						'timeout'         => 5,
-					),
-				)
-			);
+			$result = $client->request($method, 'https://api.convertkit.com/v3/' . $endpoint . '?' . http_build_query($params), [
+				'headers' => [
+					'Accept-Encoding' => 'gzip',
+					'timeout'         => 5,
+				],
+			]);
 
 			// Return JSON decoded response.
-			return json_decode( $result->getBody()->getContents(), true );
-		} catch ( \GuzzleHttp\Exception\ClientException $e ) {
-			return array();
+			return json_decode($result->getBody()->getContents(), true);
+		} catch(\GuzzleHttp\Exception\ClientException $e) {
+			return [];
 		}
 	}
 }

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -7,85 +7,95 @@ namespace Helper\Acceptance;
 
 class ConvertKitAPI extends \Codeception\Module
 {
-	/**
-	 * Check the given email address exists as a subscriber.
-	 * 
-	 * @param 	AcceptanceTester $I 			AcceptanceTester
-	 * @param 	string 			$emailAddress 	Email Address
-	 */ 	
-	public function apiCheckSubscriberExists($I, $emailAddress)
-	{
-		// Run request.
-		$results = $this->apiRequest('subscribers', 'GET', [
-			'email_address' => $emailAddress,
-		]);
+    /**
+     * Check the given email address exists as a subscriber.
+     * 
+     * @param AcceptanceTester $I            AcceptanceTester
+     * @param string           $emailAddress Email Address
+     */     
+    public function apiCheckSubscriberExists($I, $emailAddress)
+    {
+        // Run request.
+        $results = $this->apiRequest(
+            'subscribers', 'GET', [
+            'email_address' => $emailAddress,
+            ]
+        );
 
-		// Check at least one subscriber was returned and it matches the email address.
-		$I->assertGreaterThan(0, $results['total_subscribers']);
-		$I->assertEquals($emailAddress, $results['subscribers'][0]['email_address']);
-	}
+        // Check at least one subscriber was returned and it matches the email address.
+        $I->assertGreaterThan(0, $results['total_subscribers']);
+        $I->assertEquals($emailAddress, $results['subscribers'][0]['email_address']);
+    }
 
-	/**
-	 * Check the given email address does not exists as a subscriber.
-	 * 
-	 * @param 	AcceptanceTester $I 			AcceptanceTester
-	 * @param 	string 			$emailAddress 	Email Address
-	 */ 	
-	public function apiCheckSubscriberDoesNotExist($I, $emailAddress)
-	{
-		// Run request.
-		$results = $this->apiRequest('subscribers', 'GET', [
-			'email_address' => $emailAddress,
-		]);
+    /**
+     * Check the given email address does not exists as a subscriber.
+     * 
+     * @param AcceptanceTester $I            AcceptanceTester
+     * @param string           $emailAddress Email Address
+     */     
+    public function apiCheckSubscriberDoesNotExist($I, $emailAddress)
+    {
+        // Run request.
+        $results = $this->apiRequest(
+            'subscribers', 'GET', [
+            'email_address' => $emailAddress,
+            ]
+        );
 
-		// Check no subscribers are returned by this request.
-		$I->assertEquals(0, $results['total_subscribers']);
-	}
+        // Check no subscribers are returned by this request.
+        $I->assertEquals(0, $results['total_subscribers']);
+    }
 
-	/**
-	 * Unsubscribes the given email address. Useful for clearing the API
-	 * between tests.
-	 * 
-	 * @param 	string 			$emailAddress 	Email Address
-	 */ 	
-	public function apiUnsubscribe($emailAddress)
-	{
-		// Run request.
-		$this->apiRequest('unsubscribe', 'PUT', [
-			'email' => $emailAddress,
-		]);
-	}
+    /**
+     * Unsubscribes the given email address. Useful for clearing the API
+     * between tests.
+     * 
+     * @param string $emailAddress Email Address
+     */     
+    public function apiUnsubscribe($emailAddress)
+    {
+        // Run request.
+        $this->apiRequest(
+            'unsubscribe', 'PUT', [
+            'email' => $emailAddress,
+            ]
+        );
+    }
 
-	/**
-	 * Sends a request to the ConvertKit API, typically used to read an endpoint to confirm
-	 * that data in an Acceptance Test was added/edited/deleted successfully.
-	 * 
-	 * @param 	string 	$endpoint 	Endpoint
-	 * @param 	string 	$method 	Method (GET|POST|PUT)
-	 * @param 	array 	$params 	Endpoint Parameters
-	 */
-	public function apiRequest($endpoint, $method = 'GET', $params = array())
-	{
-		// Build query parameters.
-		$params = array_merge($params, [
-			'api_key' => $_ENV['CONVERTKIT_API_KEY'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-		]);
+    /**
+     * Sends a request to the ConvertKit API, typically used to read an endpoint to confirm
+     * that data in an Acceptance Test was added/edited/deleted successfully.
+     * 
+     * @param string $endpoint Endpoint
+     * @param string $method   Method (GET|POST|PUT)
+     * @param array  $params   Endpoint Parameters
+     */
+    public function apiRequest($endpoint, $method = 'GET', $params = array())
+    {
+        // Build query parameters.
+        $params = array_merge(
+            $params, [
+            'api_key' => $_ENV['CONVERTKIT_API_KEY'],
+            'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+            ]
+        );
 
-		// Send request.
-		try {
-			$client = new \GuzzleHttp\Client();
-			$result = $client->request($method, 'https://api.convertkit.com/v3/' . $endpoint . '?' . http_build_query($params), [
-				'headers' => [
-					'Accept-Encoding' => 'gzip',
-					'timeout'         => 5,
-				],
-			]);
+        // Send request.
+        try {
+            $client = new \GuzzleHttp\Client();
+            $result = $client->request(
+                $method, 'https://api.convertkit.com/v3/' . $endpoint . '?' . http_build_query($params), [
+                'headers' => [
+                'Accept-Encoding' => 'gzip',
+                'timeout'         => 5,
+                ],
+                ]
+            );
 
-			// Return JSON decoded response.
-			return json_decode($result->getBody()->getContents(), true);
-		} catch(\GuzzleHttp\Exception\ClientException $e) {
-			return [];
-		}
-	}
+            // Return JSON decoded response.
+            return json_decode($result->getBody()->getContents(), true);
+        } catch(\GuzzleHttp\Exception\ClientException $e) {
+            return [];
+        }
+    }
 }

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -1,17 +1,19 @@
 <?php
 namespace Helper\Acceptance;
 
-// Define any custom actions related to the ConvertKit API that
-// would be used across multiple tests.
-// These are then available in $I->{yourFunctionName}
-
+/**
+ * Helper methods and actions related to the ConvertKit API,
+ * which are then available using $I->{yourFunctionName}.
+ *
+ * @since   1.9.6
+ */
 class ConvertKitAPI extends \Codeception\Module
 {
 	/**
 	 * Check the given email address exists as a subscriber.
 	 *
 	 * @param   AcceptanceTester $I             AcceptanceTester.
-	 * @param   string           $emailAddress   Email Address
+	 * @param   string           $emailAddress   Email Address.
 	 */
 	public function apiCheckSubscriberExists($I, $emailAddress)
 	{
@@ -33,7 +35,7 @@ class ConvertKitAPI extends \Codeception\Module
 	 * Check the given email address does not exists as a subscriber.
 	 *
 	 * @param   AcceptanceTester $I             AcceptanceTester.
-	 * @param   string           $emailAddress   Email Address
+	 * @param   string           $emailAddress   Email Address.
 	 */
 	public function apiCheckSubscriberDoesNotExist($I, $emailAddress)
 	{
@@ -54,7 +56,7 @@ class ConvertKitAPI extends \Codeception\Module
 	 * Unsubscribes the given email address. Useful for clearing the API
 	 * between tests.
 	 *
-	 * @param   string $emailAddress   Email Address
+	 * @param   string $emailAddress   Email Address.
 	 */
 	public function apiUnsubscribe($emailAddress)
 	{
@@ -72,9 +74,9 @@ class ConvertKitAPI extends \Codeception\Module
 	 * Sends a request to the ConvertKit API, typically used to read an endpoint to confirm
 	 * that data in an Acceptance Test was added/edited/deleted successfully.
 	 *
-	 * @param   string $endpoint   Endpoint
-	 * @param   string $method     Method (GET|POST|PUT)
-	 * @param   array  $params     Endpoint Parameters
+	 * @param   string $endpoint   Endpoint.
+	 * @param   string $method     Method (GET|POST|PUT).
+	 * @param   array  $params     Endpoint Parameters.
 	 */
 	public function apiRequest($endpoint, $method = 'GET', $params = array())
 	{

--- a/tests/_support/Helper/Acceptance/Email.php
+++ b/tests/_support/Helper/Acceptance/Email.php
@@ -5,20 +5,19 @@ namespace Helper\Acceptance;
 // would be used across multiple tests.
 // These are then available in $I->{yourFunctionName}
 
-class Email extends \Codeception\Module {
-
+class Email extends \Codeception\Module
+{
 	/**
 	 * Generates a unique email address for use in a test, comprising of a prefix,
 	 * date + time and PHP version number.
-	 *
+	 * 
 	 * This ensures that if tests are run in parallel, the same email address
 	 * isn't used for two tests across parallel testing runs.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @return string     Email Address
+	 * 
+	 * @since 	1.9.6.7
 	 */
-	public function generateEmailAddress() {
+	public function generateEmailAddress()
+	{
 		return 'wordpress-' . date( 'Y-m-d-H-i-s' ) . '-php-' . PHP_VERSION_ID . '@convertkit.com';
 	}
 }

--- a/tests/_support/Helper/Acceptance/Email.php
+++ b/tests/_support/Helper/Acceptance/Email.php
@@ -7,17 +7,17 @@ namespace Helper\Acceptance;
 
 class Email extends \Codeception\Module
 {
-	/**
-	 * Generates a unique email address for use in a test, comprising of a prefix,
-	 * date + time and PHP version number.
-	 * 
-	 * This ensures that if tests are run in parallel, the same email address
-	 * isn't used for two tests across parallel testing runs.
-	 * 
-	 * @since 	1.9.6.7
-	 */
-	public function generateEmailAddress()
-	{
-		return 'wordpress-' . date( 'Y-m-d-H-i-s' ) . '-php-' . PHP_VERSION_ID . '@convertkit.com';
-	}
+    /**
+     * Generates a unique email address for use in a test, comprising of a prefix,
+     * date + time and PHP version number.
+     * 
+     * This ensures that if tests are run in parallel, the same email address
+     * isn't used for two tests across parallel testing runs.
+     * 
+     * @since 1.9.6.7
+     */
+    public function generateEmailAddress()
+    {
+        return 'wordpress-' . date('Y-m-d-H-i-s') . '-php-' . PHP_VERSION_ID . '@convertkit.com';
+    }
 }

--- a/tests/_support/Helper/Acceptance/Email.php
+++ b/tests/_support/Helper/Acceptance/Email.php
@@ -5,21 +5,20 @@ namespace Helper\Acceptance;
 // would be used across multiple tests.
 // These are then available in $I->{yourFunctionName}
 
-class Email extends \Codeception\Module
-{
-    /**
-     * Generates a unique email address for use in a test, comprising of a prefix,
-     * date + time and PHP version number.
-     * 
-     * This ensures that if tests are run in parallel, the same email address
-     * isn't used for two tests across parallel testing runs.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @return string     Email Address
-     */
-    public function generateEmailAddress()
-    {
-        return 'wordpress-' . date('Y-m-d-H-i-s') . '-php-' . PHP_VERSION_ID . '@convertkit.com';
-    }
+class Email extends \Codeception\Module {
+
+	/**
+	 * Generates a unique email address for use in a test, comprising of a prefix,
+	 * date + time and PHP version number.
+	 *
+	 * This ensures that if tests are run in parallel, the same email address
+	 * isn't used for two tests across parallel testing runs.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @return string     Email Address
+	 */
+	public function generateEmailAddress() {
+		return 'wordpress-' . date( 'Y-m-d-H-i-s' ) . '-php-' . PHP_VERSION_ID . '@convertkit.com';
+	}
 }

--- a/tests/_support/Helper/Acceptance/Email.php
+++ b/tests/_support/Helper/Acceptance/Email.php
@@ -15,6 +15,8 @@ class Email extends \Codeception\Module
      * isn't used for two tests across parallel testing runs.
      * 
      * @since 1.9.6.7
+     * 
+     * @return string     Email Address
      */
     public function generateEmailAddress()
     {

--- a/tests/_support/Helper/Acceptance/Email.php
+++ b/tests/_support/Helper/Acceptance/Email.php
@@ -10,11 +10,11 @@ class Email extends \Codeception\Module
 	/**
 	 * Generates a unique email address for use in a test, comprising of a prefix,
 	 * date + time and PHP version number.
-	 * 
+	 *
 	 * This ensures that if tests are run in parallel, the same email address
 	 * isn't used for two tests across parallel testing runs.
-	 * 
-	 * @since 	1.9.6.7
+	 *
+	 * @since   1.9.6.7
 	 */
 	public function generateEmailAddress()
 	{

--- a/tests/_support/Helper/Acceptance/Email.php
+++ b/tests/_support/Helper/Acceptance/Email.php
@@ -1,10 +1,12 @@
 <?php
 namespace Helper\Acceptance;
 
-// Define any custom actions related to Select2 interaction that
-// would be used across multiple tests.
-// These are then available in $I->{yourFunctionName}
-
+/**
+ * Helper methods and actions related to email addresses,
+ * which are then available using $I->{yourFunctionName}.
+ *
+ * @since   1.9.6
+ */
 class Email extends \Codeception\Module
 {
 	/**

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -311,7 +311,7 @@ class Plugin extends \Codeception\Module
 
 		// Confirm that UTM parameters exist on a broadcast link.
 		$I->assertStringContainsString(
-			'utm_source=WordPress&utm_content=convertkit',
+			'utm_source=wordpress&utm_content=convertkit',
 			$I->grabAttributeFrom('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast a', 'href')
 		);
 

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -5,470 +5,458 @@ namespace Helper\Acceptance;
 // would be used across multiple tests.
 // These are then available in $I->{yourFunctionName}
 
-class Plugin extends \Codeception\Module {
-
+class Plugin extends \Codeception\Module
+{
 	/**
 	 * Helper method to activate the ConvertKit Plugin, checking
 	 * it activated and no errors were output.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Acceptance Tester.
+	 * 
+	 * @since 	1.9.6
 	 */
-	public function activateConvertKitPlugin( $I ) {
-		$I->activateThirdPartyPlugin( $I, 'convertkit' );
+	public function activateConvertKitPlugin($I)
+	{
+		$I->activateThirdPartyPlugin($I, 'convertkit');
 	}
 
 	/**
 	 * Helper method to deactivate the ConvertKit Plugin, checking
 	 * it activated and no errors were output.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Acceptance Tester.
+	 * 
+	 * @since 	1.9.6
 	 */
-	public function deactivateConvertKitPlugin( $I ) {
-		$I->deactivateThirdPartyPlugin( $I, 'convertkit' );
+	public function deactivateConvertKitPlugin($I)
+	{
+		$I->deactivateThirdPartyPlugin($I, 'convertkit');
 	}
 
 	/**
 	 * Helper method to setup the Plugin's API Key and Secret.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I         Acceptance Tester.
-	 * @param mixed            $apiKey    API Key (if specified, used instead of CONVERTKIT_API_KEY)
-	 * @param mixed            $apiSecret API Secret (if specified, used instead of CONVERTKIT_API_SECRET)
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	mixed 	$apiKey 	API Key (if specified, used instead of CONVERTKIT_API_KEY)
+	 * @param 	mixed 	$apiSecret 	API Secret (if specified, used instead of CONVERTKIT_API_SECRET)
 	 */
-	public function setupConvertKitPlugin( $I, $apiKey = false, $apiSecret = false ) {
+	public function setupConvertKitPlugin($I, $apiKey = false, $apiSecret = false)
+	{
 		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen( $I );
+		$I->loadConvertKitSettingsGeneralScreen($I);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Determine API Key and Secret to use.
-		$convertKitAPIKey    = ( $apiKey !== false ? $apiKey : $_ENV['CONVERTKIT_API_KEY'] );
-		$convertKitAPISecret = ( $apiSecret !== false ? $apiSecret : $_ENV['CONVERTKIT_API_SECRET'] );
+		$convertKitAPIKey = ($apiKey !== false ? $apiKey : $_ENV['CONVERTKIT_API_KEY']);
+		$convertKitAPISecret = ($apiSecret !== false ? $apiSecret : $_ENV['CONVERTKIT_API_SECRET']);
 
 		// Complete API Fields.
-		$I->fillField( '_wp_convertkit_settings[api_key]', $convertKitAPIKey );
-		$I->fillField( '_wp_convertkit_settings[api_secret]', $convertKitAPISecret );
+		$I->fillField('_wp_convertkit_settings[api_key]', $convertKitAPIKey);
+		$I->fillField('_wp_convertkit_settings[api_secret]', $convertKitAPISecret);
 
 		// Click the Save Changes button.
-		$I->click( 'Save Changes' );
+		$I->click('Save Changes');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check the value of the fields match the inputs provided.
-		$I->seeInField( '_wp_convertkit_settings[api_key]', $convertKitAPIKey );
-		$I->seeInField( '_wp_convertkit_settings[api_secret]', $convertKitAPISecret );
+		$I->seeInField('_wp_convertkit_settings[api_key]', $convertKitAPIKey);
+		$I->seeInField('_wp_convertkit_settings[api_secret]', $convertKitAPISecret);
 	}
 
 	/**
 	 * Helper method to setup the Plugin's Default Form setting for Pages and Posts.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Acceptance Tester.
+	 * 
+	 * @since 	1.9.6
 	 */
-	public function setupConvertKitPluginDefaultForm( $I ) {
+	public function setupConvertKitPluginDefaultForm($I)
+	{
 		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen( $I );
+		$I->loadConvertKitSettingsGeneralScreen($I);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Select Default Form for Pages and Posts.
-		$I->fillSelect2Field( $I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_FORM_NAME'] );
-		$I->fillSelect2Field( $I, '#select2-_wp_convertkit_settings_post_form-container', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_post_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
 		// Click the Save Changes button.
-		$I->click( 'Save Changes' );
+		$I->click('Save Changes');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check the value of the fields match the inputs provided.
-		$I->seeInField( '_wp_convertkit_settings[page_form]', $_ENV['CONVERTKIT_API_FORM_NAME'] );
-		$I->seeInField( '_wp_convertkit_settings[post_form]', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+		$I->seeInField('_wp_convertkit_settings[page_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->seeInField('_wp_convertkit_settings[post_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
 		// Return Form ID for Pages
-		return $I->grabValueFrom( '_wp_convertkit_settings[page_form]' );
+		return $I->grabValueFrom('_wp_convertkit_settings[page_form]');
 	}
 
 	/**
 	 * Helper method to setup the Plugin's Default Legacy Form setting for Pages and Posts.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Acceptance Tester.
+	 * 
+	 * @since 	1.9.6
 	 */
-	public function setupConvertKitPluginDefaultLegacyForm( $I ) {
+	public function setupConvertKitPluginDefaultLegacyForm($I)
+	{
 		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen( $I );
+		$I->loadConvertKitSettingsGeneralScreen($I);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Select Default Form for Pages and Posts.
-		$I->fillSelect2Field( $I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] );
-		$I->fillSelect2Field( $I, '#select2-_wp_convertkit_settings_post_form-container', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] );
+		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
+		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_post_form-container', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
 
 		// Click the Save Changes button.
-		$I->click( 'Save Changes' );
+		$I->click('Save Changes');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check the value of the fields match the inputs provided.
-		$I->seeInField( '_wp_convertkit_settings[page_form]', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] );
-		$I->seeInField( '_wp_convertkit_settings[post_form]', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] );
+		$I->seeInField('_wp_convertkit_settings[page_form]', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
+		$I->seeInField('_wp_convertkit_settings[post_form]', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
 
 		// Return Form ID for Pages
-		return $I->grabValueFrom( '_wp_convertkit_settings[page_form]' );
+		return $I->grabValueFrom('_wp_convertkit_settings[page_form]');
 	}
 
 	/**
 	 * Helper method to setup the Plugin's Default Form setting for WooCommerce Products.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Acceptance Tester.
+	 * 
+	 * @since 	1.9.6
 	 */
-	public function setupConvertKitPluginDefaultFormForWooCommerceProducts( $I ) {
+	public function setupConvertKitPluginDefaultFormForWooCommerceProducts($I)
+	{
 		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen( $I );
+		$I->loadConvertKitSettingsGeneralScreen($I);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Select option.
-		$I->fillSelect2Field( $I, '#select2-_wp_convertkit_settings_product_form-container', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_product_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
 		// Click the Save Changes button.
-		$I->click( 'Save Changes' );
+		$I->click('Save Changes');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check the value of the fields match the inputs provided.
-		$I->seeInField( '_wp_convertkit_settings[product_form]', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+		$I->seeInField('_wp_convertkit_settings[product_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
 		// Return Form ID
-		return $I->grabValueFrom( '_wp_convertkit_settings[product_form]' );
+		return $I->grabValueFrom('_wp_convertkit_settings[product_form]');
 	}
 
 	/**
 	 * Helper method to reset the ConvertKit Plugin settings, as if it's a clean installation.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Acceptance Tester.
+	 * 
+	 * @since 	1.9.6.7
 	 */
-	public function resetConvertKitPlugin( $I ) {
+	public function resetConvertKitPlugin($I)
+	{
 		// Plugin Settings.
-		$I->dontHaveOptionInDatabase( '_wp_convertkit_settings' );
-		$I->dontHaveOptionInDatabase( 'convertkit_version' );
+		$I->dontHaveOptionInDatabase('_wp_convertkit_settings');
+		$I->dontHaveOptionInDatabase('convertkit_version');
 
 		// Resources.
-		$I->dontHaveOptionInDatabase( 'convertkit_forms' );
-		$I->dontHaveOptionInDatabase( 'convertkit_forms_last_queried' );
-		$I->dontHaveOptionInDatabase( 'convertkit_landing_pages' );
-		$I->dontHaveOptionInDatabase( 'convertkit_landing_pages_last_queried' );
-		$I->dontHaveOptionInDatabase( 'convertkit_tags' );
-		$I->dontHaveOptionInDatabase( 'convertkit_tags_last_queried' );
+		$I->dontHaveOptionInDatabase('convertkit_forms');
+		$I->dontHaveOptionInDatabase('convertkit_forms_last_queried');
+		$I->dontHaveOptionInDatabase('convertkit_landing_pages');
+		$I->dontHaveOptionInDatabase('convertkit_landing_pages_last_queried');
+		$I->dontHaveOptionInDatabase('convertkit_tags');
+		$I->dontHaveOptionInDatabase('convertkit_tags_last_queried');
 
 		// Review Request.
-		$I->dontHaveOptionInDatabase( 'convertkit-review-request' );
-		$I->dontHaveOptionInDatabase( 'convertkit-review-dismissed' );
+		$I->dontHaveOptionInDatabase('convertkit-review-request');
+		$I->dontHaveOptionInDatabase('convertkit-review-dismissed');
 
 		// Upgrades.
-		$I->dontHaveOptionInDatabase( '_wp_convertkit_upgrade_posts' );
+		$I->dontHaveOptionInDatabase('_wp_convertkit_upgrade_posts');
 	}
 
 	/**
 	 * Helper method to load the Plugin's Settings > General screen.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Acceptance Tester.
+	 * 
+	 * @since 	1.9.6
 	 */
-	public function loadConvertKitSettingsGeneralScreen( $I ) {
-		$I->amOnAdminPage( 'options-general.php?page=_wp_convertkit_settings' );
+	public function loadConvertKitSettingsGeneralScreen($I)
+	{
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 	}
 
 	/**
 	 * Helper method to load the Plugin's Settings > Tools screen.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Acceptance Tester.
+	 * 
+	 * @since 	1.9.6
 	 */
-	public function loadConvertKitSettingsToolsScreen( $I ) {
-		$I->amOnAdminPage( 'options-general.php?page=_wp_convertkit_settings&tab=tools' );
+	public function loadConvertKitSettingsToolsScreen($I)
+	{
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=tools');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 	}
 
 	/**
 	 * Helper method to enable the Plugin's Settings > General > Debug option.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Acceptance Tester.
+	 * 
+	 * @since 	1.9.6
 	 */
-	public function enableDebugLog( $I ) {
+	public function enableDebugLog($I)
+	{
 		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen( $I );
-
+		$I->loadConvertKitSettingsGeneralScreen($I);
+		
 		// Tick field.
-		$I->checkOption( '#debug' );
+		$I->checkOption('#debug');
 
 		// Click the Save Changes button.
-		$I->click( 'Save Changes' );
+		$I->click('Save Changes');
 	}
 
 	/**
 	 * Helper method to clear the Plugin's debug log.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Acceptance Tester.
+	 * 
+	 * @since 	1.9.6
 	 */
-	public function clearDebugLog( $I ) {
+	public function clearDebugLog($I)
+	{
 		// Go to the Plugin's Tools Screen.
-		$I->loadConvertKitSettingsToolsScreen( $I );
-
+		$I->loadConvertKitSettingsToolsScreen($I);
+		
 		// Click the Clear log button.
-		$I->click( 'Clear log' );
+		$I->click('Clear log');
 	}
 
 	/**
 	 * Helper method to determine if the given entry exists in the Plugin Debug Log screen's textarea.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I     Acceptance Tester.
-	 * @param string           $entry Expected log entry.
+	 * 
+	 * @since 	1.9.6
 	 */
-	public function seeInPluginDebugLog( $I, $entry ) {
-		$I->loadConvertKitSettingsToolsScreen( $I );
-		$I->seeInSource( $entry );
+	public function seeInPluginDebugLog($I, $entry)
+	{
+		$I->loadConvertKitSettingsToolsScreen($I);
+		$I->seeInSource($entry);
 	}
 
 	/**
 	 * Helper method to determine if the given entry does not exist in the Plugin Debug Log screen's textarea.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I     Acceptance Tester.
-	 * @param string           $entry Expected log entry.
+	 * 
+	 * @since 	1.9.6
 	 */
-	public function dontSeeInPluginDebugLog( $I, $entry ) {
-		$I->loadConvertKitSettingsToolsScreen( $I );
-		$I->dontSeeInSource( $entry );
+	public function dontSeeInPluginDebugLog($I, $entry)
+	{
+		$I->loadConvertKitSettingsToolsScreen($I);
+		$I->dontSeeInSource($entry);
 	}
 
 	/**
 	 * Check that expected HTML exists in the DOM of the page we're viewing for
 	 * a Broadcasts block or shortcode.
+	 * 
+	 * @since 	1.9.7.5
 	 *
-	 * @since 1.9.7.5
-	 *
-	 * @param AcceptanceTester $I                      Acceptance Tester.
-	 * @param bool|int         $numberOfPosts          Number of Broadcasts listed.
-	 * @param bool|string      $seePrevPaginationLabel Test if the "previous" pagination link is output and matches expected label.
-	 * @param bool|string      $seeNextPaginationLabel Test if the "next" pagination link is output and matches expected label.
+	 * @param 	AcceptanceTester 	$I 						Tester.
+	 * @param 	bool|int 			$numberOfPosts 			Number of Broadcasts listed.
+	 * @param 	bool|string 		$seePrevPaginationLabel Test if the "previous" pagination link is output and matches expected label.
+	 * @param 	bool|string 		$seePrevPaginationLabel Test if the "next" pagination link is output and matches expected label.
 	 */
-	public function seeBroadcastsOutput( $I, $numberOfPosts = false, $seePrevPaginationLabel = false, $seeNextPaginationLabel = false ) {
+	public function seeBroadcastsOutput($I, $numberOfPosts = false, $seePrevPaginationLabel = false, $seeNextPaginationLabel = false)
+	{
 		// Confirm that the block displays.
-		$I->seeElementInDOM( 'div.convertkit-broadcasts' );
-		$I->seeElementInDOM( 'div.convertkit-broadcasts ul.convertkit-broadcasts-list' );
-		$I->seeElementInDOM( 'div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast' );
-		$I->seeElementInDOM( 'div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast a' );
+		$I->seeElementInDOM('div.convertkit-broadcasts');
+		$I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-list');
+		$I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast');
+		$I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast a');
 
 		// Confirm that UTM parameters exist on a broadcast link.
 		$I->assertStringContainsString(
-			'utm_source=WordPress&utm_content=convertkit',
-			$I->grabAttributeFrom( 'div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast a', 'href' )
+			'utm_source=wordpress&utm_content=convertkit',
+			$I->grabAttributeFrom('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast a', 'href')
 		);
 
 		// Confirm that the number of expected broadcasts displays.
-		if ( $numberOfPosts !== false ) {
-			$I->seeNumberOfElements( 'li.convertkit-broadcast', $numberOfPosts );
+		if ($numberOfPosts !== false) {
+			$I->seeNumberOfElements('li.convertkit-broadcast', $numberOfPosts);
 		}
 
 		// Confirm that previous pagination displays.
-		if ( $seePrevPaginationLabel !== false ) {
-			$I->seeElementInDOM( 'div.convertkit-broadcasts ul.convertkit-broadcasts-pagination li.convertkit-broadcasts-pagination-prev a' );
-			$I->seeInSource( $seePrevPaginationLabel );
+		if ($seePrevPaginationLabel !== false) {
+			$I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-pagination li.convertkit-broadcasts-pagination-prev a');
+			$I->seeInSource($seePrevPaginationLabel);		
 		}
 
 		// Confirm that next pagination displays.
-		if ( $seeNextPaginationLabel !== false ) {
-			$I->seeElementInDOM( 'div.convertkit-broadcasts ul.convertkit-broadcasts-pagination li.convertkit-broadcasts-pagination-next a' );
+		if ($seeNextPaginationLabel !== false) {
+			$I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-pagination li.convertkit-broadcasts-pagination-next a');	
 		}
 	}
 
 	/**
 	 * Tests that the Broadcasts pagination works, and that the expected Broadcast
 	 * is displayed after using previous and next links.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param AcceptanceTester $I             Tester.
-	 * @param string           $previousLabel Previous / Newer Broadcasts Label.
-	 * @param string           $nextLabel     Next / Older Broadcasts Label.
+	 * 
+	 * @since 	2.0.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 						Tester.
+	 * @param 	string 				$previousLabel 			Previous / Newer Broadcasts Label.
+	 * @param 	string 				$nextLabel 				Next / Older Broadcasts Label.
 	 */
-	public function testBroadcastsPagination( $I, $previousLabel, $nextLabel ) {
+	public function testBroadcastsPagination($I, $previousLabel, $nextLabel)
+	{
 		// Confirm that the block displays one broadcast with a pagination link to older broadcasts.
-		$I->seeBroadcastsOutput( $I, 1, false, $nextLabel );
+		$I->seeBroadcastsOutput($I, 1, false, $nextLabel);
 
 		// Click the Older Posts link.
-		$I->click( 'li.convertkit-broadcasts-pagination-next a' );
+		$I->click('li.convertkit-broadcasts-pagination-next a');
 
 		// Wait for the AJAX request to complete, by checking if the convertkit-broadcasts-loading class has been
 		// removed from the block.
-		$I->waitForBroadcastsToLoad( $I );
+		$I->waitForBroadcastsToLoad($I);
 
 		// Confirm that the block displays one broadcast with a pagination link to newer broadcasts.
-		$I->seeBroadcastsOutput( $I, 1, $previousLabel, false );
+		$I->seeBroadcastsOutput($I, 1, $previousLabel, false);
 
 		// Fetch Broadcasts from the resource, to determine the name of the most recent two broadcasts.
-		$broadcasts      = $I->grabOptionFromDatabase( 'convertkit_posts' );
-		$firstBroadcast  = current( array_slice( $broadcasts, 0, 1 ) );
-		$secondBroadcast = current( array_slice( $broadcasts, 1, 1 ) );
+		$broadcasts = $I->grabOptionFromDatabase('convertkit_posts');
+		$firstBroadcast = current(array_slice($broadcasts, 0, 1));
+		$secondBroadcast = current(array_slice($broadcasts, 1, 1));
 
 		// Confirm that the expected Broadcast name is displayed and links to the expected URL, with UTM parameters.
-		$I->seeInSource( '<a href="' . $secondBroadcast['url'] . '?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener"' );
-		$I->seeInSource( $secondBroadcast['title'] );
+		$I->seeInSource('<a href="'.$secondBroadcast['url'].'?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener"');
+		$I->seeInSource($secondBroadcast['title']);
 
 		// Click the Newer Posts link.
-		$I->click( 'li.convertkit-broadcasts-pagination-prev a' );
+		$I->click('li.convertkit-broadcasts-pagination-prev a');
 
 		// Wait for the AJAX request to complete, by checking if the convertkit-broadcasts-loading class has been
 		// removed from the block.
-		$I->waitForBroadcastsToLoad( $I );
+		$I->waitForBroadcastsToLoad($I);
 
 		// Confirm that the block displays one broadcast with a pagination link to older broadcasts.
-		$I->seeBroadcastsOutput( $I, 1, false, $nextLabel );
+		$I->seeBroadcastsOutput($I, 1, false, $nextLabel);
 
 		// Confirm that the expected Broadcast name is displayed and links to the expected URL, with UTM parameters.
-		$I->seeInSource( '<a href="' . $firstBroadcast['url'] . '?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener"' );
-		$I->seeInSource( $firstBroadcast['title'] );
+		$I->seeInSource('<a href="'.$firstBroadcast['url'].'?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener"');
+		$I->seeInSource($firstBroadcast['title']);
 	}
 
 	/**
 	 * Wait for the AJAX request to complete, by checking if the convertkit-broadcasts-loading class has been
 	 * removed from the block.
-	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param AcceptanceTester $I Tester.
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 						Tester.
 	 */
-	public function waitForBroadcastsToLoad( $I ) {
-		$I->waitForElementChange(
-			'div.convertkit-broadcasts',
-			function ( \Facebook\WebDriver\WebDriverElement $el ) {
-				return ( strpos( $el->getAttribute( 'class' ), 'convertkit-broadcasts-loading' ) === false ? true : false );
-			},
-			5
-		);
+	public function waitForBroadcastsToLoad($I)
+	{
+		$I->waitForElementChange('div.convertkit-broadcasts', function(\Facebook\WebDriver\WebDriverElement $el) {
+			return ( strpos($el->getAttribute('class'), 'convertkit-broadcasts-loading') === false ? true : false );
+		}, 5);
 	}
 
 	/**
 	 * Check that expected HTML exists in the DOM of the page we're viewing
 	 * when a ConvertKit Product link was inserted into a paragraph or button,
 	 * and that the button loads the expected ConvertKit Product modal.
+	 * 
+	 * @since 	2.0.0
 	 *
-	 * @since 2.0.0
-	 *
-	 * @param AcceptanceTester $I          Tester.
-	 * @param string           $productURL Product URL.
-	 * @param bool|string      $text       Test if the link text matches the given value.
+	 * @param 	AcceptanceTester 	$I 				Tester.
+	 * @param 	string 				$productURL 	Product URL.
+	 * @param 	bool|string 		$text 			Test if the link text matches the given value.
 	 */
-	public function seeProductLink( $I, $productURL, $text = false ) {
+	public function seeProductLink($I, $productURL, $text = false)
+	{
 		// Confirm that the commerce.js script exists.
-		$I->seeInSource( 'commerce.js' );
+		$I->seeInSource('commerce.js');
 
 		// Confirm that the link exists.
-		$I->seeElementInDOM( 'a[data-commerce]' );
+		$I->seeElementInDOM('a[data-commerce]');
 
 		// Confirm that the link points to the correct product.
-		$I->assertEquals( $productURL, $I->grabAttributeFrom( 'a[data-commerce]', 'href' ) );
+		$I->assertEquals($productURL, $I->grabAttributeFrom('a[data-commerce]', 'href'));
 
 		// Confirm that the button text is as expected.
-		if ( $text !== false ) {
-			$I->seeInSource( '>' . $text . '</a>' );
+		if ($text !== false) {
+			$I->seeInSource('>'.$text.'</a>');		
 		}
 
 		// Click the button to confirm that the ConvertKit modal displays; this confirms
 		// necessary ConvertKit scripts have been loaded.
-		$I->click( 'a[href="' . $productURL . '"]' );
-		$I->seeElementInDOM( 'iframe[data-active]' );
+		$I->click('a[href="'.$productURL.'"]');
+		$I->seeElementInDOM('iframe[data-active]');
 	}
 
 	/**
 	 * Check that expected HTML exists in the DOM of the page we're viewing for
 	 * a Product block or shortcode, and that the button loads the expected
 	 * ConvertKit Product modal.
+	 * 
+	 * @since 	1.9.8.5
 	 *
-	 * @since 1.9.8.5
-	 *
-	 * @param AcceptanceTester $I               Tester.
-	 * @param string           $productURL      Product URL.
-	 * @param bool|string      $text            Test if the button text matches the given value.
-	 * @param bool|string      $textColor       Test if the given text color is applied.
-	 * @param bool|string      $backgroundColor Test is the given background color is applied.
+	 * @param 	AcceptanceTester 	$I 				Tester.
+	 * @param 	string 				$productURL 	Product URL.
+	 * @param 	bool|string 		$text 			Test if the button text matches the given value.
+	 * @param 	bool|string 		$textColor 		Test if the given text color is applied.
+	 * @param 	bool|string 		$backgroundColor Test is the given background color is applied.
 	 */
-	public function seeProductOutput( $I, $productURL, $text = false, $textColor = false, $backgroundColor = false ) {
+	public function seeProductOutput($I, $productURL, $text = false, $textColor = false, $backgroundColor = false)
+	{
 		// Confirm that the block displays.
-		$I->seeElementInDOM( 'a.convertkit-product.wp-block-button__link' );
+		$I->seeElementInDOM('a.convertkit-product.wp-block-button__link');
 
 		// Confirm that the button links to the correct product.
-		$I->assertEquals( $productURL, $I->grabAttributeFrom( 'a.convertkit-product', 'href' ) );
+		$I->assertEquals($productURL, $I->grabAttributeFrom('a.convertkit-product', 'href'));
 
 		// Confirm that the text color is as expected.
-		if ( $textColor !== false ) {
-			$I->seeElementInDOM( 'a.convertkit-product.has-text-color' );
+		if ($textColor !== false) {
+			$I->seeElementInDOM('a.convertkit-product.has-text-color');
 			$I->assertStringContainsString(
-				'color:' . $textColor,
-				$I->grabAttributeFrom( 'a.convertkit-product', 'style' )
+				'color:'.$textColor,
+				$I->grabAttributeFrom('a.convertkit-product', 'style')
 			);
 		}
 
 		// Confirm that the background color is as expected.
-		if ( $backgroundColor !== false ) {
-			$I->seeElementInDOM( 'a.convertkit-product.has-background' );
+		if ($backgroundColor !== false) {
+			$I->seeElementInDOM('a.convertkit-product.has-background');
 			$I->assertStringContainsString(
-				'background-color:' . $backgroundColor,
-				$I->grabAttributeFrom( 'a.convertkit-product', 'style' )
+				'background-color:'.$backgroundColor,
+				$I->grabAttributeFrom('a.convertkit-product', 'style')
 			);
 		}
 
 		// Click the button to confirm that the ConvertKit modal displays; this confirms
 		// necessary ConvertKit scripts have been loaded.
-		$I->click( 'a.convertkit-product' );
-		$I->seeElementInDOM( 'iframe[data-active]' );
+		$I->click('a.convertkit-product');
+		$I->seeElementInDOM('iframe[data-active]');
 	}
 
 	/**
 	 * Check that expected HTML does exists in the DOM of the page we're viewing for
 	 * a Product block or shortcode.
+	 * 
+	 * @since 	1.9.8.5
 	 *
-	 * @since 1.9.8.5
-	 *
-	 * @param AcceptanceTester $I    Tester.
-	 * @param bool|string      $text Test if the button text matches the given value.
+	 * @param 	AcceptanceTester 	$I 		Tester.
+	 * @param 	bool|string 		$text 	Test if the button text matches the given value.
 	 */
-	public function dontSeeProductOutput( $I, $text = false ) {
+	public function dontSeeProductOutput($I, $text = false)
+	{
 		// Confirm that the block does not display.
-		$I->dontSeeElementInDOM( 'div.wp-block-button a.convertkit-product' );
+		$I->dontSeeElementInDOM('div.wp-block-button a.convertkit-product');
 	}
 }

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -5,487 +5,470 @@ namespace Helper\Acceptance;
 // would be used across multiple tests.
 // These are then available in $I->{yourFunctionName}
 
-class Plugin extends \Codeception\Module
-{
-    /**
-     * Helper method to activate the ConvertKit Plugin, checking
-     * it activated and no errors were output.
-     * 
-     * @since 1.9.6
-     *
-     * @param AcceptanceTester $I Acceptance Tester.
-     */
-    public function activateConvertKitPlugin($I)
-    {
-        $I->activateThirdPartyPlugin($I, 'convertkit');
-    }
-
-    /**
-     * Helper method to deactivate the ConvertKit Plugin, checking
-     * it activated and no errors were output.
-     * 
-     * @since 1.9.6
-     *
-     * @param AcceptanceTester $I Acceptance Tester.
-     */
-    public function deactivateConvertKitPlugin($I)
-    {
-        $I->deactivateThirdPartyPlugin($I, 'convertkit');
-    }
-
-    /**
-     * Helper method to setup the Plugin's API Key and Secret.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I         Acceptance Tester.
-     * @param mixed            $apiKey    API Key (if specified, used instead of CONVERTKIT_API_KEY)
-     * @param mixed            $apiSecret API Secret (if specified, used instead of CONVERTKIT_API_SECRET)
-     */
-    public function setupConvertKitPlugin($I, $apiKey = false, $apiSecret = false)
-    {
-        // Go to the Plugin's Settings Screen.
-        $I->loadConvertKitSettingsGeneralScreen($I);
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Determine API Key and Secret to use.
-        $convertKitAPIKey = ($apiKey !== false ? $apiKey : $_ENV['CONVERTKIT_API_KEY']);
-        $convertKitAPISecret = ($apiSecret !== false ? $apiSecret : $_ENV['CONVERTKIT_API_SECRET']);
-
-        // Complete API Fields.
-        $I->fillField('_wp_convertkit_settings[api_key]', $convertKitAPIKey);
-        $I->fillField('_wp_convertkit_settings[api_secret]', $convertKitAPISecret);
-
-        // Click the Save Changes button.
-        $I->click('Save Changes');
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Check the value of the fields match the inputs provided.
-        $I->seeInField('_wp_convertkit_settings[api_key]', $convertKitAPIKey);
-        $I->seeInField('_wp_convertkit_settings[api_secret]', $convertKitAPISecret);
-    }
-
-    /**
-     * Helper method to setup the Plugin's Default Form setting for Pages and Posts.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Acceptance Tester.
-     */
-    public function setupConvertKitPluginDefaultForm($I)
-    {
-        // Go to the Plugin's Settings Screen.
-        $I->loadConvertKitSettingsGeneralScreen($I);
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Select Default Form for Pages and Posts.
-        $I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
-        $I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_post_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
-
-        // Click the Save Changes button.
-        $I->click('Save Changes');
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Check the value of the fields match the inputs provided.
-        $I->seeInField('_wp_convertkit_settings[page_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
-        $I->seeInField('_wp_convertkit_settings[post_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
-
-        // Return Form ID for Pages
-        return $I->grabValueFrom('_wp_convertkit_settings[page_form]');
-    }
-
-    /**
-     * Helper method to setup the Plugin's Default Legacy Form setting for Pages and Posts.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Acceptance Tester.
-     */
-    public function setupConvertKitPluginDefaultLegacyForm($I)
-    {
-        // Go to the Plugin's Settings Screen.
-        $I->loadConvertKitSettingsGeneralScreen($I);
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Select Default Form for Pages and Posts.
-        $I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
-        $I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_post_form-container', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
-
-        // Click the Save Changes button.
-        $I->click('Save Changes');
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Check the value of the fields match the inputs provided.
-        $I->seeInField('_wp_convertkit_settings[page_form]', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
-        $I->seeInField('_wp_convertkit_settings[post_form]', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
-
-        // Return Form ID for Pages
-        return $I->grabValueFrom('_wp_convertkit_settings[page_form]');
-    }
-
-    /**
-     * Helper method to setup the Plugin's Default Form setting for WooCommerce Products.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Acceptance Tester.
-     */
-    public function setupConvertKitPluginDefaultFormForWooCommerceProducts($I)
-    {
-        // Go to the Plugin's Settings Screen.
-        $I->loadConvertKitSettingsGeneralScreen($I);
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Select option.
-        $I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_product_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
-
-        // Click the Save Changes button.
-        $I->click('Save Changes');
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Check the value of the fields match the inputs provided.
-        $I->seeInField('_wp_convertkit_settings[product_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
-
-        // Return Form ID
-        return $I->grabValueFrom('_wp_convertkit_settings[product_form]');
-    }
-
-    /**
-     * Helper method to reset the ConvertKit Plugin settings, as if it's a clean installation.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Acceptance Tester.
-     */
-    public function resetConvertKitPlugin($I)
-    {
-        // Plugin Settings.
-        $I->dontHaveOptionInDatabase('_wp_convertkit_settings');
-        $I->dontHaveOptionInDatabase('convertkit_version');
-
-        // Resources.
-        $I->dontHaveOptionInDatabase('convertkit_forms');
-        $I->dontHaveOptionInDatabase('convertkit_forms_last_queried');
-        $I->dontHaveOptionInDatabase('convertkit_landing_pages');
-        $I->dontHaveOptionInDatabase('convertkit_landing_pages_last_queried');
-        $I->dontHaveOptionInDatabase('convertkit_tags');
-        $I->dontHaveOptionInDatabase('convertkit_tags_last_queried');
-
-        // Review Request.
-        $I->dontHaveOptionInDatabase('convertkit-review-request');
-        $I->dontHaveOptionInDatabase('convertkit-review-dismissed');
-
-        // Upgrades.
-        $I->dontHaveOptionInDatabase('_wp_convertkit_upgrade_posts');
-    }
-
-    /**
-     * Helper method to load the Plugin's Settings > General screen.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Acceptance Tester.
-     */
-    public function loadConvertKitSettingsGeneralScreen($I)
-    {
-        $I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings');
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-    }
-
-    /**
-     * Helper method to load the Plugin's Settings > Tools screen.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Acceptance Tester.
-     */
-    public function loadConvertKitSettingsToolsScreen($I)
-    {
-        $I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=tools');
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-    }
-
-    /**
-     * Helper method to enable the Plugin's Settings > General > Debug option.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Acceptance Tester.
-     */
-    public function enableDebugLog($I)
-    {
-        // Go to the Plugin's Settings Screen.
-        $I->loadConvertKitSettingsGeneralScreen($I);
-		
-        // Tick field.
-        $I->checkOption('#debug');
-
-        // Click the Save Changes button.
-        $I->click('Save Changes');
-    }
-
-    /**
-     * Helper method to clear the Plugin's debug log.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Acceptance Tester.
-     */
-    public function clearDebugLog($I)
-    {
-        // Go to the Plugin's Tools Screen.
-        $I->loadConvertKitSettingsToolsScreen($I);
-		
-        // Click the Clear log button.
-        $I->click('Clear log');
-    }
-
-    /**
-     * Helper method to determine if the given entry exists in the Plugin Debug Log screen's textarea.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I     Acceptance Tester.
-     * @param string           $entry Expected log entry.
-     */
-    public function seeInPluginDebugLog($I, $entry)
-    {
-        $I->loadConvertKitSettingsToolsScreen($I);
-        $I->seeInSource($entry);
-    }
-
-    /**
-     * Helper method to determine if the given entry does not exist in the Plugin Debug Log screen's textarea.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I     Acceptance Tester.
-     * @param string           $entry Expected log entry.
-     */
-    public function dontSeeInPluginDebugLog($I, $entry)
-    {
-        $I->loadConvertKitSettingsToolsScreen($I);
-        $I->dontSeeInSource($entry);
-    }
-
-    /**
-     * Check that expected HTML exists in the DOM of the page we're viewing for
-     * a Broadcasts block or shortcode.
-     * 
-     * @since 1.9.7.5
-     *
-     * @param AcceptanceTester $I                      Acceptance Tester.
-     * @param bool|int         $numberOfPosts          Number of Broadcasts listed.
-     * @param bool|string      $seePrevPaginationLabel Test if the "previous" pagination link is output and matches expected label.
-     * @param bool|string      $seeNextPaginationLabel Test if the "next" pagination link is output and matches expected label.
-     */
-    public function seeBroadcastsOutput($I, $numberOfPosts = false, $seePrevPaginationLabel = false, $seeNextPaginationLabel = false)
-    {
-        // Confirm that the block displays.
-        $I->seeElementInDOM('div.convertkit-broadcasts');
-        $I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-list');
-        $I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast');
-        $I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast a');
-
-        // Confirm that UTM parameters exist on a broadcast link.
-        $I->assertStringContainsString(
-            'utm_source=wordpress&utm_content=convertkit',
-            $I->grabAttributeFrom('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast a', 'href')
-        );
-
-        // Confirm that the number of expected broadcasts displays.
-        if ($numberOfPosts !== false) {
-            $I->seeNumberOfElements('li.convertkit-broadcast', $numberOfPosts);
-        }
-
-        // Confirm that previous pagination displays.
-        if ($seePrevPaginationLabel !== false) {
-            $I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-pagination li.convertkit-broadcasts-pagination-prev a');
-            $I->seeInSource($seePrevPaginationLabel);        
-        }
-
-        // Confirm that next pagination displays.
-        if ($seeNextPaginationLabel !== false) {
-            $I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-pagination li.convertkit-broadcasts-pagination-next a');    
-        }
-    }
-
-    /**
-     * Tests that the Broadcasts pagination works, and that the expected Broadcast
-     * is displayed after using previous and next links.
-     * 
-     * @since 2.0.0
-     * 
-     * @param AcceptanceTester $I             Tester.
-     * @param string           $previousLabel Previous / Newer Broadcasts Label.
-     * @param string           $nextLabel     Next / Older Broadcasts Label.
-     */
-    public function testBroadcastsPagination($I, $previousLabel, $nextLabel)
-    {
-        // Confirm that the block displays one broadcast with a pagination link to older broadcasts.
-        $I->seeBroadcastsOutput($I, 1, false, $nextLabel);
-
-        // Click the Older Posts link.
-        $I->click('li.convertkit-broadcasts-pagination-next a');
-
-        // Wait for the AJAX request to complete, by checking if the convertkit-broadcasts-loading class has been
-        // removed from the block.
-        $I->waitForBroadcastsToLoad($I);
-
-        // Confirm that the block displays one broadcast with a pagination link to newer broadcasts.
-        $I->seeBroadcastsOutput($I, 1, $previousLabel, false);
-
-        // Fetch Broadcasts from the resource, to determine the name of the most recent two broadcasts.
-        $broadcasts = $I->grabOptionFromDatabase('convertkit_posts');
-        $firstBroadcast = current(array_slice($broadcasts, 0, 1));
-        $secondBroadcast = current(array_slice($broadcasts, 1, 1));
-
-        // Confirm that the expected Broadcast name is displayed and links to the expected URL, with UTM parameters.
-        $I->seeInSource('<a href="'.$secondBroadcast['url'].'?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener"');
-        $I->seeInSource($secondBroadcast['title']);
-
-        // Click the Newer Posts link.
-        $I->click('li.convertkit-broadcasts-pagination-prev a');
-
-        // Wait for the AJAX request to complete, by checking if the convertkit-broadcasts-loading class has been
-        // removed from the block.
-        $I->waitForBroadcastsToLoad($I);
-
-        // Confirm that the block displays one broadcast with a pagination link to older broadcasts.
-        $I->seeBroadcastsOutput($I, 1, false, $nextLabel);
-
-        // Confirm that the expected Broadcast name is displayed and links to the expected URL, with UTM parameters.
-        $I->seeInSource('<a href="'.$firstBroadcast['url'].'?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener"');
-        $I->seeInSource($firstBroadcast['title']);
-    }
-
-    /**
-     * Wait for the AJAX request to complete, by checking if the convertkit-broadcasts-loading class has been
-     * removed from the block.
-     * 
-     * @since 1.9.7.6
-     * 
-     * @param AcceptanceTester $I Tester.
-     */
-    public function waitForBroadcastsToLoad($I)
-    {
-        $I->waitForElementChange(
-            'div.convertkit-broadcasts', function (\Facebook\WebDriver\WebDriverElement $el) {
-                return ( strpos($el->getAttribute('class'), 'convertkit-broadcasts-loading') === false ? true : false );
-            }, 5
-        );
-    }
-
-    /**
-     * Check that expected HTML exists in the DOM of the page we're viewing
-     * when a ConvertKit Product link was inserted into a paragraph or button,
-     * and that the button loads the expected ConvertKit Product modal.
-     * 
-     * @since 2.0.0
-     *
-     * @param AcceptanceTester $I          Tester.
-     * @param string           $productURL Product URL.
-     * @param bool|string      $text       Test if the link text matches the given value.
-     */
-    public function seeProductLink($I, $productURL, $text = false)
-    {
-        // Confirm that the commerce.js script exists.
-        $I->seeInSource('commerce.js');
-
-        // Confirm that the link exists.
-        $I->seeElementInDOM('a[data-commerce]');
-
-        // Confirm that the link points to the correct product.
-        $I->assertEquals($productURL, $I->grabAttributeFrom('a[data-commerce]', 'href'));
-
-        // Confirm that the button text is as expected.
-        if ($text !== false) {
-            $I->seeInSource('>'.$text.'</a>');        
-        }
-
-        // Click the button to confirm that the ConvertKit modal displays; this confirms
-        // necessary ConvertKit scripts have been loaded.
-        $I->click('a[href="'.$productURL.'"]');
-        $I->seeElementInDOM('iframe[data-active]');
-    }
-
-    /**
-     * Check that expected HTML exists in the DOM of the page we're viewing for
-     * a Product block or shortcode, and that the button loads the expected
-     * ConvertKit Product modal.
-     * 
-     * @since 1.9.8.5
-     *
-     * @param AcceptanceTester $I               Tester.
-     * @param string           $productURL      Product URL.
-     * @param bool|string      $text            Test if the button text matches the given value.
-     * @param bool|string      $textColor       Test if the given text color is applied.
-     * @param bool|string      $backgroundColor Test is the given background color is applied.
-     */
-    public function seeProductOutput($I, $productURL, $text = false, $textColor = false, $backgroundColor = false)
-    {
-        // Confirm that the block displays.
-        $I->seeElementInDOM('a.convertkit-product.wp-block-button__link');
-
-        // Confirm that the button links to the correct product.
-        $I->assertEquals($productURL, $I->grabAttributeFrom('a.convertkit-product', 'href'));
-
-        // Confirm that the text color is as expected.
-        if ($textColor !== false) {
-            $I->seeElementInDOM('a.convertkit-product.has-text-color');
-            $I->assertStringContainsString(
-                'color:'.$textColor,
-                $I->grabAttributeFrom('a.convertkit-product', 'style')
-            );
-        }
-
-        // Confirm that the background color is as expected.
-        if ($backgroundColor !== false) {
-            $I->seeElementInDOM('a.convertkit-product.has-background');
-            $I->assertStringContainsString(
-                'background-color:'.$backgroundColor,
-                $I->grabAttributeFrom('a.convertkit-product', 'style')
-            );
-        }
-
-        // Click the button to confirm that the ConvertKit modal displays; this confirms
-        // necessary ConvertKit scripts have been loaded.
-        $I->click('a.convertkit-product');
-        $I->seeElementInDOM('iframe[data-active]');
-    }
-
-    /**
-     * Check that expected HTML does exists in the DOM of the page we're viewing for
-     * a Product block or shortcode.
-     * 
-     * @since 1.9.8.5
-     *
-     * @param AcceptanceTester $I    Tester.
-     * @param bool|string      $text Test if the button text matches the given value.
-     */
-    public function dontSeeProductOutput($I, $text = false)
-    {
-        // Confirm that the block does not display.
-        $I->dontSeeElementInDOM('div.wp-block-button a.convertkit-product');
-    }
+class Plugin extends \Codeception\Module {
+
+	/**
+	 * Helper method to activate the ConvertKit Plugin, checking
+	 * it activated and no errors were output.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Acceptance Tester.
+	 */
+	public function activateConvertKitPlugin( $I ) {
+		$I->activateThirdPartyPlugin( $I, 'convertkit' );
+	}
+
+	/**
+	 * Helper method to deactivate the ConvertKit Plugin, checking
+	 * it activated and no errors were output.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Acceptance Tester.
+	 */
+	public function deactivateConvertKitPlugin( $I ) {
+		$I->deactivateThirdPartyPlugin( $I, 'convertkit' );
+	}
+
+	/**
+	 * Helper method to setup the Plugin's API Key and Secret.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I         Acceptance Tester.
+	 * @param mixed            $apiKey    API Key (if specified, used instead of CONVERTKIT_API_KEY)
+	 * @param mixed            $apiSecret API Secret (if specified, used instead of CONVERTKIT_API_SECRET)
+	 */
+	public function setupConvertKitPlugin( $I, $apiKey = false, $apiSecret = false ) {
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsGeneralScreen( $I );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Determine API Key and Secret to use.
+		$convertKitAPIKey    = ( $apiKey !== false ? $apiKey : $_ENV['CONVERTKIT_API_KEY'] );
+		$convertKitAPISecret = ( $apiSecret !== false ? $apiSecret : $_ENV['CONVERTKIT_API_SECRET'] );
+
+		// Complete API Fields.
+		$I->fillField( '_wp_convertkit_settings[api_key]', $convertKitAPIKey );
+		$I->fillField( '_wp_convertkit_settings[api_secret]', $convertKitAPISecret );
+
+		// Click the Save Changes button.
+		$I->click( 'Save Changes' );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Check the value of the fields match the inputs provided.
+		$I->seeInField( '_wp_convertkit_settings[api_key]', $convertKitAPIKey );
+		$I->seeInField( '_wp_convertkit_settings[api_secret]', $convertKitAPISecret );
+	}
+
+	/**
+	 * Helper method to setup the Plugin's Default Form setting for Pages and Posts.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Acceptance Tester.
+	 */
+	public function setupConvertKitPluginDefaultForm( $I ) {
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsGeneralScreen( $I );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Select Default Form for Pages and Posts.
+		$I->fillSelect2Field( $I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+		$I->fillSelect2Field( $I, '#select2-_wp_convertkit_settings_post_form-container', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+
+		// Click the Save Changes button.
+		$I->click( 'Save Changes' );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Check the value of the fields match the inputs provided.
+		$I->seeInField( '_wp_convertkit_settings[page_form]', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+		$I->seeInField( '_wp_convertkit_settings[post_form]', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+
+		// Return Form ID for Pages
+		return $I->grabValueFrom( '_wp_convertkit_settings[page_form]' );
+	}
+
+	/**
+	 * Helper method to setup the Plugin's Default Legacy Form setting for Pages and Posts.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Acceptance Tester.
+	 */
+	public function setupConvertKitPluginDefaultLegacyForm( $I ) {
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsGeneralScreen( $I );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Select Default Form for Pages and Posts.
+		$I->fillSelect2Field( $I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] );
+		$I->fillSelect2Field( $I, '#select2-_wp_convertkit_settings_post_form-container', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] );
+
+		// Click the Save Changes button.
+		$I->click( 'Save Changes' );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Check the value of the fields match the inputs provided.
+		$I->seeInField( '_wp_convertkit_settings[page_form]', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] );
+		$I->seeInField( '_wp_convertkit_settings[post_form]', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] );
+
+		// Return Form ID for Pages
+		return $I->grabValueFrom( '_wp_convertkit_settings[page_form]' );
+	}
+
+	/**
+	 * Helper method to setup the Plugin's Default Form setting for WooCommerce Products.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Acceptance Tester.
+	 */
+	public function setupConvertKitPluginDefaultFormForWooCommerceProducts( $I ) {
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsGeneralScreen( $I );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Select option.
+		$I->fillSelect2Field( $I, '#select2-_wp_convertkit_settings_product_form-container', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+
+		// Click the Save Changes button.
+		$I->click( 'Save Changes' );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Check the value of the fields match the inputs provided.
+		$I->seeInField( '_wp_convertkit_settings[product_form]', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+
+		// Return Form ID
+		return $I->grabValueFrom( '_wp_convertkit_settings[product_form]' );
+	}
+
+	/**
+	 * Helper method to reset the ConvertKit Plugin settings, as if it's a clean installation.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Acceptance Tester.
+	 */
+	public function resetConvertKitPlugin( $I ) {
+		// Plugin Settings.
+		$I->dontHaveOptionInDatabase( '_wp_convertkit_settings' );
+		$I->dontHaveOptionInDatabase( 'convertkit_version' );
+
+		// Resources.
+		$I->dontHaveOptionInDatabase( 'convertkit_forms' );
+		$I->dontHaveOptionInDatabase( 'convertkit_forms_last_queried' );
+		$I->dontHaveOptionInDatabase( 'convertkit_landing_pages' );
+		$I->dontHaveOptionInDatabase( 'convertkit_landing_pages_last_queried' );
+		$I->dontHaveOptionInDatabase( 'convertkit_tags' );
+		$I->dontHaveOptionInDatabase( 'convertkit_tags_last_queried' );
+
+		// Review Request.
+		$I->dontHaveOptionInDatabase( 'convertkit-review-request' );
+		$I->dontHaveOptionInDatabase( 'convertkit-review-dismissed' );
+
+		// Upgrades.
+		$I->dontHaveOptionInDatabase( '_wp_convertkit_upgrade_posts' );
+	}
+
+	/**
+	 * Helper method to load the Plugin's Settings > General screen.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Acceptance Tester.
+	 */
+	public function loadConvertKitSettingsGeneralScreen( $I ) {
+		$I->amOnAdminPage( 'options-general.php?page=_wp_convertkit_settings' );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+	}
+
+	/**
+	 * Helper method to load the Plugin's Settings > Tools screen.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Acceptance Tester.
+	 */
+	public function loadConvertKitSettingsToolsScreen( $I ) {
+		$I->amOnAdminPage( 'options-general.php?page=_wp_convertkit_settings&tab=tools' );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+	}
+
+	/**
+	 * Helper method to enable the Plugin's Settings > General > Debug option.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Acceptance Tester.
+	 */
+	public function enableDebugLog( $I ) {
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsGeneralScreen( $I );
+
+		// Tick field.
+		$I->checkOption( '#debug' );
+
+		// Click the Save Changes button.
+		$I->click( 'Save Changes' );
+	}
+
+	/**
+	 * Helper method to clear the Plugin's debug log.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Acceptance Tester.
+	 */
+	public function clearDebugLog( $I ) {
+		// Go to the Plugin's Tools Screen.
+		$I->loadConvertKitSettingsToolsScreen( $I );
+
+		// Click the Clear log button.
+		$I->click( 'Clear log' );
+	}
+
+	/**
+	 * Helper method to determine if the given entry exists in the Plugin Debug Log screen's textarea.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I     Acceptance Tester.
+	 * @param string           $entry Expected log entry.
+	 */
+	public function seeInPluginDebugLog( $I, $entry ) {
+		$I->loadConvertKitSettingsToolsScreen( $I );
+		$I->seeInSource( $entry );
+	}
+
+	/**
+	 * Helper method to determine if the given entry does not exist in the Plugin Debug Log screen's textarea.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I     Acceptance Tester.
+	 * @param string           $entry Expected log entry.
+	 */
+	public function dontSeeInPluginDebugLog( $I, $entry ) {
+		$I->loadConvertKitSettingsToolsScreen( $I );
+		$I->dontSeeInSource( $entry );
+	}
+
+	/**
+	 * Check that expected HTML exists in the DOM of the page we're viewing for
+	 * a Broadcasts block or shortcode.
+	 *
+	 * @since 1.9.7.5
+	 *
+	 * @param AcceptanceTester $I                      Acceptance Tester.
+	 * @param bool|int         $numberOfPosts          Number of Broadcasts listed.
+	 * @param bool|string      $seePrevPaginationLabel Test if the "previous" pagination link is output and matches expected label.
+	 * @param bool|string      $seeNextPaginationLabel Test if the "next" pagination link is output and matches expected label.
+	 */
+	public function seeBroadcastsOutput( $I, $numberOfPosts = false, $seePrevPaginationLabel = false, $seeNextPaginationLabel = false ) {
+		// Confirm that the block displays.
+		$I->seeElementInDOM( 'div.convertkit-broadcasts' );
+		$I->seeElementInDOM( 'div.convertkit-broadcasts ul.convertkit-broadcasts-list' );
+		$I->seeElementInDOM( 'div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast' );
+		$I->seeElementInDOM( 'div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast a' );
+
+		// Confirm that UTM parameters exist on a broadcast link.
+		$I->assertStringContainsString(
+			'utm_source=WordPress&utm_content=convertkit',
+			$I->grabAttributeFrom( 'div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast a', 'href' )
+		);
+
+		// Confirm that the number of expected broadcasts displays.
+		if ( $numberOfPosts !== false ) {
+			$I->seeNumberOfElements( 'li.convertkit-broadcast', $numberOfPosts );
+		}
+
+		// Confirm that previous pagination displays.
+		if ( $seePrevPaginationLabel !== false ) {
+			$I->seeElementInDOM( 'div.convertkit-broadcasts ul.convertkit-broadcasts-pagination li.convertkit-broadcasts-pagination-prev a' );
+			$I->seeInSource( $seePrevPaginationLabel );
+		}
+
+		// Confirm that next pagination displays.
+		if ( $seeNextPaginationLabel !== false ) {
+			$I->seeElementInDOM( 'div.convertkit-broadcasts ul.convertkit-broadcasts-pagination li.convertkit-broadcasts-pagination-next a' );
+		}
+	}
+
+	/**
+	 * Tests that the Broadcasts pagination works, and that the expected Broadcast
+	 * is displayed after using previous and next links.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param AcceptanceTester $I             Tester.
+	 * @param string           $previousLabel Previous / Newer Broadcasts Label.
+	 * @param string           $nextLabel     Next / Older Broadcasts Label.
+	 */
+	public function testBroadcastsPagination( $I, $previousLabel, $nextLabel ) {
+		// Confirm that the block displays one broadcast with a pagination link to older broadcasts.
+		$I->seeBroadcastsOutput( $I, 1, false, $nextLabel );
+
+		// Click the Older Posts link.
+		$I->click( 'li.convertkit-broadcasts-pagination-next a' );
+
+		// Wait for the AJAX request to complete, by checking if the convertkit-broadcasts-loading class has been
+		// removed from the block.
+		$I->waitForBroadcastsToLoad( $I );
+
+		// Confirm that the block displays one broadcast with a pagination link to newer broadcasts.
+		$I->seeBroadcastsOutput( $I, 1, $previousLabel, false );
+
+		// Fetch Broadcasts from the resource, to determine the name of the most recent two broadcasts.
+		$broadcasts      = $I->grabOptionFromDatabase( 'convertkit_posts' );
+		$firstBroadcast  = current( array_slice( $broadcasts, 0, 1 ) );
+		$secondBroadcast = current( array_slice( $broadcasts, 1, 1 ) );
+
+		// Confirm that the expected Broadcast name is displayed and links to the expected URL, with UTM parameters.
+		$I->seeInSource( '<a href="' . $secondBroadcast['url'] . '?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener"' );
+		$I->seeInSource( $secondBroadcast['title'] );
+
+		// Click the Newer Posts link.
+		$I->click( 'li.convertkit-broadcasts-pagination-prev a' );
+
+		// Wait for the AJAX request to complete, by checking if the convertkit-broadcasts-loading class has been
+		// removed from the block.
+		$I->waitForBroadcastsToLoad( $I );
+
+		// Confirm that the block displays one broadcast with a pagination link to older broadcasts.
+		$I->seeBroadcastsOutput( $I, 1, false, $nextLabel );
+
+		// Confirm that the expected Broadcast name is displayed and links to the expected URL, with UTM parameters.
+		$I->seeInSource( '<a href="' . $firstBroadcast['url'] . '?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener"' );
+		$I->seeInSource( $firstBroadcast['title'] );
+	}
+
+	/**
+	 * Wait for the AJAX request to complete, by checking if the convertkit-broadcasts-loading class has been
+	 * removed from the block.
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param AcceptanceTester $I Tester.
+	 */
+	public function waitForBroadcastsToLoad( $I ) {
+		$I->waitForElementChange(
+			'div.convertkit-broadcasts',
+			function ( \Facebook\WebDriver\WebDriverElement $el ) {
+				return ( strpos( $el->getAttribute( 'class' ), 'convertkit-broadcasts-loading' ) === false ? true : false );
+			},
+			5
+		);
+	}
+
+	/**
+	 * Check that expected HTML exists in the DOM of the page we're viewing
+	 * when a ConvertKit Product link was inserted into a paragraph or button,
+	 * and that the button loads the expected ConvertKit Product modal.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param AcceptanceTester $I          Tester.
+	 * @param string           $productURL Product URL.
+	 * @param bool|string      $text       Test if the link text matches the given value.
+	 */
+	public function seeProductLink( $I, $productURL, $text = false ) {
+		// Confirm that the commerce.js script exists.
+		$I->seeInSource( 'commerce.js' );
+
+		// Confirm that the link exists.
+		$I->seeElementInDOM( 'a[data-commerce]' );
+
+		// Confirm that the link points to the correct product.
+		$I->assertEquals( $productURL, $I->grabAttributeFrom( 'a[data-commerce]', 'href' ) );
+
+		// Confirm that the button text is as expected.
+		if ( $text !== false ) {
+			$I->seeInSource( '>' . $text . '</a>' );
+		}
+
+		// Click the button to confirm that the ConvertKit modal displays; this confirms
+		// necessary ConvertKit scripts have been loaded.
+		$I->click( 'a[href="' . $productURL . '"]' );
+		$I->seeElementInDOM( 'iframe[data-active]' );
+	}
+
+	/**
+	 * Check that expected HTML exists in the DOM of the page we're viewing for
+	 * a Product block or shortcode, and that the button loads the expected
+	 * ConvertKit Product modal.
+	 *
+	 * @since 1.9.8.5
+	 *
+	 * @param AcceptanceTester $I               Tester.
+	 * @param string           $productURL      Product URL.
+	 * @param bool|string      $text            Test if the button text matches the given value.
+	 * @param bool|string      $textColor       Test if the given text color is applied.
+	 * @param bool|string      $backgroundColor Test is the given background color is applied.
+	 */
+	public function seeProductOutput( $I, $productURL, $text = false, $textColor = false, $backgroundColor = false ) {
+		// Confirm that the block displays.
+		$I->seeElementInDOM( 'a.convertkit-product.wp-block-button__link' );
+
+		// Confirm that the button links to the correct product.
+		$I->assertEquals( $productURL, $I->grabAttributeFrom( 'a.convertkit-product', 'href' ) );
+
+		// Confirm that the text color is as expected.
+		if ( $textColor !== false ) {
+			$I->seeElementInDOM( 'a.convertkit-product.has-text-color' );
+			$I->assertStringContainsString(
+				'color:' . $textColor,
+				$I->grabAttributeFrom( 'a.convertkit-product', 'style' )
+			);
+		}
+
+		// Confirm that the background color is as expected.
+		if ( $backgroundColor !== false ) {
+			$I->seeElementInDOM( 'a.convertkit-product.has-background' );
+			$I->assertStringContainsString(
+				'background-color:' . $backgroundColor,
+				$I->grabAttributeFrom( 'a.convertkit-product', 'style' )
+			);
+		}
+
+		// Click the button to confirm that the ConvertKit modal displays; this confirms
+		// necessary ConvertKit scripts have been loaded.
+		$I->click( 'a.convertkit-product' );
+		$I->seeElementInDOM( 'iframe[data-active]' );
+	}
+
+	/**
+	 * Check that expected HTML does exists in the DOM of the page we're viewing for
+	 * a Product block or shortcode.
+	 *
+	 * @since 1.9.8.5
+	 *
+	 * @param AcceptanceTester $I    Tester.
+	 * @param bool|string      $text Test if the button text matches the given value.
+	 */
+	public function dontSeeProductOutput( $I, $text = false ) {
+		// Confirm that the block does not display.
+		$I->dontSeeElementInDOM( 'div.wp-block-button a.convertkit-product' );
+	}
 }

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -12,6 +12,8 @@ class Plugin extends \Codeception\Module
      * it activated and no errors were output.
      * 
      * @since 1.9.6
+     *
+     * @param AcceptanceTester $I Acceptance Tester.
      */
     public function activateConvertKitPlugin($I)
     {
@@ -23,6 +25,8 @@ class Plugin extends \Codeception\Module
      * it activated and no errors were output.
      * 
      * @since 1.9.6
+     *
+     * @param AcceptanceTester $I Acceptance Tester.
      */
     public function deactivateConvertKitPlugin($I)
     {
@@ -34,8 +38,9 @@ class Plugin extends \Codeception\Module
      * 
      * @since 1.9.6
      * 
-     * @param mixed $apiKey    API Key (if specified, used instead of CONVERTKIT_API_KEY)
-     * @param mixed $apiSecret API Secret (if specified, used instead of CONVERTKIT_API_SECRET)
+     * @param AcceptanceTester $I         Acceptance Tester.
+     * @param mixed            $apiKey    API Key (if specified, used instead of CONVERTKIT_API_KEY)
+     * @param mixed            $apiSecret API Secret (if specified, used instead of CONVERTKIT_API_SECRET)
      */
     public function setupConvertKitPlugin($I, $apiKey = false, $apiSecret = false)
     {
@@ -68,6 +73,8 @@ class Plugin extends \Codeception\Module
      * Helper method to setup the Plugin's Default Form setting for Pages and Posts.
      * 
      * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Acceptance Tester.
      */
     public function setupConvertKitPluginDefaultForm($I)
     {
@@ -99,6 +106,8 @@ class Plugin extends \Codeception\Module
      * Helper method to setup the Plugin's Default Legacy Form setting for Pages and Posts.
      * 
      * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Acceptance Tester.
      */
     public function setupConvertKitPluginDefaultLegacyForm($I)
     {
@@ -130,6 +139,8 @@ class Plugin extends \Codeception\Module
      * Helper method to setup the Plugin's Default Form setting for WooCommerce Products.
      * 
      * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Acceptance Tester.
      */
     public function setupConvertKitPluginDefaultFormForWooCommerceProducts($I)
     {
@@ -159,6 +170,8 @@ class Plugin extends \Codeception\Module
      * Helper method to reset the ConvertKit Plugin settings, as if it's a clean installation.
      * 
      * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Acceptance Tester.
      */
     public function resetConvertKitPlugin($I)
     {
@@ -186,6 +199,8 @@ class Plugin extends \Codeception\Module
      * Helper method to load the Plugin's Settings > General screen.
      * 
      * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Acceptance Tester.
      */
     public function loadConvertKitSettingsGeneralScreen($I)
     {
@@ -199,6 +214,8 @@ class Plugin extends \Codeception\Module
      * Helper method to load the Plugin's Settings > Tools screen.
      * 
      * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Acceptance Tester.
      */
     public function loadConvertKitSettingsToolsScreen($I)
     {
@@ -212,6 +229,8 @@ class Plugin extends \Codeception\Module
      * Helper method to enable the Plugin's Settings > General > Debug option.
      * 
      * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Acceptance Tester.
      */
     public function enableDebugLog($I)
     {
@@ -229,6 +248,8 @@ class Plugin extends \Codeception\Module
      * Helper method to clear the Plugin's debug log.
      * 
      * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Acceptance Tester.
      */
     public function clearDebugLog($I)
     {
@@ -243,6 +264,9 @@ class Plugin extends \Codeception\Module
      * Helper method to determine if the given entry exists in the Plugin Debug Log screen's textarea.
      * 
      * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I     Acceptance Tester.
+     * @param string           $entry Expected log entry.
      */
     public function seeInPluginDebugLog($I, $entry)
     {
@@ -254,6 +278,9 @@ class Plugin extends \Codeception\Module
      * Helper method to determine if the given entry does not exist in the Plugin Debug Log screen's textarea.
      * 
      * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I     Acceptance Tester.
+     * @param string           $entry Expected log entry.
      */
     public function dontSeeInPluginDebugLog($I, $entry)
     {
@@ -267,10 +294,10 @@ class Plugin extends \Codeception\Module
      * 
      * @since 1.9.7.5
      *
-     * @param AcceptanceTester $I                      Tester.
+     * @param AcceptanceTester $I                      Acceptance Tester.
      * @param bool|int         $numberOfPosts          Number of Broadcasts listed.
      * @param bool|string      $seePrevPaginationLabel Test if the "previous" pagination link is output and matches expected label.
-     * @param bool|string      $seePrevPaginationLabel Test if the "next" pagination link is output and matches expected label.
+     * @param bool|string      $seeNextPaginationLabel Test if the "next" pagination link is output and matches expected label.
      */
     public function seeBroadcastsOutput($I, $numberOfPosts = false, $seePrevPaginationLabel = false, $seeNextPaginationLabel = false)
     {

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -10,8 +10,8 @@ class Plugin extends \Codeception\Module
 	/**
 	 * Helper method to activate the ConvertKit Plugin, checking
 	 * it activated and no errors were output.
-	 * 
-	 * @since 	1.9.6
+	 *
+	 * @since   1.9.6
 	 */
 	public function activateConvertKitPlugin($I)
 	{
@@ -21,8 +21,8 @@ class Plugin extends \Codeception\Module
 	/**
 	 * Helper method to deactivate the ConvertKit Plugin, checking
 	 * it activated and no errors were output.
-	 * 
-	 * @since 	1.9.6
+	 *
+	 * @since   1.9.6
 	 */
 	public function deactivateConvertKitPlugin($I)
 	{
@@ -31,11 +31,11 @@ class Plugin extends \Codeception\Module
 
 	/**
 	 * Helper method to setup the Plugin's API Key and Secret.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	mixed 	$apiKey 	API Key (if specified, used instead of CONVERTKIT_API_KEY)
-	 * @param 	mixed 	$apiSecret 	API Secret (if specified, used instead of CONVERTKIT_API_SECRET)
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   mixed $apiKey     API Key (if specified, used instead of CONVERTKIT_API_KEY)
+	 * @param   mixed $apiSecret  API Secret (if specified, used instead of CONVERTKIT_API_SECRET)
 	 */
 	public function setupConvertKitPlugin($I, $apiKey = false, $apiSecret = false)
 	{
@@ -46,8 +46,8 @@ class Plugin extends \Codeception\Module
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Determine API Key and Secret to use.
-		$convertKitAPIKey = ($apiKey !== false ? $apiKey : $_ENV['CONVERTKIT_API_KEY']);
-		$convertKitAPISecret = ($apiSecret !== false ? $apiSecret : $_ENV['CONVERTKIT_API_SECRET']);
+		$convertKitAPIKey    = ( $apiKey !== false ? $apiKey : $_ENV['CONVERTKIT_API_KEY'] );
+		$convertKitAPISecret = ( $apiSecret !== false ? $apiSecret : $_ENV['CONVERTKIT_API_SECRET'] );
 
 		// Complete API Fields.
 		$I->fillField('_wp_convertkit_settings[api_key]', $convertKitAPIKey);
@@ -66,8 +66,8 @@ class Plugin extends \Codeception\Module
 
 	/**
 	 * Helper method to setup the Plugin's Default Form setting for Pages and Posts.
-	 * 
-	 * @since 	1.9.6
+	 *
+	 * @since   1.9.6
 	 */
 	public function setupConvertKitPluginDefaultForm($I)
 	{
@@ -97,8 +97,8 @@ class Plugin extends \Codeception\Module
 
 	/**
 	 * Helper method to setup the Plugin's Default Legacy Form setting for Pages and Posts.
-	 * 
-	 * @since 	1.9.6
+	 *
+	 * @since   1.9.6
 	 */
 	public function setupConvertKitPluginDefaultLegacyForm($I)
 	{
@@ -128,8 +128,8 @@ class Plugin extends \Codeception\Module
 
 	/**
 	 * Helper method to setup the Plugin's Default Form setting for WooCommerce Products.
-	 * 
-	 * @since 	1.9.6
+	 *
+	 * @since   1.9.6
 	 */
 	public function setupConvertKitPluginDefaultFormForWooCommerceProducts($I)
 	{
@@ -157,8 +157,8 @@ class Plugin extends \Codeception\Module
 
 	/**
 	 * Helper method to reset the ConvertKit Plugin settings, as if it's a clean installation.
-	 * 
-	 * @since 	1.9.6.7
+	 *
+	 * @since   1.9.6.7
 	 */
 	public function resetConvertKitPlugin($I)
 	{
@@ -184,8 +184,8 @@ class Plugin extends \Codeception\Module
 
 	/**
 	 * Helper method to load the Plugin's Settings > General screen.
-	 * 
-	 * @since 	1.9.6
+	 *
+	 * @since   1.9.6
 	 */
 	public function loadConvertKitSettingsGeneralScreen($I)
 	{
@@ -197,8 +197,8 @@ class Plugin extends \Codeception\Module
 
 	/**
 	 * Helper method to load the Plugin's Settings > Tools screen.
-	 * 
-	 * @since 	1.9.6
+	 *
+	 * @since   1.9.6
 	 */
 	public function loadConvertKitSettingsToolsScreen($I)
 	{
@@ -210,14 +210,14 @@ class Plugin extends \Codeception\Module
 
 	/**
 	 * Helper method to enable the Plugin's Settings > General > Debug option.
-	 * 
-	 * @since 	1.9.6
+	 *
+	 * @since   1.9.6
 	 */
 	public function enableDebugLog($I)
 	{
 		// Go to the Plugin's Settings Screen.
 		$I->loadConvertKitSettingsGeneralScreen($I);
-		
+
 		// Tick field.
 		$I->checkOption('#debug');
 
@@ -227,22 +227,22 @@ class Plugin extends \Codeception\Module
 
 	/**
 	 * Helper method to clear the Plugin's debug log.
-	 * 
-	 * @since 	1.9.6
+	 *
+	 * @since   1.9.6
 	 */
 	public function clearDebugLog($I)
 	{
 		// Go to the Plugin's Tools Screen.
 		$I->loadConvertKitSettingsToolsScreen($I);
-		
+
 		// Click the Clear log button.
 		$I->click('Clear log');
 	}
 
 	/**
 	 * Helper method to determine if the given entry exists in the Plugin Debug Log screen's textarea.
-	 * 
-	 * @since 	1.9.6
+	 *
+	 * @since   1.9.6
 	 */
 	public function seeInPluginDebugLog($I, $entry)
 	{
@@ -252,8 +252,8 @@ class Plugin extends \Codeception\Module
 
 	/**
 	 * Helper method to determine if the given entry does not exist in the Plugin Debug Log screen's textarea.
-	 * 
-	 * @since 	1.9.6
+	 *
+	 * @since   1.9.6
 	 */
 	public function dontSeeInPluginDebugLog($I, $entry)
 	{
@@ -264,13 +264,13 @@ class Plugin extends \Codeception\Module
 	/**
 	 * Check that expected HTML exists in the DOM of the page we're viewing for
 	 * a Broadcasts block or shortcode.
-	 * 
-	 * @since 	1.9.7.5
 	 *
-	 * @param 	AcceptanceTester 	$I 						Tester.
-	 * @param 	bool|int 			$numberOfPosts 			Number of Broadcasts listed.
-	 * @param 	bool|string 		$seePrevPaginationLabel Test if the "previous" pagination link is output and matches expected label.
-	 * @param 	bool|string 		$seePrevPaginationLabel Test if the "next" pagination link is output and matches expected label.
+	 * @since   1.9.7.5
+	 *
+	 * @param   AcceptanceTester $I                      Tester.
+	 * @param   bool|int         $numberOfPosts          Number of Broadcasts listed.
+	 * @param   bool|string      $seePrevPaginationLabel Test if the "previous" pagination link is output and matches expected label.
+	 * @param   bool|string      $seePrevPaginationLabel Test if the "next" pagination link is output and matches expected label.
 	 */
 	public function seeBroadcastsOutput($I, $numberOfPosts = false, $seePrevPaginationLabel = false, $seeNextPaginationLabel = false)
 	{
@@ -282,7 +282,7 @@ class Plugin extends \Codeception\Module
 
 		// Confirm that UTM parameters exist on a broadcast link.
 		$I->assertStringContainsString(
-			'utm_source=wordpress&utm_content=convertkit',
+			'utm_source=WordPress&utm_content=convertkit',
 			$I->grabAttributeFrom('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast a', 'href')
 		);
 
@@ -294,24 +294,24 @@ class Plugin extends \Codeception\Module
 		// Confirm that previous pagination displays.
 		if ($seePrevPaginationLabel !== false) {
 			$I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-pagination li.convertkit-broadcasts-pagination-prev a');
-			$I->seeInSource($seePrevPaginationLabel);		
+			$I->seeInSource($seePrevPaginationLabel);
 		}
 
 		// Confirm that next pagination displays.
 		if ($seeNextPaginationLabel !== false) {
-			$I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-pagination li.convertkit-broadcasts-pagination-next a');	
+			$I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-pagination li.convertkit-broadcasts-pagination-next a');
 		}
 	}
 
 	/**
 	 * Tests that the Broadcasts pagination works, and that the expected Broadcast
 	 * is displayed after using previous and next links.
-	 * 
-	 * @since 	2.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Tester.
-	 * @param 	string 				$previousLabel 			Previous / Newer Broadcasts Label.
-	 * @param 	string 				$nextLabel 				Next / Older Broadcasts Label.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @param   AcceptanceTester $I                      Tester.
+	 * @param   string           $previousLabel          Previous / Newer Broadcasts Label.
+	 * @param   string           $nextLabel              Next / Older Broadcasts Label.
 	 */
 	public function testBroadcastsPagination($I, $previousLabel, $nextLabel)
 	{
@@ -329,12 +329,12 @@ class Plugin extends \Codeception\Module
 		$I->seeBroadcastsOutput($I, 1, $previousLabel, false);
 
 		// Fetch Broadcasts from the resource, to determine the name of the most recent two broadcasts.
-		$broadcasts = $I->grabOptionFromDatabase('convertkit_posts');
-		$firstBroadcast = current(array_slice($broadcasts, 0, 1));
+		$broadcasts      = $I->grabOptionFromDatabase('convertkit_posts');
+		$firstBroadcast  = current(array_slice($broadcasts, 0, 1));
 		$secondBroadcast = current(array_slice($broadcasts, 1, 1));
 
 		// Confirm that the expected Broadcast name is displayed and links to the expected URL, with UTM parameters.
-		$I->seeInSource('<a href="'.$secondBroadcast['url'].'?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener"');
+		$I->seeInSource('<a href="' . $secondBroadcast['url'] . '?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener"');
 		$I->seeInSource($secondBroadcast['title']);
 
 		// Click the Newer Posts link.
@@ -348,35 +348,39 @@ class Plugin extends \Codeception\Module
 		$I->seeBroadcastsOutput($I, 1, false, $nextLabel);
 
 		// Confirm that the expected Broadcast name is displayed and links to the expected URL, with UTM parameters.
-		$I->seeInSource('<a href="'.$firstBroadcast['url'].'?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener"');
+		$I->seeInSource('<a href="' . $firstBroadcast['url'] . '?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener"');
 		$I->seeInSource($firstBroadcast['title']);
 	}
 
 	/**
 	 * Wait for the AJAX request to complete, by checking if the convertkit-broadcasts-loading class has been
 	 * removed from the block.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Tester.
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   AcceptanceTester $I                      Tester.
 	 */
 	public function waitForBroadcastsToLoad($I)
 	{
-		$I->waitForElementChange('div.convertkit-broadcasts', function(\Facebook\WebDriver\WebDriverElement $el) {
-			return ( strpos($el->getAttribute('class'), 'convertkit-broadcasts-loading') === false ? true : false );
-		}, 5);
+		$I->waitForElementChange(
+			'div.convertkit-broadcasts',
+			function(\Facebook\WebDriver\WebDriverElement $el) {
+				return ( strpos($el->getAttribute('class'), 'convertkit-broadcasts-loading') === false ? true : false );
+			},
+			5
+		);
 	}
 
 	/**
 	 * Check that expected HTML exists in the DOM of the page we're viewing
 	 * when a ConvertKit Product link was inserted into a paragraph or button,
 	 * and that the button loads the expected ConvertKit Product modal.
-	 * 
-	 * @since 	2.0.0
 	 *
-	 * @param 	AcceptanceTester 	$I 				Tester.
-	 * @param 	string 				$productURL 	Product URL.
-	 * @param 	bool|string 		$text 			Test if the link text matches the given value.
+	 * @since   2.0.0
+	 *
+	 * @param   AcceptanceTester $I              Tester.
+	 * @param   string           $productURL     Product URL.
+	 * @param   bool|string      $text           Test if the link text matches the given value.
 	 */
 	public function seeProductLink($I, $productURL, $text = false)
 	{
@@ -391,12 +395,12 @@ class Plugin extends \Codeception\Module
 
 		// Confirm that the button text is as expected.
 		if ($text !== false) {
-			$I->seeInSource('>'.$text.'</a>');		
+			$I->seeInSource('>' . $text . '</a>');
 		}
 
 		// Click the button to confirm that the ConvertKit modal displays; this confirms
 		// necessary ConvertKit scripts have been loaded.
-		$I->click('a[href="'.$productURL.'"]');
+		$I->click('a[href="' . $productURL . '"]');
 		$I->seeElementInDOM('iframe[data-active]');
 	}
 
@@ -404,14 +408,14 @@ class Plugin extends \Codeception\Module
 	 * Check that expected HTML exists in the DOM of the page we're viewing for
 	 * a Product block or shortcode, and that the button loads the expected
 	 * ConvertKit Product modal.
-	 * 
-	 * @since 	1.9.8.5
 	 *
-	 * @param 	AcceptanceTester 	$I 				Tester.
-	 * @param 	string 				$productURL 	Product URL.
-	 * @param 	bool|string 		$text 			Test if the button text matches the given value.
-	 * @param 	bool|string 		$textColor 		Test if the given text color is applied.
-	 * @param 	bool|string 		$backgroundColor Test is the given background color is applied.
+	 * @since   1.9.8.5
+	 *
+	 * @param   AcceptanceTester $I              Tester.
+	 * @param   string           $productURL     Product URL.
+	 * @param   bool|string      $text           Test if the button text matches the given value.
+	 * @param   bool|string      $textColor      Test if the given text color is applied.
+	 * @param   bool|string      $backgroundColor Test is the given background color is applied.
 	 */
 	public function seeProductOutput($I, $productURL, $text = false, $textColor = false, $backgroundColor = false)
 	{
@@ -425,7 +429,7 @@ class Plugin extends \Codeception\Module
 		if ($textColor !== false) {
 			$I->seeElementInDOM('a.convertkit-product.has-text-color');
 			$I->assertStringContainsString(
-				'color:'.$textColor,
+				'color:' . $textColor,
 				$I->grabAttributeFrom('a.convertkit-product', 'style')
 			);
 		}
@@ -434,7 +438,7 @@ class Plugin extends \Codeception\Module
 		if ($backgroundColor !== false) {
 			$I->seeElementInDOM('a.convertkit-product.has-background');
 			$I->assertStringContainsString(
-				'background-color:'.$backgroundColor,
+				'background-color:' . $backgroundColor,
 				$I->grabAttributeFrom('a.convertkit-product', 'style')
 			);
 		}
@@ -448,11 +452,11 @@ class Plugin extends \Codeception\Module
 	/**
 	 * Check that expected HTML does exists in the DOM of the page we're viewing for
 	 * a Product block or shortcode.
-	 * 
-	 * @since 	1.9.8.5
 	 *
-	 * @param 	AcceptanceTester 	$I 		Tester.
-	 * @param 	bool|string 		$text 	Test if the button text matches the given value.
+	 * @since   1.9.8.5
+	 *
+	 * @param   AcceptanceTester $I      Tester.
+	 * @param   bool|string      $text   Test if the button text matches the given value.
 	 */
 	public function dontSeeProductOutput($I, $text = false)
 	{

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -7,456 +7,458 @@ namespace Helper\Acceptance;
 
 class Plugin extends \Codeception\Module
 {
-	/**
-	 * Helper method to activate the ConvertKit Plugin, checking
-	 * it activated and no errors were output.
-	 * 
-	 * @since 	1.9.6
-	 */
-	public function activateConvertKitPlugin($I)
-	{
-		$I->activateThirdPartyPlugin($I, 'convertkit');
-	}
+    /**
+     * Helper method to activate the ConvertKit Plugin, checking
+     * it activated and no errors were output.
+     * 
+     * @since 1.9.6
+     */
+    public function activateConvertKitPlugin($I)
+    {
+        $I->activateThirdPartyPlugin($I, 'convertkit');
+    }
 
-	/**
-	 * Helper method to deactivate the ConvertKit Plugin, checking
-	 * it activated and no errors were output.
-	 * 
-	 * @since 	1.9.6
-	 */
-	public function deactivateConvertKitPlugin($I)
-	{
-		$I->deactivateThirdPartyPlugin($I, 'convertkit');
-	}
+    /**
+     * Helper method to deactivate the ConvertKit Plugin, checking
+     * it activated and no errors were output.
+     * 
+     * @since 1.9.6
+     */
+    public function deactivateConvertKitPlugin($I)
+    {
+        $I->deactivateThirdPartyPlugin($I, 'convertkit');
+    }
 
-	/**
-	 * Helper method to setup the Plugin's API Key and Secret.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	mixed 	$apiKey 	API Key (if specified, used instead of CONVERTKIT_API_KEY)
-	 * @param 	mixed 	$apiSecret 	API Secret (if specified, used instead of CONVERTKIT_API_SECRET)
-	 */
-	public function setupConvertKitPlugin($I, $apiKey = false, $apiSecret = false)
-	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen($I);
+    /**
+     * Helper method to setup the Plugin's API Key and Secret.
+     * 
+     * @since 1.9.6
+     * 
+     * @param mixed $apiKey    API Key (if specified, used instead of CONVERTKIT_API_KEY)
+     * @param mixed $apiSecret API Secret (if specified, used instead of CONVERTKIT_API_SECRET)
+     */
+    public function setupConvertKitPlugin($I, $apiKey = false, $apiSecret = false)
+    {
+        // Go to the Plugin's Settings Screen.
+        $I->loadConvertKitSettingsGeneralScreen($I);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Determine API Key and Secret to use.
-		$convertKitAPIKey = ($apiKey !== false ? $apiKey : $_ENV['CONVERTKIT_API_KEY']);
-		$convertKitAPISecret = ($apiSecret !== false ? $apiSecret : $_ENV['CONVERTKIT_API_SECRET']);
+        // Determine API Key and Secret to use.
+        $convertKitAPIKey = ($apiKey !== false ? $apiKey : $_ENV['CONVERTKIT_API_KEY']);
+        $convertKitAPISecret = ($apiSecret !== false ? $apiSecret : $_ENV['CONVERTKIT_API_SECRET']);
 
-		// Complete API Fields.
-		$I->fillField('_wp_convertkit_settings[api_key]', $convertKitAPIKey);
-		$I->fillField('_wp_convertkit_settings[api_secret]', $convertKitAPISecret);
+        // Complete API Fields.
+        $I->fillField('_wp_convertkit_settings[api_key]', $convertKitAPIKey);
+        $I->fillField('_wp_convertkit_settings[api_secret]', $convertKitAPISecret);
 
-		// Click the Save Changes button.
-		$I->click('Save Changes');
+        // Click the Save Changes button.
+        $I->click('Save Changes');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Check the value of the fields match the inputs provided.
-		$I->seeInField('_wp_convertkit_settings[api_key]', $convertKitAPIKey);
-		$I->seeInField('_wp_convertkit_settings[api_secret]', $convertKitAPISecret);
-	}
+        // Check the value of the fields match the inputs provided.
+        $I->seeInField('_wp_convertkit_settings[api_key]', $convertKitAPIKey);
+        $I->seeInField('_wp_convertkit_settings[api_secret]', $convertKitAPISecret);
+    }
 
-	/**
-	 * Helper method to setup the Plugin's Default Form setting for Pages and Posts.
-	 * 
-	 * @since 	1.9.6
-	 */
-	public function setupConvertKitPluginDefaultForm($I)
-	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen($I);
+    /**
+     * Helper method to setup the Plugin's Default Form setting for Pages and Posts.
+     * 
+     * @since 1.9.6
+     */
+    public function setupConvertKitPluginDefaultForm($I)
+    {
+        // Go to the Plugin's Settings Screen.
+        $I->loadConvertKitSettingsGeneralScreen($I);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Select Default Form for Pages and Posts.
-		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
-		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_post_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+        // Select Default Form for Pages and Posts.
+        $I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+        $I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_post_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
-		// Click the Save Changes button.
-		$I->click('Save Changes');
+        // Click the Save Changes button.
+        $I->click('Save Changes');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Check the value of the fields match the inputs provided.
-		$I->seeInField('_wp_convertkit_settings[page_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
-		$I->seeInField('_wp_convertkit_settings[post_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
+        // Check the value of the fields match the inputs provided.
+        $I->seeInField('_wp_convertkit_settings[page_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
+        $I->seeInField('_wp_convertkit_settings[post_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
-		// Return Form ID for Pages
-		return $I->grabValueFrom('_wp_convertkit_settings[page_form]');
-	}
+        // Return Form ID for Pages
+        return $I->grabValueFrom('_wp_convertkit_settings[page_form]');
+    }
 
-	/**
-	 * Helper method to setup the Plugin's Default Legacy Form setting for Pages and Posts.
-	 * 
-	 * @since 	1.9.6
-	 */
-	public function setupConvertKitPluginDefaultLegacyForm($I)
-	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen($I);
+    /**
+     * Helper method to setup the Plugin's Default Legacy Form setting for Pages and Posts.
+     * 
+     * @since 1.9.6
+     */
+    public function setupConvertKitPluginDefaultLegacyForm($I)
+    {
+        // Go to the Plugin's Settings Screen.
+        $I->loadConvertKitSettingsGeneralScreen($I);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Select Default Form for Pages and Posts.
-		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
-		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_post_form-container', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
+        // Select Default Form for Pages and Posts.
+        $I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
+        $I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_post_form-container', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
 
-		// Click the Save Changes button.
-		$I->click('Save Changes');
+        // Click the Save Changes button.
+        $I->click('Save Changes');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Check the value of the fields match the inputs provided.
-		$I->seeInField('_wp_convertkit_settings[page_form]', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
-		$I->seeInField('_wp_convertkit_settings[post_form]', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
+        // Check the value of the fields match the inputs provided.
+        $I->seeInField('_wp_convertkit_settings[page_form]', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
+        $I->seeInField('_wp_convertkit_settings[post_form]', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
 
-		// Return Form ID for Pages
-		return $I->grabValueFrom('_wp_convertkit_settings[page_form]');
-	}
+        // Return Form ID for Pages
+        return $I->grabValueFrom('_wp_convertkit_settings[page_form]');
+    }
 
-	/**
-	 * Helper method to setup the Plugin's Default Form setting for WooCommerce Products.
-	 * 
-	 * @since 	1.9.6
-	 */
-	public function setupConvertKitPluginDefaultFormForWooCommerceProducts($I)
-	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen($I);
+    /**
+     * Helper method to setup the Plugin's Default Form setting for WooCommerce Products.
+     * 
+     * @since 1.9.6
+     */
+    public function setupConvertKitPluginDefaultFormForWooCommerceProducts($I)
+    {
+        // Go to the Plugin's Settings Screen.
+        $I->loadConvertKitSettingsGeneralScreen($I);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Select option.
-		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_product_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+        // Select option.
+        $I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_product_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
-		// Click the Save Changes button.
-		$I->click('Save Changes');
+        // Click the Save Changes button.
+        $I->click('Save Changes');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Check the value of the fields match the inputs provided.
-		$I->seeInField('_wp_convertkit_settings[product_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
+        // Check the value of the fields match the inputs provided.
+        $I->seeInField('_wp_convertkit_settings[product_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
-		// Return Form ID
-		return $I->grabValueFrom('_wp_convertkit_settings[product_form]');
-	}
+        // Return Form ID
+        return $I->grabValueFrom('_wp_convertkit_settings[product_form]');
+    }
 
-	/**
-	 * Helper method to reset the ConvertKit Plugin settings, as if it's a clean installation.
-	 * 
-	 * @since 	1.9.6.7
-	 */
-	public function resetConvertKitPlugin($I)
-	{
-		// Plugin Settings.
-		$I->dontHaveOptionInDatabase('_wp_convertkit_settings');
-		$I->dontHaveOptionInDatabase('convertkit_version');
+    /**
+     * Helper method to reset the ConvertKit Plugin settings, as if it's a clean installation.
+     * 
+     * @since 1.9.6.7
+     */
+    public function resetConvertKitPlugin($I)
+    {
+        // Plugin Settings.
+        $I->dontHaveOptionInDatabase('_wp_convertkit_settings');
+        $I->dontHaveOptionInDatabase('convertkit_version');
 
-		// Resources.
-		$I->dontHaveOptionInDatabase('convertkit_forms');
-		$I->dontHaveOptionInDatabase('convertkit_forms_last_queried');
-		$I->dontHaveOptionInDatabase('convertkit_landing_pages');
-		$I->dontHaveOptionInDatabase('convertkit_landing_pages_last_queried');
-		$I->dontHaveOptionInDatabase('convertkit_tags');
-		$I->dontHaveOptionInDatabase('convertkit_tags_last_queried');
+        // Resources.
+        $I->dontHaveOptionInDatabase('convertkit_forms');
+        $I->dontHaveOptionInDatabase('convertkit_forms_last_queried');
+        $I->dontHaveOptionInDatabase('convertkit_landing_pages');
+        $I->dontHaveOptionInDatabase('convertkit_landing_pages_last_queried');
+        $I->dontHaveOptionInDatabase('convertkit_tags');
+        $I->dontHaveOptionInDatabase('convertkit_tags_last_queried');
 
-		// Review Request.
-		$I->dontHaveOptionInDatabase('convertkit-review-request');
-		$I->dontHaveOptionInDatabase('convertkit-review-dismissed');
+        // Review Request.
+        $I->dontHaveOptionInDatabase('convertkit-review-request');
+        $I->dontHaveOptionInDatabase('convertkit-review-dismissed');
 
-		// Upgrades.
-		$I->dontHaveOptionInDatabase('_wp_convertkit_upgrade_posts');
-	}
+        // Upgrades.
+        $I->dontHaveOptionInDatabase('_wp_convertkit_upgrade_posts');
+    }
 
-	/**
-	 * Helper method to load the Plugin's Settings > General screen.
-	 * 
-	 * @since 	1.9.6
-	 */
-	public function loadConvertKitSettingsGeneralScreen($I)
-	{
-		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings');
+    /**
+     * Helper method to load the Plugin's Settings > General screen.
+     * 
+     * @since 1.9.6
+     */
+    public function loadConvertKitSettingsGeneralScreen($I)
+    {
+        $I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-	}
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
+    }
 
-	/**
-	 * Helper method to load the Plugin's Settings > Tools screen.
-	 * 
-	 * @since 	1.9.6
-	 */
-	public function loadConvertKitSettingsToolsScreen($I)
-	{
-		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=tools');
+    /**
+     * Helper method to load the Plugin's Settings > Tools screen.
+     * 
+     * @since 1.9.6
+     */
+    public function loadConvertKitSettingsToolsScreen($I)
+    {
+        $I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=tools');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-	}
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
+    }
 
-	/**
-	 * Helper method to enable the Plugin's Settings > General > Debug option.
-	 * 
-	 * @since 	1.9.6
-	 */
-	public function enableDebugLog($I)
-	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen($I);
+    /**
+     * Helper method to enable the Plugin's Settings > General > Debug option.
+     * 
+     * @since 1.9.6
+     */
+    public function enableDebugLog($I)
+    {
+        // Go to the Plugin's Settings Screen.
+        $I->loadConvertKitSettingsGeneralScreen($I);
 		
-		// Tick field.
-		$I->checkOption('#debug');
+        // Tick field.
+        $I->checkOption('#debug');
 
-		// Click the Save Changes button.
-		$I->click('Save Changes');
-	}
+        // Click the Save Changes button.
+        $I->click('Save Changes');
+    }
 
-	/**
-	 * Helper method to clear the Plugin's debug log.
-	 * 
-	 * @since 	1.9.6
-	 */
-	public function clearDebugLog($I)
-	{
-		// Go to the Plugin's Tools Screen.
-		$I->loadConvertKitSettingsToolsScreen($I);
+    /**
+     * Helper method to clear the Plugin's debug log.
+     * 
+     * @since 1.9.6
+     */
+    public function clearDebugLog($I)
+    {
+        // Go to the Plugin's Tools Screen.
+        $I->loadConvertKitSettingsToolsScreen($I);
 		
-		// Click the Clear log button.
-		$I->click('Clear log');
-	}
+        // Click the Clear log button.
+        $I->click('Clear log');
+    }
 
-	/**
-	 * Helper method to determine if the given entry exists in the Plugin Debug Log screen's textarea.
-	 * 
-	 * @since 	1.9.6
-	 */
-	public function seeInPluginDebugLog($I, $entry)
-	{
-		$I->loadConvertKitSettingsToolsScreen($I);
-		$I->seeInSource($entry);
-	}
+    /**
+     * Helper method to determine if the given entry exists in the Plugin Debug Log screen's textarea.
+     * 
+     * @since 1.9.6
+     */
+    public function seeInPluginDebugLog($I, $entry)
+    {
+        $I->loadConvertKitSettingsToolsScreen($I);
+        $I->seeInSource($entry);
+    }
 
-	/**
-	 * Helper method to determine if the given entry does not exist in the Plugin Debug Log screen's textarea.
-	 * 
-	 * @since 	1.9.6
-	 */
-	public function dontSeeInPluginDebugLog($I, $entry)
-	{
-		$I->loadConvertKitSettingsToolsScreen($I);
-		$I->dontSeeInSource($entry);
-	}
+    /**
+     * Helper method to determine if the given entry does not exist in the Plugin Debug Log screen's textarea.
+     * 
+     * @since 1.9.6
+     */
+    public function dontSeeInPluginDebugLog($I, $entry)
+    {
+        $I->loadConvertKitSettingsToolsScreen($I);
+        $I->dontSeeInSource($entry);
+    }
 
-	/**
-	 * Check that expected HTML exists in the DOM of the page we're viewing for
-	 * a Broadcasts block or shortcode.
-	 * 
-	 * @since 	1.9.7.5
-	 *
-	 * @param 	AcceptanceTester 	$I 						Tester.
-	 * @param 	bool|int 			$numberOfPosts 			Number of Broadcasts listed.
-	 * @param 	bool|string 		$seePrevPaginationLabel Test if the "previous" pagination link is output and matches expected label.
-	 * @param 	bool|string 		$seePrevPaginationLabel Test if the "next" pagination link is output and matches expected label.
-	 */
-	public function seeBroadcastsOutput($I, $numberOfPosts = false, $seePrevPaginationLabel = false, $seeNextPaginationLabel = false)
-	{
-		// Confirm that the block displays.
-		$I->seeElementInDOM('div.convertkit-broadcasts');
-		$I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-list');
-		$I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast');
-		$I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast a');
+    /**
+     * Check that expected HTML exists in the DOM of the page we're viewing for
+     * a Broadcasts block or shortcode.
+     * 
+     * @since 1.9.7.5
+     *
+     * @param AcceptanceTester $I                      Tester.
+     * @param bool|int         $numberOfPosts          Number of Broadcasts listed.
+     * @param bool|string      $seePrevPaginationLabel Test if the "previous" pagination link is output and matches expected label.
+     * @param bool|string      $seePrevPaginationLabel Test if the "next" pagination link is output and matches expected label.
+     */
+    public function seeBroadcastsOutput($I, $numberOfPosts = false, $seePrevPaginationLabel = false, $seeNextPaginationLabel = false)
+    {
+        // Confirm that the block displays.
+        $I->seeElementInDOM('div.convertkit-broadcasts');
+        $I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-list');
+        $I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast');
+        $I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast a');
 
-		// Confirm that UTM parameters exist on a broadcast link.
-		$I->assertStringContainsString(
-			'utm_source=wordpress&utm_content=convertkit',
-			$I->grabAttributeFrom('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast a', 'href')
-		);
+        // Confirm that UTM parameters exist on a broadcast link.
+        $I->assertStringContainsString(
+            'utm_source=wordpress&utm_content=convertkit',
+            $I->grabAttributeFrom('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast a', 'href')
+        );
 
-		// Confirm that the number of expected broadcasts displays.
-		if ($numberOfPosts !== false) {
-			$I->seeNumberOfElements('li.convertkit-broadcast', $numberOfPosts);
-		}
+        // Confirm that the number of expected broadcasts displays.
+        if ($numberOfPosts !== false) {
+            $I->seeNumberOfElements('li.convertkit-broadcast', $numberOfPosts);
+        }
 
-		// Confirm that previous pagination displays.
-		if ($seePrevPaginationLabel !== false) {
-			$I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-pagination li.convertkit-broadcasts-pagination-prev a');
-			$I->seeInSource($seePrevPaginationLabel);		
-		}
+        // Confirm that previous pagination displays.
+        if ($seePrevPaginationLabel !== false) {
+            $I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-pagination li.convertkit-broadcasts-pagination-prev a');
+            $I->seeInSource($seePrevPaginationLabel);        
+        }
 
-		// Confirm that next pagination displays.
-		if ($seeNextPaginationLabel !== false) {
-			$I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-pagination li.convertkit-broadcasts-pagination-next a');	
-		}
-	}
+        // Confirm that next pagination displays.
+        if ($seeNextPaginationLabel !== false) {
+            $I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-pagination li.convertkit-broadcasts-pagination-next a');    
+        }
+    }
 
-	/**
-	 * Tests that the Broadcasts pagination works, and that the expected Broadcast
-	 * is displayed after using previous and next links.
-	 * 
-	 * @since 	2.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Tester.
-	 * @param 	string 				$previousLabel 			Previous / Newer Broadcasts Label.
-	 * @param 	string 				$nextLabel 				Next / Older Broadcasts Label.
-	 */
-	public function testBroadcastsPagination($I, $previousLabel, $nextLabel)
-	{
-		// Confirm that the block displays one broadcast with a pagination link to older broadcasts.
-		$I->seeBroadcastsOutput($I, 1, false, $nextLabel);
+    /**
+     * Tests that the Broadcasts pagination works, and that the expected Broadcast
+     * is displayed after using previous and next links.
+     * 
+     * @since 2.0.0
+     * 
+     * @param AcceptanceTester $I             Tester.
+     * @param string           $previousLabel Previous / Newer Broadcasts Label.
+     * @param string           $nextLabel     Next / Older Broadcasts Label.
+     */
+    public function testBroadcastsPagination($I, $previousLabel, $nextLabel)
+    {
+        // Confirm that the block displays one broadcast with a pagination link to older broadcasts.
+        $I->seeBroadcastsOutput($I, 1, false, $nextLabel);
 
-		// Click the Older Posts link.
-		$I->click('li.convertkit-broadcasts-pagination-next a');
+        // Click the Older Posts link.
+        $I->click('li.convertkit-broadcasts-pagination-next a');
 
-		// Wait for the AJAX request to complete, by checking if the convertkit-broadcasts-loading class has been
-		// removed from the block.
-		$I->waitForBroadcastsToLoad($I);
+        // Wait for the AJAX request to complete, by checking if the convertkit-broadcasts-loading class has been
+        // removed from the block.
+        $I->waitForBroadcastsToLoad($I);
 
-		// Confirm that the block displays one broadcast with a pagination link to newer broadcasts.
-		$I->seeBroadcastsOutput($I, 1, $previousLabel, false);
+        // Confirm that the block displays one broadcast with a pagination link to newer broadcasts.
+        $I->seeBroadcastsOutput($I, 1, $previousLabel, false);
 
-		// Fetch Broadcasts from the resource, to determine the name of the most recent two broadcasts.
-		$broadcasts = $I->grabOptionFromDatabase('convertkit_posts');
-		$firstBroadcast = current(array_slice($broadcasts, 0, 1));
-		$secondBroadcast = current(array_slice($broadcasts, 1, 1));
+        // Fetch Broadcasts from the resource, to determine the name of the most recent two broadcasts.
+        $broadcasts = $I->grabOptionFromDatabase('convertkit_posts');
+        $firstBroadcast = current(array_slice($broadcasts, 0, 1));
+        $secondBroadcast = current(array_slice($broadcasts, 1, 1));
 
-		// Confirm that the expected Broadcast name is displayed and links to the expected URL, with UTM parameters.
-		$I->seeInSource('<a href="'.$secondBroadcast['url'].'?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener"');
-		$I->seeInSource($secondBroadcast['title']);
+        // Confirm that the expected Broadcast name is displayed and links to the expected URL, with UTM parameters.
+        $I->seeInSource('<a href="'.$secondBroadcast['url'].'?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener"');
+        $I->seeInSource($secondBroadcast['title']);
 
-		// Click the Newer Posts link.
-		$I->click('li.convertkit-broadcasts-pagination-prev a');
+        // Click the Newer Posts link.
+        $I->click('li.convertkit-broadcasts-pagination-prev a');
 
-		// Wait for the AJAX request to complete, by checking if the convertkit-broadcasts-loading class has been
-		// removed from the block.
-		$I->waitForBroadcastsToLoad($I);
+        // Wait for the AJAX request to complete, by checking if the convertkit-broadcasts-loading class has been
+        // removed from the block.
+        $I->waitForBroadcastsToLoad($I);
 
-		// Confirm that the block displays one broadcast with a pagination link to older broadcasts.
-		$I->seeBroadcastsOutput($I, 1, false, $nextLabel);
+        // Confirm that the block displays one broadcast with a pagination link to older broadcasts.
+        $I->seeBroadcastsOutput($I, 1, false, $nextLabel);
 
-		// Confirm that the expected Broadcast name is displayed and links to the expected URL, with UTM parameters.
-		$I->seeInSource('<a href="'.$firstBroadcast['url'].'?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener"');
-		$I->seeInSource($firstBroadcast['title']);
-	}
+        // Confirm that the expected Broadcast name is displayed and links to the expected URL, with UTM parameters.
+        $I->seeInSource('<a href="'.$firstBroadcast['url'].'?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener"');
+        $I->seeInSource($firstBroadcast['title']);
+    }
 
-	/**
-	 * Wait for the AJAX request to complete, by checking if the convertkit-broadcasts-loading class has been
-	 * removed from the block.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Tester.
-	 */
-	public function waitForBroadcastsToLoad($I)
-	{
-		$I->waitForElementChange('div.convertkit-broadcasts', function(\Facebook\WebDriver\WebDriverElement $el) {
-			return ( strpos($el->getAttribute('class'), 'convertkit-broadcasts-loading') === false ? true : false );
-		}, 5);
-	}
+    /**
+     * Wait for the AJAX request to complete, by checking if the convertkit-broadcasts-loading class has been
+     * removed from the block.
+     * 
+     * @since 1.9.7.6
+     * 
+     * @param AcceptanceTester $I Tester.
+     */
+    public function waitForBroadcastsToLoad($I)
+    {
+        $I->waitForElementChange(
+            'div.convertkit-broadcasts', function (\Facebook\WebDriver\WebDriverElement $el) {
+                return ( strpos($el->getAttribute('class'), 'convertkit-broadcasts-loading') === false ? true : false );
+            }, 5
+        );
+    }
 
-	/**
-	 * Check that expected HTML exists in the DOM of the page we're viewing
-	 * when a ConvertKit Product link was inserted into a paragraph or button,
-	 * and that the button loads the expected ConvertKit Product modal.
-	 * 
-	 * @since 	2.0.0
-	 *
-	 * @param 	AcceptanceTester 	$I 				Tester.
-	 * @param 	string 				$productURL 	Product URL.
-	 * @param 	bool|string 		$text 			Test if the link text matches the given value.
-	 */
-	public function seeProductLink($I, $productURL, $text = false)
-	{
-		// Confirm that the commerce.js script exists.
-		$I->seeInSource('commerce.js');
+    /**
+     * Check that expected HTML exists in the DOM of the page we're viewing
+     * when a ConvertKit Product link was inserted into a paragraph or button,
+     * and that the button loads the expected ConvertKit Product modal.
+     * 
+     * @since 2.0.0
+     *
+     * @param AcceptanceTester $I          Tester.
+     * @param string           $productURL Product URL.
+     * @param bool|string      $text       Test if the link text matches the given value.
+     */
+    public function seeProductLink($I, $productURL, $text = false)
+    {
+        // Confirm that the commerce.js script exists.
+        $I->seeInSource('commerce.js');
 
-		// Confirm that the link exists.
-		$I->seeElementInDOM('a[data-commerce]');
+        // Confirm that the link exists.
+        $I->seeElementInDOM('a[data-commerce]');
 
-		// Confirm that the link points to the correct product.
-		$I->assertEquals($productURL, $I->grabAttributeFrom('a[data-commerce]', 'href'));
+        // Confirm that the link points to the correct product.
+        $I->assertEquals($productURL, $I->grabAttributeFrom('a[data-commerce]', 'href'));
 
-		// Confirm that the button text is as expected.
-		if ($text !== false) {
-			$I->seeInSource('>'.$text.'</a>');		
-		}
+        // Confirm that the button text is as expected.
+        if ($text !== false) {
+            $I->seeInSource('>'.$text.'</a>');        
+        }
 
-		// Click the button to confirm that the ConvertKit modal displays; this confirms
-		// necessary ConvertKit scripts have been loaded.
-		$I->click('a[href="'.$productURL.'"]');
-		$I->seeElementInDOM('iframe[data-active]');
-	}
+        // Click the button to confirm that the ConvertKit modal displays; this confirms
+        // necessary ConvertKit scripts have been loaded.
+        $I->click('a[href="'.$productURL.'"]');
+        $I->seeElementInDOM('iframe[data-active]');
+    }
 
-	/**
-	 * Check that expected HTML exists in the DOM of the page we're viewing for
-	 * a Product block or shortcode, and that the button loads the expected
-	 * ConvertKit Product modal.
-	 * 
-	 * @since 	1.9.8.5
-	 *
-	 * @param 	AcceptanceTester 	$I 				Tester.
-	 * @param 	string 				$productURL 	Product URL.
-	 * @param 	bool|string 		$text 			Test if the button text matches the given value.
-	 * @param 	bool|string 		$textColor 		Test if the given text color is applied.
-	 * @param 	bool|string 		$backgroundColor Test is the given background color is applied.
-	 */
-	public function seeProductOutput($I, $productURL, $text = false, $textColor = false, $backgroundColor = false)
-	{
-		// Confirm that the block displays.
-		$I->seeElementInDOM('a.convertkit-product.wp-block-button__link');
+    /**
+     * Check that expected HTML exists in the DOM of the page we're viewing for
+     * a Product block or shortcode, and that the button loads the expected
+     * ConvertKit Product modal.
+     * 
+     * @since 1.9.8.5
+     *
+     * @param AcceptanceTester $I               Tester.
+     * @param string           $productURL      Product URL.
+     * @param bool|string      $text            Test if the button text matches the given value.
+     * @param bool|string      $textColor       Test if the given text color is applied.
+     * @param bool|string      $backgroundColor Test is the given background color is applied.
+     */
+    public function seeProductOutput($I, $productURL, $text = false, $textColor = false, $backgroundColor = false)
+    {
+        // Confirm that the block displays.
+        $I->seeElementInDOM('a.convertkit-product.wp-block-button__link');
 
-		// Confirm that the button links to the correct product.
-		$I->assertEquals($productURL, $I->grabAttributeFrom('a.convertkit-product', 'href'));
+        // Confirm that the button links to the correct product.
+        $I->assertEquals($productURL, $I->grabAttributeFrom('a.convertkit-product', 'href'));
 
-		// Confirm that the text color is as expected.
-		if ($textColor !== false) {
-			$I->seeElementInDOM('a.convertkit-product.has-text-color');
-			$I->assertStringContainsString(
-				'color:'.$textColor,
-				$I->grabAttributeFrom('a.convertkit-product', 'style')
-			);
-		}
+        // Confirm that the text color is as expected.
+        if ($textColor !== false) {
+            $I->seeElementInDOM('a.convertkit-product.has-text-color');
+            $I->assertStringContainsString(
+                'color:'.$textColor,
+                $I->grabAttributeFrom('a.convertkit-product', 'style')
+            );
+        }
 
-		// Confirm that the background color is as expected.
-		if ($backgroundColor !== false) {
-			$I->seeElementInDOM('a.convertkit-product.has-background');
-			$I->assertStringContainsString(
-				'background-color:'.$backgroundColor,
-				$I->grabAttributeFrom('a.convertkit-product', 'style')
-			);
-		}
+        // Confirm that the background color is as expected.
+        if ($backgroundColor !== false) {
+            $I->seeElementInDOM('a.convertkit-product.has-background');
+            $I->assertStringContainsString(
+                'background-color:'.$backgroundColor,
+                $I->grabAttributeFrom('a.convertkit-product', 'style')
+            );
+        }
 
-		// Click the button to confirm that the ConvertKit modal displays; this confirms
-		// necessary ConvertKit scripts have been loaded.
-		$I->click('a.convertkit-product');
-		$I->seeElementInDOM('iframe[data-active]');
-	}
+        // Click the button to confirm that the ConvertKit modal displays; this confirms
+        // necessary ConvertKit scripts have been loaded.
+        $I->click('a.convertkit-product');
+        $I->seeElementInDOM('iframe[data-active]');
+    }
 
-	/**
-	 * Check that expected HTML does exists in the DOM of the page we're viewing for
-	 * a Product block or shortcode.
-	 * 
-	 * @since 	1.9.8.5
-	 *
-	 * @param 	AcceptanceTester 	$I 		Tester.
-	 * @param 	bool|string 		$text 	Test if the button text matches the given value.
-	 */
-	public function dontSeeProductOutput($I, $text = false)
-	{
-		// Confirm that the block does not display.
-		$I->dontSeeElementInDOM('div.wp-block-button a.convertkit-product');
-	}
+    /**
+     * Check that expected HTML does exists in the DOM of the page we're viewing for
+     * a Product block or shortcode.
+     * 
+     * @since 1.9.8.5
+     *
+     * @param AcceptanceTester $I    Tester.
+     * @param bool|string      $text Test if the button text matches the given value.
+     */
+    public function dontSeeProductOutput($I, $text = false)
+    {
+        // Confirm that the block does not display.
+        $I->dontSeeElementInDOM('div.wp-block-button a.convertkit-product');
+    }
 }

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -1,10 +1,12 @@
 <?php
 namespace Helper\Acceptance;
 
-// Define any custom actions related to the ConvertKit Plugin that
-// would be used across multiple tests.
-// These are then available in $I->{yourFunctionName}
-
+/**
+ * Helper methods and actions related to the ConvertKit Plugin,
+ * which are then available using $I->{yourFunctionName}.
+ *
+ * @since   1.9.6
+ */
 class Plugin extends \Codeception\Module
 {
 	/**
@@ -12,6 +14,8 @@ class Plugin extends \Codeception\Module
 	 * it activated and no errors were output.
 	 *
 	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I     AcceptanceTester.
 	 */
 	public function activateConvertKitPlugin($I)
 	{
@@ -23,6 +27,8 @@ class Plugin extends \Codeception\Module
 	 * it activated and no errors were output.
 	 *
 	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I     AcceptanceTester.
 	 */
 	public function deactivateConvertKitPlugin($I)
 	{
@@ -34,8 +40,9 @@ class Plugin extends \Codeception\Module
 	 *
 	 * @since   1.9.6
 	 *
-	 * @param   mixed $apiKey     API Key (if specified, used instead of CONVERTKIT_API_KEY)
-	 * @param   mixed $apiSecret  API Secret (if specified, used instead of CONVERTKIT_API_SECRET)
+	 * @param   AcceptanceTester $I          AcceptanceTester.
+	 * @param   mixed            $apiKey     API Key (if specified, used instead of CONVERTKIT_API_KEY).
+	 * @param   mixed            $apiSecret  API Secret (if specified, used instead of CONVERTKIT_API_SECRET).
 	 */
 	public function setupConvertKitPlugin($I, $apiKey = false, $apiSecret = false)
 	{
@@ -68,6 +75,8 @@ class Plugin extends \Codeception\Module
 	 * Helper method to setup the Plugin's Default Form setting for Pages and Posts.
 	 *
 	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I     AcceptanceTester.
 	 */
 	public function setupConvertKitPluginDefaultForm($I)
 	{
@@ -91,7 +100,7 @@ class Plugin extends \Codeception\Module
 		$I->seeInField('_wp_convertkit_settings[page_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
 		$I->seeInField('_wp_convertkit_settings[post_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
-		// Return Form ID for Pages
+		// Return Form ID for Pages.
 		return $I->grabValueFrom('_wp_convertkit_settings[page_form]');
 	}
 
@@ -99,6 +108,8 @@ class Plugin extends \Codeception\Module
 	 * Helper method to setup the Plugin's Default Legacy Form setting for Pages and Posts.
 	 *
 	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I     AcceptanceTester.
 	 */
 	public function setupConvertKitPluginDefaultLegacyForm($I)
 	{
@@ -122,7 +133,7 @@ class Plugin extends \Codeception\Module
 		$I->seeInField('_wp_convertkit_settings[page_form]', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
 		$I->seeInField('_wp_convertkit_settings[post_form]', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
 
-		// Return Form ID for Pages
+		// Return Form ID for Pages.
 		return $I->grabValueFrom('_wp_convertkit_settings[page_form]');
 	}
 
@@ -130,6 +141,8 @@ class Plugin extends \Codeception\Module
 	 * Helper method to setup the Plugin's Default Form setting for WooCommerce Products.
 	 *
 	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I     AcceptanceTester.
 	 */
 	public function setupConvertKitPluginDefaultFormForWooCommerceProducts($I)
 	{
@@ -151,7 +164,7 @@ class Plugin extends \Codeception\Module
 		// Check the value of the fields match the inputs provided.
 		$I->seeInField('_wp_convertkit_settings[product_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
-		// Return Form ID
+		// Return Form ID.
 		return $I->grabValueFrom('_wp_convertkit_settings[product_form]');
 	}
 
@@ -159,6 +172,8 @@ class Plugin extends \Codeception\Module
 	 * Helper method to reset the ConvertKit Plugin settings, as if it's a clean installation.
 	 *
 	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I     AcceptanceTester.
 	 */
 	public function resetConvertKitPlugin($I)
 	{
@@ -186,6 +201,8 @@ class Plugin extends \Codeception\Module
 	 * Helper method to load the Plugin's Settings > General screen.
 	 *
 	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I     AcceptanceTester.
 	 */
 	public function loadConvertKitSettingsGeneralScreen($I)
 	{
@@ -199,6 +216,8 @@ class Plugin extends \Codeception\Module
 	 * Helper method to load the Plugin's Settings > Tools screen.
 	 *
 	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I     AcceptanceTester.
 	 */
 	public function loadConvertKitSettingsToolsScreen($I)
 	{
@@ -212,6 +231,8 @@ class Plugin extends \Codeception\Module
 	 * Helper method to enable the Plugin's Settings > General > Debug option.
 	 *
 	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I     AcceptanceTester.
 	 */
 	public function enableDebugLog($I)
 	{
@@ -229,6 +250,8 @@ class Plugin extends \Codeception\Module
 	 * Helper method to clear the Plugin's debug log.
 	 *
 	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I     AcceptanceTester.
 	 */
 	public function clearDebugLog($I)
 	{
@@ -243,6 +266,9 @@ class Plugin extends \Codeception\Module
 	 * Helper method to determine if the given entry exists in the Plugin Debug Log screen's textarea.
 	 *
 	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I         AcceptanceTester.
+	 * @param   string           $entry     Log entry.
 	 */
 	public function seeInPluginDebugLog($I, $entry)
 	{
@@ -254,6 +280,9 @@ class Plugin extends \Codeception\Module
 	 * Helper method to determine if the given entry does not exist in the Plugin Debug Log screen's textarea.
 	 *
 	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I         AcceptanceTester.
+	 * @param   string           $entry     Log entry.
 	 */
 	public function dontSeeInPluginDebugLog($I, $entry)
 	{
@@ -270,7 +299,7 @@ class Plugin extends \Codeception\Module
 	 * @param   AcceptanceTester $I                      Tester.
 	 * @param   bool|int         $numberOfPosts          Number of Broadcasts listed.
 	 * @param   bool|string      $seePrevPaginationLabel Test if the "previous" pagination link is output and matches expected label.
-	 * @param   bool|string      $seePrevPaginationLabel Test if the "next" pagination link is output and matches expected label.
+	 * @param   bool|string      $seeNextPaginationLabel Test if the "next" pagination link is output and matches expected label.
 	 */
 	public function seeBroadcastsOutput($I, $numberOfPosts = false, $seePrevPaginationLabel = false, $seeNextPaginationLabel = false)
 	{
@@ -425,6 +454,11 @@ class Plugin extends \Codeception\Module
 		// Confirm that the button links to the correct product.
 		$I->assertEquals($productURL, $I->grabAttributeFrom('a.convertkit-product', 'href'));
 
+		// Confirm that the text is as expected.
+		if ($text !== false) {
+			$I->see($text);
+		}
+
 		// Confirm that the text color is as expected.
 		if ($textColor !== false) {
 			$I->seeElementInDOM('a.convertkit-product.has-text-color');
@@ -456,9 +490,8 @@ class Plugin extends \Codeception\Module
 	 * @since   1.9.8.5
 	 *
 	 * @param   AcceptanceTester $I      Tester.
-	 * @param   bool|string      $text   Test if the button text matches the given value.
 	 */
-	public function dontSeeProductOutput($I, $text = false)
+	public function dontSeeProductOutput($I)
 	{
 		// Confirm that the block does not display.
 		$I->dontSeeElementInDOM('div.wp-block-button a.convertkit-product');

--- a/tests/_support/Helper/Acceptance/Select2.php
+++ b/tests/_support/Helper/Acceptance/Select2.php
@@ -1,10 +1,12 @@
 <?php
 namespace Helper\Acceptance;
 
-// Define any custom actions related to Select2 interaction that
-// would be used across multiple tests.
-// These are then available in $I->{yourFunctionName}
-
+/**
+ * Helper methods and actions related to the Select2 component,
+ * which are then available using $I->{yourFunctionName}.
+ *
+ * @since   1.9.6
+ */
 class Select2 extends \Codeception\Module
 {
 	/**
@@ -12,10 +14,10 @@ class Select2 extends \Codeception\Module
 	 *
 	 * @since   1.9.6.4
 	 *
-	 * @param   AcceptanceTester $I
-	 * @param   string           $container  Field CSS Class / ID
-	 * @param   string           $value      Field Value
-	 * @param   string           $ariaAttributeName  Aria Attribute Name (aria-controls|aria-owns)
+	 * @param   AcceptanceTester $I          Tester.
+	 * @param   string           $container  Field CSS Class / ID.
+	 * @param   string           $value      Field Value.
+	 * @param   string           $ariaAttributeName  Aria Attribute Name (aria-controls|aria-owns).
 	 */
 	public function fillSelect2Field($I, $container, $value, $ariaAttributeName = 'aria-controls')
 	{
@@ -26,22 +28,5 @@ class Select2 extends \Codeception\Module
 		$I->fillField('.select2-search__field[' . $ariaAttributeName . '="select2-' . $fieldName . '-results"]', $value);
 		$I->waitForElementVisible('ul#select2-' . $fieldName . '-results li.select2-results__option--highlighted');
 		$I->pressKey('.select2-search__field[' . $ariaAttributeName . '="select2-' . $fieldName . '-results"]', \Facebook\WebDriver\WebDriverKeys::ENTER);
-	}
-
-	/**
-	 * Helper method to open a jQuery Select2 Field.
-	 *
-	 * @since   1.9.8.1
-	 *
-	 * @param   AcceptanceTester $I
-	 * @param   string           $container  Field CSS Class / ID
-	 * @param   string           $value      Field Value
-	 * @param   string           $ariaAttributeName  Aria Attribute Name (aria-controls|aria-owns)
-	 */
-	public function openSelect2Field($I, $container, $value, $ariaAttributeName = 'aria-controls')
-	{
-		$fieldID   = $I->grabAttributeFrom($container, 'id');
-		$fieldName = str_replace('-container', '', str_replace('select2-', '', $fieldID));
-		$I->click('#' . $fieldID);
 	}
 }

--- a/tests/_support/Helper/Acceptance/Select2.php
+++ b/tests/_support/Helper/Acceptance/Select2.php
@@ -5,43 +5,41 @@ namespace Helper\Acceptance;
 // would be used across multiple tests.
 // These are then available in $I->{yourFunctionName}
 
-class Select2 extends \Codeception\Module
-{
-    /**
-     * Helper method to enter text into a jQuery Select2 Field, selecting the option that appears.
-     * 
-     * @since 1.9.6.4
-     * 
-     * @param AcceptanceTester $I                 Tester
-     * @param string           $container         Field CSS Class / ID
-     * @param string           $value             Field Value
-     * @param string           $ariaAttributeName Aria Attribute Name (aria-controls|aria-owns)
-     */
-    public function fillSelect2Field($I, $container, $value, $ariaAttributeName = 'aria-controls')
-    {
-        $fieldID = $I->grabAttributeFrom($container, 'id');
-        $fieldName = str_replace('-container', '', str_replace('select2-', '', $fieldID));
-        $I->click('#'.$fieldID);
-        $I->waitForElementVisible('.select2-search__field[' . $ariaAttributeName . '="select2-' . $fieldName . '-results"]');
-        $I->fillField('.select2-search__field[' . $ariaAttributeName . '="select2-' . $fieldName . '-results"]', $value);
-        $I->waitForElementVisible('ul#select2-' . $fieldName . '-results li.select2-results__option--highlighted');
-        $I->pressKey('.select2-search__field[' . $ariaAttributeName . '="select2-' . $fieldName . '-results"]', \Facebook\WebDriver\WebDriverKeys::ENTER);
-    }
+class Select2 extends \Codeception\Module {
 
-    /**
-     * Helper method to open a jQuery Select2 Field.
-     * 
-     * @since 1.9.8.1
-     * 
-     * @param AcceptanceTester $I                 Tester
-     * @param string           $container         Field CSS Class / ID
-     * @param string           $value             Field Value
-     * @param string           $ariaAttributeName Aria Attribute Name (aria-controls|aria-owns)
-     */
-    public function openSelect2Field($I, $container, $value, $ariaAttributeName = 'aria-controls')
-    {
-        $fieldID = $I->grabAttributeFrom($container, 'id');
-        $fieldName = str_replace('-container', '', str_replace('select2-', '', $fieldID));
-        $I->click('#'.$fieldID);
-    }
+	/**
+	 * Helper method to enter text into a jQuery Select2 Field, selecting the option that appears.
+	 *
+	 * @since 1.9.6.4
+	 *
+	 * @param AcceptanceTester $I                 Tester
+	 * @param string           $container         Field CSS Class / ID
+	 * @param string           $value             Field Value
+	 * @param string           $ariaAttributeName Aria Attribute Name (aria-controls|aria-owns)
+	 */
+	public function fillSelect2Field( $I, $container, $value, $ariaAttributeName = 'aria-controls' ) {
+		$fieldID   = $I->grabAttributeFrom( $container, 'id' );
+		$fieldName = str_replace( '-container', '', str_replace( 'select2-', '', $fieldID ) );
+		$I->click( '#' . $fieldID );
+		$I->waitForElementVisible( '.select2-search__field[' . $ariaAttributeName . '="select2-' . $fieldName . '-results"]' );
+		$I->fillField( '.select2-search__field[' . $ariaAttributeName . '="select2-' . $fieldName . '-results"]', $value );
+		$I->waitForElementVisible( 'ul#select2-' . $fieldName . '-results li.select2-results__option--highlighted' );
+		$I->pressKey( '.select2-search__field[' . $ariaAttributeName . '="select2-' . $fieldName . '-results"]', \Facebook\WebDriver\WebDriverKeys::ENTER );
+	}
+
+	/**
+	 * Helper method to open a jQuery Select2 Field.
+	 *
+	 * @since 1.9.8.1
+	 *
+	 * @param AcceptanceTester $I                 Tester
+	 * @param string           $container         Field CSS Class / ID
+	 * @param string           $value             Field Value
+	 * @param string           $ariaAttributeName Aria Attribute Name (aria-controls|aria-owns)
+	 */
+	public function openSelect2Field( $I, $container, $value, $ariaAttributeName = 'aria-controls' ) {
+		$fieldID   = $I->grabAttributeFrom( $container, 'id' );
+		$fieldName = str_replace( '-container', '', str_replace( 'select2-', '', $fieldID ) );
+		$I->click( '#' . $fieldID );
+	}
 }

--- a/tests/_support/Helper/Acceptance/Select2.php
+++ b/tests/_support/Helper/Acceptance/Select2.php
@@ -7,41 +7,41 @@ namespace Helper\Acceptance;
 
 class Select2 extends \Codeception\Module
 {
-	/**
-	 * Helper method to enter text into a jQuery Select2 Field, selecting the option that appears.
-	 * 
-	 * @since 	1.9.6.4
-	 * 
-	 * @param 	AcceptanceTester 	$I
-	 * @param 	string 				$container 	Field CSS Class / ID
-	 * @param 	string 				$value 		Field Value
-	 * @param 	string 				$ariaAttributeName 	Aria Attribute Name (aria-controls|aria-owns)
-	 */
-	public function fillSelect2Field($I, $container, $value, $ariaAttributeName = 'aria-controls')
-	{
-		$fieldID = $I->grabAttributeFrom($container, 'id');
-		$fieldName = str_replace('-container', '', str_replace('select2-', '', $fieldID));
-		$I->click('#'.$fieldID);
-		$I->waitForElementVisible('.select2-search__field[' . $ariaAttributeName . '="select2-' . $fieldName . '-results"]');
-		$I->fillField('.select2-search__field[' . $ariaAttributeName . '="select2-' . $fieldName . '-results"]', $value);
-		$I->waitForElementVisible('ul#select2-' . $fieldName . '-results li.select2-results__option--highlighted');
-		$I->pressKey('.select2-search__field[' . $ariaAttributeName . '="select2-' . $fieldName . '-results"]', \Facebook\WebDriver\WebDriverKeys::ENTER);
-	}
+    /**
+     * Helper method to enter text into a jQuery Select2 Field, selecting the option that appears.
+     * 
+     * @since 1.9.6.4
+     * 
+     * @param AcceptanceTester $I
+     * @param string           $container         Field CSS Class / ID
+     * @param string           $value             Field Value
+     * @param string           $ariaAttributeName Aria Attribute Name (aria-controls|aria-owns)
+     */
+    public function fillSelect2Field($I, $container, $value, $ariaAttributeName = 'aria-controls')
+    {
+        $fieldID = $I->grabAttributeFrom($container, 'id');
+        $fieldName = str_replace('-container', '', str_replace('select2-', '', $fieldID));
+        $I->click('#'.$fieldID);
+        $I->waitForElementVisible('.select2-search__field[' . $ariaAttributeName . '="select2-' . $fieldName . '-results"]');
+        $I->fillField('.select2-search__field[' . $ariaAttributeName . '="select2-' . $fieldName . '-results"]', $value);
+        $I->waitForElementVisible('ul#select2-' . $fieldName . '-results li.select2-results__option--highlighted');
+        $I->pressKey('.select2-search__field[' . $ariaAttributeName . '="select2-' . $fieldName . '-results"]', \Facebook\WebDriver\WebDriverKeys::ENTER);
+    }
 
-	/**
-	 * Helper method to open a jQuery Select2 Field.
-	 * 
-	 * @since 	1.9.8.1
-	 * 
-	 * @param 	AcceptanceTester 	$I
-	 * @param 	string 				$container 	Field CSS Class / ID
-	 * @param 	string 				$value 		Field Value
-	 * @param 	string 				$ariaAttributeName 	Aria Attribute Name (aria-controls|aria-owns)
-	 */
-	public function openSelect2Field($I, $container, $value, $ariaAttributeName = 'aria-controls')
-	{
-		$fieldID = $I->grabAttributeFrom($container, 'id');
-		$fieldName = str_replace('-container', '', str_replace('select2-', '', $fieldID));
-		$I->click('#'.$fieldID);
-	}
+    /**
+     * Helper method to open a jQuery Select2 Field.
+     * 
+     * @since 1.9.8.1
+     * 
+     * @param AcceptanceTester $I
+     * @param string           $container         Field CSS Class / ID
+     * @param string           $value             Field Value
+     * @param string           $ariaAttributeName Aria Attribute Name (aria-controls|aria-owns)
+     */
+    public function openSelect2Field($I, $container, $value, $ariaAttributeName = 'aria-controls')
+    {
+        $fieldID = $I->grabAttributeFrom($container, 'id');
+        $fieldName = str_replace('-container', '', str_replace('select2-', '', $fieldID));
+        $I->click('#'.$fieldID);
+    }
 }

--- a/tests/_support/Helper/Acceptance/Select2.php
+++ b/tests/_support/Helper/Acceptance/Select2.php
@@ -5,41 +5,43 @@ namespace Helper\Acceptance;
 // would be used across multiple tests.
 // These are then available in $I->{yourFunctionName}
 
-class Select2 extends \Codeception\Module {
-
+class Select2 extends \Codeception\Module
+{
 	/**
 	 * Helper method to enter text into a jQuery Select2 Field, selecting the option that appears.
-	 *
-	 * @since 1.9.6.4
-	 *
-	 * @param AcceptanceTester $I                 Tester
-	 * @param string           $container         Field CSS Class / ID
-	 * @param string           $value             Field Value
-	 * @param string           $ariaAttributeName Aria Attribute Name (aria-controls|aria-owns)
+	 * 
+	 * @since 	1.9.6.4
+	 * 
+	 * @param 	AcceptanceTester 	$I
+	 * @param 	string 				$container 	Field CSS Class / ID
+	 * @param 	string 				$value 		Field Value
+	 * @param 	string 				$ariaAttributeName 	Aria Attribute Name (aria-controls|aria-owns)
 	 */
-	public function fillSelect2Field( $I, $container, $value, $ariaAttributeName = 'aria-controls' ) {
-		$fieldID   = $I->grabAttributeFrom( $container, 'id' );
-		$fieldName = str_replace( '-container', '', str_replace( 'select2-', '', $fieldID ) );
-		$I->click( '#' . $fieldID );
-		$I->waitForElementVisible( '.select2-search__field[' . $ariaAttributeName . '="select2-' . $fieldName . '-results"]' );
-		$I->fillField( '.select2-search__field[' . $ariaAttributeName . '="select2-' . $fieldName . '-results"]', $value );
-		$I->waitForElementVisible( 'ul#select2-' . $fieldName . '-results li.select2-results__option--highlighted' );
-		$I->pressKey( '.select2-search__field[' . $ariaAttributeName . '="select2-' . $fieldName . '-results"]', \Facebook\WebDriver\WebDriverKeys::ENTER );
+	public function fillSelect2Field($I, $container, $value, $ariaAttributeName = 'aria-controls')
+	{
+		$fieldID = $I->grabAttributeFrom($container, 'id');
+		$fieldName = str_replace('-container', '', str_replace('select2-', '', $fieldID));
+		$I->click('#'.$fieldID);
+		$I->waitForElementVisible('.select2-search__field[' . $ariaAttributeName . '="select2-' . $fieldName . '-results"]');
+		$I->fillField('.select2-search__field[' . $ariaAttributeName . '="select2-' . $fieldName . '-results"]', $value);
+		$I->waitForElementVisible('ul#select2-' . $fieldName . '-results li.select2-results__option--highlighted');
+		$I->pressKey('.select2-search__field[' . $ariaAttributeName . '="select2-' . $fieldName . '-results"]', \Facebook\WebDriver\WebDriverKeys::ENTER);
 	}
 
 	/**
 	 * Helper method to open a jQuery Select2 Field.
-	 *
-	 * @since 1.9.8.1
-	 *
-	 * @param AcceptanceTester $I                 Tester
-	 * @param string           $container         Field CSS Class / ID
-	 * @param string           $value             Field Value
-	 * @param string           $ariaAttributeName Aria Attribute Name (aria-controls|aria-owns)
+	 * 
+	 * @since 	1.9.8.1
+	 * 
+	 * @param 	AcceptanceTester 	$I
+	 * @param 	string 				$container 	Field CSS Class / ID
+	 * @param 	string 				$value 		Field Value
+	 * @param 	string 				$ariaAttributeName 	Aria Attribute Name (aria-controls|aria-owns)
 	 */
-	public function openSelect2Field( $I, $container, $value, $ariaAttributeName = 'aria-controls' ) {
-		$fieldID   = $I->grabAttributeFrom( $container, 'id' );
-		$fieldName = str_replace( '-container', '', str_replace( 'select2-', '', $fieldID ) );
-		$I->click( '#' . $fieldID );
+	public function openSelect2Field($I, $container, $value, $ariaAttributeName = 'aria-controls')
+	{
+		$fieldID = $I->grabAttributeFrom($container, 'id');
+		$fieldName = str_replace('-container', '', str_replace('select2-', '', $fieldID));
+		$I->click('#'.$fieldID);
 	}
 }

--- a/tests/_support/Helper/Acceptance/Select2.php
+++ b/tests/_support/Helper/Acceptance/Select2.php
@@ -12,7 +12,7 @@ class Select2 extends \Codeception\Module
      * 
      * @since 1.9.6.4
      * 
-     * @param AcceptanceTester $I
+     * @param AcceptanceTester $I                 Tester
      * @param string           $container         Field CSS Class / ID
      * @param string           $value             Field Value
      * @param string           $ariaAttributeName Aria Attribute Name (aria-controls|aria-owns)
@@ -33,7 +33,7 @@ class Select2 extends \Codeception\Module
      * 
      * @since 1.9.8.1
      * 
-     * @param AcceptanceTester $I
+     * @param AcceptanceTester $I                 Tester
      * @param string           $container         Field CSS Class / ID
      * @param string           $value             Field Value
      * @param string           $ariaAttributeName Aria Attribute Name (aria-controls|aria-owns)

--- a/tests/_support/Helper/Acceptance/Select2.php
+++ b/tests/_support/Helper/Acceptance/Select2.php
@@ -9,19 +9,19 @@ class Select2 extends \Codeception\Module
 {
 	/**
 	 * Helper method to enter text into a jQuery Select2 Field, selecting the option that appears.
-	 * 
-	 * @since 	1.9.6.4
-	 * 
-	 * @param 	AcceptanceTester 	$I
-	 * @param 	string 				$container 	Field CSS Class / ID
-	 * @param 	string 				$value 		Field Value
-	 * @param 	string 				$ariaAttributeName 	Aria Attribute Name (aria-controls|aria-owns)
+	 *
+	 * @since   1.9.6.4
+	 *
+	 * @param   AcceptanceTester $I
+	 * @param   string           $container  Field CSS Class / ID
+	 * @param   string           $value      Field Value
+	 * @param   string           $ariaAttributeName  Aria Attribute Name (aria-controls|aria-owns)
 	 */
 	public function fillSelect2Field($I, $container, $value, $ariaAttributeName = 'aria-controls')
 	{
-		$fieldID = $I->grabAttributeFrom($container, 'id');
+		$fieldID   = $I->grabAttributeFrom($container, 'id');
 		$fieldName = str_replace('-container', '', str_replace('select2-', '', $fieldID));
-		$I->click('#'.$fieldID);
+		$I->click('#' . $fieldID);
 		$I->waitForElementVisible('.select2-search__field[' . $ariaAttributeName . '="select2-' . $fieldName . '-results"]');
 		$I->fillField('.select2-search__field[' . $ariaAttributeName . '="select2-' . $fieldName . '-results"]', $value);
 		$I->waitForElementVisible('ul#select2-' . $fieldName . '-results li.select2-results__option--highlighted');
@@ -30,18 +30,18 @@ class Select2 extends \Codeception\Module
 
 	/**
 	 * Helper method to open a jQuery Select2 Field.
-	 * 
-	 * @since 	1.9.8.1
-	 * 
-	 * @param 	AcceptanceTester 	$I
-	 * @param 	string 				$container 	Field CSS Class / ID
-	 * @param 	string 				$value 		Field Value
-	 * @param 	string 				$ariaAttributeName 	Aria Attribute Name (aria-controls|aria-owns)
+	 *
+	 * @since   1.9.8.1
+	 *
+	 * @param   AcceptanceTester $I
+	 * @param   string           $container  Field CSS Class / ID
+	 * @param   string           $value      Field Value
+	 * @param   string           $ariaAttributeName  Aria Attribute Name (aria-controls|aria-owns)
 	 */
 	public function openSelect2Field($I, $container, $value, $ariaAttributeName = 'aria-controls')
 	{
-		$fieldID = $I->grabAttributeFrom($container, 'id');
+		$fieldID   = $I->grabAttributeFrom($container, 'id');
 		$fieldName = str_replace('-container', '', str_replace('select2-', '', $fieldID));
-		$I->click('#'.$fieldID);
+		$I->click('#' . $fieldID);
 	}
 }

--- a/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
+++ b/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
@@ -5,63 +5,61 @@ namespace Helper\Acceptance;
 // would be used across multiple tests.
 // These are then available in $I->{yourFunctionName}
 
-class ThirdPartyPlugin extends \Codeception\Module
-{
-    /**
-     * Helper method to activate a third party Plugin, checking
-     * it activated and no errors were output.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I    Acceptance Tester.
-     * @param string           $name Plugin Slug.
-     */
-    public function activateThirdPartyPlugin($I, $name)
-    {
-        // Login as the Administrator
-        $I->loginAsAdmin();
+class ThirdPartyPlugin extends \Codeception\Module {
 
-        // Go to the Plugins screen in the WordPress Administration interface.
-        $I->amOnPluginsPage();
+	/**
+	 * Helper method to activate a third party Plugin, checking
+	 * it activated and no errors were output.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I    Acceptance Tester.
+	 * @param string           $name Plugin Slug.
+	 */
+	public function activateThirdPartyPlugin( $I, $name ) {
+		// Login as the Administrator
+		$I->loginAsAdmin();
 
-        // Activate the Plugin.
-        $I->activatePlugin($name);
+		// Go to the Plugins screen in the WordPress Administration interface.
+		$I->amOnPluginsPage();
 
-        // Go to the Plugins screen again; this prevents any Plugin that loads a wizard-style screen from
-        // causing seePluginActivated() to fail.
-        $I->amOnPluginsPage();
+		// Activate the Plugin.
+		$I->activatePlugin( $name );
 
-        // Check that the Plugin activated successfully.
-        $I->seePluginActivated($name);
+		// Go to the Plugins screen again; this prevents any Plugin that loads a wizard-style screen from
+		// causing seePluginActivated() to fail.
+		$I->amOnPluginsPage();
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-    }
+		// Check that the Plugin activated successfully.
+		$I->seePluginActivated( $name );
 
-    /**
-     * Helper method to activate a third party Plugin, checking
-     * it activated and no errors were output.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I    Acceptance Tester.
-     * @param string           $name Plugin Slug.
-     */
-    public function deactivateThirdPartyPlugin($I, $name)
-    {
-        // Login as the Administrator
-        $I->loginAsAdmin();
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+	}
 
-        // Go to the Plugins screen in the WordPress Administration interface.
-        $I->amOnPluginsPage();
+	/**
+	 * Helper method to activate a third party Plugin, checking
+	 * it activated and no errors were output.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I    Acceptance Tester.
+	 * @param string           $name Plugin Slug.
+	 */
+	public function deactivateThirdPartyPlugin( $I, $name ) {
+		// Login as the Administrator
+		$I->loginAsAdmin();
 
-        // Deactivate the Plugin.
-        $I->deactivatePlugin($name);
+		// Go to the Plugins screen in the WordPress Administration interface.
+		$I->amOnPluginsPage();
 
-        // Check that the Plugin deactivated successfully.
-        $I->seePluginDeactivated($name);
+		// Deactivate the Plugin.
+		$I->deactivatePlugin( $name );
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-    }
+		// Check that the Plugin deactivated successfully.
+		$I->seePluginDeactivated( $name );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+	}
 }

--- a/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
+++ b/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
@@ -10,10 +10,10 @@ class ThirdPartyPlugin extends \Codeception\Module
 	/**
 	 * Helper method to activate a third party Plugin, checking
 	 * it activated and no errors were output.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	string 	$name 	Plugin Slug.
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   string $name   Plugin Slug.
 	 */
 	public function activateThirdPartyPlugin($I, $name)
 	{
@@ -40,10 +40,10 @@ class ThirdPartyPlugin extends \Codeception\Module
 	/**
 	 * Helper method to activate a third party Plugin, checking
 	 * it activated and no errors were output.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	string 	$name 	Plugin Slug.
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   string $name   Plugin Slug.
 	 */
 	public function deactivateThirdPartyPlugin($I, $name)
 	{

--- a/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
+++ b/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
@@ -1,10 +1,12 @@
 <?php
 namespace Helper\Acceptance;
 
-// Define any custom actions related to third party Plugins that
-// would be used across multiple tests.
-// These are then available in $I->{yourFunctionName}
-
+/**
+ * Helper methods and actions related to third party Plugins,
+ * which are then available using $I->{yourFunctionName}.
+ *
+ * @since   1.9.6
+ */
 class ThirdPartyPlugin extends \Codeception\Module
 {
 	/**
@@ -13,11 +15,12 @@ class ThirdPartyPlugin extends \Codeception\Module
 	 *
 	 * @since   1.9.6.7
 	 *
-	 * @param   string $name   Plugin Slug.
+	 * @param   AcceptanceTester $I     AcceptanceTester.
+	 * @param   string           $name  Plugin Slug.
 	 */
 	public function activateThirdPartyPlugin($I, $name)
 	{
-		// Login as the Administrator
+		// Login as the Administrator.
 		$I->loginAsAdmin();
 
 		// Go to the Plugins screen in the WordPress Administration interface.
@@ -43,11 +46,12 @@ class ThirdPartyPlugin extends \Codeception\Module
 	 *
 	 * @since   1.9.6.7
 	 *
-	 * @param   string $name   Plugin Slug.
+	 * @param   AcceptanceTester $I      Acceptance Tester.
+	 * @param   string           $name   Plugin Slug.
 	 */
 	public function deactivateThirdPartyPlugin($I, $name)
 	{
-		// Login as the Administrator
+		// Login as the Administrator.
 		$I->loginAsAdmin();
 
 		// Go to the Plugins screen in the WordPress Administration interface.

--- a/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
+++ b/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
@@ -7,59 +7,59 @@ namespace Helper\Acceptance;
 
 class ThirdPartyPlugin extends \Codeception\Module
 {
-	/**
-	 * Helper method to activate a third party Plugin, checking
-	 * it activated and no errors were output.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	string 	$name 	Plugin Slug.
-	 */
-	public function activateThirdPartyPlugin($I, $name)
-	{
-		// Login as the Administrator
-		$I->loginAsAdmin();
+    /**
+     * Helper method to activate a third party Plugin, checking
+     * it activated and no errors were output.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param string $name Plugin Slug.
+     */
+    public function activateThirdPartyPlugin($I, $name)
+    {
+        // Login as the Administrator
+        $I->loginAsAdmin();
 
-		// Go to the Plugins screen in the WordPress Administration interface.
-		$I->amOnPluginsPage();
+        // Go to the Plugins screen in the WordPress Administration interface.
+        $I->amOnPluginsPage();
 
-		// Activate the Plugin.
-		$I->activatePlugin($name);
+        // Activate the Plugin.
+        $I->activatePlugin($name);
 
-		// Go to the Plugins screen again; this prevents any Plugin that loads a wizard-style screen from
-		// causing seePluginActivated() to fail.
-		$I->amOnPluginsPage();
+        // Go to the Plugins screen again; this prevents any Plugin that loads a wizard-style screen from
+        // causing seePluginActivated() to fail.
+        $I->amOnPluginsPage();
 
-		// Check that the Plugin activated successfully.
-		$I->seePluginActivated($name);
+        // Check that the Plugin activated successfully.
+        $I->seePluginActivated($name);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-	}
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
+    }
 
-	/**
-	 * Helper method to activate a third party Plugin, checking
-	 * it activated and no errors were output.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	string 	$name 	Plugin Slug.
-	 */
-	public function deactivateThirdPartyPlugin($I, $name)
-	{
-		// Login as the Administrator
-		$I->loginAsAdmin();
+    /**
+     * Helper method to activate a third party Plugin, checking
+     * it activated and no errors were output.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param string $name Plugin Slug.
+     */
+    public function deactivateThirdPartyPlugin($I, $name)
+    {
+        // Login as the Administrator
+        $I->loginAsAdmin();
 
-		// Go to the Plugins screen in the WordPress Administration interface.
-		$I->amOnPluginsPage();
+        // Go to the Plugins screen in the WordPress Administration interface.
+        $I->amOnPluginsPage();
 
-		// Deactivate the Plugin.
-		$I->deactivatePlugin($name);
+        // Deactivate the Plugin.
+        $I->deactivatePlugin($name);
 
-		// Check that the Plugin deactivated successfully.
-		$I->seePluginDeactivated($name);
+        // Check that the Plugin deactivated successfully.
+        $I->seePluginDeactivated($name);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-	}
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
+    }
 }

--- a/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
+++ b/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
@@ -13,7 +13,8 @@ class ThirdPartyPlugin extends \Codeception\Module
      * 
      * @since 1.9.6.7
      * 
-     * @param string $name Plugin Slug.
+     * @param AcceptanceTester $I    Acceptance Tester.
+     * @param string           $name Plugin Slug.
      */
     public function activateThirdPartyPlugin($I, $name)
     {
@@ -43,7 +44,8 @@ class ThirdPartyPlugin extends \Codeception\Module
      * 
      * @since 1.9.6.7
      * 
-     * @param string $name Plugin Slug.
+     * @param AcceptanceTester $I    Acceptance Tester.
+     * @param string           $name Plugin Slug.
      */
     public function deactivateThirdPartyPlugin($I, $name)
     {

--- a/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
+++ b/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
@@ -5,18 +5,18 @@ namespace Helper\Acceptance;
 // would be used across multiple tests.
 // These are then available in $I->{yourFunctionName}
 
-class ThirdPartyPlugin extends \Codeception\Module {
-
+class ThirdPartyPlugin extends \Codeception\Module
+{
 	/**
 	 * Helper method to activate a third party Plugin, checking
 	 * it activated and no errors were output.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I    Acceptance Tester.
-	 * @param string           $name Plugin Slug.
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	string 	$name 	Plugin Slug.
 	 */
-	public function activateThirdPartyPlugin( $I, $name ) {
+	public function activateThirdPartyPlugin($I, $name)
+	{
 		// Login as the Administrator
 		$I->loginAsAdmin();
 
@@ -24,29 +24,29 @@ class ThirdPartyPlugin extends \Codeception\Module {
 		$I->amOnPluginsPage();
 
 		// Activate the Plugin.
-		$I->activatePlugin( $name );
+		$I->activatePlugin($name);
 
 		// Go to the Plugins screen again; this prevents any Plugin that loads a wizard-style screen from
 		// causing seePluginActivated() to fail.
 		$I->amOnPluginsPage();
 
 		// Check that the Plugin activated successfully.
-		$I->seePluginActivated( $name );
+		$I->seePluginActivated($name);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 	}
 
 	/**
 	 * Helper method to activate a third party Plugin, checking
 	 * it activated and no errors were output.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I    Acceptance Tester.
-	 * @param string           $name Plugin Slug.
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	string 	$name 	Plugin Slug.
 	 */
-	public function deactivateThirdPartyPlugin( $I, $name ) {
+	public function deactivateThirdPartyPlugin($I, $name)
+	{
 		// Login as the Administrator
 		$I->loginAsAdmin();
 
@@ -54,12 +54,12 @@ class ThirdPartyPlugin extends \Codeception\Module {
 		$I->amOnPluginsPage();
 
 		// Deactivate the Plugin.
-		$I->deactivatePlugin( $name );
+		$I->deactivatePlugin($name);
 
 		// Check that the Plugin deactivated successfully.
-		$I->seePluginDeactivated( $name );
+		$I->seePluginDeactivated($name);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 	}
 }

--- a/tests/_support/Helper/Acceptance/WPBulkEdit.php
+++ b/tests/_support/Helper/Acceptance/WPBulkEdit.php
@@ -12,10 +12,10 @@ class WPBulkEdit extends \Codeception\Module
      * 
      * @since 1.9.8.0
      * 
-     * @param $I             AcceptanceHelper     Acceptance Helper.
-     * @param string $postType      Programmatic Post Type.
-     * @param array  $postIDs       Post IDs.
-     * @param array  $configuration Configuration (field => value key/value array).
+     * @param AcceptanceHelper $I             Acceptance Helper.
+     * @param string           $postType      Programmatic Post Type.
+     * @param array            $postIDs       Post IDs.
+     * @param array            $configuration Configuration (field => value key/value array).
      */
     public function bulkEdit($I, $postType, $postIDs, $configuration)
     {
@@ -56,9 +56,9 @@ class WPBulkEdit extends \Codeception\Module
      * 
      * @since 1.9.8.1
      * 
-     * @param $I        AcceptanceHelper     Acceptance Helper.
-     * @param string $postType Programmatic Post Type.
-     * @param array  $postIDs  Post IDs.
+     * @param AcceptanceHelper $I        Acceptance Helper.
+     * @param string           $postType Programmatic Post Type.
+     * @param array            $postIDs  Post IDs.
      */
     public function openBulkEdit($I, $postType, $postIDs)
     {
@@ -66,7 +66,7 @@ class WPBulkEdit extends \Codeception\Module
         $I->amOnAdminPage('edit.php?post_type='.$postType);
 
         // Check boxes for Post IDs.
-        foreach($postIDs as $postID) {
+        foreach ($postIDs as $postID) {
             $I->checkOption('#cb-select-'.$postID);
         }
 

--- a/tests/_support/Helper/Acceptance/WPBulkEdit.php
+++ b/tests/_support/Helper/Acceptance/WPBulkEdit.php
@@ -7,73 +7,73 @@ namespace Helper\Acceptance;
 
 class WPBulkEdit extends \Codeception\Module
 {
-	/**
-	 * Bulk Edits the given Post IDs, changing form field values and saving.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
-	 * @param 	string 	$postType 		Programmatic Post Type.
-	 * @param 	array 	$postIDs 		Post IDs.
-	 * @param 	array 	$configuration 	Configuration (field => value key/value array).
-	 */
-	public function bulkEdit($I, $postType, $postIDs, $configuration)
-	{
-		// Open Bulk Edit form for the Posts.
-		$I->openBulkEdit($I, $postType, $postIDs);
+    /**
+     * Bulk Edits the given Post IDs, changing form field values and saving.
+     * 
+     * @since 1.9.8.0
+     * 
+     * @param $I             AcceptanceHelper     Acceptance Helper.
+     * @param string $postType      Programmatic Post Type.
+     * @param array  $postIDs       Post IDs.
+     * @param array  $configuration Configuration (field => value key/value array).
+     */
+    public function bulkEdit($I, $postType, $postIDs, $configuration)
+    {
+        // Open Bulk Edit form for the Posts.
+        $I->openBulkEdit($I, $postType, $postIDs);
 
-		// Apply configuration.
-		foreach ($configuration as $field=>$attributes) {
-			// Field ID will be prefixed with wp-convertkit-bulk-edit-.
-			$fieldID = 'wp-convertkit-bulk-edit-' . $field;
+        // Apply configuration.
+        foreach ($configuration as $field=>$attributes) {
+            // Field ID will be prefixed with wp-convertkit-bulk-edit-.
+            $fieldID = 'wp-convertkit-bulk-edit-' . $field;
 
-			// Check that the field exists.
-			$I->seeElementInDOM('#convertkit-bulk-edit #' . $fieldID);
+            // Check that the field exists.
+            $I->seeElementInDOM('#convertkit-bulk-edit #' . $fieldID);
 			
-			// Depending on the field's type, define its value.
-			switch ($attributes[0]) {
-				case 'select':
-					$I->selectOption('#convertkit-bulk-edit #' . $fieldID, $attributes[1]);
-					break;
-				default:
-					$I->fillField('#convertkit-bulk-edit #' . $fieldID, $attributes[1]);
-					break;
-			}
-		}
+            // Depending on the field's type, define its value.
+            switch ($attributes[0]) {
+            case 'select':
+                $I->selectOption('#convertkit-bulk-edit #' . $fieldID, $attributes[1]);
+                break;
+            default:
+                $I->fillField('#convertkit-bulk-edit #' . $fieldID, $attributes[1]);
+                break;
+            }
+        }
 
-		// Scroll to Update button.
-		$I->scrollTo('#bulk_edit');
+        // Scroll to Update button.
+        $I->scrollTo('#bulk_edit');
 
-		// Click Update.
-		$I->click('Update');
+        // Click Update.
+        $I->click('Update');
 
-		// Confirm that Bulk Editing saved with no errors.
-		$I->seeInSource(count($postIDs).' '.$postType.'s updated');
-	}
+        // Confirm that Bulk Editing saved with no errors.
+        $I->seeInSource(count($postIDs).' '.$postType.'s updated');
+    }
 
-	/**
-	 * Opens the Bulk Edit form for the given Post ID.
-	 * 
-	 * @since 	1.9.8.1
-	 * 
-	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
-	 * @param 	string 	$postType 		Programmatic Post Type.
-	 * @param 	array 	$postIDs 		Post IDs.
-	 */
-	public function openBulkEdit($I, $postType, $postIDs)
-	{
-		// Navigate to Post Type's WP_List_Table.
-		$I->amOnAdminPage('edit.php?post_type='.$postType);
+    /**
+     * Opens the Bulk Edit form for the given Post ID.
+     * 
+     * @since 1.9.8.1
+     * 
+     * @param $I        AcceptanceHelper     Acceptance Helper.
+     * @param string $postType Programmatic Post Type.
+     * @param array  $postIDs  Post IDs.
+     */
+    public function openBulkEdit($I, $postType, $postIDs)
+    {
+        // Navigate to Post Type's WP_List_Table.
+        $I->amOnAdminPage('edit.php?post_type='.$postType);
 
-		// Check boxes for Post IDs.
-		foreach($postIDs as $postID) {
-			$I->checkOption('#cb-select-'.$postID);
-		}
+        // Check boxes for Post IDs.
+        foreach($postIDs as $postID) {
+            $I->checkOption('#cb-select-'.$postID);
+        }
 
-		// Select Edit from the Bulk actions dropdown.
-		$I->selectOption('#bulk-action-selector-top', 'Edit');
+        // Select Edit from the Bulk actions dropdown.
+        $I->selectOption('#bulk-action-selector-top', 'Edit');
 
-		// Click Apply button.
-		$I->click('#doaction');
-	}
+        // Click Apply button.
+        $I->click('#doaction');
+    }
 }

--- a/tests/_support/Helper/Acceptance/WPBulkEdit.php
+++ b/tests/_support/Helper/Acceptance/WPBulkEdit.php
@@ -5,75 +5,73 @@ namespace Helper\Acceptance;
 // would be used across multiple tests.
 // These are then available in $I->{yourFunctionName}
 
-class WPBulkEdit extends \Codeception\Module
-{
-    /**
-     * Bulk Edits the given Post IDs, changing form field values and saving.
-     * 
-     * @since 1.9.8.0
-     * 
-     * @param AcceptanceHelper $I             Acceptance Helper.
-     * @param string           $postType      Programmatic Post Type.
-     * @param array            $postIDs       Post IDs.
-     * @param array            $configuration Configuration (field => value key/value array).
-     */
-    public function bulkEdit($I, $postType, $postIDs, $configuration)
-    {
-        // Open Bulk Edit form for the Posts.
-        $I->openBulkEdit($I, $postType, $postIDs);
+class WPBulkEdit extends \Codeception\Module {
 
-        // Apply configuration.
-        foreach ($configuration as $field=>$attributes) {
-            // Field ID will be prefixed with wp-convertkit-bulk-edit-.
-            $fieldID = 'wp-convertkit-bulk-edit-' . $field;
+	/**
+	 * Bulk Edits the given Post IDs, changing form field values and saving.
+	 *
+	 * @since 1.9.8.0
+	 *
+	 * @param AcceptanceHelper $I             Acceptance Helper.
+	 * @param string           $postType      Programmatic Post Type.
+	 * @param array            $postIDs       Post IDs.
+	 * @param array            $configuration Configuration (field => value key/value array).
+	 */
+	public function bulkEdit( $I, $postType, $postIDs, $configuration ) {
+		// Open Bulk Edit form for the Posts.
+		$I->openBulkEdit( $I, $postType, $postIDs );
 
-            // Check that the field exists.
-            $I->seeElementInDOM('#convertkit-bulk-edit #' . $fieldID);
-			
-            // Depending on the field's type, define its value.
-            switch ($attributes[0]) {
-            case 'select':
-                $I->selectOption('#convertkit-bulk-edit #' . $fieldID, $attributes[1]);
-                break;
-            default:
-                $I->fillField('#convertkit-bulk-edit #' . $fieldID, $attributes[1]);
-                break;
-            }
-        }
+		// Apply configuration.
+		foreach ( $configuration as $field => $attributes ) {
+			// Field ID will be prefixed with wp-convertkit-bulk-edit-.
+			$fieldID = 'wp-convertkit-bulk-edit-' . $field;
 
-        // Scroll to Update button.
-        $I->scrollTo('#bulk_edit');
+			// Check that the field exists.
+			$I->seeElementInDOM( '#convertkit-bulk-edit #' . $fieldID );
 
-        // Click Update.
-        $I->click('Update');
+			// Depending on the field's type, define its value.
+			switch ( $attributes[0] ) {
+				case 'select':
+					$I->selectOption( '#convertkit-bulk-edit #' . $fieldID, $attributes[1] );
+					break;
+				default:
+					$I->fillField( '#convertkit-bulk-edit #' . $fieldID, $attributes[1] );
+					break;
+			}
+		}
 
-        // Confirm that Bulk Editing saved with no errors.
-        $I->seeInSource(count($postIDs).' '.$postType.'s updated');
-    }
+		// Scroll to Update button.
+		$I->scrollTo( '#bulk_edit' );
 
-    /**
-     * Opens the Bulk Edit form for the given Post ID.
-     * 
-     * @since 1.9.8.1
-     * 
-     * @param AcceptanceHelper $I        Acceptance Helper.
-     * @param string           $postType Programmatic Post Type.
-     * @param array            $postIDs  Post IDs.
-     */
-    public function openBulkEdit($I, $postType, $postIDs)
-    {
-        // Navigate to Post Type's WP_List_Table.
-        $I->amOnAdminPage('edit.php?post_type='.$postType);
+		// Click Update.
+		$I->click( 'Update' );
 
-        // Check boxes for Post IDs.
-        foreach ($postIDs as $postID) {
-            $I->checkOption('#cb-select-'.$postID);
-        }
+		// Confirm that Bulk Editing saved with no errors.
+		$I->seeInSource( count( $postIDs ) . ' ' . $postType . 's updated' );
+	}
 
-        // Select Edit from the Bulk actions dropdown.
-        $I->selectOption('#bulk-action-selector-top', 'Edit');
+	/**
+	 * Opens the Bulk Edit form for the given Post ID.
+	 *
+	 * @since 1.9.8.1
+	 *
+	 * @param AcceptanceHelper $I        Acceptance Helper.
+	 * @param string           $postType Programmatic Post Type.
+	 * @param array            $postIDs  Post IDs.
+	 */
+	public function openBulkEdit( $I, $postType, $postIDs ) {
+		// Navigate to Post Type's WP_List_Table.
+		$I->amOnAdminPage( 'edit.php?post_type=' . $postType );
 
-        // Click Apply button.
-        $I->click('#doaction');
-    }
+		// Check boxes for Post IDs.
+		foreach ( $postIDs as $postID ) {
+			$I->checkOption( '#cb-select-' . $postID );
+		}
+
+		// Select Edit from the Bulk actions dropdown.
+		$I->selectOption( '#bulk-action-selector-top', 'Edit' );
+
+		// Click Apply button.
+		$I->click( '#doaction' );
+	}
 }

--- a/tests/_support/Helper/Acceptance/WPBulkEdit.php
+++ b/tests/_support/Helper/Acceptance/WPBulkEdit.php
@@ -1,10 +1,12 @@
 <?php
 namespace Helper\Acceptance;
 
-// Define any custom actions related to WordPress' Bulk Edit functionality that
-// would be used across multiple tests.
-// These are then available in $I->{yourFunctionName}
-
+/**
+ * Helper methods and actions related to WordPress' Bulk Edit functionality,
+ * which are then available using $I->{yourFunctionName}.
+ *
+ * @since   1.9.6
+ */
 class WPBulkEdit extends \Codeception\Module
 {
 	/**
@@ -12,10 +14,10 @@ class WPBulkEdit extends \Codeception\Module
 	 *
 	 * @since   1.9.8.0
 	 *
-	 * @param   $I  AcceptanceHelper    Acceptance Helper.
-	 * @param   string                                   $postType       Programmatic Post Type.
-	 * @param   array                                    $postIDs        Post IDs.
-	 * @param   array                                    $configuration  Configuration (field => value key/value array).
+	 * @param   AcceptanceHelper $I              Acceptance Helper.
+	 * @param   string           $postType       Programmatic Post Type.
+	 * @param   array            $postIDs        Post IDs.
+	 * @param   array            $configuration  Configuration (field => value key/value array).
 	 */
 	public function bulkEdit($I, $postType, $postIDs, $configuration)
 	{
@@ -56,9 +58,9 @@ class WPBulkEdit extends \Codeception\Module
 	 *
 	 * @since   1.9.8.1
 	 *
-	 * @param   $I  AcceptanceHelper    Acceptance Helper.
-	 * @param   string                                   $postType       Programmatic Post Type.
-	 * @param   array                                    $postIDs        Post IDs.
+	 * @param   AcceptanceHelper $I              Acceptance Helper.
+	 * @param   string           $postType       Programmatic Post Type.
+	 * @param   array            $postIDs        Post IDs.
 	 */
 	public function openBulkEdit($I, $postType, $postIDs)
 	{

--- a/tests/_support/Helper/Acceptance/WPBulkEdit.php
+++ b/tests/_support/Helper/Acceptance/WPBulkEdit.php
@@ -9,13 +9,13 @@ class WPBulkEdit extends \Codeception\Module
 {
 	/**
 	 * Bulk Edits the given Post IDs, changing form field values and saving.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
-	 * @param 	string 	$postType 		Programmatic Post Type.
-	 * @param 	array 	$postIDs 		Post IDs.
-	 * @param 	array 	$configuration 	Configuration (field => value key/value array).
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   $I  AcceptanceHelper    Acceptance Helper.
+	 * @param   string                                   $postType       Programmatic Post Type.
+	 * @param   array                                    $postIDs        Post IDs.
+	 * @param   array                                    $configuration  Configuration (field => value key/value array).
 	 */
 	public function bulkEdit($I, $postType, $postIDs, $configuration)
 	{
@@ -23,13 +23,13 @@ class WPBulkEdit extends \Codeception\Module
 		$I->openBulkEdit($I, $postType, $postIDs);
 
 		// Apply configuration.
-		foreach ($configuration as $field=>$attributes) {
+		foreach ($configuration as $field => $attributes) {
 			// Field ID will be prefixed with wp-convertkit-bulk-edit-.
 			$fieldID = 'wp-convertkit-bulk-edit-' . $field;
 
 			// Check that the field exists.
 			$I->seeElementInDOM('#convertkit-bulk-edit #' . $fieldID);
-			
+
 			// Depending on the field's type, define its value.
 			switch ($attributes[0]) {
 				case 'select':
@@ -48,26 +48,26 @@ class WPBulkEdit extends \Codeception\Module
 		$I->click('Update');
 
 		// Confirm that Bulk Editing saved with no errors.
-		$I->seeInSource(count($postIDs).' '.$postType.'s updated');
+		$I->seeInSource(count($postIDs) . ' ' . $postType . 's updated');
 	}
 
 	/**
 	 * Opens the Bulk Edit form for the given Post ID.
-	 * 
-	 * @since 	1.9.8.1
-	 * 
-	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
-	 * @param 	string 	$postType 		Programmatic Post Type.
-	 * @param 	array 	$postIDs 		Post IDs.
+	 *
+	 * @since   1.9.8.1
+	 *
+	 * @param   $I  AcceptanceHelper    Acceptance Helper.
+	 * @param   string                                   $postType       Programmatic Post Type.
+	 * @param   array                                    $postIDs        Post IDs.
 	 */
 	public function openBulkEdit($I, $postType, $postIDs)
 	{
 		// Navigate to Post Type's WP_List_Table.
-		$I->amOnAdminPage('edit.php?post_type='.$postType);
+		$I->amOnAdminPage('edit.php?post_type=' . $postType);
 
 		// Check boxes for Post IDs.
-		foreach($postIDs as $postID) {
-			$I->checkOption('#cb-select-'.$postID);
+		foreach ($postIDs as $postID) {
+			$I->checkOption('#cb-select-' . $postID);
 		}
 
 		// Select Edit from the Bulk actions dropdown.

--- a/tests/_support/Helper/Acceptance/WPBulkEdit.php
+++ b/tests/_support/Helper/Acceptance/WPBulkEdit.php
@@ -5,73 +5,75 @@ namespace Helper\Acceptance;
 // would be used across multiple tests.
 // These are then available in $I->{yourFunctionName}
 
-class WPBulkEdit extends \Codeception\Module {
-
+class WPBulkEdit extends \Codeception\Module
+{
 	/**
 	 * Bulk Edits the given Post IDs, changing form field values and saving.
-	 *
-	 * @since 1.9.8.0
-	 *
-	 * @param AcceptanceHelper $I             Acceptance Helper.
-	 * @param string           $postType      Programmatic Post Type.
-	 * @param array            $postIDs       Post IDs.
-	 * @param array            $configuration Configuration (field => value key/value array).
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
+	 * @param 	string 	$postType 		Programmatic Post Type.
+	 * @param 	array 	$postIDs 		Post IDs.
+	 * @param 	array 	$configuration 	Configuration (field => value key/value array).
 	 */
-	public function bulkEdit( $I, $postType, $postIDs, $configuration ) {
+	public function bulkEdit($I, $postType, $postIDs, $configuration)
+	{
 		// Open Bulk Edit form for the Posts.
-		$I->openBulkEdit( $I, $postType, $postIDs );
+		$I->openBulkEdit($I, $postType, $postIDs);
 
 		// Apply configuration.
-		foreach ( $configuration as $field => $attributes ) {
+		foreach ($configuration as $field=>$attributes) {
 			// Field ID will be prefixed with wp-convertkit-bulk-edit-.
 			$fieldID = 'wp-convertkit-bulk-edit-' . $field;
 
 			// Check that the field exists.
-			$I->seeElementInDOM( '#convertkit-bulk-edit #' . $fieldID );
-
+			$I->seeElementInDOM('#convertkit-bulk-edit #' . $fieldID);
+			
 			// Depending on the field's type, define its value.
-			switch ( $attributes[0] ) {
+			switch ($attributes[0]) {
 				case 'select':
-					$I->selectOption( '#convertkit-bulk-edit #' . $fieldID, $attributes[1] );
+					$I->selectOption('#convertkit-bulk-edit #' . $fieldID, $attributes[1]);
 					break;
 				default:
-					$I->fillField( '#convertkit-bulk-edit #' . $fieldID, $attributes[1] );
+					$I->fillField('#convertkit-bulk-edit #' . $fieldID, $attributes[1]);
 					break;
 			}
 		}
 
 		// Scroll to Update button.
-		$I->scrollTo( '#bulk_edit' );
+		$I->scrollTo('#bulk_edit');
 
 		// Click Update.
-		$I->click( 'Update' );
+		$I->click('Update');
 
 		// Confirm that Bulk Editing saved with no errors.
-		$I->seeInSource( count( $postIDs ) . ' ' . $postType . 's updated' );
+		$I->seeInSource(count($postIDs).' '.$postType.'s updated');
 	}
 
 	/**
 	 * Opens the Bulk Edit form for the given Post ID.
-	 *
-	 * @since 1.9.8.1
-	 *
-	 * @param AcceptanceHelper $I        Acceptance Helper.
-	 * @param string           $postType Programmatic Post Type.
-	 * @param array            $postIDs  Post IDs.
+	 * 
+	 * @since 	1.9.8.1
+	 * 
+	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
+	 * @param 	string 	$postType 		Programmatic Post Type.
+	 * @param 	array 	$postIDs 		Post IDs.
 	 */
-	public function openBulkEdit( $I, $postType, $postIDs ) {
+	public function openBulkEdit($I, $postType, $postIDs)
+	{
 		// Navigate to Post Type's WP_List_Table.
-		$I->amOnAdminPage( 'edit.php?post_type=' . $postType );
+		$I->amOnAdminPage('edit.php?post_type='.$postType);
 
 		// Check boxes for Post IDs.
-		foreach ( $postIDs as $postID ) {
-			$I->checkOption( '#cb-select-' . $postID );
+		foreach($postIDs as $postID) {
+			$I->checkOption('#cb-select-'.$postID);
 		}
 
 		// Select Edit from the Bulk actions dropdown.
-		$I->selectOption( '#bulk-action-selector-top', 'Edit' );
+		$I->selectOption('#bulk-action-selector-top', 'Edit');
 
 		// Click Apply button.
-		$I->click( '#doaction' );
+		$I->click('#doaction');
 	}
 }

--- a/tests/_support/Helper/Acceptance/WPClassicEditor.php
+++ b/tests/_support/Helper/Acceptance/WPClassicEditor.php
@@ -1,10 +1,12 @@
 <?php
 namespace Helper\Acceptance;
 
-// Define any custom actions related to the Classic Editor that
-// would be used across multiple tests.
-// These are then available in $I->{yourFunctionName}
-
+/**
+ * Helper methods and actions related to WordPress' Classic Editor,
+ * which are then available using $I->{yourFunctionName}.
+ *
+ * @since   1.9.6
+ */
 class WPClassicEditor extends \Codeception\Module
 {
 	/**
@@ -12,14 +14,16 @@ class WPClassicEditor extends \Codeception\Module
 	 *
 	 * @since   1.9.7.5
 	 *
-	 * @param   AcceptanceTester $I                      Acceptance Tester.
+	 * @param   AcceptanceTester $I          Acceptance Tester.
+	 * @param   string           $postType   Post Type.
+	 * @param   string           $title      Post Title.
 	 */
-	public function addClassicEditorPage($I, $postType = 'page', $title)
+	public function addClassicEditorPage($I, $postType = 'page', $title = 'Classic Editor Title')
 	{
-		// Activate Classic Editor Plugin
+		// Activate Classic Editor Plugin.
 		$I->activateThirdPartyPlugin($I, 'classic-editor');
 
-		// Navigate to Post Type (e.g. Pages / Posts) > Add New
+		// Navigate to Post Type (e.g. Pages / Posts) > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=' . $postType);
 
 		// Define the Title.
@@ -36,12 +40,11 @@ class WPClassicEditor extends \Codeception\Module
 	 *
 	 * @param   AcceptanceTester $I                          Acceptance Tester.
 	 * @param   string           $shortcodeName              Shortcode Name (e.g. 'ConvertKit Form').
-	 * @param   string           $shortcodeProgrammaticName  Programmatic Shortcode Name (e.g. 'convertkit-form').
 	 * @param   bool|array       $shortcodeConfiguration     Shortcode Configuration (field => value key/value array).
 	 * @param   bool|string      $expectedShortcodeOutput    Expected Shortcode Output (e.g. [convertkit_form form="12345"]).
 	 * @param   string           $targetEditor               Target TinyMCE editor instance.
 	 */
-	public function addVisualEditorShortcode($I, $shortcodeName, $shortcodeProgrammaticName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false, $targetEditor = 'content')
+	public function addVisualEditorShortcode($I, $shortcodeName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false, $targetEditor = 'content')
 	{
 		// Scroll to the applicable TinyMCE editor.
 		switch ($targetEditor) {
@@ -66,7 +69,7 @@ class WPClassicEditor extends \Codeception\Module
 		// If a shortcode configuration is specified, apply it to the shortcode's modal window now.
 		if ($shortcodeConfiguration) {
 			foreach ($shortcodeConfiguration as $field => $attributes) {
-				// Field ID will be the attribute name, prefixed with tinymce_modal
+				// Field ID will be the attribute name, prefixed with tinymce_modal.
 				$fieldID = '#tinymce_modal_' . $field;
 
 				// Depending on the field's type, define its value.
@@ -104,13 +107,12 @@ class WPClassicEditor extends \Codeception\Module
 	 * @since   1.9.7.5
 	 *
 	 * @param   AcceptanceTester $I                          Acceptance Tester.
-	 * @param   string           $shortcodeName              Shortcode Name (e.g. 'ConvertKit Form').
 	 * @param   string           $shortcodeProgrammaticName  Programmatic Shortcode Name (e.g. 'convertkit-form').
 	 * @param   bool|array       $shortcodeConfiguration     Shortcode Configuration (field => value key/value array).
 	 * @param   bool|string      $expectedShortcodeOutput    Expected Shortcode Output (e.g. [convertkit_form form="12345"]).
 	 * @param   string           $targetEditor               ID of text editor instance.
 	 */
-	public function addTextEditorShortcode($I, $shortcodeName, $shortcodeProgrammaticName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false, $targetEditor = 'content')
+	public function addTextEditorShortcode($I, $shortcodeProgrammaticName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false, $targetEditor = 'content')
 	{
 		// Scroll to the applicable TinyMCE editor.
 		switch ($targetEditor) {
@@ -135,7 +137,7 @@ class WPClassicEditor extends \Codeception\Module
 		// If a shortcode configuration is specified, apply it to the shortcode's modal window now.
 		if ($shortcodeConfiguration) {
 			foreach ($shortcodeConfiguration as $field => $attributes) {
-				// Field ID will be the attribute name, prefixed with tinymce_modal
+				// Field ID will be the attribute name, prefixed with tinymce_modal.
 				$fieldID = '#tinymce_modal_' . $field;
 
 				// Depending on the field's type, define its value.

--- a/tests/_support/Helper/Acceptance/WPClassicEditor.php
+++ b/tests/_support/Helper/Acceptance/WPClassicEditor.php
@@ -12,9 +12,11 @@ class WPClassicEditor extends \Codeception\Module
      * 
      * @since 1.9.7.5
      * 
-     * @param AcceptanceTester $I Acceptance Tester.
+     * @param AcceptanceTester $I        Acceptance Tester.
+     * @param string           $postType Post Type.
+     * @param string           $title    Post Title.
      */
-    public function addClassicEditorPage($I, $postType = 'page', $title)
+    public function addClassicEditorPage($I, $postType = 'page', $title = 'Classic Editor Title')
     {
         // Activate Classic Editor Plugin
         $I->activateThirdPartyPlugin($I, 'classic-editor');

--- a/tests/_support/Helper/Acceptance/WPClassicEditor.php
+++ b/tests/_support/Helper/Acceptance/WPClassicEditor.php
@@ -5,92 +5,92 @@ namespace Helper\Acceptance;
 // would be used across multiple tests.
 // These are then available in $I->{yourFunctionName}
 
-class WPClassicEditor extends \Codeception\Module {
-
+class WPClassicEditor extends \Codeception\Module
+{
 	/**
 	 * Add a Page, Post or Custom Post Type using the Classic Editor in WordPress.
-	 *
-	 * @since 1.9.7.5
-	 *
-	 * @param AcceptanceTester $I        Acceptance Tester.
-	 * @param string           $postType Post Type.
-	 * @param string           $title    Post Title.
+	 * 
+	 * @since 	1.9.7.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
 	 */
-	public function addClassicEditorPage( $I, $postType = 'page', $title = 'Classic Editor Title' ) {
+	public function addClassicEditorPage($I, $postType = 'page', $title)
+	{
 		// Activate Classic Editor Plugin
-		$I->activateThirdPartyPlugin( $I, 'classic-editor' );
+		$I->activateThirdPartyPlugin($I, 'classic-editor');
 
 		// Navigate to Post Type (e.g. Pages / Posts) > Add New
-		$I->amOnAdminPage( 'post-new.php?post_type=' . $postType );
+		$I->amOnAdminPage('post-new.php?post_type='.$postType);
 
 		// Define the Title.
-		$I->fillField( '#title', $title );
+		$I->fillField('#title', $title);
 	}
 
 	/**
 	 * Add the given shortcode when adding or editing a Page, Post or Custom Post Type
 	 * in the Visual Editor (TinyMCE).
-	 *
+	 * 
 	 * If a shortcode configuration is specified, applies it to the newly added shortcode.
-	 *
-	 * @since 1.9.7.5
-	 *
-	 * @param AcceptanceTester $I                         Acceptance Tester.
-	 * @param string           $shortcodeName             Shortcode Name (e.g. 'ConvertKit Form').
-	 * @param string           $shortcodeProgrammaticName Programmatic Shortcode Name (e.g. 'convertkit-form').
-	 * @param bool|array       $shortcodeConfiguration    Shortcode Configuration (field => value key/value array).
-	 * @param bool|string      $expectedShortcodeOutput   Expected Shortcode Output (e.g. [convertkit_form form="12345"]).
-	 * @param string           $targetEditor              Target TinyMCE editor instance.
+	 * 
+	 * @since 	1.9.7.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 							Acceptance Tester.
+	 * @param 	string 				$shortcodeName 				Shortcode Name (e.g. 'ConvertKit Form').
+	 * @param 	string 				$shortcodeProgrammaticName 	Programmatic Shortcode Name (e.g. 'convertkit-form').
+	 * @param 	bool|array 			$shortcodeConfiguration 	Shortcode Configuration (field => value key/value array).
+	 * @param 	bool|string 		$expectedShortcodeOutput 	Expected Shortcode Output (e.g. [convertkit_form form="12345"]).
+	 * @param 	string 				$targetEditor				Target TinyMCE editor instance.
 	 */
-	public function addVisualEditorShortcode( $I, $shortcodeName, $shortcodeProgrammaticName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false, $targetEditor = 'content' ) {
+	public function addVisualEditorShortcode($I, $shortcodeName, $shortcodeProgrammaticName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false, $targetEditor = 'content')
+	{
 		// Scroll to the applicable TinyMCE editor.
-		switch ( $targetEditor ) {
+		switch($targetEditor) {
 			case 'excerpt':
-				$I->scrollTo( '#postexcerpt' );
-				$I->click( '#postexcerpt button.handlediv' );
+				$I->scrollTo('#postexcerpt');
+				$I->click('#postexcerpt button.handlediv');
 				break;
 			default:
-				$I->scrollTo( 'h1.wp-heading-inline' );
+				$I->scrollTo('h1.wp-heading-inline');
 				break;
 		}
 
 		// Click the Visual tab on the applicable TinyMCE editor.
-		$I->click( 'button#' . $targetEditor . '-tmce' );
+		$I->click('button#'.$targetEditor.'-tmce');
 
 		// Click the TinyMCE Button for this shortcode.
-		$I->click( '#wp-' . $targetEditor . '-editor-container div.mce-container div[aria-label="' . $shortcodeName . '"] button' );
+		$I->click('#wp-'.$targetEditor.'-editor-container div.mce-container div[aria-label="'.$shortcodeName.'"] button');
 
 		// Wait for the modal's contents to load.
-		$I->waitForElementVisible( '#convertkit-modal-body input.button-primary' );
+		$I->waitForElementVisible('#convertkit-modal-body input.button-primary');
 
 		// If a shortcode configuration is specified, apply it to the shortcode's modal window now.
-		if ( $shortcodeConfiguration ) {
-			foreach ( $shortcodeConfiguration as $field => $attributes ) {
+		if ($shortcodeConfiguration) {
+			foreach ($shortcodeConfiguration as $field=>$attributes) {
 				// Field ID will be the attribute name, prefixed with tinymce_modal
 				$fieldID = '#tinymce_modal_' . $field;
 
 				// Depending on the field's type, define its value.
-				switch ( $attributes[0] ) {
+				switch ($attributes[0]) {
 					case 'select':
-						$I->selectOption( '#convertkit-modal-body-body ' . $fieldID, $attributes[1] );
+						$I->selectOption('#convertkit-modal-body-body '.$fieldID, $attributes[1]);
 						break;
 					case 'toggle':
-						$I->selectOption( '#convertkit-modal-body-body ' . $fieldID, $attributes[1] );
+						$I->selectOption('#convertkit-modal-body-body '.$fieldID, $attributes[1]);
 						break;
 					default:
-						$I->fillField( '#convertkit-modal-body-body ' . $fieldID, $attributes[1] );
+						$I->fillField('#convertkit-modal-body-body '.$fieldID, $attributes[1]);
 						break;
 				}
 			}
 		}
 
 		// Click the Insert button.
-		$I->click( '#convertkit-modal-body input.button-primary' );
+		$I->click('#convertkit-modal-body input.button-primary');
 
 		// If the expected shortcode output is provided, check it exists in the Visual editor.
-		if ( $expectedShortcodeOutput ) {
-			$I->switchToIFrame( 'iframe#' . $targetEditor . '_ifr' );
-			$I->seeInSource( $expectedShortcodeOutput );
+		if ($expectedShortcodeOutput) {
+			$I->switchToIFrame('iframe#'.$targetEditor.'_ifr');
+			$I->seeInSource($expectedShortcodeOutput);
 			$I->switchToIFrame();
 		}
 	}
@@ -98,119 +98,122 @@ class WPClassicEditor extends \Codeception\Module {
 	/**
 	 * Add the given shortcode when adding or editing a Page, Post or Custom Post Type
 	 * in the Text Editor.
-	 *
+	 * 
 	 * If a shortcode configuration is specified, applies it to the newly added shortcode.
-	 *
-	 * @since 1.9.7.5
-	 *
-	 * @param AcceptanceTester $I                         Acceptance Tester.
-	 * @param string           $shortcodeName             Shortcode Name (e.g. 'ConvertKit Form').
-	 * @param string           $shortcodeProgrammaticName Programmatic Shortcode Name (e.g. 'convertkit-form').
-	 * @param bool|array       $shortcodeConfiguration    Shortcode Configuration (field => value key/value array).
-	 * @param bool|string      $expectedShortcodeOutput   Expected Shortcode Output (e.g. [convertkit_form form="12345"]).
-	 * @param string           $targetEditor              ID of text editor instance.
+	 * 
+	 * @since 	1.9.7.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 							Acceptance Tester.
+	 * @param 	string 				$shortcodeName 				Shortcode Name (e.g. 'ConvertKit Form').
+	 * @param 	string 				$shortcodeProgrammaticName 	Programmatic Shortcode Name (e.g. 'convertkit-form').
+	 * @param 	bool|array 			$shortcodeConfiguration 	Shortcode Configuration (field => value key/value array).
+	 * @param 	bool|string 		$expectedShortcodeOutput 	Expected Shortcode Output (e.g. [convertkit_form form="12345"]).
+	 * @param 	string 				$targetEditor				ID of text editor instance.
 	 */
-	public function addTextEditorShortcode( $I, $shortcodeName, $shortcodeProgrammaticName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false, $targetEditor = 'content' ) {
+	public function addTextEditorShortcode($I, $shortcodeName, $shortcodeProgrammaticName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false, $targetEditor = 'content')
+	{
 		// Scroll to the applicable TinyMCE editor.
-		switch ( $targetEditor ) {
+		switch($targetEditor) {
 			case 'excerpt':
-				$I->scrollTo( '#postexcerpt' );
-				$I->click( '#postexcerpt button.handlediv' );
+				$I->scrollTo('#postexcerpt');
+				$I->click('#postexcerpt button.handlediv');
 				break;
 			default:
-				$I->scrollTo( 'h1.wp-heading-inline' );
+				$I->scrollTo('h1.wp-heading-inline');
 				break;
 		}
 
 		// Click the Text tab.
-		$I->click( 'button#' . $targetEditor . '-html' );
+		$I->click('button#'.$targetEditor.'-html');
 
 		// Click the QuickTags Button for this shortcode.
-		$I->click( 'input#qt_' . $targetEditor . '_' . $shortcodeProgrammaticName );
+		$I->click('input#qt_'.$targetEditor.'_'.$shortcodeProgrammaticName);
 
 		// Wait for the modal's contents to load.
-		$I->waitForElementVisible( '#convertkit-quicktags-modal input.button-primary' );
+		$I->waitForElementVisible('#convertkit-quicktags-modal input.button-primary');
 
 		// If a shortcode configuration is specified, apply it to the shortcode's modal window now.
-		if ( $shortcodeConfiguration ) {
-			foreach ( $shortcodeConfiguration as $field => $attributes ) {
+		if ($shortcodeConfiguration) {
+			foreach ($shortcodeConfiguration as $field=>$attributes) {
 				// Field ID will be the attribute name, prefixed with tinymce_modal
 				$fieldID = '#tinymce_modal_' . $field;
-
+				
 				// Depending on the field's type, define its value.
-				switch ( $attributes[0] ) {
+				switch ($attributes[0]) {
 					case 'select':
-						$I->selectOption( $fieldID, $attributes[1] );
+						$I->selectOption($fieldID, $attributes[1]);
 						break;
 					case 'toggle':
-						$I->selectOption( $fieldID, $attributes[1] );
+						$I->selectOption($fieldID, $attributes[1]);
 						break;
 					default:
-						$I->fillField( $fieldID, $attributes[1] );
+						$I->fillField($fieldID, $attributes[1]);
 						break;
 				}
 			}
 		}
 
 		// Click the Insert button.
-		$I->click( '#convertkit-quicktags-modal input.button-primary' );
+		$I->click('#convertkit-quicktags-modal input.button-primary');
 
 		// If the expected shortcode output is provided, check it exists in the Text editor.
-		if ( $expectedShortcodeOutput ) {
-			$I->seeInField( 'textarea#' . $targetEditor, $expectedShortcodeOutput );
+		if ($expectedShortcodeOutput) {
+			$I->seeInField('textarea#'.$targetEditor, $expectedShortcodeOutput);
 		}
 	}
 
 	/**
 	 * Adds a link to the given Page, Post or Custom Post Type Name using the Classic Editor's
 	 * link button.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param AcceptanceTester $I    Acceptance Tester.
-	 * @param string           $name Page, Post or Custom Post Type Title/Name to link to.
+	 * 
+	 * @since 	2.0.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 		Acceptance Tester.
+	 * @param 	string 				$name 	Page, Post or Custom Post Type Title/Name to link to.
 	 */
-	public function addClassicEditorLink( $I, $name ) {
+	public function addClassicEditorLink($I, $name)
+	{
 		// Click link button in toolbar.
-		$I->click( 'div.mce-container i.mce-i-link' );
+		$I->click('div.mce-container i.mce-i-link');
 
 		// Enter Product name in search field.
-		$I->waitForElementVisible( 'input.ui-autocomplete-input' );
-		$I->fillField( 'input.ui-autocomplete-input', $name );
-		$I->waitForElementVisible( 'ul.wplink-autocomplete' );
+		$I->waitForElementVisible('input.ui-autocomplete-input');
+		$I->fillField('input.ui-autocomplete-input', $name);
+		$I->waitForElementVisible('ul.wplink-autocomplete');
 
 		// Click the Product name in the search list.
-		$I->click( 'ul.wplink-autocomplete li' );
+		$I->click('ul.wplink-autocomplete li');
 
 		// Press the enter key to insert the link.
-		$I->pressKey( 'input.ui-autocomplete-input', \Facebook\WebDriver\WebDriverKeys::ENTER );
+		$I->pressKey('input.ui-autocomplete-input', \Facebook\WebDriver\WebDriverKeys::ENTER);
 	}
 
 	/**
 	 * Publish a Page, Post or Custom Post Type initiated by the addClassicEditorPage() function,
 	 * loading it on the frontend web site.
-	 *
-	 * @since 1.9.7.5
-	 *
-	 * @param AcceptanceTester $I Acceptance Tester.
+	 * 
+	 * @since 	1.9.7.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
 	 */
-	public function publishAndViewClassicEditorPage( $I ) {
+	public function publishAndViewClassicEditorPage($I)
+	{
 		// Scroll to Publish meta box, so its buttons are not hidden.
-		$I->scrollTo( '#submitdiv' );
-
+		$I->scrollTo('#submitdiv');
+		
 		// Click the Publish button.
-		$I->click( 'input#publish' );
+		$I->click('input#publish');
 
 		// Wait for notice to display.
-		$I->waitForElementVisible( '.notice-success' );
-
+		$I->waitForElementVisible('.notice-success');
+		
 		// Load the Page on the frontend site.
-		$I->click( '.notice-success a' );
+		$I->click('.notice-success a');
 
 		// Wait for frontend web site to load.
-		$I->waitForElementVisible( 'body' );
+		$I->waitForElementVisible('body');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 	}
 }

--- a/tests/_support/Helper/Acceptance/WPClassicEditor.php
+++ b/tests/_support/Helper/Acceptance/WPClassicEditor.php
@@ -7,213 +7,213 @@ namespace Helper\Acceptance;
 
 class WPClassicEditor extends \Codeception\Module
 {
-	/**
-	 * Add a Page, Post or Custom Post Type using the Classic Editor in WordPress.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
-	 */
-	public function addClassicEditorPage($I, $postType = 'page', $title)
-	{
-		// Activate Classic Editor Plugin
-		$I->activateThirdPartyPlugin($I, 'classic-editor');
+    /**
+     * Add a Page, Post or Custom Post Type using the Classic Editor in WordPress.
+     * 
+     * @since 1.9.7.5
+     * 
+     * @param AcceptanceTester $I Acceptance Tester.
+     */
+    public function addClassicEditorPage($I, $postType = 'page', $title)
+    {
+        // Activate Classic Editor Plugin
+        $I->activateThirdPartyPlugin($I, 'classic-editor');
 
-		// Navigate to Post Type (e.g. Pages / Posts) > Add New
-		$I->amOnAdminPage('post-new.php?post_type='.$postType);
+        // Navigate to Post Type (e.g. Pages / Posts) > Add New
+        $I->amOnAdminPage('post-new.php?post_type='.$postType);
 
-		// Define the Title.
-		$I->fillField('#title', $title);
-	}
+        // Define the Title.
+        $I->fillField('#title', $title);
+    }
 
-	/**
-	 * Add the given shortcode when adding or editing a Page, Post or Custom Post Type
-	 * in the Visual Editor (TinyMCE).
-	 * 
-	 * If a shortcode configuration is specified, applies it to the newly added shortcode.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 							Acceptance Tester.
-	 * @param 	string 				$shortcodeName 				Shortcode Name (e.g. 'ConvertKit Form').
-	 * @param 	string 				$shortcodeProgrammaticName 	Programmatic Shortcode Name (e.g. 'convertkit-form').
-	 * @param 	bool|array 			$shortcodeConfiguration 	Shortcode Configuration (field => value key/value array).
-	 * @param 	bool|string 		$expectedShortcodeOutput 	Expected Shortcode Output (e.g. [convertkit_form form="12345"]).
-	 * @param 	string 				$targetEditor				Target TinyMCE editor instance.
-	 */
-	public function addVisualEditorShortcode($I, $shortcodeName, $shortcodeProgrammaticName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false, $targetEditor = 'content')
-	{
-		// Scroll to the applicable TinyMCE editor.
-		switch($targetEditor) {
-			case 'excerpt':
-				$I->scrollTo('#postexcerpt');
-				$I->click('#postexcerpt button.handlediv');
-				break;
-			default:
-				$I->scrollTo('h1.wp-heading-inline');
-				break;
-		}
+    /**
+     * Add the given shortcode when adding or editing a Page, Post or Custom Post Type
+     * in the Visual Editor (TinyMCE).
+     * 
+     * If a shortcode configuration is specified, applies it to the newly added shortcode.
+     * 
+     * @since 1.9.7.5
+     * 
+     * @param AcceptanceTester $I                         Acceptance Tester.
+     * @param string           $shortcodeName             Shortcode Name (e.g. 'ConvertKit Form').
+     * @param string           $shortcodeProgrammaticName Programmatic Shortcode Name (e.g. 'convertkit-form').
+     * @param bool|array       $shortcodeConfiguration    Shortcode Configuration (field => value key/value array).
+     * @param bool|string      $expectedShortcodeOutput   Expected Shortcode Output (e.g. [convertkit_form form="12345"]).
+     * @param string           $targetEditor              Target TinyMCE editor instance.
+     */
+    public function addVisualEditorShortcode($I, $shortcodeName, $shortcodeProgrammaticName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false, $targetEditor = 'content')
+    {
+        // Scroll to the applicable TinyMCE editor.
+        switch($targetEditor) {
+        case 'excerpt':
+            $I->scrollTo('#postexcerpt');
+            $I->click('#postexcerpt button.handlediv');
+            break;
+        default:
+            $I->scrollTo('h1.wp-heading-inline');
+            break;
+        }
 
-		// Click the Visual tab on the applicable TinyMCE editor.
-		$I->click('button#'.$targetEditor.'-tmce');
+        // Click the Visual tab on the applicable TinyMCE editor.
+        $I->click('button#'.$targetEditor.'-tmce');
 
-		// Click the TinyMCE Button for this shortcode.
-		$I->click('#wp-'.$targetEditor.'-editor-container div.mce-container div[aria-label="'.$shortcodeName.'"] button');
+        // Click the TinyMCE Button for this shortcode.
+        $I->click('#wp-'.$targetEditor.'-editor-container div.mce-container div[aria-label="'.$shortcodeName.'"] button');
 
-		// Wait for the modal's contents to load.
-		$I->waitForElementVisible('#convertkit-modal-body input.button-primary');
+        // Wait for the modal's contents to load.
+        $I->waitForElementVisible('#convertkit-modal-body input.button-primary');
 
-		// If a shortcode configuration is specified, apply it to the shortcode's modal window now.
-		if ($shortcodeConfiguration) {
-			foreach ($shortcodeConfiguration as $field=>$attributes) {
-				// Field ID will be the attribute name, prefixed with tinymce_modal
-				$fieldID = '#tinymce_modal_' . $field;
+        // If a shortcode configuration is specified, apply it to the shortcode's modal window now.
+        if ($shortcodeConfiguration) {
+            foreach ($shortcodeConfiguration as $field=>$attributes) {
+                // Field ID will be the attribute name, prefixed with tinymce_modal
+                $fieldID = '#tinymce_modal_' . $field;
 
-				// Depending on the field's type, define its value.
-				switch ($attributes[0]) {
-					case 'select':
-						$I->selectOption('#convertkit-modal-body-body '.$fieldID, $attributes[1]);
-						break;
-					case 'toggle':
-						$I->selectOption('#convertkit-modal-body-body '.$fieldID, $attributes[1]);
-						break;
-					default:
-						$I->fillField('#convertkit-modal-body-body '.$fieldID, $attributes[1]);
-						break;
-				}
-			}
-		}
+                // Depending on the field's type, define its value.
+                switch ($attributes[0]) {
+                case 'select':
+                    $I->selectOption('#convertkit-modal-body-body '.$fieldID, $attributes[1]);
+                    break;
+                case 'toggle':
+                    $I->selectOption('#convertkit-modal-body-body '.$fieldID, $attributes[1]);
+                    break;
+                default:
+                    $I->fillField('#convertkit-modal-body-body '.$fieldID, $attributes[1]);
+                    break;
+                }
+            }
+        }
 
-		// Click the Insert button.
-		$I->click('#convertkit-modal-body input.button-primary');
+        // Click the Insert button.
+        $I->click('#convertkit-modal-body input.button-primary');
 
-		// If the expected shortcode output is provided, check it exists in the Visual editor.
-		if ($expectedShortcodeOutput) {
-			$I->switchToIFrame('iframe#'.$targetEditor.'_ifr');
-			$I->seeInSource($expectedShortcodeOutput);
-			$I->switchToIFrame();
-		}
-	}
+        // If the expected shortcode output is provided, check it exists in the Visual editor.
+        if ($expectedShortcodeOutput) {
+            $I->switchToIFrame('iframe#'.$targetEditor.'_ifr');
+            $I->seeInSource($expectedShortcodeOutput);
+            $I->switchToIFrame();
+        }
+    }
 
-	/**
-	 * Add the given shortcode when adding or editing a Page, Post or Custom Post Type
-	 * in the Text Editor.
-	 * 
-	 * If a shortcode configuration is specified, applies it to the newly added shortcode.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 							Acceptance Tester.
-	 * @param 	string 				$shortcodeName 				Shortcode Name (e.g. 'ConvertKit Form').
-	 * @param 	string 				$shortcodeProgrammaticName 	Programmatic Shortcode Name (e.g. 'convertkit-form').
-	 * @param 	bool|array 			$shortcodeConfiguration 	Shortcode Configuration (field => value key/value array).
-	 * @param 	bool|string 		$expectedShortcodeOutput 	Expected Shortcode Output (e.g. [convertkit_form form="12345"]).
-	 * @param 	string 				$targetEditor				ID of text editor instance.
-	 */
-	public function addTextEditorShortcode($I, $shortcodeName, $shortcodeProgrammaticName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false, $targetEditor = 'content')
-	{
-		// Scroll to the applicable TinyMCE editor.
-		switch($targetEditor) {
-			case 'excerpt':
-				$I->scrollTo('#postexcerpt');
-				$I->click('#postexcerpt button.handlediv');
-				break;
-			default:
-				$I->scrollTo('h1.wp-heading-inline');
-				break;
-		}
+    /**
+     * Add the given shortcode when adding or editing a Page, Post or Custom Post Type
+     * in the Text Editor.
+     * 
+     * If a shortcode configuration is specified, applies it to the newly added shortcode.
+     * 
+     * @since 1.9.7.5
+     * 
+     * @param AcceptanceTester $I                         Acceptance Tester.
+     * @param string           $shortcodeName             Shortcode Name (e.g. 'ConvertKit Form').
+     * @param string           $shortcodeProgrammaticName Programmatic Shortcode Name (e.g. 'convertkit-form').
+     * @param bool|array       $shortcodeConfiguration    Shortcode Configuration (field => value key/value array).
+     * @param bool|string      $expectedShortcodeOutput   Expected Shortcode Output (e.g. [convertkit_form form="12345"]).
+     * @param string           $targetEditor              ID of text editor instance.
+     */
+    public function addTextEditorShortcode($I, $shortcodeName, $shortcodeProgrammaticName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false, $targetEditor = 'content')
+    {
+        // Scroll to the applicable TinyMCE editor.
+        switch($targetEditor) {
+        case 'excerpt':
+            $I->scrollTo('#postexcerpt');
+            $I->click('#postexcerpt button.handlediv');
+            break;
+        default:
+            $I->scrollTo('h1.wp-heading-inline');
+            break;
+        }
 
-		// Click the Text tab.
-		$I->click('button#'.$targetEditor.'-html');
+        // Click the Text tab.
+        $I->click('button#'.$targetEditor.'-html');
 
-		// Click the QuickTags Button for this shortcode.
-		$I->click('input#qt_'.$targetEditor.'_'.$shortcodeProgrammaticName);
+        // Click the QuickTags Button for this shortcode.
+        $I->click('input#qt_'.$targetEditor.'_'.$shortcodeProgrammaticName);
 
-		// Wait for the modal's contents to load.
-		$I->waitForElementVisible('#convertkit-quicktags-modal input.button-primary');
+        // Wait for the modal's contents to load.
+        $I->waitForElementVisible('#convertkit-quicktags-modal input.button-primary');
 
-		// If a shortcode configuration is specified, apply it to the shortcode's modal window now.
-		if ($shortcodeConfiguration) {
-			foreach ($shortcodeConfiguration as $field=>$attributes) {
-				// Field ID will be the attribute name, prefixed with tinymce_modal
-				$fieldID = '#tinymce_modal_' . $field;
+        // If a shortcode configuration is specified, apply it to the shortcode's modal window now.
+        if ($shortcodeConfiguration) {
+            foreach ($shortcodeConfiguration as $field=>$attributes) {
+                // Field ID will be the attribute name, prefixed with tinymce_modal
+                $fieldID = '#tinymce_modal_' . $field;
 				
-				// Depending on the field's type, define its value.
-				switch ($attributes[0]) {
-					case 'select':
-						$I->selectOption($fieldID, $attributes[1]);
-						break;
-					case 'toggle':
-						$I->selectOption($fieldID, $attributes[1]);
-						break;
-					default:
-						$I->fillField($fieldID, $attributes[1]);
-						break;
-				}
-			}
-		}
+                // Depending on the field's type, define its value.
+                switch ($attributes[0]) {
+                case 'select':
+                    $I->selectOption($fieldID, $attributes[1]);
+                    break;
+                case 'toggle':
+                    $I->selectOption($fieldID, $attributes[1]);
+                    break;
+                default:
+                    $I->fillField($fieldID, $attributes[1]);
+                    break;
+                }
+            }
+        }
 
-		// Click the Insert button.
-		$I->click('#convertkit-quicktags-modal input.button-primary');
+        // Click the Insert button.
+        $I->click('#convertkit-quicktags-modal input.button-primary');
 
-		// If the expected shortcode output is provided, check it exists in the Text editor.
-		if ($expectedShortcodeOutput) {
-			$I->seeInField('textarea#'.$targetEditor, $expectedShortcodeOutput);
-		}
-	}
+        // If the expected shortcode output is provided, check it exists in the Text editor.
+        if ($expectedShortcodeOutput) {
+            $I->seeInField('textarea#'.$targetEditor, $expectedShortcodeOutput);
+        }
+    }
 
-	/**
-	 * Adds a link to the given Page, Post or Custom Post Type Name using the Classic Editor's
-	 * link button.
-	 * 
-	 * @since 	2.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 		Acceptance Tester.
-	 * @param 	string 				$name 	Page, Post or Custom Post Type Title/Name to link to.
-	 */
-	public function addClassicEditorLink($I, $name)
-	{
-		// Click link button in toolbar.
-		$I->click('div.mce-container i.mce-i-link');
+    /**
+     * Adds a link to the given Page, Post or Custom Post Type Name using the Classic Editor's
+     * link button.
+     * 
+     * @since 2.0.0
+     * 
+     * @param AcceptanceTester $I    Acceptance Tester.
+     * @param string           $name Page, Post or Custom Post Type Title/Name to link to.
+     */
+    public function addClassicEditorLink($I, $name)
+    {
+        // Click link button in toolbar.
+        $I->click('div.mce-container i.mce-i-link');
 
-		// Enter Product name in search field.
-		$I->waitForElementVisible('input.ui-autocomplete-input');
-		$I->fillField('input.ui-autocomplete-input', $name);
-		$I->waitForElementVisible('ul.wplink-autocomplete');
+        // Enter Product name in search field.
+        $I->waitForElementVisible('input.ui-autocomplete-input');
+        $I->fillField('input.ui-autocomplete-input', $name);
+        $I->waitForElementVisible('ul.wplink-autocomplete');
 
-		// Click the Product name in the search list.
-		$I->click('ul.wplink-autocomplete li');
+        // Click the Product name in the search list.
+        $I->click('ul.wplink-autocomplete li');
 
-		// Press the enter key to insert the link.
-		$I->pressKey('input.ui-autocomplete-input', \Facebook\WebDriver\WebDriverKeys::ENTER);
-	}
+        // Press the enter key to insert the link.
+        $I->pressKey('input.ui-autocomplete-input', \Facebook\WebDriver\WebDriverKeys::ENTER);
+    }
 
-	/**
-	 * Publish a Page, Post or Custom Post Type initiated by the addClassicEditorPage() function,
-	 * loading it on the frontend web site.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
-	 */
-	public function publishAndViewClassicEditorPage($I)
-	{
-		// Scroll to Publish meta box, so its buttons are not hidden.
-		$I->scrollTo('#submitdiv');
+    /**
+     * Publish a Page, Post or Custom Post Type initiated by the addClassicEditorPage() function,
+     * loading it on the frontend web site.
+     * 
+     * @since 1.9.7.5
+     * 
+     * @param AcceptanceTester $I Acceptance Tester.
+     */
+    public function publishAndViewClassicEditorPage($I)
+    {
+        // Scroll to Publish meta box, so its buttons are not hidden.
+        $I->scrollTo('#submitdiv');
 		
-		// Click the Publish button.
-		$I->click('input#publish');
+        // Click the Publish button.
+        $I->click('input#publish');
 
-		// Wait for notice to display.
-		$I->waitForElementVisible('.notice-success');
+        // Wait for notice to display.
+        $I->waitForElementVisible('.notice-success');
 		
-		// Load the Page on the frontend site.
-		$I->click('.notice-success a');
+        // Load the Page on the frontend site.
+        $I->click('.notice-success a');
 
-		// Wait for frontend web site to load.
-		$I->waitForElementVisible('body');
+        // Wait for frontend web site to load.
+        $I->waitForElementVisible('body');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-	}
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
+    }
 }

--- a/tests/_support/Helper/Acceptance/WPClassicEditor.php
+++ b/tests/_support/Helper/Acceptance/WPClassicEditor.php
@@ -5,217 +5,212 @@ namespace Helper\Acceptance;
 // would be used across multiple tests.
 // These are then available in $I->{yourFunctionName}
 
-class WPClassicEditor extends \Codeception\Module
-{
-    /**
-     * Add a Page, Post or Custom Post Type using the Classic Editor in WordPress.
-     * 
-     * @since 1.9.7.5
-     * 
-     * @param AcceptanceTester $I        Acceptance Tester.
-     * @param string           $postType Post Type.
-     * @param string           $title    Post Title.
-     */
-    public function addClassicEditorPage($I, $postType = 'page', $title = 'Classic Editor Title')
-    {
-        // Activate Classic Editor Plugin
-        $I->activateThirdPartyPlugin($I, 'classic-editor');
+class WPClassicEditor extends \Codeception\Module {
 
-        // Navigate to Post Type (e.g. Pages / Posts) > Add New
-        $I->amOnAdminPage('post-new.php?post_type='.$postType);
+	/**
+	 * Add a Page, Post or Custom Post Type using the Classic Editor in WordPress.
+	 *
+	 * @since 1.9.7.5
+	 *
+	 * @param AcceptanceTester $I        Acceptance Tester.
+	 * @param string           $postType Post Type.
+	 * @param string           $title    Post Title.
+	 */
+	public function addClassicEditorPage( $I, $postType = 'page', $title = 'Classic Editor Title' ) {
+		// Activate Classic Editor Plugin
+		$I->activateThirdPartyPlugin( $I, 'classic-editor' );
 
-        // Define the Title.
-        $I->fillField('#title', $title);
-    }
+		// Navigate to Post Type (e.g. Pages / Posts) > Add New
+		$I->amOnAdminPage( 'post-new.php?post_type=' . $postType );
 
-    /**
-     * Add the given shortcode when adding or editing a Page, Post or Custom Post Type
-     * in the Visual Editor (TinyMCE).
-     * 
-     * If a shortcode configuration is specified, applies it to the newly added shortcode.
-     * 
-     * @since 1.9.7.5
-     * 
-     * @param AcceptanceTester $I                         Acceptance Tester.
-     * @param string           $shortcodeName             Shortcode Name (e.g. 'ConvertKit Form').
-     * @param string           $shortcodeProgrammaticName Programmatic Shortcode Name (e.g. 'convertkit-form').
-     * @param bool|array       $shortcodeConfiguration    Shortcode Configuration (field => value key/value array).
-     * @param bool|string      $expectedShortcodeOutput   Expected Shortcode Output (e.g. [convertkit_form form="12345"]).
-     * @param string           $targetEditor              Target TinyMCE editor instance.
-     */
-    public function addVisualEditorShortcode($I, $shortcodeName, $shortcodeProgrammaticName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false, $targetEditor = 'content')
-    {
-        // Scroll to the applicable TinyMCE editor.
-        switch($targetEditor) {
-        case 'excerpt':
-            $I->scrollTo('#postexcerpt');
-            $I->click('#postexcerpt button.handlediv');
-            break;
-        default:
-            $I->scrollTo('h1.wp-heading-inline');
-            break;
-        }
+		// Define the Title.
+		$I->fillField( '#title', $title );
+	}
 
-        // Click the Visual tab on the applicable TinyMCE editor.
-        $I->click('button#'.$targetEditor.'-tmce');
+	/**
+	 * Add the given shortcode when adding or editing a Page, Post or Custom Post Type
+	 * in the Visual Editor (TinyMCE).
+	 *
+	 * If a shortcode configuration is specified, applies it to the newly added shortcode.
+	 *
+	 * @since 1.9.7.5
+	 *
+	 * @param AcceptanceTester $I                         Acceptance Tester.
+	 * @param string           $shortcodeName             Shortcode Name (e.g. 'ConvertKit Form').
+	 * @param string           $shortcodeProgrammaticName Programmatic Shortcode Name (e.g. 'convertkit-form').
+	 * @param bool|array       $shortcodeConfiguration    Shortcode Configuration (field => value key/value array).
+	 * @param bool|string      $expectedShortcodeOutput   Expected Shortcode Output (e.g. [convertkit_form form="12345"]).
+	 * @param string           $targetEditor              Target TinyMCE editor instance.
+	 */
+	public function addVisualEditorShortcode( $I, $shortcodeName, $shortcodeProgrammaticName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false, $targetEditor = 'content' ) {
+		// Scroll to the applicable TinyMCE editor.
+		switch ( $targetEditor ) {
+			case 'excerpt':
+				$I->scrollTo( '#postexcerpt' );
+				$I->click( '#postexcerpt button.handlediv' );
+				break;
+			default:
+				$I->scrollTo( 'h1.wp-heading-inline' );
+				break;
+		}
 
-        // Click the TinyMCE Button for this shortcode.
-        $I->click('#wp-'.$targetEditor.'-editor-container div.mce-container div[aria-label="'.$shortcodeName.'"] button');
+		// Click the Visual tab on the applicable TinyMCE editor.
+		$I->click( 'button#' . $targetEditor . '-tmce' );
 
-        // Wait for the modal's contents to load.
-        $I->waitForElementVisible('#convertkit-modal-body input.button-primary');
+		// Click the TinyMCE Button for this shortcode.
+		$I->click( '#wp-' . $targetEditor . '-editor-container div.mce-container div[aria-label="' . $shortcodeName . '"] button' );
 
-        // If a shortcode configuration is specified, apply it to the shortcode's modal window now.
-        if ($shortcodeConfiguration) {
-            foreach ($shortcodeConfiguration as $field=>$attributes) {
-                // Field ID will be the attribute name, prefixed with tinymce_modal
-                $fieldID = '#tinymce_modal_' . $field;
+		// Wait for the modal's contents to load.
+		$I->waitForElementVisible( '#convertkit-modal-body input.button-primary' );
 
-                // Depending on the field's type, define its value.
-                switch ($attributes[0]) {
-                case 'select':
-                    $I->selectOption('#convertkit-modal-body-body '.$fieldID, $attributes[1]);
-                    break;
-                case 'toggle':
-                    $I->selectOption('#convertkit-modal-body-body '.$fieldID, $attributes[1]);
-                    break;
-                default:
-                    $I->fillField('#convertkit-modal-body-body '.$fieldID, $attributes[1]);
-                    break;
-                }
-            }
-        }
+		// If a shortcode configuration is specified, apply it to the shortcode's modal window now.
+		if ( $shortcodeConfiguration ) {
+			foreach ( $shortcodeConfiguration as $field => $attributes ) {
+				// Field ID will be the attribute name, prefixed with tinymce_modal
+				$fieldID = '#tinymce_modal_' . $field;
 
-        // Click the Insert button.
-        $I->click('#convertkit-modal-body input.button-primary');
+				// Depending on the field's type, define its value.
+				switch ( $attributes[0] ) {
+					case 'select':
+						$I->selectOption( '#convertkit-modal-body-body ' . $fieldID, $attributes[1] );
+						break;
+					case 'toggle':
+						$I->selectOption( '#convertkit-modal-body-body ' . $fieldID, $attributes[1] );
+						break;
+					default:
+						$I->fillField( '#convertkit-modal-body-body ' . $fieldID, $attributes[1] );
+						break;
+				}
+			}
+		}
 
-        // If the expected shortcode output is provided, check it exists in the Visual editor.
-        if ($expectedShortcodeOutput) {
-            $I->switchToIFrame('iframe#'.$targetEditor.'_ifr');
-            $I->seeInSource($expectedShortcodeOutput);
-            $I->switchToIFrame();
-        }
-    }
+		// Click the Insert button.
+		$I->click( '#convertkit-modal-body input.button-primary' );
 
-    /**
-     * Add the given shortcode when adding or editing a Page, Post or Custom Post Type
-     * in the Text Editor.
-     * 
-     * If a shortcode configuration is specified, applies it to the newly added shortcode.
-     * 
-     * @since 1.9.7.5
-     * 
-     * @param AcceptanceTester $I                         Acceptance Tester.
-     * @param string           $shortcodeName             Shortcode Name (e.g. 'ConvertKit Form').
-     * @param string           $shortcodeProgrammaticName Programmatic Shortcode Name (e.g. 'convertkit-form').
-     * @param bool|array       $shortcodeConfiguration    Shortcode Configuration (field => value key/value array).
-     * @param bool|string      $expectedShortcodeOutput   Expected Shortcode Output (e.g. [convertkit_form form="12345"]).
-     * @param string           $targetEditor              ID of text editor instance.
-     */
-    public function addTextEditorShortcode($I, $shortcodeName, $shortcodeProgrammaticName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false, $targetEditor = 'content')
-    {
-        // Scroll to the applicable TinyMCE editor.
-        switch($targetEditor) {
-        case 'excerpt':
-            $I->scrollTo('#postexcerpt');
-            $I->click('#postexcerpt button.handlediv');
-            break;
-        default:
-            $I->scrollTo('h1.wp-heading-inline');
-            break;
-        }
+		// If the expected shortcode output is provided, check it exists in the Visual editor.
+		if ( $expectedShortcodeOutput ) {
+			$I->switchToIFrame( 'iframe#' . $targetEditor . '_ifr' );
+			$I->seeInSource( $expectedShortcodeOutput );
+			$I->switchToIFrame();
+		}
+	}
 
-        // Click the Text tab.
-        $I->click('button#'.$targetEditor.'-html');
+	/**
+	 * Add the given shortcode when adding or editing a Page, Post or Custom Post Type
+	 * in the Text Editor.
+	 *
+	 * If a shortcode configuration is specified, applies it to the newly added shortcode.
+	 *
+	 * @since 1.9.7.5
+	 *
+	 * @param AcceptanceTester $I                         Acceptance Tester.
+	 * @param string           $shortcodeName             Shortcode Name (e.g. 'ConvertKit Form').
+	 * @param string           $shortcodeProgrammaticName Programmatic Shortcode Name (e.g. 'convertkit-form').
+	 * @param bool|array       $shortcodeConfiguration    Shortcode Configuration (field => value key/value array).
+	 * @param bool|string      $expectedShortcodeOutput   Expected Shortcode Output (e.g. [convertkit_form form="12345"]).
+	 * @param string           $targetEditor              ID of text editor instance.
+	 */
+	public function addTextEditorShortcode( $I, $shortcodeName, $shortcodeProgrammaticName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false, $targetEditor = 'content' ) {
+		// Scroll to the applicable TinyMCE editor.
+		switch ( $targetEditor ) {
+			case 'excerpt':
+				$I->scrollTo( '#postexcerpt' );
+				$I->click( '#postexcerpt button.handlediv' );
+				break;
+			default:
+				$I->scrollTo( 'h1.wp-heading-inline' );
+				break;
+		}
 
-        // Click the QuickTags Button for this shortcode.
-        $I->click('input#qt_'.$targetEditor.'_'.$shortcodeProgrammaticName);
+		// Click the Text tab.
+		$I->click( 'button#' . $targetEditor . '-html' );
 
-        // Wait for the modal's contents to load.
-        $I->waitForElementVisible('#convertkit-quicktags-modal input.button-primary');
+		// Click the QuickTags Button for this shortcode.
+		$I->click( 'input#qt_' . $targetEditor . '_' . $shortcodeProgrammaticName );
 
-        // If a shortcode configuration is specified, apply it to the shortcode's modal window now.
-        if ($shortcodeConfiguration) {
-            foreach ($shortcodeConfiguration as $field=>$attributes) {
-                // Field ID will be the attribute name, prefixed with tinymce_modal
-                $fieldID = '#tinymce_modal_' . $field;
-				
-                // Depending on the field's type, define its value.
-                switch ($attributes[0]) {
-                case 'select':
-                    $I->selectOption($fieldID, $attributes[1]);
-                    break;
-                case 'toggle':
-                    $I->selectOption($fieldID, $attributes[1]);
-                    break;
-                default:
-                    $I->fillField($fieldID, $attributes[1]);
-                    break;
-                }
-            }
-        }
+		// Wait for the modal's contents to load.
+		$I->waitForElementVisible( '#convertkit-quicktags-modal input.button-primary' );
 
-        // Click the Insert button.
-        $I->click('#convertkit-quicktags-modal input.button-primary');
+		// If a shortcode configuration is specified, apply it to the shortcode's modal window now.
+		if ( $shortcodeConfiguration ) {
+			foreach ( $shortcodeConfiguration as $field => $attributes ) {
+				// Field ID will be the attribute name, prefixed with tinymce_modal
+				$fieldID = '#tinymce_modal_' . $field;
 
-        // If the expected shortcode output is provided, check it exists in the Text editor.
-        if ($expectedShortcodeOutput) {
-            $I->seeInField('textarea#'.$targetEditor, $expectedShortcodeOutput);
-        }
-    }
+				// Depending on the field's type, define its value.
+				switch ( $attributes[0] ) {
+					case 'select':
+						$I->selectOption( $fieldID, $attributes[1] );
+						break;
+					case 'toggle':
+						$I->selectOption( $fieldID, $attributes[1] );
+						break;
+					default:
+						$I->fillField( $fieldID, $attributes[1] );
+						break;
+				}
+			}
+		}
 
-    /**
-     * Adds a link to the given Page, Post or Custom Post Type Name using the Classic Editor's
-     * link button.
-     * 
-     * @since 2.0.0
-     * 
-     * @param AcceptanceTester $I    Acceptance Tester.
-     * @param string           $name Page, Post or Custom Post Type Title/Name to link to.
-     */
-    public function addClassicEditorLink($I, $name)
-    {
-        // Click link button in toolbar.
-        $I->click('div.mce-container i.mce-i-link');
+		// Click the Insert button.
+		$I->click( '#convertkit-quicktags-modal input.button-primary' );
 
-        // Enter Product name in search field.
-        $I->waitForElementVisible('input.ui-autocomplete-input');
-        $I->fillField('input.ui-autocomplete-input', $name);
-        $I->waitForElementVisible('ul.wplink-autocomplete');
+		// If the expected shortcode output is provided, check it exists in the Text editor.
+		if ( $expectedShortcodeOutput ) {
+			$I->seeInField( 'textarea#' . $targetEditor, $expectedShortcodeOutput );
+		}
+	}
 
-        // Click the Product name in the search list.
-        $I->click('ul.wplink-autocomplete li');
+	/**
+	 * Adds a link to the given Page, Post or Custom Post Type Name using the Classic Editor's
+	 * link button.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param AcceptanceTester $I    Acceptance Tester.
+	 * @param string           $name Page, Post or Custom Post Type Title/Name to link to.
+	 */
+	public function addClassicEditorLink( $I, $name ) {
+		// Click link button in toolbar.
+		$I->click( 'div.mce-container i.mce-i-link' );
 
-        // Press the enter key to insert the link.
-        $I->pressKey('input.ui-autocomplete-input', \Facebook\WebDriver\WebDriverKeys::ENTER);
-    }
+		// Enter Product name in search field.
+		$I->waitForElementVisible( 'input.ui-autocomplete-input' );
+		$I->fillField( 'input.ui-autocomplete-input', $name );
+		$I->waitForElementVisible( 'ul.wplink-autocomplete' );
 
-    /**
-     * Publish a Page, Post or Custom Post Type initiated by the addClassicEditorPage() function,
-     * loading it on the frontend web site.
-     * 
-     * @since 1.9.7.5
-     * 
-     * @param AcceptanceTester $I Acceptance Tester.
-     */
-    public function publishAndViewClassicEditorPage($I)
-    {
-        // Scroll to Publish meta box, so its buttons are not hidden.
-        $I->scrollTo('#submitdiv');
-		
-        // Click the Publish button.
-        $I->click('input#publish');
+		// Click the Product name in the search list.
+		$I->click( 'ul.wplink-autocomplete li' );
 
-        // Wait for notice to display.
-        $I->waitForElementVisible('.notice-success');
-		
-        // Load the Page on the frontend site.
-        $I->click('.notice-success a');
+		// Press the enter key to insert the link.
+		$I->pressKey( 'input.ui-autocomplete-input', \Facebook\WebDriver\WebDriverKeys::ENTER );
+	}
 
-        // Wait for frontend web site to load.
-        $I->waitForElementVisible('body');
+	/**
+	 * Publish a Page, Post or Custom Post Type initiated by the addClassicEditorPage() function,
+	 * loading it on the frontend web site.
+	 *
+	 * @since 1.9.7.5
+	 *
+	 * @param AcceptanceTester $I Acceptance Tester.
+	 */
+	public function publishAndViewClassicEditorPage( $I ) {
+		// Scroll to Publish meta box, so its buttons are not hidden.
+		$I->scrollTo( '#submitdiv' );
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-    }
+		// Click the Publish button.
+		$I->click( 'input#publish' );
+
+		// Wait for notice to display.
+		$I->waitForElementVisible( '.notice-success' );
+
+		// Load the Page on the frontend site.
+		$I->click( '.notice-success a' );
+
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible( 'body' );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+	}
 }

--- a/tests/_support/Helper/Acceptance/WPClassicEditor.php
+++ b/tests/_support/Helper/Acceptance/WPClassicEditor.php
@@ -9,10 +9,10 @@ class WPClassicEditor extends \Codeception\Module
 {
 	/**
 	 * Add a Page, Post or Custom Post Type using the Classic Editor in WordPress.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
+	 *
+	 * @since   1.9.7.5
+	 *
+	 * @param   AcceptanceTester $I                      Acceptance Tester.
 	 */
 	public function addClassicEditorPage($I, $postType = 'page', $title)
 	{
@@ -20,7 +20,7 @@ class WPClassicEditor extends \Codeception\Module
 		$I->activateThirdPartyPlugin($I, 'classic-editor');
 
 		// Navigate to Post Type (e.g. Pages / Posts) > Add New
-		$I->amOnAdminPage('post-new.php?post_type='.$postType);
+		$I->amOnAdminPage('post-new.php?post_type=' . $postType);
 
 		// Define the Title.
 		$I->fillField('#title', $title);
@@ -29,22 +29,22 @@ class WPClassicEditor extends \Codeception\Module
 	/**
 	 * Add the given shortcode when adding or editing a Page, Post or Custom Post Type
 	 * in the Visual Editor (TinyMCE).
-	 * 
+	 *
 	 * If a shortcode configuration is specified, applies it to the newly added shortcode.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 							Acceptance Tester.
-	 * @param 	string 				$shortcodeName 				Shortcode Name (e.g. 'ConvertKit Form').
-	 * @param 	string 				$shortcodeProgrammaticName 	Programmatic Shortcode Name (e.g. 'convertkit-form').
-	 * @param 	bool|array 			$shortcodeConfiguration 	Shortcode Configuration (field => value key/value array).
-	 * @param 	bool|string 		$expectedShortcodeOutput 	Expected Shortcode Output (e.g. [convertkit_form form="12345"]).
-	 * @param 	string 				$targetEditor				Target TinyMCE editor instance.
+	 *
+	 * @since   1.9.7.5
+	 *
+	 * @param   AcceptanceTester $I                          Acceptance Tester.
+	 * @param   string           $shortcodeName              Shortcode Name (e.g. 'ConvertKit Form').
+	 * @param   string           $shortcodeProgrammaticName  Programmatic Shortcode Name (e.g. 'convertkit-form').
+	 * @param   bool|array       $shortcodeConfiguration     Shortcode Configuration (field => value key/value array).
+	 * @param   bool|string      $expectedShortcodeOutput    Expected Shortcode Output (e.g. [convertkit_form form="12345"]).
+	 * @param   string           $targetEditor               Target TinyMCE editor instance.
 	 */
 	public function addVisualEditorShortcode($I, $shortcodeName, $shortcodeProgrammaticName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false, $targetEditor = 'content')
 	{
 		// Scroll to the applicable TinyMCE editor.
-		switch($targetEditor) {
+		switch ($targetEditor) {
 			case 'excerpt':
 				$I->scrollTo('#postexcerpt');
 				$I->click('#postexcerpt button.handlediv');
@@ -55,30 +55,30 @@ class WPClassicEditor extends \Codeception\Module
 		}
 
 		// Click the Visual tab on the applicable TinyMCE editor.
-		$I->click('button#'.$targetEditor.'-tmce');
+		$I->click('button#' . $targetEditor . '-tmce');
 
 		// Click the TinyMCE Button for this shortcode.
-		$I->click('#wp-'.$targetEditor.'-editor-container div.mce-container div[aria-label="'.$shortcodeName.'"] button');
+		$I->click('#wp-' . $targetEditor . '-editor-container div.mce-container div[aria-label="' . $shortcodeName . '"] button');
 
 		// Wait for the modal's contents to load.
 		$I->waitForElementVisible('#convertkit-modal-body input.button-primary');
 
 		// If a shortcode configuration is specified, apply it to the shortcode's modal window now.
 		if ($shortcodeConfiguration) {
-			foreach ($shortcodeConfiguration as $field=>$attributes) {
+			foreach ($shortcodeConfiguration as $field => $attributes) {
 				// Field ID will be the attribute name, prefixed with tinymce_modal
 				$fieldID = '#tinymce_modal_' . $field;
 
 				// Depending on the field's type, define its value.
 				switch ($attributes[0]) {
 					case 'select':
-						$I->selectOption('#convertkit-modal-body-body '.$fieldID, $attributes[1]);
+						$I->selectOption('#convertkit-modal-body-body ' . $fieldID, $attributes[1]);
 						break;
 					case 'toggle':
-						$I->selectOption('#convertkit-modal-body-body '.$fieldID, $attributes[1]);
+						$I->selectOption('#convertkit-modal-body-body ' . $fieldID, $attributes[1]);
 						break;
 					default:
-						$I->fillField('#convertkit-modal-body-body '.$fieldID, $attributes[1]);
+						$I->fillField('#convertkit-modal-body-body ' . $fieldID, $attributes[1]);
 						break;
 				}
 			}
@@ -89,7 +89,7 @@ class WPClassicEditor extends \Codeception\Module
 
 		// If the expected shortcode output is provided, check it exists in the Visual editor.
 		if ($expectedShortcodeOutput) {
-			$I->switchToIFrame('iframe#'.$targetEditor.'_ifr');
+			$I->switchToIFrame('iframe#' . $targetEditor . '_ifr');
 			$I->seeInSource($expectedShortcodeOutput);
 			$I->switchToIFrame();
 		}
@@ -98,22 +98,22 @@ class WPClassicEditor extends \Codeception\Module
 	/**
 	 * Add the given shortcode when adding or editing a Page, Post or Custom Post Type
 	 * in the Text Editor.
-	 * 
+	 *
 	 * If a shortcode configuration is specified, applies it to the newly added shortcode.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 							Acceptance Tester.
-	 * @param 	string 				$shortcodeName 				Shortcode Name (e.g. 'ConvertKit Form').
-	 * @param 	string 				$shortcodeProgrammaticName 	Programmatic Shortcode Name (e.g. 'convertkit-form').
-	 * @param 	bool|array 			$shortcodeConfiguration 	Shortcode Configuration (field => value key/value array).
-	 * @param 	bool|string 		$expectedShortcodeOutput 	Expected Shortcode Output (e.g. [convertkit_form form="12345"]).
-	 * @param 	string 				$targetEditor				ID of text editor instance.
+	 *
+	 * @since   1.9.7.5
+	 *
+	 * @param   AcceptanceTester $I                          Acceptance Tester.
+	 * @param   string           $shortcodeName              Shortcode Name (e.g. 'ConvertKit Form').
+	 * @param   string           $shortcodeProgrammaticName  Programmatic Shortcode Name (e.g. 'convertkit-form').
+	 * @param   bool|array       $shortcodeConfiguration     Shortcode Configuration (field => value key/value array).
+	 * @param   bool|string      $expectedShortcodeOutput    Expected Shortcode Output (e.g. [convertkit_form form="12345"]).
+	 * @param   string           $targetEditor               ID of text editor instance.
 	 */
 	public function addTextEditorShortcode($I, $shortcodeName, $shortcodeProgrammaticName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false, $targetEditor = 'content')
 	{
 		// Scroll to the applicable TinyMCE editor.
-		switch($targetEditor) {
+		switch ($targetEditor) {
 			case 'excerpt':
 				$I->scrollTo('#postexcerpt');
 				$I->click('#postexcerpt button.handlediv');
@@ -124,20 +124,20 @@ class WPClassicEditor extends \Codeception\Module
 		}
 
 		// Click the Text tab.
-		$I->click('button#'.$targetEditor.'-html');
+		$I->click('button#' . $targetEditor . '-html');
 
 		// Click the QuickTags Button for this shortcode.
-		$I->click('input#qt_'.$targetEditor.'_'.$shortcodeProgrammaticName);
+		$I->click('input#qt_' . $targetEditor . '_' . $shortcodeProgrammaticName);
 
 		// Wait for the modal's contents to load.
 		$I->waitForElementVisible('#convertkit-quicktags-modal input.button-primary');
 
 		// If a shortcode configuration is specified, apply it to the shortcode's modal window now.
 		if ($shortcodeConfiguration) {
-			foreach ($shortcodeConfiguration as $field=>$attributes) {
+			foreach ($shortcodeConfiguration as $field => $attributes) {
 				// Field ID will be the attribute name, prefixed with tinymce_modal
 				$fieldID = '#tinymce_modal_' . $field;
-				
+
 				// Depending on the field's type, define its value.
 				switch ($attributes[0]) {
 					case 'select':
@@ -158,18 +158,18 @@ class WPClassicEditor extends \Codeception\Module
 
 		// If the expected shortcode output is provided, check it exists in the Text editor.
 		if ($expectedShortcodeOutput) {
-			$I->seeInField('textarea#'.$targetEditor, $expectedShortcodeOutput);
+			$I->seeInField('textarea#' . $targetEditor, $expectedShortcodeOutput);
 		}
 	}
 
 	/**
 	 * Adds a link to the given Page, Post or Custom Post Type Name using the Classic Editor's
 	 * link button.
-	 * 
-	 * @since 	2.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 		Acceptance Tester.
-	 * @param 	string 				$name 	Page, Post or Custom Post Type Title/Name to link to.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @param   AcceptanceTester $I      Acceptance Tester.
+	 * @param   string           $name   Page, Post or Custom Post Type Title/Name to link to.
 	 */
 	public function addClassicEditorLink($I, $name)
 	{
@@ -191,22 +191,22 @@ class WPClassicEditor extends \Codeception\Module
 	/**
 	 * Publish a Page, Post or Custom Post Type initiated by the addClassicEditorPage() function,
 	 * loading it on the frontend web site.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
+	 *
+	 * @since   1.9.7.5
+	 *
+	 * @param   AcceptanceTester $I                      Acceptance Tester.
 	 */
 	public function publishAndViewClassicEditorPage($I)
 	{
 		// Scroll to Publish meta box, so its buttons are not hidden.
 		$I->scrollTo('#submitdiv');
-		
+
 		// Click the Publish button.
 		$I->click('input#publish');
 
 		// Wait for notice to display.
 		$I->waitForElementVisible('.notice-success');
-		
+
 		// Load the Page on the frontend site.
 		$I->click('.notice-success a');
 

--- a/tests/_support/Helper/Acceptance/WPGutenberg.php
+++ b/tests/_support/Helper/Acceptance/WPGutenberg.php
@@ -5,240 +5,234 @@ namespace Helper\Acceptance;
 // would be used across multiple tests.
 // These are then available in $I->{yourFunctionName}
 
-class WPGutenberg extends \Codeception\Module
-{
-    /**
-     * Helper method to close the Gutenberg "Welcome to the block editor" dialog, which
-     * might show for each Page/Post test performed due to there being no persistence
-     * remembering that the user dismissed the dialog.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Acceptance Tester.
-     */
-    public function maybeCloseGutenbergWelcomeModal($I)
-    {
-        try {
-            $I->performOn(
-                '.components-modal__screen-overlay', [
-                'click' => '.components-modal__screen-overlay .components-modal__header button.components-button'
-                ], 3
-            );
-        } catch ( \Facebook\WebDriver\Exception\TimeoutException $e ) {
-        }
-    }
+class WPGutenberg extends \Codeception\Module {
 
-    /**
-     * Add a Page, Post or Custom Post Type using Gutenberg in WordPress.
-     * 
-     * @since 1.9.7.5
-     * 
-     * @param AcceptanceTester $I        Acceptance Tester.
-     * @param string           $postType Post Type.
-     * @param string           $title    Post Title.
-     */
-    public function addGutenbergPage($I, $postType = 'page', $title = 'Gutenberg Page')
-    {
-        // Navigate to Post Type (e.g. Pages / Posts) > Add New
-        $I->amOnAdminPage('post-new.php?post_type='.$postType);
+	/**
+	 * Helper method to close the Gutenberg "Welcome to the block editor" dialog, which
+	 * might show for each Page/Post test performed due to there being no persistence
+	 * remembering that the user dismissed the dialog.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Acceptance Tester.
+	 */
+	public function maybeCloseGutenbergWelcomeModal( $I ) {
+		try {
+			$I->performOn(
+				'.components-modal__screen-overlay',
+				array(
+					'click' => '.components-modal__screen-overlay .components-modal__header button.components-button',
+				),
+				3
+			);
+		} catch ( \Facebook\WebDriver\Exception\TimeoutException $e ) {
+		}
+	}
 
-        // Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
-        $I->maybeCloseGutenbergWelcomeModal($I);
+	/**
+	 * Add a Page, Post or Custom Post Type using Gutenberg in WordPress.
+	 *
+	 * @since 1.9.7.5
+	 *
+	 * @param AcceptanceTester $I        Acceptance Tester.
+	 * @param string           $postType Post Type.
+	 * @param string           $title    Post Title.
+	 */
+	public function addGutenbergPage( $I, $postType = 'page', $title = 'Gutenberg Page' ) {
+		// Navigate to Post Type (e.g. Pages / Posts) > Add New
+		$I->amOnAdminPage( 'post-new.php?post_type=' . $postType );
 
-        // Define the Title.
-        $I->fillField('.editor-post-title__input', $title);
-    }
+		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
+		$I->maybeCloseGutenbergWelcomeModal( $I );
 
-    /**
-     * Add the given block when adding or editing a Page, Post or Custom Post Type
-     * in Gutenberg.
-     * 
-     * If a block configuration is specified, applies it to the newly added block.
-     * 
-     * @since 1.9.7.4
-     * 
-     * @param AcceptanceTester $I                     Acceptance Tester.
-     * @param string           $blockName             Block Name (e.g. 'ConvertKit Form').
-     * @param string           $blockProgrammaticName Programmatic Block Name (e.g. 'convertkit-form').
-     * @param bool|array       $blockConfiguration    Block Configuration (field => value key/value array).
-     */
-    public function addGutenbergBlock($I, $blockName, $blockProgrammaticName, $blockConfiguration = false)
-    {
-        // Click Add Block Button.
-        $I->click('button.edit-post-header-toolbar__inserter-toggle');
+		// Define the Title.
+		$I->fillField( '.editor-post-title__input', $title );
+	}
 
-        // When the Blocks sidebar appears, search for the block.
-        $I->waitForElementVisible('.interface-interface-skeleton__secondary-sidebar[aria-label="Block Library"]');
-        $I->fillField('.block-editor-inserter__content input[type=search]', $blockName);
-        $I->seeElementInDOM('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
-        $I->click('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
+	/**
+	 * Add the given block when adding or editing a Page, Post or Custom Post Type
+	 * in Gutenberg.
+	 *
+	 * If a block configuration is specified, applies it to the newly added block.
+	 *
+	 * @since 1.9.7.4
+	 *
+	 * @param AcceptanceTester $I                     Acceptance Tester.
+	 * @param string           $blockName             Block Name (e.g. 'ConvertKit Form').
+	 * @param string           $blockProgrammaticName Programmatic Block Name (e.g. 'convertkit-form').
+	 * @param bool|array       $blockConfiguration    Block Configuration (field => value key/value array).
+	 */
+	public function addGutenbergBlock( $I, $blockName, $blockProgrammaticName, $blockConfiguration = false ) {
+		// Click Add Block Button.
+		$I->click( 'button.edit-post-header-toolbar__inserter-toggle' );
 
-        // If a Block configuration is specified, apply it to the Block now.
-        if ($blockConfiguration) {
-            $I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
-            foreach ($blockConfiguration as $field=>$attributes) {
-                // Field ID will be block's programmatic name with underscores instead of hyphens,
-                // followed by the attribute name.
-                $fieldID = '#' . str_replace('-', '_', $blockProgrammaticName) . '_' . $field;
-				
-                // Depending on the field's type, define its value.
-                switch ($attributes[0]) {
-                case 'select':
-                    $I->selectOption($fieldID, $attributes[1]);
-                    break;
-                case 'toggle':
-                    $I->click($field);
-                    break;
-                default:
-                    $I->fillField($fieldID, $attributes[1]);
-                    break;
-                }
-            }
-        }
-    }
+		// When the Blocks sidebar appears, search for the block.
+		$I->waitForElementVisible( '.interface-interface-skeleton__secondary-sidebar[aria-label="Block Library"]' );
+		$I->fillField( '.block-editor-inserter__content input[type=search]', $blockName );
+		$I->seeElementInDOM( '.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName );
+		$I->click( '.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName );
 
-    /**
-     * Adds a paragraph block when adding or editing a Page, Post or Custom Post Type
-     * in Gutenberg.
-     * 
-     * @since 2.0.0
-     * 
-     * @param AcceptanceTester $I    Acceptance Tester.
-     * @param string           $text Paragraph Text.
-     */
-    public function addGutenbergParagraphBlock($I, $text)
-    {
-        $I->click('.is-root-container');
-        $I->fillField('.is-root-container p', $text);
-    }
+		// If a Block configuration is specified, apply it to the Block now.
+		if ( $blockConfiguration ) {
+			$I->waitForElementVisible( '.interface-interface-skeleton__sidebar[aria-label="Editor settings"]' );
+			foreach ( $blockConfiguration as $field => $attributes ) {
+				// Field ID will be block's programmatic name with underscores instead of hyphens,
+				// followed by the attribute name.
+				$fieldID = '#' . str_replace( '-', '_', $blockProgrammaticName ) . '_' . $field;
 
-    /**
-     * Adds a link to the given Page, Post or Custom Post Type Name in the last paragraph in the Gutenberg
-     * editor.
-     * 
-     * @since 2.0.0
-     * 
-     * @param AcceptanceTester $I    Acceptance Tester.
-     * @param string           $name Page, Post or Custom Post Type Title/Name to link to.
-     */
-    public function addGutenbergLinkToParagraph($I, $name)
-    {
-        // Focus away from paragraph and then back to the paragraph, so that the block toolbar displays.
-        $I->click('div.edit-post-visual-editor__post-title-wrapper h1');
-        $I->click('.is-root-container p');
-        $I->waitForElementVisible('.is-root-container p.is-selected');
+				// Depending on the field's type, define its value.
+				switch ( $attributes[0] ) {
+					case 'select':
+						$I->selectOption( $fieldID, $attributes[1] );
+						break;
+					case 'toggle':
+						$I->click( $field );
+						break;
+					default:
+						$I->fillField( $fieldID, $attributes[1] );
+						break;
+				}
+			}
+		}
+	}
 
-        // Insert link via block toolbar.
-        $this->insertGutenbergLink($I, $name);
+	/**
+	 * Adds a paragraph block when adding or editing a Page, Post or Custom Post Type
+	 * in Gutenberg.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param AcceptanceTester $I    Acceptance Tester.
+	 * @param string           $text Paragraph Text.
+	 */
+	public function addGutenbergParagraphBlock( $I, $text ) {
+		$I->click( '.is-root-container' );
+		$I->fillField( '.is-root-container p', $text );
+	}
 
-        // Confirm that the Product text exists in the paragraph.
-        $I->see($name, '.is-root-container p.is-selected');
-    }
+	/**
+	 * Adds a link to the given Page, Post or Custom Post Type Name in the last paragraph in the Gutenberg
+	 * editor.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param AcceptanceTester $I    Acceptance Tester.
+	 * @param string           $name Page, Post or Custom Post Type Title/Name to link to.
+	 */
+	public function addGutenbergLinkToParagraph( $I, $name ) {
+		// Focus away from paragraph and then back to the paragraph, so that the block toolbar displays.
+		$I->click( 'div.edit-post-visual-editor__post-title-wrapper h1' );
+		$I->click( '.is-root-container p' );
+		$I->waitForElementVisible( '.is-root-container p.is-selected' );
 
-    /**
-     * Adds a link to the given Page, Post or Custom Post Type Name in the selected Button block
-     * in the Gutenberg editor.
-     * 
-     * @since 2.0.0
-     * 
-     * @param AcceptanceTester $I    Acceptance Tester.
-     * @param string           $name Page, Post or Custom Post Type Title/Name to link to.
-     */
-    public function addGutenbergLinkToButton($I, $name)
-    {
-        // Enter text.
-        $I->fillField('.is-root-container .wp-block-button .block-editor-rich-text__editable', $name);
+		// Insert link via block toolbar.
+		$this->insertGutenbergLink( $I, $name );
 
-        // Focus away from button and then back to the button, so that the block toolbar displays.
-        $I->click('div.edit-post-visual-editor__post-title-wrapper h1');
-        $I->click('.is-root-container .wp-block-button');
-        $I->waitForElementVisible('.is-root-container div.is-selected');
+		// Confirm that the Product text exists in the paragraph.
+		$I->see( $name, '.is-root-container p.is-selected' );
+	}
 
-        // Insert link via block toolbar.
-        $this->insertGutenbergLink($I, $name);
+	/**
+	 * Adds a link to the given Page, Post or Custom Post Type Name in the selected Button block
+	 * in the Gutenberg editor.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param AcceptanceTester $I    Acceptance Tester.
+	 * @param string           $name Page, Post or Custom Post Type Title/Name to link to.
+	 */
+	public function addGutenbergLinkToButton( $I, $name ) {
+		// Enter text.
+		$I->fillField( '.is-root-container .wp-block-button .block-editor-rich-text__editable', $name );
 
-        // Confirm that the Product text exists in the button.
-        $I->see($name, '.is-root-container .wp-block-button');
-    }
+		// Focus away from button and then back to the button, so that the block toolbar displays.
+		$I->click( 'div.edit-post-visual-editor__post-title-wrapper h1' );
+		$I->click( '.is-root-container .wp-block-button' );
+		$I->waitForElementVisible( '.is-root-container div.is-selected' );
 
-    /**
-     * Helper method to insert a link into the selected element, by:
-     * - clicking the link button in the selected block's toolbar,
-     * - searching for the Page, Post or Custom Post Type,
-     * - clicking the matched result to insert the link and text.
-     * 
-     * The block must be selected in Gutenberg prior to calling this function.
-     * 
-     * @since 2.0.0
-     * 
-     * @param AcceptanceTester $I    Acceptance Tester.
-     * @param string           $name Page, Post or Custom Post Type Title/Name to link to.
-     */
-    private function insertGutenbergLink($I, $name)
-    {
-        // Click link button in block toolbar.
-        $I->waitForElementVisible('.block-editor-block-toolbar button[aria-label="Link"]');
-        $I->click('.block-editor-block-toolbar button[aria-label="Link"]');
+		// Insert link via block toolbar.
+		$this->insertGutenbergLink( $I, $name );
 
-        // Enter Product name in search field.
-        $I->waitForElementVisible('.block-editor-link-control__search-input-wrapper input.block-editor-url-input__input');
-        $I->fillField('.block-editor-link-control__search-input-wrapper input.block-editor-url-input__input', $name);
-        $I->waitForElementVisible('.block-editor-link-control__search-results-wrapper');
-        $I->see($name);
+		// Confirm that the Product text exists in the button.
+		$I->see( $name, '.is-root-container .wp-block-button' );
+	}
 
-        // Click the Product name to create a link to it.
-        $I->click($name, '.block-editor-link-control__search-results');
-    }
+	/**
+	 * Helper method to insert a link into the selected element, by:
+	 * - clicking the link button in the selected block's toolbar,
+	 * - searching for the Page, Post or Custom Post Type,
+	 * - clicking the matched result to insert the link and text.
+	 *
+	 * The block must be selected in Gutenberg prior to calling this function.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param AcceptanceTester $I    Acceptance Tester.
+	 * @param string           $name Page, Post or Custom Post Type Title/Name to link to.
+	 */
+	private function insertGutenbergLink( $I, $name ) {
+		// Click link button in block toolbar.
+		$I->waitForElementVisible( '.block-editor-block-toolbar button[aria-label="Link"]' );
+		$I->click( '.block-editor-block-toolbar button[aria-label="Link"]' );
 
-    /**
-     * Check that the given block did not output any errors when rendered in the
-     * Gutenberg editor.
-     * 
-     * @since 1.9.7.4
-     * 
-     * @param AcceptanceTester $I         Acceptance Tester.
-     * @param string           $blockName Block Name (e.g. 'ConvertKit Form')
-     */
-    public function checkGutenbergBlockHasNoErrors($I, $blockName)
-    {
-        // Wait a couple of seconds for the block to render.
-        // @TODO Improve this method.
-        sleep(2);
+		// Enter Product name in search field.
+		$I->waitForElementVisible( '.block-editor-link-control__search-input-wrapper input.block-editor-url-input__input' );
+		$I->fillField( '.block-editor-link-control__search-input-wrapper input.block-editor-url-input__input', $name );
+		$I->waitForElementVisible( '.block-editor-link-control__search-results-wrapper' );
+		$I->see( $name );
 
-        // Check that the "This block has encountered an error and cannot be previewed." element doesn't exist.
-        $I->dontSeeElementInDOM('.block-editor-block-list__layout div[data-title="'.$blockName.'"] .block-editor-block-list__block-crash-warning');
-    }
+		// Click the Product name to create a link to it.
+		$I->click( $name, '.block-editor-link-control__search-results' );
+	}
 
-    /**
-     * Publish a Page, Post or Custom Post Type initiated by the addGutenbergPage() function,
-     * loading it on the frontend web site.
-     * 
-     * @since 1.9.7.5
-     * 
-     * @param AcceptanceTester $I Acceptance Tester.
-     */
-    public function publishAndViewGutenbergPage($I)
-    {
-        // Click the Publish button.
-        $I->click('.editor-post-publish-button__button');
-		
-        // When the pre-publish panel displays, click Publish again.
-        $I->performOn(
-            '.editor-post-publish-panel__prepublish', function ($I) {
-                $I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');    
-            }
-        );
+	/**
+	 * Check that the given block did not output any errors when rendered in the
+	 * Gutenberg editor.
+	 *
+	 * @since 1.9.7.4
+	 *
+	 * @param AcceptanceTester $I         Acceptance Tester.
+	 * @param string           $blockName Block Name (e.g. 'ConvertKit Form')
+	 */
+	public function checkGutenbergBlockHasNoErrors( $I, $blockName ) {
+		// Wait a couple of seconds for the block to render.
+		// @TODO Improve this method.
+		sleep( 2 );
 
-        // Wait for confirmation that the Page published.
-        $I->waitForElementVisible('.post-publish-panel__postpublish-buttons a.components-button');
+		// Check that the "This block has encountered an error and cannot be previewed." element doesn't exist.
+		$I->dontSeeElementInDOM( '.block-editor-block-list__layout div[data-title="' . $blockName . '"] .block-editor-block-list__block-crash-warning' );
+	}
 
-        // Load the Page on the frontend site.
-        $I->click('.post-publish-panel__postpublish-buttons a.components-button');
+	/**
+	 * Publish a Page, Post or Custom Post Type initiated by the addGutenbergPage() function,
+	 * loading it on the frontend web site.
+	 *
+	 * @since 1.9.7.5
+	 *
+	 * @param AcceptanceTester $I Acceptance Tester.
+	 */
+	public function publishAndViewGutenbergPage( $I ) {
+		// Click the Publish button.
+		$I->click( '.editor-post-publish-button__button' );
 
-        // Wait for frontend web site to load.
-        $I->waitForElementVisible('body');
+		// When the pre-publish panel displays, click Publish again.
+		$I->performOn(
+			'.editor-post-publish-panel__prepublish',
+			function ( $I ) {
+				$I->click( '.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button' );
+			}
+		);
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-    }
+		// Wait for confirmation that the Page published.
+		$I->waitForElementVisible( '.post-publish-panel__postpublish-buttons a.components-button' );
+
+		// Load the Page on the frontend site.
+		$I->click( '.post-publish-panel__postpublish-buttons a.components-button' );
+
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible( 'body' );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+	}
 }

--- a/tests/_support/Helper/Acceptance/WPGutenberg.php
+++ b/tests/_support/Helper/Acceptance/WPGutenberg.php
@@ -7,230 +7,234 @@ namespace Helper\Acceptance;
 
 class WPGutenberg extends \Codeception\Module
 {
-	/**
-	 * Helper method to close the Gutenberg "Welcome to the block editor" dialog, which
-	 * might show for each Page/Post test performed due to there being no persistence
-	 * remembering that the user dismissed the dialog.
-	 * 
-	 * @since 	1.9.6
-	 */
-	public function maybeCloseGutenbergWelcomeModal($I)
-	{
-		try {
-			$I->performOn('.components-modal__screen-overlay', [
-				'click' => '.components-modal__screen-overlay .components-modal__header button.components-button'
-			], 3);
-		} catch ( \Facebook\WebDriver\Exception\TimeoutException $e ) {
-		}
-	}
+    /**
+     * Helper method to close the Gutenberg "Welcome to the block editor" dialog, which
+     * might show for each Page/Post test performed due to there being no persistence
+     * remembering that the user dismissed the dialog.
+     * 
+     * @since 1.9.6
+     */
+    public function maybeCloseGutenbergWelcomeModal($I)
+    {
+        try {
+            $I->performOn(
+                '.components-modal__screen-overlay', [
+                'click' => '.components-modal__screen-overlay .components-modal__header button.components-button'
+                ], 3
+            );
+        } catch ( \Facebook\WebDriver\Exception\TimeoutException $e ) {
+        }
+    }
 
-	/**
-	 * Add a Page, Post or Custom Post Type using Gutenberg in WordPress.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
-	 */
-	public function addGutenbergPage($I, $postType = 'page', $title)
-	{
-		// Navigate to Post Type (e.g. Pages / Posts) > Add New
-		$I->amOnAdminPage('post-new.php?post_type='.$postType);
+    /**
+     * Add a Page, Post or Custom Post Type using Gutenberg in WordPress.
+     * 
+     * @since 1.9.7.5
+     * 
+     * @param AcceptanceTester $I Acceptance Tester.
+     */
+    public function addGutenbergPage($I, $postType = 'page', $title)
+    {
+        // Navigate to Post Type (e.g. Pages / Posts) > Add New
+        $I->amOnAdminPage('post-new.php?post_type='.$postType);
 
-		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
-		$I->maybeCloseGutenbergWelcomeModal($I);
+        // Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
+        $I->maybeCloseGutenbergWelcomeModal($I);
 
-		// Define the Title.
-		$I->fillField('.editor-post-title__input', $title);
-	}
+        // Define the Title.
+        $I->fillField('.editor-post-title__input', $title);
+    }
 
-	/**
-	 * Add the given block when adding or editing a Page, Post or Custom Post Type
-	 * in Gutenberg.
-	 * 
-	 * If a block configuration is specified, applies it to the newly added block.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
-	 * @param 	string 				$blockName 				Block Name (e.g. 'ConvertKit Form').
-	 * @param 	string 				$blockProgrammaticName 	Programmatic Block Name (e.g. 'convertkit-form').
-	 * @param 	bool|array 			$blockConfiguration 	Block Configuration (field => value key/value array).
-	 */
-	public function addGutenbergBlock($I, $blockName, $blockProgrammaticName, $blockConfiguration = false)
-	{
-		// Click Add Block Button.
-		$I->click('button.edit-post-header-toolbar__inserter-toggle');
+    /**
+     * Add the given block when adding or editing a Page, Post or Custom Post Type
+     * in Gutenberg.
+     * 
+     * If a block configuration is specified, applies it to the newly added block.
+     * 
+     * @since 1.9.7.4
+     * 
+     * @param AcceptanceTester $I                     Acceptance Tester.
+     * @param string           $blockName             Block Name (e.g. 'ConvertKit Form').
+     * @param string           $blockProgrammaticName Programmatic Block Name (e.g. 'convertkit-form').
+     * @param bool|array       $blockConfiguration    Block Configuration (field => value key/value array).
+     */
+    public function addGutenbergBlock($I, $blockName, $blockProgrammaticName, $blockConfiguration = false)
+    {
+        // Click Add Block Button.
+        $I->click('button.edit-post-header-toolbar__inserter-toggle');
 
-		// When the Blocks sidebar appears, search for the block.
-		$I->waitForElementVisible('.interface-interface-skeleton__secondary-sidebar[aria-label="Block Library"]');
-		$I->fillField('.block-editor-inserter__content input[type=search]', $blockName);
-		$I->seeElementInDOM('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
-		$I->click('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
+        // When the Blocks sidebar appears, search for the block.
+        $I->waitForElementVisible('.interface-interface-skeleton__secondary-sidebar[aria-label="Block Library"]');
+        $I->fillField('.block-editor-inserter__content input[type=search]', $blockName);
+        $I->seeElementInDOM('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
+        $I->click('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
 
-		// If a Block configuration is specified, apply it to the Block now.
-		if ($blockConfiguration) {
-			$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
-			foreach ($blockConfiguration as $field=>$attributes) {
-				// Field ID will be block's programmatic name with underscores instead of hyphens,
-				// followed by the attribute name.
-				$fieldID = '#' . str_replace('-', '_', $blockProgrammaticName) . '_' . $field;
+        // If a Block configuration is specified, apply it to the Block now.
+        if ($blockConfiguration) {
+            $I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
+            foreach ($blockConfiguration as $field=>$attributes) {
+                // Field ID will be block's programmatic name with underscores instead of hyphens,
+                // followed by the attribute name.
+                $fieldID = '#' . str_replace('-', '_', $blockProgrammaticName) . '_' . $field;
 				
-				// Depending on the field's type, define its value.
-				switch ($attributes[0]) {
-					case 'select':
-						$I->selectOption($fieldID, $attributes[1]);
-						break;
-					case 'toggle':
-						$I->click($field);
-						break;
-					default:
-						$I->fillField($fieldID, $attributes[1]);
-						break;
-				}
-			}
-		}
-	}
+                // Depending on the field's type, define its value.
+                switch ($attributes[0]) {
+                case 'select':
+                    $I->selectOption($fieldID, $attributes[1]);
+                    break;
+                case 'toggle':
+                    $I->click($field);
+                    break;
+                default:
+                    $I->fillField($fieldID, $attributes[1]);
+                    break;
+                }
+            }
+        }
+    }
 
-	/**
-	 * Adds a paragraph block when adding or editing a Page, Post or Custom Post Type
-	 * in Gutenberg.
-	 * 
-	 * @since 	2.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 		Acceptance Tester.
-	 * @param 	string 				$text 	Paragraph Text.
-	 */
-	public function addGutenbergParagraphBlock($I, $text)
-	{
-		$I->click('.is-root-container');
-		$I->fillField('.is-root-container p', $text);
-	}
+    /**
+     * Adds a paragraph block when adding or editing a Page, Post or Custom Post Type
+     * in Gutenberg.
+     * 
+     * @since 2.0.0
+     * 
+     * @param AcceptanceTester $I    Acceptance Tester.
+     * @param string           $text Paragraph Text.
+     */
+    public function addGutenbergParagraphBlock($I, $text)
+    {
+        $I->click('.is-root-container');
+        $I->fillField('.is-root-container p', $text);
+    }
 
-	/**
-	 * Adds a link to the given Page, Post or Custom Post Type Name in the last paragraph in the Gutenberg
-	 * editor.
-	 * 
-	 * @since 	2.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 		Acceptance Tester.
-	 * @param 	string 				$name 	Page, Post or Custom Post Type Title/Name to link to.
-	 */
-	public function addGutenbergLinkToParagraph($I, $name)
-	{
-		// Focus away from paragraph and then back to the paragraph, so that the block toolbar displays.
-		$I->click('div.edit-post-visual-editor__post-title-wrapper h1');
-		$I->click('.is-root-container p');
-		$I->waitForElementVisible('.is-root-container p.is-selected');
+    /**
+     * Adds a link to the given Page, Post or Custom Post Type Name in the last paragraph in the Gutenberg
+     * editor.
+     * 
+     * @since 2.0.0
+     * 
+     * @param AcceptanceTester $I    Acceptance Tester.
+     * @param string           $name Page, Post or Custom Post Type Title/Name to link to.
+     */
+    public function addGutenbergLinkToParagraph($I, $name)
+    {
+        // Focus away from paragraph and then back to the paragraph, so that the block toolbar displays.
+        $I->click('div.edit-post-visual-editor__post-title-wrapper h1');
+        $I->click('.is-root-container p');
+        $I->waitForElementVisible('.is-root-container p.is-selected');
 
-		// Insert link via block toolbar.
-		$this->insertGutenbergLink($I, $name);
+        // Insert link via block toolbar.
+        $this->insertGutenbergLink($I, $name);
 
-		// Confirm that the Product text exists in the paragraph.
-		$I->see($name, '.is-root-container p.is-selected');
-	}
+        // Confirm that the Product text exists in the paragraph.
+        $I->see($name, '.is-root-container p.is-selected');
+    }
 
-	/**
-	 * Adds a link to the given Page, Post or Custom Post Type Name in the selected Button block
-	 * in the Gutenberg editor.
-	 * 
-	 * @since 	2.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 		Acceptance Tester.
-	 * @param 	string 				$name 	Page, Post or Custom Post Type Title/Name to link to.
-	 */
-	public function addGutenbergLinkToButton($I, $name)
-	{
-		// Enter text.
-		$I->fillField('.is-root-container .wp-block-button .block-editor-rich-text__editable', $name);
+    /**
+     * Adds a link to the given Page, Post or Custom Post Type Name in the selected Button block
+     * in the Gutenberg editor.
+     * 
+     * @since 2.0.0
+     * 
+     * @param AcceptanceTester $I    Acceptance Tester.
+     * @param string           $name Page, Post or Custom Post Type Title/Name to link to.
+     */
+    public function addGutenbergLinkToButton($I, $name)
+    {
+        // Enter text.
+        $I->fillField('.is-root-container .wp-block-button .block-editor-rich-text__editable', $name);
 
-		// Focus away from button and then back to the button, so that the block toolbar displays.
-		$I->click('div.edit-post-visual-editor__post-title-wrapper h1');
-		$I->click('.is-root-container .wp-block-button');
-		$I->waitForElementVisible('.is-root-container div.is-selected');
+        // Focus away from button and then back to the button, so that the block toolbar displays.
+        $I->click('div.edit-post-visual-editor__post-title-wrapper h1');
+        $I->click('.is-root-container .wp-block-button');
+        $I->waitForElementVisible('.is-root-container div.is-selected');
 
-		// Insert link via block toolbar.
-		$this->insertGutenbergLink($I, $name);
+        // Insert link via block toolbar.
+        $this->insertGutenbergLink($I, $name);
 
-		// Confirm that the Product text exists in the button.
-		$I->see($name, '.is-root-container .wp-block-button');
-	}
+        // Confirm that the Product text exists in the button.
+        $I->see($name, '.is-root-container .wp-block-button');
+    }
 
-	/**
-	 * Helper method to insert a link into the selected element, by:
-	 * - clicking the link button in the selected block's toolbar,
-	 * - searching for the Page, Post or Custom Post Type,
-	 * - clicking the matched result to insert the link and text.
-	 * 
-	 * The block must be selected in Gutenberg prior to calling this function.
-	 * 
-	 * @since 	2.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 		Acceptance Tester.
-	 * @param 	string 				$name 	Page, Post or Custom Post Type Title/Name to link to.
-	 */
-	private function insertGutenbergLink($I, $name)
-	{
-		// Click link button in block toolbar.
-		$I->waitForElementVisible('.block-editor-block-toolbar button[aria-label="Link"]');
-		$I->click('.block-editor-block-toolbar button[aria-label="Link"]');
+    /**
+     * Helper method to insert a link into the selected element, by:
+     * - clicking the link button in the selected block's toolbar,
+     * - searching for the Page, Post or Custom Post Type,
+     * - clicking the matched result to insert the link and text.
+     * 
+     * The block must be selected in Gutenberg prior to calling this function.
+     * 
+     * @since 2.0.0
+     * 
+     * @param AcceptanceTester $I    Acceptance Tester.
+     * @param string           $name Page, Post or Custom Post Type Title/Name to link to.
+     */
+    private function insertGutenbergLink($I, $name)
+    {
+        // Click link button in block toolbar.
+        $I->waitForElementVisible('.block-editor-block-toolbar button[aria-label="Link"]');
+        $I->click('.block-editor-block-toolbar button[aria-label="Link"]');
 
-		// Enter Product name in search field.
-		$I->waitForElementVisible('.block-editor-link-control__search-input-wrapper input.block-editor-url-input__input');
-		$I->fillField('.block-editor-link-control__search-input-wrapper input.block-editor-url-input__input', $name);
-		$I->waitForElementVisible('.block-editor-link-control__search-results-wrapper');
-		$I->see($name);
+        // Enter Product name in search field.
+        $I->waitForElementVisible('.block-editor-link-control__search-input-wrapper input.block-editor-url-input__input');
+        $I->fillField('.block-editor-link-control__search-input-wrapper input.block-editor-url-input__input', $name);
+        $I->waitForElementVisible('.block-editor-link-control__search-results-wrapper');
+        $I->see($name);
 
-		// Click the Product name to create a link to it.
-		$I->click($name, '.block-editor-link-control__search-results');
-	}
+        // Click the Product name to create a link to it.
+        $I->click($name, '.block-editor-link-control__search-results');
+    }
 
-	/**
-	 * Check that the given block did not output any errors when rendered in the
-	 * Gutenberg editor.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
-	 * @param 	string 				$blockName 				Block Name (e.g. 'ConvertKit Form')
-	 */
-	public function checkGutenbergBlockHasNoErrors($I, $blockName)
-	{
-		// Wait a couple of seconds for the block to render.
-		// @TODO Improve this method.
-		sleep(2);
+    /**
+     * Check that the given block did not output any errors when rendered in the
+     * Gutenberg editor.
+     * 
+     * @since 1.9.7.4
+     * 
+     * @param AcceptanceTester $I         Acceptance Tester.
+     * @param string           $blockName Block Name (e.g. 'ConvertKit Form')
+     */
+    public function checkGutenbergBlockHasNoErrors($I, $blockName)
+    {
+        // Wait a couple of seconds for the block to render.
+        // @TODO Improve this method.
+        sleep(2);
 
-		// Check that the "This block has encountered an error and cannot be previewed." element doesn't exist.
-		$I->dontSeeElementInDOM('.block-editor-block-list__layout div[data-title="'.$blockName.'"] .block-editor-block-list__block-crash-warning');
-	}
+        // Check that the "This block has encountered an error and cannot be previewed." element doesn't exist.
+        $I->dontSeeElementInDOM('.block-editor-block-list__layout div[data-title="'.$blockName.'"] .block-editor-block-list__block-crash-warning');
+    }
 
-	/**
-	 * Publish a Page, Post or Custom Post Type initiated by the addGutenbergPage() function,
-	 * loading it on the frontend web site.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
-	 */
-	public function publishAndViewGutenbergPage($I)
-	{
-		// Click the Publish button.
-		$I->click('.editor-post-publish-button__button');
+    /**
+     * Publish a Page, Post or Custom Post Type initiated by the addGutenbergPage() function,
+     * loading it on the frontend web site.
+     * 
+     * @since 1.9.7.5
+     * 
+     * @param AcceptanceTester $I Acceptance Tester.
+     */
+    public function publishAndViewGutenbergPage($I)
+    {
+        // Click the Publish button.
+        $I->click('.editor-post-publish-button__button');
 		
-		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
+        // When the pre-publish panel displays, click Publish again.
+        $I->performOn(
+            '.editor-post-publish-panel__prepublish', function ($I) {
+                $I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');    
+            }
+        );
 
-		// Wait for confirmation that the Page published.
-		$I->waitForElementVisible('.post-publish-panel__postpublish-buttons a.components-button');
+        // Wait for confirmation that the Page published.
+        $I->waitForElementVisible('.post-publish-panel__postpublish-buttons a.components-button');
 
-		// Load the Page on the frontend site.
-		$I->click('.post-publish-panel__postpublish-buttons a.components-button');
+        // Load the Page on the frontend site.
+        $I->click('.post-publish-panel__postpublish-buttons a.components-button');
 
-		// Wait for frontend web site to load.
-		$I->waitForElementVisible('body');
+        // Wait for frontend web site to load.
+        $I->waitForElementVisible('body');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-	}
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
+    }
 }

--- a/tests/_support/Helper/Acceptance/WPGutenberg.php
+++ b/tests/_support/Helper/Acceptance/WPGutenberg.php
@@ -1,10 +1,12 @@
 <?php
 namespace Helper\Acceptance;
 
-// Define any custom actions related to Gutenberg that
-// would be used across multiple tests.
-// These are then available in $I->{yourFunctionName}
-
+/**
+ * Helper methods and actions related to WordPress' Gutenberg / Block editor,
+ * which are then available using $I->{yourFunctionName}.
+ *
+ * @since   1.9.6
+ */
 class WPGutenberg extends \Codeception\Module
 {
 	/**
@@ -13,6 +15,8 @@ class WPGutenberg extends \Codeception\Module
 	 * remembering that the user dismissed the dialog.
 	 *
 	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I Acceptance Tester.
 	 */
 	public function maybeCloseGutenbergWelcomeModal($I)
 	{
@@ -24,7 +28,8 @@ class WPGutenberg extends \Codeception\Module
 				],
 				3
 			);
-		} catch ( \Facebook\WebDriver\Exception\TimeoutException $e ) {
+		} catch ( \Facebook\WebDriver\Exception\TimeoutException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// No modal exists, so nothing to dismiss.
 		}
 	}
 
@@ -33,14 +38,16 @@ class WPGutenberg extends \Codeception\Module
 	 *
 	 * @since   1.9.7.5
 	 *
-	 * @param   AcceptanceTester $I                      Acceptance Tester.
+	 * @param   AcceptanceTester $I          Acceptance Tester.
+	 * @param   string           $postType   Post Type.
+	 * @param   string           $title      Post Title.
 	 */
-	public function addGutenbergPage($I, $postType = 'page', $title)
+	public function addGutenbergPage($I, $postType = 'page', $title = 'Gutenberg Title')
 	{
-		// Navigate to Post Type (e.g. Pages / Posts) > Add New
+		// Navigate to Post Type (e.g. Pages / Posts) > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=' . $postType);
 
-		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
+		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed.
 		$I->maybeCloseGutenbergWelcomeModal($I);
 
 		// Define the Title.
@@ -195,12 +202,11 @@ class WPGutenberg extends \Codeception\Module
 	 * @since   1.9.7.4
 	 *
 	 * @param   AcceptanceTester $I                      Acceptance Tester.
-	 * @param   string           $blockName              Block Name (e.g. 'ConvertKit Form')
+	 * @param   string           $blockName              Block Name (e.g. 'ConvertKit Form').
 	 */
 	public function checkGutenbergBlockHasNoErrors($I, $blockName)
 	{
 		// Wait a couple of seconds for the block to render.
-		// @TODO Improve this method.
 		sleep(2);
 
 		// Check that the "This block has encountered an error and cannot be previewed." element doesn't exist.

--- a/tests/_support/Helper/Acceptance/WPGutenberg.php
+++ b/tests/_support/Helper/Acceptance/WPGutenberg.php
@@ -13,6 +13,8 @@ class WPGutenberg extends \Codeception\Module
      * remembering that the user dismissed the dialog.
      * 
      * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Acceptance Tester.
      */
     public function maybeCloseGutenbergWelcomeModal($I)
     {
@@ -31,9 +33,11 @@ class WPGutenberg extends \Codeception\Module
      * 
      * @since 1.9.7.5
      * 
-     * @param AcceptanceTester $I Acceptance Tester.
+     * @param AcceptanceTester $I        Acceptance Tester.
+     * @param string           $postType Post Type.
+     * @param string           $title    Post Title.
      */
-    public function addGutenbergPage($I, $postType = 'page', $title)
+    public function addGutenbergPage($I, $postType = 'page', $title = 'Gutenberg Page')
     {
         // Navigate to Post Type (e.g. Pages / Posts) > Add New
         $I->amOnAdminPage('post-new.php?post_type='.$postType);

--- a/tests/_support/Helper/Acceptance/WPGutenberg.php
+++ b/tests/_support/Helper/Acceptance/WPGutenberg.php
@@ -5,91 +5,86 @@ namespace Helper\Acceptance;
 // would be used across multiple tests.
 // These are then available in $I->{yourFunctionName}
 
-class WPGutenberg extends \Codeception\Module {
-
+class WPGutenberg extends \Codeception\Module
+{
 	/**
 	 * Helper method to close the Gutenberg "Welcome to the block editor" dialog, which
 	 * might show for each Page/Post test performed due to there being no persistence
 	 * remembering that the user dismissed the dialog.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Acceptance Tester.
+	 * 
+	 * @since 	1.9.6
 	 */
-	public function maybeCloseGutenbergWelcomeModal( $I ) {
+	public function maybeCloseGutenbergWelcomeModal($I)
+	{
 		try {
-			$I->performOn(
-				'.components-modal__screen-overlay',
-				array(
-					'click' => '.components-modal__screen-overlay .components-modal__header button.components-button',
-				),
-				3
-			);
+			$I->performOn('.components-modal__screen-overlay', [
+				'click' => '.components-modal__screen-overlay .components-modal__header button.components-button'
+			], 3);
 		} catch ( \Facebook\WebDriver\Exception\TimeoutException $e ) {
 		}
 	}
 
 	/**
 	 * Add a Page, Post or Custom Post Type using Gutenberg in WordPress.
-	 *
-	 * @since 1.9.7.5
-	 *
-	 * @param AcceptanceTester $I        Acceptance Tester.
-	 * @param string           $postType Post Type.
-	 * @param string           $title    Post Title.
+	 * 
+	 * @since 	1.9.7.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
 	 */
-	public function addGutenbergPage( $I, $postType = 'page', $title = 'Gutenberg Page' ) {
+	public function addGutenbergPage($I, $postType = 'page', $title)
+	{
 		// Navigate to Post Type (e.g. Pages / Posts) > Add New
-		$I->amOnAdminPage( 'post-new.php?post_type=' . $postType );
+		$I->amOnAdminPage('post-new.php?post_type='.$postType);
 
 		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
-		$I->maybeCloseGutenbergWelcomeModal( $I );
+		$I->maybeCloseGutenbergWelcomeModal($I);
 
 		// Define the Title.
-		$I->fillField( '.editor-post-title__input', $title );
+		$I->fillField('.editor-post-title__input', $title);
 	}
 
 	/**
 	 * Add the given block when adding or editing a Page, Post or Custom Post Type
 	 * in Gutenberg.
-	 *
+	 * 
 	 * If a block configuration is specified, applies it to the newly added block.
-	 *
-	 * @since 1.9.7.4
-	 *
-	 * @param AcceptanceTester $I                     Acceptance Tester.
-	 * @param string           $blockName             Block Name (e.g. 'ConvertKit Form').
-	 * @param string           $blockProgrammaticName Programmatic Block Name (e.g. 'convertkit-form').
-	 * @param bool|array       $blockConfiguration    Block Configuration (field => value key/value array).
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
+	 * @param 	string 				$blockName 				Block Name (e.g. 'ConvertKit Form').
+	 * @param 	string 				$blockProgrammaticName 	Programmatic Block Name (e.g. 'convertkit-form').
+	 * @param 	bool|array 			$blockConfiguration 	Block Configuration (field => value key/value array).
 	 */
-	public function addGutenbergBlock( $I, $blockName, $blockProgrammaticName, $blockConfiguration = false ) {
+	public function addGutenbergBlock($I, $blockName, $blockProgrammaticName, $blockConfiguration = false)
+	{
 		// Click Add Block Button.
-		$I->click( 'button.edit-post-header-toolbar__inserter-toggle' );
+		$I->click('button.edit-post-header-toolbar__inserter-toggle');
 
 		// When the Blocks sidebar appears, search for the block.
-		$I->waitForElementVisible( '.interface-interface-skeleton__secondary-sidebar[aria-label="Block Library"]' );
-		$I->fillField( '.block-editor-inserter__content input[type=search]', $blockName );
-		$I->seeElementInDOM( '.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName );
-		$I->click( '.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName );
+		$I->waitForElementVisible('.interface-interface-skeleton__secondary-sidebar[aria-label="Block Library"]');
+		$I->fillField('.block-editor-inserter__content input[type=search]', $blockName);
+		$I->seeElementInDOM('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
+		$I->click('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
 
 		// If a Block configuration is specified, apply it to the Block now.
-		if ( $blockConfiguration ) {
-			$I->waitForElementVisible( '.interface-interface-skeleton__sidebar[aria-label="Editor settings"]' );
-			foreach ( $blockConfiguration as $field => $attributes ) {
+		if ($blockConfiguration) {
+			$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
+			foreach ($blockConfiguration as $field=>$attributes) {
 				// Field ID will be block's programmatic name with underscores instead of hyphens,
 				// followed by the attribute name.
-				$fieldID = '#' . str_replace( '-', '_', $blockProgrammaticName ) . '_' . $field;
-
+				$fieldID = '#' . str_replace('-', '_', $blockProgrammaticName) . '_' . $field;
+				
 				// Depending on the field's type, define its value.
-				switch ( $attributes[0] ) {
+				switch ($attributes[0]) {
 					case 'select':
-						$I->selectOption( $fieldID, $attributes[1] );
+						$I->selectOption($fieldID, $attributes[1]);
 						break;
 					case 'toggle':
-						$I->click( $field );
+						$I->click($field);
 						break;
 					default:
-						$I->fillField( $fieldID, $attributes[1] );
+						$I->fillField($fieldID, $attributes[1]);
 						break;
 				}
 			}
@@ -99,62 +94,65 @@ class WPGutenberg extends \Codeception\Module {
 	/**
 	 * Adds a paragraph block when adding or editing a Page, Post or Custom Post Type
 	 * in Gutenberg.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param AcceptanceTester $I    Acceptance Tester.
-	 * @param string           $text Paragraph Text.
+	 * 
+	 * @since 	2.0.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 		Acceptance Tester.
+	 * @param 	string 				$text 	Paragraph Text.
 	 */
-	public function addGutenbergParagraphBlock( $I, $text ) {
-		$I->click( '.is-root-container' );
-		$I->fillField( '.is-root-container p', $text );
+	public function addGutenbergParagraphBlock($I, $text)
+	{
+		$I->click('.is-root-container');
+		$I->fillField('.is-root-container p', $text);
 	}
 
 	/**
 	 * Adds a link to the given Page, Post or Custom Post Type Name in the last paragraph in the Gutenberg
 	 * editor.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param AcceptanceTester $I    Acceptance Tester.
-	 * @param string           $name Page, Post or Custom Post Type Title/Name to link to.
+	 * 
+	 * @since 	2.0.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 		Acceptance Tester.
+	 * @param 	string 				$name 	Page, Post or Custom Post Type Title/Name to link to.
 	 */
-	public function addGutenbergLinkToParagraph( $I, $name ) {
+	public function addGutenbergLinkToParagraph($I, $name)
+	{
 		// Focus away from paragraph and then back to the paragraph, so that the block toolbar displays.
-		$I->click( 'div.edit-post-visual-editor__post-title-wrapper h1' );
-		$I->click( '.is-root-container p' );
-		$I->waitForElementVisible( '.is-root-container p.is-selected' );
+		$I->click('div.edit-post-visual-editor__post-title-wrapper h1');
+		$I->click('.is-root-container p');
+		$I->waitForElementVisible('.is-root-container p.is-selected');
 
 		// Insert link via block toolbar.
-		$this->insertGutenbergLink( $I, $name );
+		$this->insertGutenbergLink($I, $name);
 
 		// Confirm that the Product text exists in the paragraph.
-		$I->see( $name, '.is-root-container p.is-selected' );
+		$I->see($name, '.is-root-container p.is-selected');
 	}
 
 	/**
 	 * Adds a link to the given Page, Post or Custom Post Type Name in the selected Button block
 	 * in the Gutenberg editor.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param AcceptanceTester $I    Acceptance Tester.
-	 * @param string           $name Page, Post or Custom Post Type Title/Name to link to.
+	 * 
+	 * @since 	2.0.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 		Acceptance Tester.
+	 * @param 	string 				$name 	Page, Post or Custom Post Type Title/Name to link to.
 	 */
-	public function addGutenbergLinkToButton( $I, $name ) {
+	public function addGutenbergLinkToButton($I, $name)
+	{
 		// Enter text.
-		$I->fillField( '.is-root-container .wp-block-button .block-editor-rich-text__editable', $name );
+		$I->fillField('.is-root-container .wp-block-button .block-editor-rich-text__editable', $name);
 
 		// Focus away from button and then back to the button, so that the block toolbar displays.
-		$I->click( 'div.edit-post-visual-editor__post-title-wrapper h1' );
-		$I->click( '.is-root-container .wp-block-button' );
-		$I->waitForElementVisible( '.is-root-container div.is-selected' );
+		$I->click('div.edit-post-visual-editor__post-title-wrapper h1');
+		$I->click('.is-root-container .wp-block-button');
+		$I->waitForElementVisible('.is-root-container div.is-selected');
 
 		// Insert link via block toolbar.
-		$this->insertGutenbergLink( $I, $name );
+		$this->insertGutenbergLink($I, $name);
 
 		// Confirm that the Product text exists in the button.
-		$I->see( $name, '.is-root-container .wp-block-button' );
+		$I->see($name, '.is-root-container .wp-block-button');
 	}
 
 	/**
@@ -162,77 +160,77 @@ class WPGutenberg extends \Codeception\Module {
 	 * - clicking the link button in the selected block's toolbar,
 	 * - searching for the Page, Post or Custom Post Type,
 	 * - clicking the matched result to insert the link and text.
-	 *
+	 * 
 	 * The block must be selected in Gutenberg prior to calling this function.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param AcceptanceTester $I    Acceptance Tester.
-	 * @param string           $name Page, Post or Custom Post Type Title/Name to link to.
+	 * 
+	 * @since 	2.0.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 		Acceptance Tester.
+	 * @param 	string 				$name 	Page, Post or Custom Post Type Title/Name to link to.
 	 */
-	private function insertGutenbergLink( $I, $name ) {
+	private function insertGutenbergLink($I, $name)
+	{
 		// Click link button in block toolbar.
-		$I->waitForElementVisible( '.block-editor-block-toolbar button[aria-label="Link"]' );
-		$I->click( '.block-editor-block-toolbar button[aria-label="Link"]' );
+		$I->waitForElementVisible('.block-editor-block-toolbar button[aria-label="Link"]');
+		$I->click('.block-editor-block-toolbar button[aria-label="Link"]');
 
 		// Enter Product name in search field.
-		$I->waitForElementVisible( '.block-editor-link-control__search-input-wrapper input.block-editor-url-input__input' );
-		$I->fillField( '.block-editor-link-control__search-input-wrapper input.block-editor-url-input__input', $name );
-		$I->waitForElementVisible( '.block-editor-link-control__search-results-wrapper' );
-		$I->see( $name );
+		$I->waitForElementVisible('.block-editor-link-control__search-input-wrapper input.block-editor-url-input__input');
+		$I->fillField('.block-editor-link-control__search-input-wrapper input.block-editor-url-input__input', $name);
+		$I->waitForElementVisible('.block-editor-link-control__search-results-wrapper');
+		$I->see($name);
 
 		// Click the Product name to create a link to it.
-		$I->click( $name, '.block-editor-link-control__search-results' );
+		$I->click($name, '.block-editor-link-control__search-results');
 	}
 
 	/**
 	 * Check that the given block did not output any errors when rendered in the
 	 * Gutenberg editor.
-	 *
-	 * @since 1.9.7.4
-	 *
-	 * @param AcceptanceTester $I         Acceptance Tester.
-	 * @param string           $blockName Block Name (e.g. 'ConvertKit Form')
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
+	 * @param 	string 				$blockName 				Block Name (e.g. 'ConvertKit Form')
 	 */
-	public function checkGutenbergBlockHasNoErrors( $I, $blockName ) {
+	public function checkGutenbergBlockHasNoErrors($I, $blockName)
+	{
 		// Wait a couple of seconds for the block to render.
 		// @TODO Improve this method.
-		sleep( 2 );
+		sleep(2);
 
 		// Check that the "This block has encountered an error and cannot be previewed." element doesn't exist.
-		$I->dontSeeElementInDOM( '.block-editor-block-list__layout div[data-title="' . $blockName . '"] .block-editor-block-list__block-crash-warning' );
+		$I->dontSeeElementInDOM('.block-editor-block-list__layout div[data-title="'.$blockName.'"] .block-editor-block-list__block-crash-warning');
 	}
 
 	/**
 	 * Publish a Page, Post or Custom Post Type initiated by the addGutenbergPage() function,
 	 * loading it on the frontend web site.
-	 *
-	 * @since 1.9.7.5
-	 *
-	 * @param AcceptanceTester $I Acceptance Tester.
+	 * 
+	 * @since 	1.9.7.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
 	 */
-	public function publishAndViewGutenbergPage( $I ) {
+	public function publishAndViewGutenbergPage($I)
+	{
 		// Click the Publish button.
-		$I->click( '.editor-post-publish-button__button' );
-
+		$I->click('.editor-post-publish-button__button');
+		
 		// When the pre-publish panel displays, click Publish again.
-		$I->performOn(
-			'.editor-post-publish-panel__prepublish',
-			function ( $I ) {
-				$I->click( '.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button' );
-			}
-		);
+		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
+			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
+		});
 
 		// Wait for confirmation that the Page published.
-		$I->waitForElementVisible( '.post-publish-panel__postpublish-buttons a.components-button' );
+		$I->waitForElementVisible('.post-publish-panel__postpublish-buttons a.components-button');
 
 		// Load the Page on the frontend site.
-		$I->click( '.post-publish-panel__postpublish-buttons a.components-button' );
+		$I->click('.post-publish-panel__postpublish-buttons a.components-button');
 
 		// Wait for frontend web site to load.
-		$I->waitForElementVisible( 'body' );
+		$I->waitForElementVisible('body');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 	}
 }

--- a/tests/_support/Helper/Acceptance/WPGutenberg.php
+++ b/tests/_support/Helper/Acceptance/WPGutenberg.php
@@ -11,30 +11,34 @@ class WPGutenberg extends \Codeception\Module
 	 * Helper method to close the Gutenberg "Welcome to the block editor" dialog, which
 	 * might show for each Page/Post test performed due to there being no persistence
 	 * remembering that the user dismissed the dialog.
-	 * 
-	 * @since 	1.9.6
+	 *
+	 * @since   1.9.6
 	 */
 	public function maybeCloseGutenbergWelcomeModal($I)
 	{
 		try {
-			$I->performOn('.components-modal__screen-overlay', [
-				'click' => '.components-modal__screen-overlay .components-modal__header button.components-button'
-			], 3);
+			$I->performOn(
+				'.components-modal__screen-overlay',
+				[
+					'click' => '.components-modal__screen-overlay .components-modal__header button.components-button',
+				],
+				3
+			);
 		} catch ( \Facebook\WebDriver\Exception\TimeoutException $e ) {
 		}
 	}
 
 	/**
 	 * Add a Page, Post or Custom Post Type using Gutenberg in WordPress.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
+	 *
+	 * @since   1.9.7.5
+	 *
+	 * @param   AcceptanceTester $I                      Acceptance Tester.
 	 */
 	public function addGutenbergPage($I, $postType = 'page', $title)
 	{
 		// Navigate to Post Type (e.g. Pages / Posts) > Add New
-		$I->amOnAdminPage('post-new.php?post_type='.$postType);
+		$I->amOnAdminPage('post-new.php?post_type=' . $postType);
 
 		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
 		$I->maybeCloseGutenbergWelcomeModal($I);
@@ -46,15 +50,15 @@ class WPGutenberg extends \Codeception\Module
 	/**
 	 * Add the given block when adding or editing a Page, Post or Custom Post Type
 	 * in Gutenberg.
-	 * 
+	 *
 	 * If a block configuration is specified, applies it to the newly added block.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
-	 * @param 	string 				$blockName 				Block Name (e.g. 'ConvertKit Form').
-	 * @param 	string 				$blockProgrammaticName 	Programmatic Block Name (e.g. 'convertkit-form').
-	 * @param 	bool|array 			$blockConfiguration 	Block Configuration (field => value key/value array).
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @param   AcceptanceTester $I                      Acceptance Tester.
+	 * @param   string           $blockName              Block Name (e.g. 'ConvertKit Form').
+	 * @param   string           $blockProgrammaticName  Programmatic Block Name (e.g. 'convertkit-form').
+	 * @param   bool|array       $blockConfiguration     Block Configuration (field => value key/value array).
 	 */
 	public function addGutenbergBlock($I, $blockName, $blockProgrammaticName, $blockConfiguration = false)
 	{
@@ -70,11 +74,11 @@ class WPGutenberg extends \Codeception\Module
 		// If a Block configuration is specified, apply it to the Block now.
 		if ($blockConfiguration) {
 			$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
-			foreach ($blockConfiguration as $field=>$attributes) {
+			foreach ($blockConfiguration as $field => $attributes) {
 				// Field ID will be block's programmatic name with underscores instead of hyphens,
 				// followed by the attribute name.
 				$fieldID = '#' . str_replace('-', '_', $blockProgrammaticName) . '_' . $field;
-				
+
 				// Depending on the field's type, define its value.
 				switch ($attributes[0]) {
 					case 'select':
@@ -94,11 +98,11 @@ class WPGutenberg extends \Codeception\Module
 	/**
 	 * Adds a paragraph block when adding or editing a Page, Post or Custom Post Type
 	 * in Gutenberg.
-	 * 
-	 * @since 	2.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 		Acceptance Tester.
-	 * @param 	string 				$text 	Paragraph Text.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @param   AcceptanceTester $I      Acceptance Tester.
+	 * @param   string           $text   Paragraph Text.
 	 */
 	public function addGutenbergParagraphBlock($I, $text)
 	{
@@ -109,11 +113,11 @@ class WPGutenberg extends \Codeception\Module
 	/**
 	 * Adds a link to the given Page, Post or Custom Post Type Name in the last paragraph in the Gutenberg
 	 * editor.
-	 * 
-	 * @since 	2.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 		Acceptance Tester.
-	 * @param 	string 				$name 	Page, Post or Custom Post Type Title/Name to link to.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @param   AcceptanceTester $I      Acceptance Tester.
+	 * @param   string           $name   Page, Post or Custom Post Type Title/Name to link to.
 	 */
 	public function addGutenbergLinkToParagraph($I, $name)
 	{
@@ -132,11 +136,11 @@ class WPGutenberg extends \Codeception\Module
 	/**
 	 * Adds a link to the given Page, Post or Custom Post Type Name in the selected Button block
 	 * in the Gutenberg editor.
-	 * 
-	 * @since 	2.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 		Acceptance Tester.
-	 * @param 	string 				$name 	Page, Post or Custom Post Type Title/Name to link to.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @param   AcceptanceTester $I      Acceptance Tester.
+	 * @param   string           $name   Page, Post or Custom Post Type Title/Name to link to.
 	 */
 	public function addGutenbergLinkToButton($I, $name)
 	{
@@ -160,13 +164,13 @@ class WPGutenberg extends \Codeception\Module
 	 * - clicking the link button in the selected block's toolbar,
 	 * - searching for the Page, Post or Custom Post Type,
 	 * - clicking the matched result to insert the link and text.
-	 * 
+	 *
 	 * The block must be selected in Gutenberg prior to calling this function.
-	 * 
-	 * @since 	2.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 		Acceptance Tester.
-	 * @param 	string 				$name 	Page, Post or Custom Post Type Title/Name to link to.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @param   AcceptanceTester $I      Acceptance Tester.
+	 * @param   string           $name   Page, Post or Custom Post Type Title/Name to link to.
 	 */
 	private function insertGutenbergLink($I, $name)
 	{
@@ -187,11 +191,11 @@ class WPGutenberg extends \Codeception\Module
 	/**
 	 * Check that the given block did not output any errors when rendered in the
 	 * Gutenberg editor.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
-	 * @param 	string 				$blockName 				Block Name (e.g. 'ConvertKit Form')
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @param   AcceptanceTester $I                      Acceptance Tester.
+	 * @param   string           $blockName              Block Name (e.g. 'ConvertKit Form')
 	 */
 	public function checkGutenbergBlockHasNoErrors($I, $blockName)
 	{
@@ -200,26 +204,29 @@ class WPGutenberg extends \Codeception\Module
 		sleep(2);
 
 		// Check that the "This block has encountered an error and cannot be previewed." element doesn't exist.
-		$I->dontSeeElementInDOM('.block-editor-block-list__layout div[data-title="'.$blockName.'"] .block-editor-block-list__block-crash-warning');
+		$I->dontSeeElementInDOM('.block-editor-block-list__layout div[data-title="' . $blockName . '"] .block-editor-block-list__block-crash-warning');
 	}
 
 	/**
 	 * Publish a Page, Post or Custom Post Type initiated by the addGutenbergPage() function,
 	 * loading it on the frontend web site.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
+	 *
+	 * @since   1.9.7.5
+	 *
+	 * @param   AcceptanceTester $I                      Acceptance Tester.
 	 */
 	public function publishAndViewGutenbergPage($I)
 	{
 		// Click the Publish button.
 		$I->click('.editor-post-publish-button__button');
-		
+
 		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
+		$I->performOn(
+			'.editor-post-publish-panel__prepublish',
+			function($I) {
+				$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');
+			}
+		);
 
 		// Wait for confirmation that the Page published.
 		$I->waitForElementVisible('.post-publish-panel__postpublish-buttons a.components-button');

--- a/tests/_support/Helper/Acceptance/WPMetabox.php
+++ b/tests/_support/Helper/Acceptance/WPMetabox.php
@@ -7,40 +7,40 @@ namespace Helper\Acceptance;
 
 class WPMetabox extends \Codeception\Module
 {
-	/**
-	 * Configure a given metabox's fields with the given values.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
-	 * @param 	string 	$metabox 		Programmatic Metabox Name.
-	 * @param 	array 	$coniguration 	Metabox Configuration (field => value key/value array).
-	 */
-	public function configureMetaboxSettings($I, $metabox, $configuration)
-	{
-		// Check that the metabox exists.
-		$I->seeElementInDOM('#' . $metabox);
+    /**
+     * Configure a given metabox's fields with the given values.
+     * 
+     * @since 1.9.7.5
+     * 
+     * @param $I            AcceptanceHelper     Acceptance Helper.
+     * @param string $metabox      Programmatic Metabox Name.
+     * @param array  $coniguration Metabox Configuration (field => value key/value array).
+     */
+    public function configureMetaboxSettings($I, $metabox, $configuration)
+    {
+        // Check that the metabox exists.
+        $I->seeElementInDOM('#' . $metabox);
 
-		// Apply configuration.
-		foreach ($configuration as $field=>$attributes) {
-			// Field ID will be prefixed with wp-convertkit- in the metabox.
-			$fieldID = 'wp-convertkit-' . $field;
+        // Apply configuration.
+        foreach ($configuration as $field=>$attributes) {
+            // Field ID will be prefixed with wp-convertkit- in the metabox.
+            $fieldID = 'wp-convertkit-' . $field;
 
-			// Check that the field exists.
-			$I->seeElementInDOM('#' . $fieldID);
+            // Check that the field exists.
+            $I->seeElementInDOM('#' . $fieldID);
 			
-			// Depending on the field's type, define its value.
-			switch ($attributes[0]) {
-				case 'select2':
-					$I->fillSelect2Field($I, '#select2-' . $fieldID . '-container', $attributes[1]);
-					break;
-				case 'select':
-					$I->selectOption('#' . $fieldID, $attributes[1]);
-					break;
-				default:
-					$I->fillField('#' . $fieldID, $attributes[1]);
-					break;
-			}
-		}
-	}
+            // Depending on the field's type, define its value.
+            switch ($attributes[0]) {
+            case 'select2':
+                $I->fillSelect2Field($I, '#select2-' . $fieldID . '-container', $attributes[1]);
+                break;
+            case 'select':
+                $I->selectOption('#' . $fieldID, $attributes[1]);
+                break;
+            default:
+                   $I->fillField('#' . $fieldID, $attributes[1]);
+                break;
+            }
+        }
+    }
 }

--- a/tests/_support/Helper/Acceptance/WPMetabox.php
+++ b/tests/_support/Helper/Acceptance/WPMetabox.php
@@ -1,10 +1,12 @@
 <?php
 namespace Helper\Acceptance;
 
-// Define any custom actions related to metaboxes that
-// would be used across multiple tests.
-// These are then available in $I->{yourFunctionName}
-
+/**
+ * Helper methods and actions related to metaboxes,
+ * which are then available using $I->{yourFunctionName}.
+ *
+ * @since   1.9.6
+ */
 class WPMetabox extends \Codeception\Module
 {
 	/**
@@ -12,9 +14,9 @@ class WPMetabox extends \Codeception\Module
 	 *
 	 * @since   1.9.7.5
 	 *
-	 * @param   $I  AcceptanceHelper    Acceptance Helper.
-	 * @param   string                                   $metabox        Programmatic Metabox Name.
-	 * @param   array                                    $coniguration   Metabox Configuration (field => value key/value array).
+	 * @param   AcceptanceHelper $I              Acceptance Helper.
+	 * @param   string           $metabox        Programmatic Metabox Name.
+	 * @param   array            $configuration  Metabox Configuration (field => value key/value array).
 	 */
 	public function configureMetaboxSettings($I, $metabox, $configuration)
 	{

--- a/tests/_support/Helper/Acceptance/WPMetabox.php
+++ b/tests/_support/Helper/Acceptance/WPMetabox.php
@@ -9,12 +9,12 @@ class WPMetabox extends \Codeception\Module
 {
 	/**
 	 * Configure a given metabox's fields with the given values.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
-	 * @param 	string 	$metabox 		Programmatic Metabox Name.
-	 * @param 	array 	$coniguration 	Metabox Configuration (field => value key/value array).
+	 *
+	 * @since   1.9.7.5
+	 *
+	 * @param   $I  AcceptanceHelper    Acceptance Helper.
+	 * @param   string                                   $metabox        Programmatic Metabox Name.
+	 * @param   array                                    $coniguration   Metabox Configuration (field => value key/value array).
 	 */
 	public function configureMetaboxSettings($I, $metabox, $configuration)
 	{
@@ -22,13 +22,13 @@ class WPMetabox extends \Codeception\Module
 		$I->seeElementInDOM('#' . $metabox);
 
 		// Apply configuration.
-		foreach ($configuration as $field=>$attributes) {
+		foreach ($configuration as $field => $attributes) {
 			// Field ID will be prefixed with wp-convertkit- in the metabox.
 			$fieldID = 'wp-convertkit-' . $field;
 
 			// Check that the field exists.
 			$I->seeElementInDOM('#' . $fieldID);
-			
+
 			// Depending on the field's type, define its value.
 			switch ($attributes[0]) {
 				case 'select2':

--- a/tests/_support/Helper/Acceptance/WPMetabox.php
+++ b/tests/_support/Helper/Acceptance/WPMetabox.php
@@ -12,9 +12,9 @@ class WPMetabox extends \Codeception\Module
      * 
      * @since 1.9.7.5
      * 
-     * @param $I            AcceptanceHelper     Acceptance Helper.
-     * @param string $metabox      Programmatic Metabox Name.
-     * @param array  $coniguration Metabox Configuration (field => value key/value array).
+     * @param AcceptanceHelper $I             Acceptance Helper.
+     * @param string           $metabox       Programmatic Metabox Name.
+     * @param array            $configuration Metabox Configuration (field => value key/value array).
      */
     public function configureMetaboxSettings($I, $metabox, $configuration)
     {

--- a/tests/_support/Helper/Acceptance/WPMetabox.php
+++ b/tests/_support/Helper/Acceptance/WPMetabox.php
@@ -5,39 +5,40 @@ namespace Helper\Acceptance;
 // would be used across multiple tests.
 // These are then available in $I->{yourFunctionName}
 
-class WPMetabox extends \Codeception\Module {
-
+class WPMetabox extends \Codeception\Module
+{
 	/**
 	 * Configure a given metabox's fields with the given values.
-	 *
-	 * @since 1.9.7.5
-	 *
-	 * @param AcceptanceHelper $I             Acceptance Helper.
-	 * @param string           $metabox       Programmatic Metabox Name.
-	 * @param array            $configuration Metabox Configuration (field => value key/value array).
+	 * 
+	 * @since 	1.9.7.5
+	 * 
+	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
+	 * @param 	string 	$metabox 		Programmatic Metabox Name.
+	 * @param 	array 	$coniguration 	Metabox Configuration (field => value key/value array).
 	 */
-	public function configureMetaboxSettings( $I, $metabox, $configuration ) {
+	public function configureMetaboxSettings($I, $metabox, $configuration)
+	{
 		// Check that the metabox exists.
-		$I->seeElementInDOM( '#' . $metabox );
+		$I->seeElementInDOM('#' . $metabox);
 
 		// Apply configuration.
-		foreach ( $configuration as $field => $attributes ) {
+		foreach ($configuration as $field=>$attributes) {
 			// Field ID will be prefixed with wp-convertkit- in the metabox.
 			$fieldID = 'wp-convertkit-' . $field;
 
 			// Check that the field exists.
-			$I->seeElementInDOM( '#' . $fieldID );
-
+			$I->seeElementInDOM('#' . $fieldID);
+			
 			// Depending on the field's type, define its value.
-			switch ( $attributes[0] ) {
+			switch ($attributes[0]) {
 				case 'select2':
-					$I->fillSelect2Field( $I, '#select2-' . $fieldID . '-container', $attributes[1] );
+					$I->fillSelect2Field($I, '#select2-' . $fieldID . '-container', $attributes[1]);
 					break;
 				case 'select':
-					$I->selectOption( '#' . $fieldID, $attributes[1] );
+					$I->selectOption('#' . $fieldID, $attributes[1]);
 					break;
 				default:
-					   $I->fillField( '#' . $fieldID, $attributes[1] );
+					$I->fillField('#' . $fieldID, $attributes[1]);
 					break;
 			}
 		}

--- a/tests/_support/Helper/Acceptance/WPMetabox.php
+++ b/tests/_support/Helper/Acceptance/WPMetabox.php
@@ -5,42 +5,41 @@ namespace Helper\Acceptance;
 // would be used across multiple tests.
 // These are then available in $I->{yourFunctionName}
 
-class WPMetabox extends \Codeception\Module
-{
-    /**
-     * Configure a given metabox's fields with the given values.
-     * 
-     * @since 1.9.7.5
-     * 
-     * @param AcceptanceHelper $I             Acceptance Helper.
-     * @param string           $metabox       Programmatic Metabox Name.
-     * @param array            $configuration Metabox Configuration (field => value key/value array).
-     */
-    public function configureMetaboxSettings($I, $metabox, $configuration)
-    {
-        // Check that the metabox exists.
-        $I->seeElementInDOM('#' . $metabox);
+class WPMetabox extends \Codeception\Module {
 
-        // Apply configuration.
-        foreach ($configuration as $field=>$attributes) {
-            // Field ID will be prefixed with wp-convertkit- in the metabox.
-            $fieldID = 'wp-convertkit-' . $field;
+	/**
+	 * Configure a given metabox's fields with the given values.
+	 *
+	 * @since 1.9.7.5
+	 *
+	 * @param AcceptanceHelper $I             Acceptance Helper.
+	 * @param string           $metabox       Programmatic Metabox Name.
+	 * @param array            $configuration Metabox Configuration (field => value key/value array).
+	 */
+	public function configureMetaboxSettings( $I, $metabox, $configuration ) {
+		// Check that the metabox exists.
+		$I->seeElementInDOM( '#' . $metabox );
 
-            // Check that the field exists.
-            $I->seeElementInDOM('#' . $fieldID);
-			
-            // Depending on the field's type, define its value.
-            switch ($attributes[0]) {
-            case 'select2':
-                $I->fillSelect2Field($I, '#select2-' . $fieldID . '-container', $attributes[1]);
-                break;
-            case 'select':
-                $I->selectOption('#' . $fieldID, $attributes[1]);
-                break;
-            default:
-                   $I->fillField('#' . $fieldID, $attributes[1]);
-                break;
-            }
-        }
-    }
+		// Apply configuration.
+		foreach ( $configuration as $field => $attributes ) {
+			// Field ID will be prefixed with wp-convertkit- in the metabox.
+			$fieldID = 'wp-convertkit-' . $field;
+
+			// Check that the field exists.
+			$I->seeElementInDOM( '#' . $fieldID );
+
+			// Depending on the field's type, define its value.
+			switch ( $attributes[0] ) {
+				case 'select2':
+					$I->fillSelect2Field( $I, '#select2-' . $fieldID . '-container', $attributes[1] );
+					break;
+				case 'select':
+					$I->selectOption( '#' . $fieldID, $attributes[1] );
+					break;
+				default:
+					   $I->fillField( '#' . $fieldID, $attributes[1] );
+					break;
+			}
+		}
+	}
 }

--- a/tests/_support/Helper/Acceptance/WPQuickEdit.php
+++ b/tests/_support/Helper/Acceptance/WPQuickEdit.php
@@ -5,67 +5,65 @@ namespace Helper\Acceptance;
 // would be used across multiple tests.
 // These are then available in $I->{yourFunctionName}
 
-class WPQuickEdit extends \Codeception\Module
-{
-    /**
-     * Quick Edits the given Post ID, changing form field values and saving.
-     * 
-     * @since 1.9.8.0
-     * 
-     * @param AcceptanceHelper $I             Acceptance Helper.
-     * @param string           $postType      Programmatic Post Type.
-     * @param int              $postID        Post ID.
-     * @param array            $configuration Configuration (field => value key/value array).
-     */
-    public function quickEdit($I, $postType, $postID, $configuration)
-    {
-        // Open Quick Edit form for the Post.
-        $I->openQuickEdit($I, $postType, $postID);
+class WPQuickEdit extends \Codeception\Module {
 
-        // Apply configuration.
-        foreach ($configuration as $field=>$attributes) {
-            // Field ID will be prefixed with wp-convertkit-quick-edit.
-            $fieldID = 'wp-convertkit-quick-edit-' . $field;
+	/**
+	 * Quick Edits the given Post ID, changing form field values and saving.
+	 *
+	 * @since 1.9.8.0
+	 *
+	 * @param AcceptanceHelper $I             Acceptance Helper.
+	 * @param string           $postType      Programmatic Post Type.
+	 * @param int              $postID        Post ID.
+	 * @param array            $configuration Configuration (field => value key/value array).
+	 */
+	public function quickEdit( $I, $postType, $postID, $configuration ) {
+		// Open Quick Edit form for the Post.
+		$I->openQuickEdit( $I, $postType, $postID );
 
-            // Check that the field exists.
-            $I->seeElementInDOM('#convertkit-quick-edit #' . $fieldID);
-			
-            // Depending on the field's type, define its value.
-            switch ($attributes[0]) {
-            case 'select':
-                $I->selectOption('#convertkit-quick-edit #' . $fieldID, $attributes[1]);
-                break;
-            default:
-                $I->fillField('#convertkit-quick-edit #' . $fieldID, $attributes[1]);
-                break;
-            }
-        }
+		// Apply configuration.
+		foreach ( $configuration as $field => $attributes ) {
+			// Field ID will be prefixed with wp-convertkit-quick-edit.
+			$fieldID = 'wp-convertkit-quick-edit-' . $field;
 
-        // Click Update.
-        $I->click('Update');
-    }
+			// Check that the field exists.
+			$I->seeElementInDOM( '#convertkit-quick-edit #' . $fieldID );
 
-    /**
-     * Opens the Quick Edit form for the given Post ID.
-     * 
-     * @since 1.9.8.1
-     * 
-     * @param AcceptanceHelper $I        Acceptance Helper.
-     * @param string           $postType Programmatic Post Type.
-     * @param int              $postID   Post ID.
-     */
-    public function openQuickEdit($I, $postType, $postID)
-    {
-        // Navigate to Post Type's WP_List_Table.
-        $I->amOnAdminPage('edit.php?post_type='.$postType);
+			// Depending on the field's type, define its value.
+			switch ( $attributes[0] ) {
+				case 'select':
+					$I->selectOption( '#convertkit-quick-edit #' . $fieldID, $attributes[1] );
+					break;
+				default:
+					$I->fillField( '#convertkit-quick-edit #' . $fieldID, $attributes[1] );
+					break;
+			}
+		}
 
-        // Hover mouse over Post's table row.
-        $I->moveMouseOver('tr#post-'.$postID);
+		// Click Update.
+		$I->click( 'Update' );
+	}
 
-        // Wait for Quick edit link to be visible.
-        $I->waitForElementVisible('tr#post-'.$postID.' button.editinline');
-		
-        // Click Quick Edit link.
-        $I->click('tr#post-'.$postID.' button.editinline');
-    }
+	/**
+	 * Opens the Quick Edit form for the given Post ID.
+	 *
+	 * @since 1.9.8.1
+	 *
+	 * @param AcceptanceHelper $I        Acceptance Helper.
+	 * @param string           $postType Programmatic Post Type.
+	 * @param int              $postID   Post ID.
+	 */
+	public function openQuickEdit( $I, $postType, $postID ) {
+		// Navigate to Post Type's WP_List_Table.
+		$I->amOnAdminPage( 'edit.php?post_type=' . $postType );
+
+		// Hover mouse over Post's table row.
+		$I->moveMouseOver( 'tr#post-' . $postID );
+
+		// Wait for Quick edit link to be visible.
+		$I->waitForElementVisible( 'tr#post-' . $postID . ' button.editinline' );
+
+		// Click Quick Edit link.
+		$I->click( 'tr#post-' . $postID . ' button.editinline' );
+	}
 }

--- a/tests/_support/Helper/Acceptance/WPQuickEdit.php
+++ b/tests/_support/Helper/Acceptance/WPQuickEdit.php
@@ -5,65 +5,67 @@ namespace Helper\Acceptance;
 // would be used across multiple tests.
 // These are then available in $I->{yourFunctionName}
 
-class WPQuickEdit extends \Codeception\Module {
-
+class WPQuickEdit extends \Codeception\Module
+{
 	/**
 	 * Quick Edits the given Post ID, changing form field values and saving.
-	 *
-	 * @since 1.9.8.0
-	 *
-	 * @param AcceptanceHelper $I             Acceptance Helper.
-	 * @param string           $postType      Programmatic Post Type.
-	 * @param int              $postID        Post ID.
-	 * @param array            $configuration Configuration (field => value key/value array).
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
+	 * @param 	string 	$postType 		Programmatic Post Type.
+	 * @param 	int 	$postID 		Post ID.
+	 * @param 	array 	$configuration 	Configuration (field => value key/value array).
 	 */
-	public function quickEdit( $I, $postType, $postID, $configuration ) {
+	public function quickEdit($I, $postType, $postID, $configuration)
+	{
 		// Open Quick Edit form for the Post.
-		$I->openQuickEdit( $I, $postType, $postID );
+		$I->openQuickEdit($I, $postType, $postID);
 
 		// Apply configuration.
-		foreach ( $configuration as $field => $attributes ) {
+		foreach ($configuration as $field=>$attributes) {
 			// Field ID will be prefixed with wp-convertkit-quick-edit.
 			$fieldID = 'wp-convertkit-quick-edit-' . $field;
 
 			// Check that the field exists.
-			$I->seeElementInDOM( '#convertkit-quick-edit #' . $fieldID );
-
+			$I->seeElementInDOM('#convertkit-quick-edit #' . $fieldID);
+			
 			// Depending on the field's type, define its value.
-			switch ( $attributes[0] ) {
+			switch ($attributes[0]) {
 				case 'select':
-					$I->selectOption( '#convertkit-quick-edit #' . $fieldID, $attributes[1] );
+					$I->selectOption('#convertkit-quick-edit #' . $fieldID, $attributes[1]);
 					break;
 				default:
-					$I->fillField( '#convertkit-quick-edit #' . $fieldID, $attributes[1] );
+					$I->fillField('#convertkit-quick-edit #' . $fieldID, $attributes[1]);
 					break;
 			}
 		}
 
 		// Click Update.
-		$I->click( 'Update' );
+		$I->click('Update');
 	}
 
 	/**
 	 * Opens the Quick Edit form for the given Post ID.
-	 *
-	 * @since 1.9.8.1
-	 *
-	 * @param AcceptanceHelper $I        Acceptance Helper.
-	 * @param string           $postType Programmatic Post Type.
-	 * @param int              $postID   Post ID.
+	 * 
+	 * @since 	1.9.8.1
+	 * 
+	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
+	 * @param 	string 	$postType 		Programmatic Post Type.
+	 * @param 	int 	$postID 		Post ID.
 	 */
-	public function openQuickEdit( $I, $postType, $postID ) {
+	public function openQuickEdit($I, $postType, $postID)
+	{
 		// Navigate to Post Type's WP_List_Table.
-		$I->amOnAdminPage( 'edit.php?post_type=' . $postType );
+		$I->amOnAdminPage('edit.php?post_type='.$postType);
 
 		// Hover mouse over Post's table row.
-		$I->moveMouseOver( 'tr#post-' . $postID );
+		$I->moveMouseOver('tr#post-'.$postID);
 
 		// Wait for Quick edit link to be visible.
-		$I->waitForElementVisible( 'tr#post-' . $postID . ' button.editinline' );
-
+		$I->waitForElementVisible('tr#post-'.$postID.' button.editinline');
+		
 		// Click Quick Edit link.
-		$I->click( 'tr#post-' . $postID . ' button.editinline' );
+		$I->click('tr#post-'.$postID.' button.editinline');
 	}
 }

--- a/tests/_support/Helper/Acceptance/WPQuickEdit.php
+++ b/tests/_support/Helper/Acceptance/WPQuickEdit.php
@@ -12,10 +12,10 @@ class WPQuickEdit extends \Codeception\Module
      * 
      * @since 1.9.8.0
      * 
-     * @param $I             AcceptanceHelper     Acceptance Helper.
-     * @param string $postType      Programmatic Post Type.
-     * @param int    $postID        Post ID.
-     * @param array  $configuration Configuration (field => value key/value array).
+     * @param AcceptanceHelper $I             Acceptance Helper.
+     * @param string           $postType      Programmatic Post Type.
+     * @param int              $postID        Post ID.
+     * @param array            $configuration Configuration (field => value key/value array).
      */
     public function quickEdit($I, $postType, $postID, $configuration)
     {
@@ -50,9 +50,9 @@ class WPQuickEdit extends \Codeception\Module
      * 
      * @since 1.9.8.1
      * 
-     * @param $I        AcceptanceHelper     Acceptance Helper.
-     * @param string $postType Programmatic Post Type.
-     * @param int    $postID   Post ID.
+     * @param AcceptanceHelper $I        Acceptance Helper.
+     * @param string           $postType Programmatic Post Type.
+     * @param int              $postID   Post ID.
      */
     public function openQuickEdit($I, $postType, $postID)
     {

--- a/tests/_support/Helper/Acceptance/WPQuickEdit.php
+++ b/tests/_support/Helper/Acceptance/WPQuickEdit.php
@@ -9,13 +9,13 @@ class WPQuickEdit extends \Codeception\Module
 {
 	/**
 	 * Quick Edits the given Post ID, changing form field values and saving.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
-	 * @param 	string 	$postType 		Programmatic Post Type.
-	 * @param 	int 	$postID 		Post ID.
-	 * @param 	array 	$configuration 	Configuration (field => value key/value array).
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   $I  AcceptanceHelper    Acceptance Helper.
+	 * @param   string                                   $postType       Programmatic Post Type.
+	 * @param   int                                      $postID         Post ID.
+	 * @param   array                                    $configuration  Configuration (field => value key/value array).
 	 */
 	public function quickEdit($I, $postType, $postID, $configuration)
 	{
@@ -23,13 +23,13 @@ class WPQuickEdit extends \Codeception\Module
 		$I->openQuickEdit($I, $postType, $postID);
 
 		// Apply configuration.
-		foreach ($configuration as $field=>$attributes) {
+		foreach ($configuration as $field => $attributes) {
 			// Field ID will be prefixed with wp-convertkit-quick-edit.
 			$fieldID = 'wp-convertkit-quick-edit-' . $field;
 
 			// Check that the field exists.
 			$I->seeElementInDOM('#convertkit-quick-edit #' . $fieldID);
-			
+
 			// Depending on the field's type, define its value.
 			switch ($attributes[0]) {
 				case 'select':
@@ -47,25 +47,25 @@ class WPQuickEdit extends \Codeception\Module
 
 	/**
 	 * Opens the Quick Edit form for the given Post ID.
-	 * 
-	 * @since 	1.9.8.1
-	 * 
-	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
-	 * @param 	string 	$postType 		Programmatic Post Type.
-	 * @param 	int 	$postID 		Post ID.
+	 *
+	 * @since   1.9.8.1
+	 *
+	 * @param   $I  AcceptanceHelper    Acceptance Helper.
+	 * @param   string                                   $postType       Programmatic Post Type.
+	 * @param   int                                      $postID         Post ID.
 	 */
 	public function openQuickEdit($I, $postType, $postID)
 	{
 		// Navigate to Post Type's WP_List_Table.
-		$I->amOnAdminPage('edit.php?post_type='.$postType);
+		$I->amOnAdminPage('edit.php?post_type=' . $postType);
 
 		// Hover mouse over Post's table row.
-		$I->moveMouseOver('tr#post-'.$postID);
+		$I->moveMouseOver('tr#post-' . $postID);
 
 		// Wait for Quick edit link to be visible.
-		$I->waitForElementVisible('tr#post-'.$postID.' button.editinline');
-		
+		$I->waitForElementVisible('tr#post-' . $postID . ' button.editinline');
+
 		// Click Quick Edit link.
-		$I->click('tr#post-'.$postID.' button.editinline');
+		$I->click('tr#post-' . $postID . ' button.editinline');
 	}
 }

--- a/tests/_support/Helper/Acceptance/WPQuickEdit.php
+++ b/tests/_support/Helper/Acceptance/WPQuickEdit.php
@@ -7,65 +7,65 @@ namespace Helper\Acceptance;
 
 class WPQuickEdit extends \Codeception\Module
 {
-	/**
-	 * Quick Edits the given Post ID, changing form field values and saving.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
-	 * @param 	string 	$postType 		Programmatic Post Type.
-	 * @param 	int 	$postID 		Post ID.
-	 * @param 	array 	$configuration 	Configuration (field => value key/value array).
-	 */
-	public function quickEdit($I, $postType, $postID, $configuration)
-	{
-		// Open Quick Edit form for the Post.
-		$I->openQuickEdit($I, $postType, $postID);
+    /**
+     * Quick Edits the given Post ID, changing form field values and saving.
+     * 
+     * @since 1.9.8.0
+     * 
+     * @param $I             AcceptanceHelper     Acceptance Helper.
+     * @param string $postType      Programmatic Post Type.
+     * @param int    $postID        Post ID.
+     * @param array  $configuration Configuration (field => value key/value array).
+     */
+    public function quickEdit($I, $postType, $postID, $configuration)
+    {
+        // Open Quick Edit form for the Post.
+        $I->openQuickEdit($I, $postType, $postID);
 
-		// Apply configuration.
-		foreach ($configuration as $field=>$attributes) {
-			// Field ID will be prefixed with wp-convertkit-quick-edit.
-			$fieldID = 'wp-convertkit-quick-edit-' . $field;
+        // Apply configuration.
+        foreach ($configuration as $field=>$attributes) {
+            // Field ID will be prefixed with wp-convertkit-quick-edit.
+            $fieldID = 'wp-convertkit-quick-edit-' . $field;
 
-			// Check that the field exists.
-			$I->seeElementInDOM('#convertkit-quick-edit #' . $fieldID);
+            // Check that the field exists.
+            $I->seeElementInDOM('#convertkit-quick-edit #' . $fieldID);
 			
-			// Depending on the field's type, define its value.
-			switch ($attributes[0]) {
-				case 'select':
-					$I->selectOption('#convertkit-quick-edit #' . $fieldID, $attributes[1]);
-					break;
-				default:
-					$I->fillField('#convertkit-quick-edit #' . $fieldID, $attributes[1]);
-					break;
-			}
-		}
+            // Depending on the field's type, define its value.
+            switch ($attributes[0]) {
+            case 'select':
+                $I->selectOption('#convertkit-quick-edit #' . $fieldID, $attributes[1]);
+                break;
+            default:
+                $I->fillField('#convertkit-quick-edit #' . $fieldID, $attributes[1]);
+                break;
+            }
+        }
 
-		// Click Update.
-		$I->click('Update');
-	}
+        // Click Update.
+        $I->click('Update');
+    }
 
-	/**
-	 * Opens the Quick Edit form for the given Post ID.
-	 * 
-	 * @since 	1.9.8.1
-	 * 
-	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
-	 * @param 	string 	$postType 		Programmatic Post Type.
-	 * @param 	int 	$postID 		Post ID.
-	 */
-	public function openQuickEdit($I, $postType, $postID)
-	{
-		// Navigate to Post Type's WP_List_Table.
-		$I->amOnAdminPage('edit.php?post_type='.$postType);
+    /**
+     * Opens the Quick Edit form for the given Post ID.
+     * 
+     * @since 1.9.8.1
+     * 
+     * @param $I        AcceptanceHelper     Acceptance Helper.
+     * @param string $postType Programmatic Post Type.
+     * @param int    $postID   Post ID.
+     */
+    public function openQuickEdit($I, $postType, $postID)
+    {
+        // Navigate to Post Type's WP_List_Table.
+        $I->amOnAdminPage('edit.php?post_type='.$postType);
 
-		// Hover mouse over Post's table row.
-		$I->moveMouseOver('tr#post-'.$postID);
+        // Hover mouse over Post's table row.
+        $I->moveMouseOver('tr#post-'.$postID);
 
-		// Wait for Quick edit link to be visible.
-		$I->waitForElementVisible('tr#post-'.$postID.' button.editinline');
+        // Wait for Quick edit link to be visible.
+        $I->waitForElementVisible('tr#post-'.$postID.' button.editinline');
 		
-		// Click Quick Edit link.
-		$I->click('tr#post-'.$postID.' button.editinline');
-	}
+        // Click Quick Edit link.
+        $I->click('tr#post-'.$postID.' button.editinline');
+    }
 }

--- a/tests/_support/Helper/Acceptance/WPQuickEdit.php
+++ b/tests/_support/Helper/Acceptance/WPQuickEdit.php
@@ -1,10 +1,12 @@
 <?php
 namespace Helper\Acceptance;
 
-// Define any custom actions related to WordPress' Quick Edit functionality that
-// would be used across multiple tests.
-// These are then available in $I->{yourFunctionName}
-
+/**
+ * Helper methods and actions related to WordPress' Quick Edit functionality,
+ * which are then available using $I->{yourFunctionName}.
+ *
+ * @since   1.9.6
+ */
 class WPQuickEdit extends \Codeception\Module
 {
 	/**
@@ -12,10 +14,10 @@ class WPQuickEdit extends \Codeception\Module
 	 *
 	 * @since   1.9.8.0
 	 *
-	 * @param   $I  AcceptanceHelper    Acceptance Helper.
-	 * @param   string                                   $postType       Programmatic Post Type.
-	 * @param   int                                      $postID         Post ID.
-	 * @param   array                                    $configuration  Configuration (field => value key/value array).
+	 * @param   AcceptanceHelper $I              Acceptance Helper.
+	 * @param   string           $postType       Programmatic Post Type.
+	 * @param   int              $postID         Post ID.
+	 * @param   array            $configuration  Configuration (field => value key/value array).
 	 */
 	public function quickEdit($I, $postType, $postID, $configuration)
 	{
@@ -50,9 +52,9 @@ class WPQuickEdit extends \Codeception\Module
 	 *
 	 * @since   1.9.8.1
 	 *
-	 * @param   $I  AcceptanceHelper    Acceptance Helper.
-	 * @param   string                                   $postType       Programmatic Post Type.
-	 * @param   int                                      $postID         Post ID.
+	 * @param   AcceptanceHelper $I              Acceptance Helper.
+	 * @param   string           $postType       Programmatic Post Type.
+	 * @param   int              $postID         Post ID.
 	 */
 	public function openQuickEdit($I, $postType, $postID)
 	{

--- a/tests/_support/Helper/Acceptance/WPWidget.php
+++ b/tests/_support/Helper/Acceptance/WPWidget.php
@@ -1,10 +1,12 @@
 <?php
 namespace Helper\Acceptance;
 
-// Define any custom actions related to metaboxes that
-// would be used across multiple tests.
-// These are then available in $I->{yourFunctionName}
-
+/**
+ * Helper methods and actions related to WordPress' Widgets functionality,
+ * which are then available using $I->{yourFunctionName}.
+ *
+ * @since   1.9.6
+ */
 class WPWidget extends \Codeception\Module
 {
 	/**
@@ -73,9 +75,8 @@ class WPWidget extends \Codeception\Module
 	 * @since   1.9.7.6
 	 *
 	 * @param   AcceptanceTester $I                      Acceptance Tester.
-	 * @param   string           $blockName              Block Name (e.g. 'ConvertKit Form').
 	 * @param   string           $blockProgrammaticName  Programmatic Block Name (e.g. 'convertkit-form').
-	 * @param   bool|array       $blockConfiguration     Block Configuration (field => value key/value array).
+	 * @param   bool|array       $expectedMarkup         Expected HTML markup.
 	 */
 	public function seeLegacyWidget($I, $blockProgrammaticName, $expectedMarkup)
 	{
@@ -88,7 +89,7 @@ class WPWidget extends \Codeception\Module
 		// Confirm that the widget exists in an expected widget area.
 		$I->seeElementInDOM('aside.widget-area .widget_' . str_replace('-', '_', $blockProgrammaticName));
 
-		// Confirm that the ConvertKit Form is displayed in the widget.
+		// Confirm that the expected markup is displayed in the widget.
 		$I->seeElementInDOM($expectedMarkup);
 	}
 
@@ -171,16 +172,14 @@ class WPWidget extends \Codeception\Module
 	 * @since   1.9.7.6
 	 *
 	 * @param   AcceptanceTester $I                      Acceptance Tester.
-	 * @param   string           $blockName              Block Name (e.g. 'ConvertKit Form').
-	 * @param   string           $blockProgrammaticName  Programmatic Block Name (e.g. 'convertkit-form').
-	 * @param   bool|array       $blockConfiguration     Block Configuration (field => value key/value array).
+	 * @param   bool|array       $expectedMarkup         Expected HTML markup.
 	 */
-	public function seeBlockWidget($I, $blockProgrammaticName, $expectedMarkup)
+	public function seeBlockWidget($I, $expectedMarkup)
 	{
 		// View the home page.
 		$I->amOnPage('/');
 
-		// Confirm that the ConvertKit Form is displayed in the widget area.
+		// Confirm that the expected markup is displayed in the widget area.
 		$I->seeElementInDOM($expectedMarkup);
 	}
 

--- a/tests/_support/Helper/Acceptance/WPWidget.php
+++ b/tests/_support/Helper/Acceptance/WPWidget.php
@@ -5,198 +5,193 @@ namespace Helper\Acceptance;
 // would be used across multiple tests.
 // These are then available in $I->{yourFunctionName}
 
-class WPWidget extends \Codeception\Module
-{
-    /**
-     * Configure a given legacy widget's fields with the given values.
-     * 
-     * @since 1.9.7.6
-     * 
-     * @param AcceptanceTester $I                     Acceptance Tester.
-     * @param string           $blockName             Block Name (e.g. 'ConvertKit Form').
-     * @param string           $blockProgrammaticName Programmatic Block Name (e.g. 'convertkit-form').
-     * @param bool|array       $blockConfiguration    Block Configuration (field => value key/value array).
-     */
-    public function addLegacyWidget($I, $blockName, $blockProgrammaticName, $blockConfiguration = false)
-    {
-        // Navigate to Appearance > Widgets.
-        $I->amOnAdminPage('widgets.php');
+class WPWidget extends \Codeception\Module {
 
-        // Dismiss welcome message.
-        $I->maybeCloseGutenbergWelcomeModal($I);
+	/**
+	 * Configure a given legacy widget's fields with the given values.
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param AcceptanceTester $I                     Acceptance Tester.
+	 * @param string           $blockName             Block Name (e.g. 'ConvertKit Form').
+	 * @param string           $blockProgrammaticName Programmatic Block Name (e.g. 'convertkit-form').
+	 * @param bool|array       $blockConfiguration    Block Configuration (field => value key/value array).
+	 */
+	public function addLegacyWidget( $I, $blockName, $blockProgrammaticName, $blockConfiguration = false ) {
+		// Navigate to Appearance > Widgets.
+		$I->amOnAdminPage( 'widgets.php' );
 
-        // Click Add Block Button.
-        $I->click('button.edit-widgets-header-toolbar__inserter-toggle');
+		// Dismiss welcome message.
+		$I->maybeCloseGutenbergWelcomeModal( $I );
 
-        // When the Blocks sidebar appears, search for the legacy widget.
-        $I->waitForElementVisible('.interface-interface-skeleton__secondary-sidebar');
-        $I->fillField('.block-editor-inserter__content input[type=search]', $blockName);
+		// Click Add Block Button.
+		$I->click( 'button.edit-widgets-header-toolbar__inserter-toggle' );
 
-        // First matching item will be the legacy widget; any blocks will follow.
-        // We can't target using the CSS selector button.editor-block-list-item-legacy-widget/{name}, as Codeception
-        // fails stating this is malformed CSS.
-        $I->seeElementInDOM('.block-editor-inserter__panel-content .block-editor-block-types-list__list-item button[tabindex="0"]');
-        $I->click('.block-editor-inserter__panel-content .block-editor-block-types-list__list-item button[tabindex="0"]');
-		
-        // If a Block configuration is specified, apply it to the Block now.
-        if ($blockConfiguration) {
-            $I->waitForElementVisible('.wp-block-legacy-widget form');
+		// When the Blocks sidebar appears, search for the legacy widget.
+		$I->waitForElementVisible( '.interface-interface-skeleton__secondary-sidebar' );
+		$I->fillField( '.block-editor-inserter__content input[type=search]', $blockName );
 
-            foreach ($blockConfiguration as $field=>$attributes) {
-                $fieldID = '#widget-' . str_replace('-', '_', $blockProgrammaticName) . '-1-' . $field;
-				
-                // Depending on the field's type, define its value.
-                switch ($attributes[0]) {
-                case 'select':
-                    $I->selectOption($fieldID, $attributes[1]);
-                    break;
-                default:
-                    $I->fillField($fieldID, $attributes[1]);
-                    break;
-                }
-            }
-        }
+		// First matching item will be the legacy widget; any blocks will follow.
+		// We can't target using the CSS selector button.editor-block-list-item-legacy-widget/{name}, as Codeception
+		// fails stating this is malformed CSS.
+		$I->seeElementInDOM( '.block-editor-inserter__panel-content .block-editor-block-types-list__list-item button[tabindex="0"]' );
+		$I->click( '.block-editor-inserter__panel-content .block-editor-block-types-list__list-item button[tabindex="0"]' );
 
-        // Wait for Update button to change its state from disabled.
-        $I->wait(2);
+		// If a Block configuration is specified, apply it to the Block now.
+		if ( $blockConfiguration ) {
+			$I->waitForElementVisible( '.wp-block-legacy-widget form' );
 
-        // Save.
-        $I->click('Update');
+			foreach ( $blockConfiguration as $field => $attributes ) {
+				$fieldID = '#widget-' . str_replace( '-', '_', $blockProgrammaticName ) . '-1-' . $field;
 
-        // Wait for save to complete.
-        $I->wait(2);
-    }
+				// Depending on the field's type, define its value.
+				switch ( $attributes[0] ) {
+					case 'select':
+						$I->selectOption( $fieldID, $attributes[1] );
+						break;
+					default:
+						$I->fillField( $fieldID, $attributes[1] );
+						break;
+				}
+			}
+		}
 
-    /**
-     * Check a given legacy widget is displayed on the frontend site.
-     * 
-     * @since 1.9.7.6
-     * 
-     * @param AcceptanceTester $I                     Acceptance Tester.
-     * @param string           $blockProgrammaticName Programmatic Block Name (e.g. 'convertkit-form').
-     * @param bool|array       $expectedMarkup        Expected HTML markup.
-     */
-    public function seeLegacyWidget($I, $blockProgrammaticName, $expectedMarkup)
-    {
-        // View the home page.
-        $I->amOnPage('/');
+		// Wait for Update button to change its state from disabled.
+		$I->wait( 2 );
 
-        // Wait for frontend web site to load.
-        $I->waitForElementVisible('body');
+		// Save.
+		$I->click( 'Update' );
 
-        // Confirm that the widget exists in an expected widget area.
-        $I->seeElementInDOM('aside.widget-area .widget_'.str_replace('-', '_', $blockProgrammaticName));
+		// Wait for save to complete.
+		$I->wait( 2 );
+	}
 
-        // Confirm that the ConvertKit Form is displayed in the widget.
-        $I->seeElementInDOM($expectedMarkup);
-    }
+	/**
+	 * Check a given legacy widget is displayed on the frontend site.
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param AcceptanceTester $I                     Acceptance Tester.
+	 * @param string           $blockProgrammaticName Programmatic Block Name (e.g. 'convertkit-form').
+	 * @param bool|array       $expectedMarkup        Expected HTML markup.
+	 */
+	public function seeLegacyWidget( $I, $blockProgrammaticName, $expectedMarkup ) {
+		// View the home page.
+		$I->amOnPage( '/' );
 
-    /**
-     * Add the given block when editing widgets using Gutenberg.
-     * 
-     * If a block configuration is specified, applies it to the newly added block.
-     * 
-     * @since 1.9.7.6
-     * 
-     * @param AcceptanceTester $I                     Acceptance Tester.
-     * @param string           $blockName             Block Name (e.g. 'ConvertKit Form').
-     * @param string           $blockProgrammaticName Programmatic Block Name (e.g. 'convertkit-form').
-     * @param bool|array       $blockConfiguration    Block Configuration (field => value key/value array).
-     */
-    public function addBlockWidget($I, $blockName, $blockProgrammaticName, $blockConfiguration = false)
-    {
-        // Navigate to Appearance > Widgets.
-        $I->amOnAdminPage('widgets.php');
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible( 'body' );
 
-        // Dismiss welcome message.
-        $I->maybeCloseGutenbergWelcomeModal($I);
+		// Confirm that the widget exists in an expected widget area.
+		$I->seeElementInDOM( 'aside.widget-area .widget_' . str_replace( '-', '_', $blockProgrammaticName ) );
 
-        // Click Add Block Button.
-        $I->click('button.edit-widgets-header-toolbar__inserter-toggle');
+		// Confirm that the ConvertKit Form is displayed in the widget.
+		$I->seeElementInDOM( $expectedMarkup );
+	}
 
-        // When the Blocks sidebar appears, search for the legacy widget.
-        $I->waitForElementVisible('.interface-interface-skeleton__secondary-sidebar');
-        $I->fillField('.block-editor-inserter__content input[type=search]', $blockName);
-        $I->seeElementInDOM('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
-        $I->click('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
+	/**
+	 * Add the given block when editing widgets using Gutenberg.
+	 *
+	 * If a block configuration is specified, applies it to the newly added block.
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param AcceptanceTester $I                     Acceptance Tester.
+	 * @param string           $blockName             Block Name (e.g. 'ConvertKit Form').
+	 * @param string           $blockProgrammaticName Programmatic Block Name (e.g. 'convertkit-form').
+	 * @param bool|array       $blockConfiguration    Block Configuration (field => value key/value array).
+	 */
+	public function addBlockWidget( $I, $blockName, $blockProgrammaticName, $blockConfiguration = false ) {
+		// Navigate to Appearance > Widgets.
+		$I->amOnAdminPage( 'widgets.php' );
 
-        // If a Block configuration is specified, apply it to the Block now.
-        if ($blockConfiguration) {
-            $I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Widgets settings"]');
+		// Dismiss welcome message.
+		$I->maybeCloseGutenbergWelcomeModal( $I );
 
-            foreach ($blockConfiguration as $field=>$attributes) {
-                // Field ID will be block's programmatic name with underscores instead of hyphens,
-                // followed by the attribute name.
-                $fieldID = '#' . str_replace('-', '_', $blockProgrammaticName) . '_' . $field;
-				
-                // Depending on the field's type, define its value.
-                switch ($attributes[0]) {
-                case 'select':
-                    $I->selectOption($fieldID, $attributes[1]);
-                    break;
-                case 'toggle':
-                    $I->click($field);
-                    break;
-                default:
-                    $I->fillField($fieldID, $attributes[1]);
-                    break;
-                }
-            }
-        }
+		// Click Add Block Button.
+		$I->click( 'button.edit-widgets-header-toolbar__inserter-toggle' );
 
-        // Save.
-        $I->click('Update');
+		// When the Blocks sidebar appears, search for the legacy widget.
+		$I->waitForElementVisible( '.interface-interface-skeleton__secondary-sidebar' );
+		$I->fillField( '.block-editor-inserter__content input[type=search]', $blockName );
+		$I->seeElementInDOM( '.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName );
+		$I->click( '.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName );
 
-        // Wait for save to complete.
-        $I->waitForElementVisible('.components-snackbar__content');
-        $result = $I->grabTextFrom('.components-snackbar__content');
+		// If a Block configuration is specified, apply it to the Block now.
+		if ( $blockConfiguration ) {
+			$I->waitForElementVisible( '.interface-interface-skeleton__sidebar[aria-label="Widgets settings"]' );
 
-        // Sometimes, WordPress throws an intermittent "There was an error. The response is not a valid JSON response."
-        // when saving Widgets in WordPress 5.8+ using the block editor
-        // It's not clear why - see https://wordpress.org/support/topic/widget-config-json-error/, https://wordpress.org/support/topic/there-was-an-error-the-response-is-not-a-valid-json-response/
-        // If this happens, attempt to save again after a couple of seconds.
-        if ($result !== 'Widgets saved.') {
-            $I->wait(5);
-            $I->click('Update');
+			foreach ( $blockConfiguration as $field => $attributes ) {
+				// Field ID will be block's programmatic name with underscores instead of hyphens,
+				// followed by the attribute name.
+				$fieldID = '#' . str_replace( '-', '_', $blockProgrammaticName ) . '_' . $field;
 
-            // Wait for save to complete.
-            $I->waitForElementVisible('.components-snackbar__content');
-        }
-    }
+				// Depending on the field's type, define its value.
+				switch ( $attributes[0] ) {
+					case 'select':
+						$I->selectOption( $fieldID, $attributes[1] );
+						break;
+					case 'toggle':
+						$I->click( $field );
+						break;
+					default:
+						$I->fillField( $fieldID, $attributes[1] );
+						break;
+				}
+			}
+		}
 
-    /**
-     * Check a given block widget is displayed on the frontend site.
-     * 
-     * @since 1.9.7.6
-     * 
-     * @param AcceptanceTester $I                     Acceptance Tester.
-     * @param string           $blockProgrammaticName Programmatic Block Name (e.g. 'convertkit-form').
-     * @param bool|array       $expectedMarkup        Expected HTML Markup.
-     */
-    public function seeBlockWidget($I, $blockProgrammaticName, $expectedMarkup)
-    {
-        // View the home page.
-        $I->amOnPage('/');
+		// Save.
+		$I->click( 'Update' );
 
-        // Confirm that the ConvertKit Form is displayed in the widget area.
-        $I->seeElementInDOM($expectedMarkup);
-    }
+		// Wait for save to complete.
+		$I->waitForElementVisible( '.components-snackbar__content' );
+		$result = $I->grabTextFrom( '.components-snackbar__content' );
 
-    /**
-     * Removes all widgets from widget areas, resetting their state to blank
-     * for the next test.
-     * 
-     * @since 1.9.7.6
-     * 
-     * @param AcceptanceTester $I Acceptance Tester.
-     */
-    public function resetWidgets($I)
-    {
-        $I->dontHaveOptionInDatabase('sidebar_widgets');
-        $I->dontHaveOptionInDatabase('widget_block');
+		// Sometimes, WordPress throws an intermittent "There was an error. The response is not a valid JSON response."
+		// when saving Widgets in WordPress 5.8+ using the block editor
+		// It's not clear why - see https://wordpress.org/support/topic/widget-config-json-error/, https://wordpress.org/support/topic/there-was-an-error-the-response-is-not-a-valid-json-response/
+		// If this happens, attempt to save again after a couple of seconds.
+		if ( $result !== 'Widgets saved.' ) {
+			$I->wait( 5 );
+			$I->click( 'Update' );
 
-        // List any ConvertKit blocks here, so they're also removed as widgets from sidebars/footers.
-        $I->dontHaveOptionInDatabase('widget_convertkit_form');
-        $I->dontHaveOptionInDatabase('widget_convertkit_broadcasts');
-    }
+			// Wait for save to complete.
+			$I->waitForElementVisible( '.components-snackbar__content' );
+		}
+	}
+
+	/**
+	 * Check a given block widget is displayed on the frontend site.
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param AcceptanceTester $I                     Acceptance Tester.
+	 * @param string           $blockProgrammaticName Programmatic Block Name (e.g. 'convertkit-form').
+	 * @param bool|array       $expectedMarkup        Expected HTML Markup.
+	 */
+	public function seeBlockWidget( $I, $blockProgrammaticName, $expectedMarkup ) {
+		// View the home page.
+		$I->amOnPage( '/' );
+
+		// Confirm that the ConvertKit Form is displayed in the widget area.
+		$I->seeElementInDOM( $expectedMarkup );
+	}
+
+	/**
+	 * Removes all widgets from widget areas, resetting their state to blank
+	 * for the next test.
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param AcceptanceTester $I Acceptance Tester.
+	 */
+	public function resetWidgets( $I ) {
+		$I->dontHaveOptionInDatabase( 'sidebar_widgets' );
+		$I->dontHaveOptionInDatabase( 'widget_block' );
+
+		// List any ConvertKit blocks here, so they're also removed as widgets from sidebars/footers.
+		$I->dontHaveOptionInDatabase( 'widget_convertkit_form' );
+		$I->dontHaveOptionInDatabase( 'widget_convertkit_broadcasts' );
+	}
 }

--- a/tests/_support/Helper/Acceptance/WPWidget.php
+++ b/tests/_support/Helper/Acceptance/WPWidget.php
@@ -5,193 +5,200 @@ namespace Helper\Acceptance;
 // would be used across multiple tests.
 // These are then available in $I->{yourFunctionName}
 
-class WPWidget extends \Codeception\Module {
-
+class WPWidget extends \Codeception\Module
+{
 	/**
 	 * Configure a given legacy widget's fields with the given values.
-	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param AcceptanceTester $I                     Acceptance Tester.
-	 * @param string           $blockName             Block Name (e.g. 'ConvertKit Form').
-	 * @param string           $blockProgrammaticName Programmatic Block Name (e.g. 'convertkit-form').
-	 * @param bool|array       $blockConfiguration    Block Configuration (field => value key/value array).
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
+	 * @param 	string 				$blockName 				Block Name (e.g. 'ConvertKit Form').
+	 * @param 	string 				$blockProgrammaticName 	Programmatic Block Name (e.g. 'convertkit-form').
+	 * @param 	bool|array 			$blockConfiguration 	Block Configuration (field => value key/value array).
 	 */
-	public function addLegacyWidget( $I, $blockName, $blockProgrammaticName, $blockConfiguration = false ) {
+	public function addLegacyWidget($I, $blockName, $blockProgrammaticName, $blockConfiguration = false)
+	{
 		// Navigate to Appearance > Widgets.
-		$I->amOnAdminPage( 'widgets.php' );
+		$I->amOnAdminPage('widgets.php');
 
 		// Dismiss welcome message.
-		$I->maybeCloseGutenbergWelcomeModal( $I );
+		$I->maybeCloseGutenbergWelcomeModal($I);
 
 		// Click Add Block Button.
-		$I->click( 'button.edit-widgets-header-toolbar__inserter-toggle' );
+		$I->click('button.edit-widgets-header-toolbar__inserter-toggle');
 
 		// When the Blocks sidebar appears, search for the legacy widget.
-		$I->waitForElementVisible( '.interface-interface-skeleton__secondary-sidebar' );
-		$I->fillField( '.block-editor-inserter__content input[type=search]', $blockName );
+		$I->waitForElementVisible('.interface-interface-skeleton__secondary-sidebar');
+		$I->fillField('.block-editor-inserter__content input[type=search]', $blockName);
 
 		// First matching item will be the legacy widget; any blocks will follow.
 		// We can't target using the CSS selector button.editor-block-list-item-legacy-widget/{name}, as Codeception
 		// fails stating this is malformed CSS.
-		$I->seeElementInDOM( '.block-editor-inserter__panel-content .block-editor-block-types-list__list-item button[tabindex="0"]' );
-		$I->click( '.block-editor-inserter__panel-content .block-editor-block-types-list__list-item button[tabindex="0"]' );
-
+		$I->seeElementInDOM('.block-editor-inserter__panel-content .block-editor-block-types-list__list-item button[tabindex="0"]');
+		$I->click('.block-editor-inserter__panel-content .block-editor-block-types-list__list-item button[tabindex="0"]');
+		
 		// If a Block configuration is specified, apply it to the Block now.
-		if ( $blockConfiguration ) {
-			$I->waitForElementVisible( '.wp-block-legacy-widget form' );
+		if ($blockConfiguration) {
+			$I->waitForElementVisible('.wp-block-legacy-widget form');
 
-			foreach ( $blockConfiguration as $field => $attributes ) {
-				$fieldID = '#widget-' . str_replace( '-', '_', $blockProgrammaticName ) . '-1-' . $field;
-
+			foreach ($blockConfiguration as $field=>$attributes) {
+				$fieldID = '#widget-' . str_replace('-', '_', $blockProgrammaticName) . '-1-' . $field;
+				
 				// Depending on the field's type, define its value.
-				switch ( $attributes[0] ) {
+				switch ($attributes[0]) {
 					case 'select':
-						$I->selectOption( $fieldID, $attributes[1] );
+						$I->selectOption($fieldID, $attributes[1]);
 						break;
 					default:
-						$I->fillField( $fieldID, $attributes[1] );
+						$I->fillField($fieldID, $attributes[1]);
 						break;
 				}
 			}
 		}
 
 		// Wait for Update button to change its state from disabled.
-		$I->wait( 2 );
+		$I->wait(2);
 
 		// Save.
-		$I->click( 'Update' );
+		$I->click('Update');
 
 		// Wait for save to complete.
-		$I->wait( 2 );
+		$I->wait(2);
 	}
 
 	/**
 	 * Check a given legacy widget is displayed on the frontend site.
-	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param AcceptanceTester $I                     Acceptance Tester.
-	 * @param string           $blockProgrammaticName Programmatic Block Name (e.g. 'convertkit-form').
-	 * @param bool|array       $expectedMarkup        Expected HTML markup.
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
+	 * @param 	string 				$blockName 				Block Name (e.g. 'ConvertKit Form').
+	 * @param 	string 				$blockProgrammaticName 	Programmatic Block Name (e.g. 'convertkit-form').
+	 * @param 	bool|array 			$blockConfiguration 	Block Configuration (field => value key/value array).
 	 */
-	public function seeLegacyWidget( $I, $blockProgrammaticName, $expectedMarkup ) {
+	public function seeLegacyWidget($I, $blockProgrammaticName, $expectedMarkup)
+	{
 		// View the home page.
-		$I->amOnPage( '/' );
+		$I->amOnPage('/');
 
 		// Wait for frontend web site to load.
-		$I->waitForElementVisible( 'body' );
+		$I->waitForElementVisible('body');
 
 		// Confirm that the widget exists in an expected widget area.
-		$I->seeElementInDOM( 'aside.widget-area .widget_' . str_replace( '-', '_', $blockProgrammaticName ) );
+		$I->seeElementInDOM('aside.widget-area .widget_'.str_replace('-', '_', $blockProgrammaticName));
 
 		// Confirm that the ConvertKit Form is displayed in the widget.
-		$I->seeElementInDOM( $expectedMarkup );
+		$I->seeElementInDOM($expectedMarkup);
 	}
 
 	/**
 	 * Add the given block when editing widgets using Gutenberg.
-	 *
+	 * 
 	 * If a block configuration is specified, applies it to the newly added block.
-	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param AcceptanceTester $I                     Acceptance Tester.
-	 * @param string           $blockName             Block Name (e.g. 'ConvertKit Form').
-	 * @param string           $blockProgrammaticName Programmatic Block Name (e.g. 'convertkit-form').
-	 * @param bool|array       $blockConfiguration    Block Configuration (field => value key/value array).
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
+	 * @param 	string 				$blockName 				Block Name (e.g. 'ConvertKit Form').
+	 * @param 	string 				$blockProgrammaticName 	Programmatic Block Name (e.g. 'convertkit-form').
+	 * @param 	bool|array 			$blockConfiguration 	Block Configuration (field => value key/value array).
 	 */
-	public function addBlockWidget( $I, $blockName, $blockProgrammaticName, $blockConfiguration = false ) {
+	public function addBlockWidget($I, $blockName, $blockProgrammaticName, $blockConfiguration = false)
+	{
 		// Navigate to Appearance > Widgets.
-		$I->amOnAdminPage( 'widgets.php' );
+		$I->amOnAdminPage('widgets.php');
 
 		// Dismiss welcome message.
-		$I->maybeCloseGutenbergWelcomeModal( $I );
+		$I->maybeCloseGutenbergWelcomeModal($I);
 
 		// Click Add Block Button.
-		$I->click( 'button.edit-widgets-header-toolbar__inserter-toggle' );
+		$I->click('button.edit-widgets-header-toolbar__inserter-toggle');
 
 		// When the Blocks sidebar appears, search for the legacy widget.
-		$I->waitForElementVisible( '.interface-interface-skeleton__secondary-sidebar' );
-		$I->fillField( '.block-editor-inserter__content input[type=search]', $blockName );
-		$I->seeElementInDOM( '.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName );
-		$I->click( '.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName );
+		$I->waitForElementVisible('.interface-interface-skeleton__secondary-sidebar');
+		$I->fillField('.block-editor-inserter__content input[type=search]', $blockName);
+		$I->seeElementInDOM('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
+		$I->click('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
 
 		// If a Block configuration is specified, apply it to the Block now.
-		if ( $blockConfiguration ) {
-			$I->waitForElementVisible( '.interface-interface-skeleton__sidebar[aria-label="Widgets settings"]' );
+		if ($blockConfiguration) {
+			$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Widgets settings"]');
 
-			foreach ( $blockConfiguration as $field => $attributes ) {
+			foreach ($blockConfiguration as $field=>$attributes) {
 				// Field ID will be block's programmatic name with underscores instead of hyphens,
 				// followed by the attribute name.
-				$fieldID = '#' . str_replace( '-', '_', $blockProgrammaticName ) . '_' . $field;
-
+				$fieldID = '#' . str_replace('-', '_', $blockProgrammaticName) . '_' . $field;
+				
 				// Depending on the field's type, define its value.
-				switch ( $attributes[0] ) {
+				switch ($attributes[0]) {
 					case 'select':
-						$I->selectOption( $fieldID, $attributes[1] );
+						$I->selectOption($fieldID, $attributes[1]);
 						break;
 					case 'toggle':
-						$I->click( $field );
+						$I->click($field);
 						break;
 					default:
-						$I->fillField( $fieldID, $attributes[1] );
+						$I->fillField($fieldID, $attributes[1]);
 						break;
 				}
 			}
 		}
 
 		// Save.
-		$I->click( 'Update' );
+		$I->click('Update');
 
 		// Wait for save to complete.
-		$I->waitForElementVisible( '.components-snackbar__content' );
-		$result = $I->grabTextFrom( '.components-snackbar__content' );
+		$I->waitForElementVisible('.components-snackbar__content');
+		$result = $I->grabTextFrom('.components-snackbar__content');
 
 		// Sometimes, WordPress throws an intermittent "There was an error. The response is not a valid JSON response."
 		// when saving Widgets in WordPress 5.8+ using the block editor
 		// It's not clear why - see https://wordpress.org/support/topic/widget-config-json-error/, https://wordpress.org/support/topic/there-was-an-error-the-response-is-not-a-valid-json-response/
 		// If this happens, attempt to save again after a couple of seconds.
-		if ( $result !== 'Widgets saved.' ) {
-			$I->wait( 5 );
-			$I->click( 'Update' );
+		if ($result !== 'Widgets saved.') {
+			$I->wait(5);
+			$I->click('Update');
 
 			// Wait for save to complete.
-			$I->waitForElementVisible( '.components-snackbar__content' );
+			$I->waitForElementVisible('.components-snackbar__content');
 		}
 	}
 
 	/**
 	 * Check a given block widget is displayed on the frontend site.
-	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param AcceptanceTester $I                     Acceptance Tester.
-	 * @param string           $blockProgrammaticName Programmatic Block Name (e.g. 'convertkit-form').
-	 * @param bool|array       $expectedMarkup        Expected HTML Markup.
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
+	 * @param 	string 				$blockName 				Block Name (e.g. 'ConvertKit Form').
+	 * @param 	string 				$blockProgrammaticName 	Programmatic Block Name (e.g. 'convertkit-form').
+	 * @param 	bool|array 			$blockConfiguration 	Block Configuration (field => value key/value array).
 	 */
-	public function seeBlockWidget( $I, $blockProgrammaticName, $expectedMarkup ) {
+	public function seeBlockWidget($I, $blockProgrammaticName, $expectedMarkup)
+	{
 		// View the home page.
-		$I->amOnPage( '/' );
+		$I->amOnPage('/');
 
 		// Confirm that the ConvertKit Form is displayed in the widget area.
-		$I->seeElementInDOM( $expectedMarkup );
+		$I->seeElementInDOM($expectedMarkup);
 	}
 
 	/**
 	 * Removes all widgets from widget areas, resetting their state to blank
 	 * for the next test.
-	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param AcceptanceTester $I Acceptance Tester.
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
 	 */
-	public function resetWidgets( $I ) {
-		$I->dontHaveOptionInDatabase( 'sidebar_widgets' );
-		$I->dontHaveOptionInDatabase( 'widget_block' );
+	public function resetWidgets($I)
+	{
+		$I->dontHaveOptionInDatabase('sidebar_widgets');
+		$I->dontHaveOptionInDatabase('widget_block');
 
 		// List any ConvertKit blocks here, so they're also removed as widgets from sidebars/footers.
-		$I->dontHaveOptionInDatabase( 'widget_convertkit_form' );
-		$I->dontHaveOptionInDatabase( 'widget_convertkit_broadcasts' );
+		$I->dontHaveOptionInDatabase('widget_convertkit_form');
+		$I->dontHaveOptionInDatabase('widget_convertkit_broadcasts');
 	}
 }

--- a/tests/_support/Helper/Acceptance/WPWidget.php
+++ b/tests/_support/Helper/Acceptance/WPWidget.php
@@ -9,13 +9,13 @@ class WPWidget extends \Codeception\Module
 {
 	/**
 	 * Configure a given legacy widget's fields with the given values.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
-	 * @param 	string 				$blockName 				Block Name (e.g. 'ConvertKit Form').
-	 * @param 	string 				$blockProgrammaticName 	Programmatic Block Name (e.g. 'convertkit-form').
-	 * @param 	bool|array 			$blockConfiguration 	Block Configuration (field => value key/value array).
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   AcceptanceTester $I                      Acceptance Tester.
+	 * @param   string           $blockName              Block Name (e.g. 'ConvertKit Form').
+	 * @param   string           $blockProgrammaticName  Programmatic Block Name (e.g. 'convertkit-form').
+	 * @param   bool|array       $blockConfiguration     Block Configuration (field => value key/value array).
 	 */
 	public function addLegacyWidget($I, $blockName, $blockProgrammaticName, $blockConfiguration = false)
 	{
@@ -37,14 +37,14 @@ class WPWidget extends \Codeception\Module
 		// fails stating this is malformed CSS.
 		$I->seeElementInDOM('.block-editor-inserter__panel-content .block-editor-block-types-list__list-item button[tabindex="0"]');
 		$I->click('.block-editor-inserter__panel-content .block-editor-block-types-list__list-item button[tabindex="0"]');
-		
+
 		// If a Block configuration is specified, apply it to the Block now.
 		if ($blockConfiguration) {
 			$I->waitForElementVisible('.wp-block-legacy-widget form');
 
-			foreach ($blockConfiguration as $field=>$attributes) {
+			foreach ($blockConfiguration as $field => $attributes) {
 				$fieldID = '#widget-' . str_replace('-', '_', $blockProgrammaticName) . '-1-' . $field;
-				
+
 				// Depending on the field's type, define its value.
 				switch ($attributes[0]) {
 					case 'select':
@@ -69,13 +69,13 @@ class WPWidget extends \Codeception\Module
 
 	/**
 	 * Check a given legacy widget is displayed on the frontend site.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
-	 * @param 	string 				$blockName 				Block Name (e.g. 'ConvertKit Form').
-	 * @param 	string 				$blockProgrammaticName 	Programmatic Block Name (e.g. 'convertkit-form').
-	 * @param 	bool|array 			$blockConfiguration 	Block Configuration (field => value key/value array).
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   AcceptanceTester $I                      Acceptance Tester.
+	 * @param   string           $blockName              Block Name (e.g. 'ConvertKit Form').
+	 * @param   string           $blockProgrammaticName  Programmatic Block Name (e.g. 'convertkit-form').
+	 * @param   bool|array       $blockConfiguration     Block Configuration (field => value key/value array).
 	 */
 	public function seeLegacyWidget($I, $blockProgrammaticName, $expectedMarkup)
 	{
@@ -86,7 +86,7 @@ class WPWidget extends \Codeception\Module
 		$I->waitForElementVisible('body');
 
 		// Confirm that the widget exists in an expected widget area.
-		$I->seeElementInDOM('aside.widget-area .widget_'.str_replace('-', '_', $blockProgrammaticName));
+		$I->seeElementInDOM('aside.widget-area .widget_' . str_replace('-', '_', $blockProgrammaticName));
 
 		// Confirm that the ConvertKit Form is displayed in the widget.
 		$I->seeElementInDOM($expectedMarkup);
@@ -94,15 +94,15 @@ class WPWidget extends \Codeception\Module
 
 	/**
 	 * Add the given block when editing widgets using Gutenberg.
-	 * 
+	 *
 	 * If a block configuration is specified, applies it to the newly added block.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
-	 * @param 	string 				$blockName 				Block Name (e.g. 'ConvertKit Form').
-	 * @param 	string 				$blockProgrammaticName 	Programmatic Block Name (e.g. 'convertkit-form').
-	 * @param 	bool|array 			$blockConfiguration 	Block Configuration (field => value key/value array).
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   AcceptanceTester $I                      Acceptance Tester.
+	 * @param   string           $blockName              Block Name (e.g. 'ConvertKit Form').
+	 * @param   string           $blockProgrammaticName  Programmatic Block Name (e.g. 'convertkit-form').
+	 * @param   bool|array       $blockConfiguration     Block Configuration (field => value key/value array).
 	 */
 	public function addBlockWidget($I, $blockName, $blockProgrammaticName, $blockConfiguration = false)
 	{
@@ -125,11 +125,11 @@ class WPWidget extends \Codeception\Module
 		if ($blockConfiguration) {
 			$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Widgets settings"]');
 
-			foreach ($blockConfiguration as $field=>$attributes) {
+			foreach ($blockConfiguration as $field => $attributes) {
 				// Field ID will be block's programmatic name with underscores instead of hyphens,
 				// followed by the attribute name.
 				$fieldID = '#' . str_replace('-', '_', $blockProgrammaticName) . '_' . $field;
-				
+
 				// Depending on the field's type, define its value.
 				switch ($attributes[0]) {
 					case 'select':
@@ -167,13 +167,13 @@ class WPWidget extends \Codeception\Module
 
 	/**
 	 * Check a given block widget is displayed on the frontend site.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
-	 * @param 	string 				$blockName 				Block Name (e.g. 'ConvertKit Form').
-	 * @param 	string 				$blockProgrammaticName 	Programmatic Block Name (e.g. 'convertkit-form').
-	 * @param 	bool|array 			$blockConfiguration 	Block Configuration (field => value key/value array).
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   AcceptanceTester $I                      Acceptance Tester.
+	 * @param   string           $blockName              Block Name (e.g. 'ConvertKit Form').
+	 * @param   string           $blockProgrammaticName  Programmatic Block Name (e.g. 'convertkit-form').
+	 * @param   bool|array       $blockConfiguration     Block Configuration (field => value key/value array).
 	 */
 	public function seeBlockWidget($I, $blockProgrammaticName, $expectedMarkup)
 	{
@@ -187,10 +187,10 @@ class WPWidget extends \Codeception\Module
 	/**
 	 * Removes all widgets from widget areas, resetting their state to blank
 	 * for the next test.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   AcceptanceTester $I                      Acceptance Tester.
 	 */
 	public function resetWidgets($I)
 	{

--- a/tests/_support/Helper/Acceptance/WPWidget.php
+++ b/tests/_support/Helper/Acceptance/WPWidget.php
@@ -73,9 +73,8 @@ class WPWidget extends \Codeception\Module
      * @since 1.9.7.6
      * 
      * @param AcceptanceTester $I                     Acceptance Tester.
-     * @param string           $blockName             Block Name (e.g. 'ConvertKit Form').
      * @param string           $blockProgrammaticName Programmatic Block Name (e.g. 'convertkit-form').
-     * @param bool|array       $blockConfiguration    Block Configuration (field => value key/value array).
+     * @param bool|array       $expectedMarkup        Expected HTML markup.
      */
     public function seeLegacyWidget($I, $blockProgrammaticName, $expectedMarkup)
     {
@@ -171,9 +170,8 @@ class WPWidget extends \Codeception\Module
      * @since 1.9.7.6
      * 
      * @param AcceptanceTester $I                     Acceptance Tester.
-     * @param string           $blockName             Block Name (e.g. 'ConvertKit Form').
      * @param string           $blockProgrammaticName Programmatic Block Name (e.g. 'convertkit-form').
-     * @param bool|array       $blockConfiguration    Block Configuration (field => value key/value array).
+     * @param bool|array       $expectedMarkup        Expected HTML Markup.
      */
     public function seeBlockWidget($I, $blockProgrammaticName, $expectedMarkup)
     {

--- a/tests/_support/Helper/Acceptance/WPWidget.php
+++ b/tests/_support/Helper/Acceptance/WPWidget.php
@@ -7,198 +7,198 @@ namespace Helper\Acceptance;
 
 class WPWidget extends \Codeception\Module
 {
-	/**
-	 * Configure a given legacy widget's fields with the given values.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
-	 * @param 	string 				$blockName 				Block Name (e.g. 'ConvertKit Form').
-	 * @param 	string 				$blockProgrammaticName 	Programmatic Block Name (e.g. 'convertkit-form').
-	 * @param 	bool|array 			$blockConfiguration 	Block Configuration (field => value key/value array).
-	 */
-	public function addLegacyWidget($I, $blockName, $blockProgrammaticName, $blockConfiguration = false)
-	{
-		// Navigate to Appearance > Widgets.
-		$I->amOnAdminPage('widgets.php');
+    /**
+     * Configure a given legacy widget's fields with the given values.
+     * 
+     * @since 1.9.7.6
+     * 
+     * @param AcceptanceTester $I                     Acceptance Tester.
+     * @param string           $blockName             Block Name (e.g. 'ConvertKit Form').
+     * @param string           $blockProgrammaticName Programmatic Block Name (e.g. 'convertkit-form').
+     * @param bool|array       $blockConfiguration    Block Configuration (field => value key/value array).
+     */
+    public function addLegacyWidget($I, $blockName, $blockProgrammaticName, $blockConfiguration = false)
+    {
+        // Navigate to Appearance > Widgets.
+        $I->amOnAdminPage('widgets.php');
 
-		// Dismiss welcome message.
-		$I->maybeCloseGutenbergWelcomeModal($I);
+        // Dismiss welcome message.
+        $I->maybeCloseGutenbergWelcomeModal($I);
 
-		// Click Add Block Button.
-		$I->click('button.edit-widgets-header-toolbar__inserter-toggle');
+        // Click Add Block Button.
+        $I->click('button.edit-widgets-header-toolbar__inserter-toggle');
 
-		// When the Blocks sidebar appears, search for the legacy widget.
-		$I->waitForElementVisible('.interface-interface-skeleton__secondary-sidebar');
-		$I->fillField('.block-editor-inserter__content input[type=search]', $blockName);
+        // When the Blocks sidebar appears, search for the legacy widget.
+        $I->waitForElementVisible('.interface-interface-skeleton__secondary-sidebar');
+        $I->fillField('.block-editor-inserter__content input[type=search]', $blockName);
 
-		// First matching item will be the legacy widget; any blocks will follow.
-		// We can't target using the CSS selector button.editor-block-list-item-legacy-widget/{name}, as Codeception
-		// fails stating this is malformed CSS.
-		$I->seeElementInDOM('.block-editor-inserter__panel-content .block-editor-block-types-list__list-item button[tabindex="0"]');
-		$I->click('.block-editor-inserter__panel-content .block-editor-block-types-list__list-item button[tabindex="0"]');
+        // First matching item will be the legacy widget; any blocks will follow.
+        // We can't target using the CSS selector button.editor-block-list-item-legacy-widget/{name}, as Codeception
+        // fails stating this is malformed CSS.
+        $I->seeElementInDOM('.block-editor-inserter__panel-content .block-editor-block-types-list__list-item button[tabindex="0"]');
+        $I->click('.block-editor-inserter__panel-content .block-editor-block-types-list__list-item button[tabindex="0"]');
 		
-		// If a Block configuration is specified, apply it to the Block now.
-		if ($blockConfiguration) {
-			$I->waitForElementVisible('.wp-block-legacy-widget form');
+        // If a Block configuration is specified, apply it to the Block now.
+        if ($blockConfiguration) {
+            $I->waitForElementVisible('.wp-block-legacy-widget form');
 
-			foreach ($blockConfiguration as $field=>$attributes) {
-				$fieldID = '#widget-' . str_replace('-', '_', $blockProgrammaticName) . '-1-' . $field;
+            foreach ($blockConfiguration as $field=>$attributes) {
+                $fieldID = '#widget-' . str_replace('-', '_', $blockProgrammaticName) . '-1-' . $field;
 				
-				// Depending on the field's type, define its value.
-				switch ($attributes[0]) {
-					case 'select':
-						$I->selectOption($fieldID, $attributes[1]);
-						break;
-					default:
-						$I->fillField($fieldID, $attributes[1]);
-						break;
-				}
-			}
-		}
+                // Depending on the field's type, define its value.
+                switch ($attributes[0]) {
+                case 'select':
+                    $I->selectOption($fieldID, $attributes[1]);
+                    break;
+                default:
+                    $I->fillField($fieldID, $attributes[1]);
+                    break;
+                }
+            }
+        }
 
-		// Wait for Update button to change its state from disabled.
-		$I->wait(2);
+        // Wait for Update button to change its state from disabled.
+        $I->wait(2);
 
-		// Save.
-		$I->click('Update');
+        // Save.
+        $I->click('Update');
 
-		// Wait for save to complete.
-		$I->wait(2);
-	}
+        // Wait for save to complete.
+        $I->wait(2);
+    }
 
-	/**
-	 * Check a given legacy widget is displayed on the frontend site.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
-	 * @param 	string 				$blockName 				Block Name (e.g. 'ConvertKit Form').
-	 * @param 	string 				$blockProgrammaticName 	Programmatic Block Name (e.g. 'convertkit-form').
-	 * @param 	bool|array 			$blockConfiguration 	Block Configuration (field => value key/value array).
-	 */
-	public function seeLegacyWidget($I, $blockProgrammaticName, $expectedMarkup)
-	{
-		// View the home page.
-		$I->amOnPage('/');
+    /**
+     * Check a given legacy widget is displayed on the frontend site.
+     * 
+     * @since 1.9.7.6
+     * 
+     * @param AcceptanceTester $I                     Acceptance Tester.
+     * @param string           $blockName             Block Name (e.g. 'ConvertKit Form').
+     * @param string           $blockProgrammaticName Programmatic Block Name (e.g. 'convertkit-form').
+     * @param bool|array       $blockConfiguration    Block Configuration (field => value key/value array).
+     */
+    public function seeLegacyWidget($I, $blockProgrammaticName, $expectedMarkup)
+    {
+        // View the home page.
+        $I->amOnPage('/');
 
-		// Wait for frontend web site to load.
-		$I->waitForElementVisible('body');
+        // Wait for frontend web site to load.
+        $I->waitForElementVisible('body');
 
-		// Confirm that the widget exists in an expected widget area.
-		$I->seeElementInDOM('aside.widget-area .widget_'.str_replace('-', '_', $blockProgrammaticName));
+        // Confirm that the widget exists in an expected widget area.
+        $I->seeElementInDOM('aside.widget-area .widget_'.str_replace('-', '_', $blockProgrammaticName));
 
-		// Confirm that the ConvertKit Form is displayed in the widget.
-		$I->seeElementInDOM($expectedMarkup);
-	}
+        // Confirm that the ConvertKit Form is displayed in the widget.
+        $I->seeElementInDOM($expectedMarkup);
+    }
 
-	/**
-	 * Add the given block when editing widgets using Gutenberg.
-	 * 
-	 * If a block configuration is specified, applies it to the newly added block.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
-	 * @param 	string 				$blockName 				Block Name (e.g. 'ConvertKit Form').
-	 * @param 	string 				$blockProgrammaticName 	Programmatic Block Name (e.g. 'convertkit-form').
-	 * @param 	bool|array 			$blockConfiguration 	Block Configuration (field => value key/value array).
-	 */
-	public function addBlockWidget($I, $blockName, $blockProgrammaticName, $blockConfiguration = false)
-	{
-		// Navigate to Appearance > Widgets.
-		$I->amOnAdminPage('widgets.php');
+    /**
+     * Add the given block when editing widgets using Gutenberg.
+     * 
+     * If a block configuration is specified, applies it to the newly added block.
+     * 
+     * @since 1.9.7.6
+     * 
+     * @param AcceptanceTester $I                     Acceptance Tester.
+     * @param string           $blockName             Block Name (e.g. 'ConvertKit Form').
+     * @param string           $blockProgrammaticName Programmatic Block Name (e.g. 'convertkit-form').
+     * @param bool|array       $blockConfiguration    Block Configuration (field => value key/value array).
+     */
+    public function addBlockWidget($I, $blockName, $blockProgrammaticName, $blockConfiguration = false)
+    {
+        // Navigate to Appearance > Widgets.
+        $I->amOnAdminPage('widgets.php');
 
-		// Dismiss welcome message.
-		$I->maybeCloseGutenbergWelcomeModal($I);
+        // Dismiss welcome message.
+        $I->maybeCloseGutenbergWelcomeModal($I);
 
-		// Click Add Block Button.
-		$I->click('button.edit-widgets-header-toolbar__inserter-toggle');
+        // Click Add Block Button.
+        $I->click('button.edit-widgets-header-toolbar__inserter-toggle');
 
-		// When the Blocks sidebar appears, search for the legacy widget.
-		$I->waitForElementVisible('.interface-interface-skeleton__secondary-sidebar');
-		$I->fillField('.block-editor-inserter__content input[type=search]', $blockName);
-		$I->seeElementInDOM('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
-		$I->click('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
+        // When the Blocks sidebar appears, search for the legacy widget.
+        $I->waitForElementVisible('.interface-interface-skeleton__secondary-sidebar');
+        $I->fillField('.block-editor-inserter__content input[type=search]', $blockName);
+        $I->seeElementInDOM('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
+        $I->click('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
 
-		// If a Block configuration is specified, apply it to the Block now.
-		if ($blockConfiguration) {
-			$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Widgets settings"]');
+        // If a Block configuration is specified, apply it to the Block now.
+        if ($blockConfiguration) {
+            $I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Widgets settings"]');
 
-			foreach ($blockConfiguration as $field=>$attributes) {
-				// Field ID will be block's programmatic name with underscores instead of hyphens,
-				// followed by the attribute name.
-				$fieldID = '#' . str_replace('-', '_', $blockProgrammaticName) . '_' . $field;
+            foreach ($blockConfiguration as $field=>$attributes) {
+                // Field ID will be block's programmatic name with underscores instead of hyphens,
+                // followed by the attribute name.
+                $fieldID = '#' . str_replace('-', '_', $blockProgrammaticName) . '_' . $field;
 				
-				// Depending on the field's type, define its value.
-				switch ($attributes[0]) {
-					case 'select':
-						$I->selectOption($fieldID, $attributes[1]);
-						break;
-					case 'toggle':
-						$I->click($field);
-						break;
-					default:
-						$I->fillField($fieldID, $attributes[1]);
-						break;
-				}
-			}
-		}
+                // Depending on the field's type, define its value.
+                switch ($attributes[0]) {
+                case 'select':
+                    $I->selectOption($fieldID, $attributes[1]);
+                    break;
+                case 'toggle':
+                    $I->click($field);
+                    break;
+                default:
+                    $I->fillField($fieldID, $attributes[1]);
+                    break;
+                }
+            }
+        }
 
-		// Save.
-		$I->click('Update');
+        // Save.
+        $I->click('Update');
 
-		// Wait for save to complete.
-		$I->waitForElementVisible('.components-snackbar__content');
-		$result = $I->grabTextFrom('.components-snackbar__content');
+        // Wait for save to complete.
+        $I->waitForElementVisible('.components-snackbar__content');
+        $result = $I->grabTextFrom('.components-snackbar__content');
 
-		// Sometimes, WordPress throws an intermittent "There was an error. The response is not a valid JSON response."
-		// when saving Widgets in WordPress 5.8+ using the block editor
-		// It's not clear why - see https://wordpress.org/support/topic/widget-config-json-error/, https://wordpress.org/support/topic/there-was-an-error-the-response-is-not-a-valid-json-response/
-		// If this happens, attempt to save again after a couple of seconds.
-		if ($result !== 'Widgets saved.') {
-			$I->wait(5);
-			$I->click('Update');
+        // Sometimes, WordPress throws an intermittent "There was an error. The response is not a valid JSON response."
+        // when saving Widgets in WordPress 5.8+ using the block editor
+        // It's not clear why - see https://wordpress.org/support/topic/widget-config-json-error/, https://wordpress.org/support/topic/there-was-an-error-the-response-is-not-a-valid-json-response/
+        // If this happens, attempt to save again after a couple of seconds.
+        if ($result !== 'Widgets saved.') {
+            $I->wait(5);
+            $I->click('Update');
 
-			// Wait for save to complete.
-			$I->waitForElementVisible('.components-snackbar__content');
-		}
-	}
+            // Wait for save to complete.
+            $I->waitForElementVisible('.components-snackbar__content');
+        }
+    }
 
-	/**
-	 * Check a given block widget is displayed on the frontend site.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
-	 * @param 	string 				$blockName 				Block Name (e.g. 'ConvertKit Form').
-	 * @param 	string 				$blockProgrammaticName 	Programmatic Block Name (e.g. 'convertkit-form').
-	 * @param 	bool|array 			$blockConfiguration 	Block Configuration (field => value key/value array).
-	 */
-	public function seeBlockWidget($I, $blockProgrammaticName, $expectedMarkup)
-	{
-		// View the home page.
-		$I->amOnPage('/');
+    /**
+     * Check a given block widget is displayed on the frontend site.
+     * 
+     * @since 1.9.7.6
+     * 
+     * @param AcceptanceTester $I                     Acceptance Tester.
+     * @param string           $blockName             Block Name (e.g. 'ConvertKit Form').
+     * @param string           $blockProgrammaticName Programmatic Block Name (e.g. 'convertkit-form').
+     * @param bool|array       $blockConfiguration    Block Configuration (field => value key/value array).
+     */
+    public function seeBlockWidget($I, $blockProgrammaticName, $expectedMarkup)
+    {
+        // View the home page.
+        $I->amOnPage('/');
 
-		// Confirm that the ConvertKit Form is displayed in the widget area.
-		$I->seeElementInDOM($expectedMarkup);
-	}
+        // Confirm that the ConvertKit Form is displayed in the widget area.
+        $I->seeElementInDOM($expectedMarkup);
+    }
 
-	/**
-	 * Removes all widgets from widget areas, resetting their state to blank
-	 * for the next test.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
-	 */
-	public function resetWidgets($I)
-	{
-		$I->dontHaveOptionInDatabase('sidebar_widgets');
-		$I->dontHaveOptionInDatabase('widget_block');
+    /**
+     * Removes all widgets from widget areas, resetting their state to blank
+     * for the next test.
+     * 
+     * @since 1.9.7.6
+     * 
+     * @param AcceptanceTester $I Acceptance Tester.
+     */
+    public function resetWidgets($I)
+    {
+        $I->dontHaveOptionInDatabase('sidebar_widgets');
+        $I->dontHaveOptionInDatabase('widget_block');
 
-		// List any ConvertKit blocks here, so they're also removed as widgets from sidebars/footers.
-		$I->dontHaveOptionInDatabase('widget_convertkit_form');
-		$I->dontHaveOptionInDatabase('widget_convertkit_broadcasts');
-	}
+        // List any ConvertKit blocks here, so they're also removed as widgets from sidebars/footers.
+        $I->dontHaveOptionInDatabase('widget_convertkit_form');
+        $I->dontHaveOptionInDatabase('widget_convertkit_broadcasts');
+    }
 }

--- a/tests/_support/Helper/Acceptance/Xdebug.php
+++ b/tests/_support/Helper/Acceptance/Xdebug.php
@@ -11,6 +11,8 @@ class Xdebug extends \Codeception\Module
      * Helper method to assert that there are non PHP errors, warnings or notices output
      * 
      * @since 1.9.6
+     *
+     * @param AcceptanceTester $I Acceptance Tester.
      */
     public function checkNoWarningsAndNoticesOnScreen($I)
     {

--- a/tests/_support/Helper/Acceptance/Xdebug.php
+++ b/tests/_support/Helper/Acceptance/Xdebug.php
@@ -5,18 +5,17 @@ namespace Helper\Acceptance;
 // would be used across multiple tests.
 // These are then available in $I->{yourFunctionName}
 
-class Xdebug extends \Codeception\Module {
-
+class Xdebug extends \Codeception\Module
+{
 	/**
 	 * Helper method to assert that there are non PHP errors, warnings or notices output
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Acceptance Tester.
+	 * 
+	 * @since 	1.9.6
 	 */
-	public function checkNoWarningsAndNoticesOnScreen( $I ) {
+	public function checkNoWarningsAndNoticesOnScreen($I)
+	{
 		// Check that no Xdebug errors exist.
-		$I->dontSeeElement( '.xdebug-error' );
-		$I->dontSeeElement( '.xe-notice' );
+		$I->dontSeeElement('.xdebug-error');
+		$I->dontSeeElement('.xe-notice');
 	}
 }

--- a/tests/_support/Helper/Acceptance/Xdebug.php
+++ b/tests/_support/Helper/Acceptance/Xdebug.php
@@ -9,8 +9,8 @@ class Xdebug extends \Codeception\Module
 {
 	/**
 	 * Helper method to assert that there are non PHP errors, warnings or notices output
-	 * 
-	 * @since 	1.9.6
+	 *
+	 * @since   1.9.6
 	 */
 	public function checkNoWarningsAndNoticesOnScreen($I)
 	{

--- a/tests/_support/Helper/Acceptance/Xdebug.php
+++ b/tests/_support/Helper/Acceptance/Xdebug.php
@@ -5,19 +5,18 @@ namespace Helper\Acceptance;
 // would be used across multiple tests.
 // These are then available in $I->{yourFunctionName}
 
-class Xdebug extends \Codeception\Module
-{
-    /**
-     * Helper method to assert that there are non PHP errors, warnings or notices output
-     * 
-     * @since 1.9.6
-     *
-     * @param AcceptanceTester $I Acceptance Tester.
-     */
-    public function checkNoWarningsAndNoticesOnScreen($I)
-    {
-        // Check that no Xdebug errors exist.
-        $I->dontSeeElement('.xdebug-error');
-        $I->dontSeeElement('.xe-notice');
-    }
+class Xdebug extends \Codeception\Module {
+
+	/**
+	 * Helper method to assert that there are non PHP errors, warnings or notices output
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Acceptance Tester.
+	 */
+	public function checkNoWarningsAndNoticesOnScreen( $I ) {
+		// Check that no Xdebug errors exist.
+		$I->dontSeeElement( '.xdebug-error' );
+		$I->dontSeeElement( '.xe-notice' );
+	}
 }

--- a/tests/_support/Helper/Acceptance/Xdebug.php
+++ b/tests/_support/Helper/Acceptance/Xdebug.php
@@ -1,16 +1,20 @@
 <?php
 namespace Helper\Acceptance;
 
-// Define any custom actions related to PHP's Xdebug that
-// would be used across multiple tests.
-// These are then available in $I->{yourFunctionName}
-
+/**
+ * Helper methods and actions related to PHP's Xdebug,
+ * which are then available using $I->{yourFunctionName}.
+ *
+ * @since   1.9.6
+ */
 class Xdebug extends \Codeception\Module
 {
 	/**
 	 * Helper method to assert that there are non PHP errors, warnings or notices output
 	 *
 	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I Acceptance Tester.
 	 */
 	public function checkNoWarningsAndNoticesOnScreen($I)
 	{

--- a/tests/_support/Helper/Acceptance/Xdebug.php
+++ b/tests/_support/Helper/Acceptance/Xdebug.php
@@ -7,15 +7,15 @@ namespace Helper\Acceptance;
 
 class Xdebug extends \Codeception\Module
 {
-	/**
-	 * Helper method to assert that there are non PHP errors, warnings or notices output
-	 * 
-	 * @since 	1.9.6
-	 */
-	public function checkNoWarningsAndNoticesOnScreen($I)
-	{
-		// Check that no Xdebug errors exist.
-		$I->dontSeeElement('.xdebug-error');
-		$I->dontSeeElement('.xe-notice');
-	}
+    /**
+     * Helper method to assert that there are non PHP errors, warnings or notices output
+     * 
+     * @since 1.9.6
+     */
+    public function checkNoWarningsAndNoticesOnScreen($I)
+    {
+        // Check that no Xdebug errors exist.
+        $I->dontSeeElement('.xdebug-error');
+        $I->dontSeeElement('.xe-notice');
+    }
 }

--- a/tests/_support/Helper/Functional.php
+++ b/tests/_support/Helper/Functional.php
@@ -4,7 +4,7 @@ namespace Helper;
 // here you can define custom actions
 // all public methods declared in helper class will be available in $I
 
-class Functional extends \Codeception\Module
-{
+class Functional extends \Codeception\Module {
+
 
 }

--- a/tests/_support/Helper/Functional.php
+++ b/tests/_support/Helper/Functional.php
@@ -1,9 +1,10 @@
 <?php
 namespace Helper;
 
-// here you can define custom actions
-// all public methods declared in helper class will be available in $I
-
+/**
+ * Here you can define custom actions
+ * All public methods declared in helper class will be available in $I
+ */
 class Functional extends \Codeception\Module
 {
 

--- a/tests/_support/Helper/Functional.php
+++ b/tests/_support/Helper/Functional.php
@@ -4,7 +4,7 @@ namespace Helper;
 // here you can define custom actions
 // all public methods declared in helper class will be available in $I
 
-class Functional extends \Codeception\Module {
-
+class Functional extends \Codeception\Module
+{
 
 }

--- a/tests/_support/Helper/Unit.php
+++ b/tests/_support/Helper/Unit.php
@@ -4,7 +4,7 @@ namespace Helper;
 // here you can define custom actions
 // all public methods declared in helper class will be available in $I
 
-class Unit extends \Codeception\Module
-{
+class Unit extends \Codeception\Module {
+
 
 }

--- a/tests/_support/Helper/Unit.php
+++ b/tests/_support/Helper/Unit.php
@@ -4,7 +4,7 @@ namespace Helper;
 // here you can define custom actions
 // all public methods declared in helper class will be available in $I
 
-class Unit extends \Codeception\Module {
-
+class Unit extends \Codeception\Module
+{
 
 }

--- a/tests/_support/Helper/Unit.php
+++ b/tests/_support/Helper/Unit.php
@@ -1,9 +1,10 @@
 <?php
 namespace Helper;
 
-// here you can define custom actions
-// all public methods declared in helper class will be available in $I
-
+/**
+ * Here you can define custom actions
+ * All public methods declared in helper class will be available in $I
+ */
 class Unit extends \Codeception\Module
 {
 

--- a/tests/_support/Helper/Wpunit.php
+++ b/tests/_support/Helper/Wpunit.php
@@ -4,7 +4,7 @@ namespace Helper;
 // here you can define custom actions
 // all public methods declared in helper class will be available in $I
 
-class Wpunit extends \Codeception\Module
-{
+class Wpunit extends \Codeception\Module {
+
 
 }

--- a/tests/_support/Helper/Wpunit.php
+++ b/tests/_support/Helper/Wpunit.php
@@ -1,9 +1,10 @@
 <?php
 namespace Helper;
 
-// here you can define custom actions
-// all public methods declared in helper class will be available in $I
-
+/**
+ * Here you can define custom actions
+ * All public methods declared in helper class will be available in $I
+ */
 class Wpunit extends \Codeception\Module
 {
 

--- a/tests/_support/Helper/Wpunit.php
+++ b/tests/_support/Helper/Wpunit.php
@@ -4,7 +4,7 @@ namespace Helper;
 // here you can define custom actions
 // all public methods declared in helper class will be available in $I
 
-class Wpunit extends \Codeception\Module {
-
+class Wpunit extends \Codeception\Module
+{
 
 }

--- a/tests/_support/UnitTester.php
+++ b/tests/_support/UnitTester.php
@@ -3,7 +3,6 @@
 
 /**
  * Inherited Methods
- *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)
@@ -16,9 +15,9 @@
  * @method void pause()
  *
  * @SuppressWarnings(PHPMD)
- */
-class UnitTester extends \Codeception\Actor {
-
+*/
+class UnitTester extends \Codeception\Actor
+{
 	use _generated\UnitTesterActions;
 
 	/**

--- a/tests/_support/UnitTester.php
+++ b/tests/_support/UnitTester.php
@@ -17,11 +17,11 @@
  *
  * @SuppressWarnings(PHPMD)
  */
-class UnitTester extends \Codeception\Actor
-{
-    use _generated\UnitTesterActions;
+class UnitTester extends \Codeception\Actor {
 
-    /**
-     * Define custom actions here
-     */
+	use _generated\UnitTesterActions;
+
+	/**
+	 * Define custom actions here
+	 */
 }

--- a/tests/_support/UnitTester.php
+++ b/tests/_support/UnitTester.php
@@ -3,6 +3,7 @@
 
 /**
  * Inherited Methods
+ *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)
@@ -15,7 +16,7 @@
  * @method void pause()
  *
  * @SuppressWarnings(PHPMD)
-*/
+ */
 class UnitTester extends \Codeception\Actor
 {
 	use _generated\UnitTesterActions;

--- a/tests/_support/UnitTester.php
+++ b/tests/_support/UnitTester.php
@@ -3,6 +3,7 @@
 
 /**
  * Inherited Methods
+ *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)
@@ -15,12 +16,12 @@
  * @method void pause()
  *
  * @SuppressWarnings(PHPMD)
-*/
+ */
 class UnitTester extends \Codeception\Actor
 {
-	use _generated\UnitTesterActions;
+    use _generated\UnitTesterActions;
 
-	/**
-	 * Define custom actions here
-	 */
+    /**
+     * Define custom actions here
+     */
 }

--- a/tests/_support/WpunitTester.php
+++ b/tests/_support/WpunitTester.php
@@ -3,6 +3,7 @@
 
 /**
  * Inherited Methods
+ *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)
@@ -15,7 +16,7 @@
  * @method void pause()
  *
  * @SuppressWarnings(PHPMD)
-*/
+ */
 class WpunitTester extends \Codeception\Actor
 {
 	use _generated\WpunitTesterActions;

--- a/tests/_support/WpunitTester.php
+++ b/tests/_support/WpunitTester.php
@@ -3,6 +3,7 @@
 
 /**
  * Inherited Methods
+ *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)
@@ -15,12 +16,12 @@
  * @method void pause()
  *
  * @SuppressWarnings(PHPMD)
-*/
+ */
 class WpunitTester extends \Codeception\Actor
 {
-	use _generated\WpunitTesterActions;
+    use _generated\WpunitTesterActions;
 
-	/**
-	 * Define custom actions here
-	 */
+    /**
+     * Define custom actions here
+     */
 }

--- a/tests/_support/WpunitTester.php
+++ b/tests/_support/WpunitTester.php
@@ -17,11 +17,11 @@
  *
  * @SuppressWarnings(PHPMD)
  */
-class WpunitTester extends \Codeception\Actor
-{
-    use _generated\WpunitTesterActions;
+class WpunitTester extends \Codeception\Actor {
 
-    /**
-     * Define custom actions here
-     */
+	use _generated\WpunitTesterActions;
+
+	/**
+	 * Define custom actions here
+	 */
 }

--- a/tests/_support/WpunitTester.php
+++ b/tests/_support/WpunitTester.php
@@ -3,7 +3,6 @@
 
 /**
  * Inherited Methods
- *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)
@@ -16,9 +15,9 @@
  * @method void pause()
  *
  * @SuppressWarnings(PHPMD)
- */
-class WpunitTester extends \Codeception\Actor {
-
+*/
+class WpunitTester extends \Codeception\Actor
+{
 	use _generated\WpunitTesterActions;
 
 	/**

--- a/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
@@ -1,301 +1,303 @@
 <?php
 /**
  * Tests for the ConvertKit Broadcasts Gutenberg Block.
- * 
+ *
  * @since 1.9.7.4
  */
-class PageBlockBroadcastsCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.7.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        $I->activateConvertKitPlugin($I);
-        $I->setupConvertKitPlugin($I);
-        $I->enableDebugLog($I);
-    }
+class PageBlockBroadcastsCest {
 
-    /**
-     * Test the Broadcasts block works when using the default parameters.
-     * 
-     * @since 1.9.7.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsBlockWithDefaultParameters(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Default Params');
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.7.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		$I->activateConvertKitPlugin( $I );
+		$I->setupConvertKitPlugin( $I );
+		$I->enableDebugLog( $I );
+	}
 
-        // Add block to Page.
-        $I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
+	/**
+	 * Test the Broadcasts block works when using the default parameters.
+	 *
+	 * @since 1.9.7.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsBlockWithDefaultParameters( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Default Params' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
+		// Add block to Page.
+		$I->addGutenbergBlock( $I, 'ConvertKit Broadcasts', 'convertkit-broadcasts' );
 
-        // Confirm that the block displays.
-        $I->seeBroadcastsOutput($I);
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
 
-        // Confirm that the default date format is as expected.
-        $I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
+		// Confirm that the block displays.
+		$I->seeBroadcastsOutput( $I );
 
-        // Confirm that the default expected number of Broadcasts are displayed.
-        $I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
-    }
+		// Confirm that the default date format is as expected.
+		$I->seeInSource( '<time datetime="2022-04-08">April 8, 2022</time>' );
 
-    /**
-     * Test the Broadcasts block's date format parameter works.
-     * 
-     * @since 1.9.7.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsBlockWithDateFormatParameter(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Date Format Param');
+		// Confirm that the default expected number of Broadcasts are displayed.
+		$I->seeNumberOfElements( 'li.convertkit-broadcast', array( 1, 10 ) );
+	}
 
-        // Add block to Page, setting the date format.
-        $I->addGutenbergBlock(
-            $I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
-            'date_format' => [ 'select', 'Y-m-d' ],
-            ]
-        );
+	/**
+	 * Test the Broadcasts block's date format parameter works.
+	 *
+	 * @since 1.9.7.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsBlockWithDateFormatParameter( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Date Format Param' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
+		// Add block to Page, setting the date format.
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			array(
+				'date_format' => array( 'select', 'Y-m-d' ),
+			)
+		);
 
-        // Confirm that the block displays.
-        $I->seeBroadcastsOutput($I);
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
 
-        // Confirm that the date format is as expected.
-        $I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
+		// Confirm that the block displays.
+		$I->seeBroadcastsOutput( $I );
 
-        // Confirm that the default expected number of Broadcasts are displayed.
-        $I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
-    }
+		// Confirm that the date format is as expected.
+		$I->seeInSource( '<time datetime="2022-04-08">2022-04-08</time>' );
 
-    /**
-     * Test the Broadcasts block's limit parameter works.
-     * 
-     * @since 1.9.7.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsBlockWithLimitParameter(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Limit Param');
+		// Confirm that the default expected number of Broadcasts are displayed.
+		$I->seeNumberOfElements( 'li.convertkit-broadcast', array( 1, 10 ) );
+	}
 
-        // Add block to Page, setting the limit.
-        $I->addGutenbergBlock(
-            $I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
-            'limit' => [ 'input', '2' ],
-            ]
-        );
+	/**
+	 * Test the Broadcasts block's limit parameter works.
+	 *
+	 * @since 1.9.7.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsBlockWithLimitParameter( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Limit Param' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
+		// Add block to Page, setting the limit.
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			array(
+				'limit' => array( 'input', '2' ),
+			)
+		);
 
-        // Confirm that the block displays.
-        $I->seeBroadcastsOutput($I);
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
 
-        // Confirm that the expected number of Broadcasts are displayed.
-        $I->seeNumberOfElements('li.convertkit-broadcast', 2);
-    }
+		// Confirm that the block displays.
+		$I->seeBroadcastsOutput( $I );
 
-    /**
-     * Test the Broadcasts block renders when the limit parameter is blank.
-     * 
-     * @since 1.9.7.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsBlockWithBlankLimitParameter(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Blank Limit Param');
+		// Confirm that the expected number of Broadcasts are displayed.
+		$I->seeNumberOfElements( 'li.convertkit-broadcast', 2 );
+	}
 
-        // Add block to Page.
-        $I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
+	/**
+	 * Test the Broadcasts block renders when the limit parameter is blank.
+	 *
+	 * @since 1.9.7.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsBlockWithBlankLimitParameter( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Blank Limit Param' );
 
-        // When the sidebar appears, blank the limit parameter as the user might, by pressing the backspace key twice.
-        $I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
-        $I->pressKey('#convertkit_broadcasts_limit', \Facebook\WebDriver\WebDriverKeys::BACKSPACE);
-        $I->pressKey('#convertkit_broadcasts_limit', \Facebook\WebDriver\WebDriverKeys::BACKSPACE);
+		// Add block to Page.
+		$I->addGutenbergBlock( $I, 'ConvertKit Broadcasts', 'convertkit-broadcasts' );
 
-        // Confirm that the block did not encounter an error and fail to render.
-        $I->checkGutenbergBlockHasNoErrors($I, 'ConvertKit Broadcasts');
+		// When the sidebar appears, blank the limit parameter as the user might, by pressing the backspace key twice.
+		$I->waitForElementVisible( '.interface-interface-skeleton__sidebar[aria-label="Editor settings"]' );
+		$I->pressKey( '#convertkit_broadcasts_limit', \Facebook\WebDriver\WebDriverKeys::BACKSPACE );
+		$I->pressKey( '#convertkit_broadcasts_limit', \Facebook\WebDriver\WebDriverKeys::BACKSPACE );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
+		// Confirm that the block did not encounter an error and fail to render.
+		$I->checkGutenbergBlockHasNoErrors( $I, 'ConvertKit Broadcasts' );
 
-        // Confirm that the block displays.
-        $I->seeBroadcastsOutput($I);
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
 
-        // Confirm that the expected number of Broadcasts are displayed.
-        $I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
-    }
+		// Confirm that the block displays.
+		$I->seeBroadcastsOutput( $I );
 
-    /**
-     * Test the Broadcasts block's pagination works when enabled.
-     * 
-     * @since 1.9.7.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsBlockWithPaginationEnabled(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Pagination');
+		// Confirm that the expected number of Broadcasts are displayed.
+		$I->seeNumberOfElements( 'li.convertkit-broadcast', array( 1, 10 ) );
+	}
 
-        // Add block to Page, setting the limit.
-        $I->addGutenbergBlock(
-            $I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
-            'limit'                      => [ 'input', '1' ],
-            '.components-form-toggle'     => [ 'toggle', true ],
-            ]
-        );
+	/**
+	 * Test the Broadcasts block's pagination works when enabled.
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsBlockWithPaginationEnabled( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Pagination' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
+		// Add block to Page, setting the limit.
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			array(
+				'limit'                   => array( 'input', '1' ),
+				'.components-form-toggle' => array( 'toggle', true ),
+			)
+		);
 
-        // Test pagination.
-        $I->testBroadcastsPagination($I, 'Previous', 'Next');
-    }
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
 
-    /**
-     * Test the Broadcasts block's pagination labels work when defined.
-     * 
-     * @since 1.9.7.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsBlockWithPaginationLabelParameters(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Pagination Labels');
+		// Test pagination.
+		$I->testBroadcastsPagination( $I, 'Previous', 'Next' );
+	}
 
-        // Add block to Page, setting the limit.
-        $I->addGutenbergBlock(
-            $I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
-            'limit'                        => [ 'input', '1' ],
-            '.components-form-toggle'     => [ 'toggle', true ],
-            'paginate_label_prev'         => [ 'input', 'Newer' ],
-            'paginate_label_next'         => [ 'input', 'Older' ],
-            ]
-        );
+	/**
+	 * Test the Broadcasts block's pagination labels work when defined.
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsBlockWithPaginationLabelParameters( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Pagination Labels' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
+		// Add block to Page, setting the limit.
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			array(
+				'limit'                   => array( 'input', '1' ),
+				'.components-form-toggle' => array( 'toggle', true ),
+				'paginate_label_prev'     => array( 'input', 'Newer' ),
+				'paginate_label_next'     => array( 'input', 'Older' ),
+			)
+		);
 
-        // Test pagination.
-        $I->testBroadcastsPagination($I, 'Older', 'Newer');
-    }
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
 
-    /**
-     * Test the Broadcasts block's theme color parameters works.
-     * 
-     * @since 1.9.7.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsBlockWithThemeColorParameters(AcceptanceTester $I)
-    {
-        // Define colors.
-        $backgroundColor = 'white';
-        $textColor = 'purple';
+		// Test pagination.
+		$I->testBroadcastsPagination( $I, 'Older', 'Newer' );
+	}
 
-        // It's tricky to interact with Gutenberg's color picker, so we programmatically create the Page
-        // instead to then confirm the color settings apply on the output.
-        // We don't need to test the color picker itself, as it's a Gutenberg supplied component, and our
-        // other Acceptance tests confirm that the block can be added in Gutenberg etc.
-        $I->havePageInDatabase(
-            [
-            'post_name'     => 'convertkit-page-broadcasts-block-theme-color-params',
-            'post_content'     => '<!-- wp:convertkit/broadcasts {"backgroundColor":"'.$backgroundColor.'","textColor":"'.$textColor.'"} /-->',
-            ]
-        );
+	/**
+	 * Test the Broadcasts block's theme color parameters works.
+	 *
+	 * @since 1.9.7.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsBlockWithThemeColorParameters( AcceptanceTester $I ) {
+		// Define colors.
+		$backgroundColor = 'white';
+		$textColor       = 'purple';
 
-        // Load the Page on the frontend site.
-        $I->amOnPage('/convertkit-page-broadcasts-block-theme-color-params');
+		// It's tricky to interact with Gutenberg's color picker, so we programmatically create the Page
+		// instead to then confirm the color settings apply on the output.
+		// We don't need to test the color picker itself, as it's a Gutenberg supplied component, and our
+		// other Acceptance tests confirm that the block can be added in Gutenberg etc.
+		$I->havePageInDatabase(
+			array(
+				'post_name'    => 'convertkit-page-broadcasts-block-theme-color-params',
+				'post_content' => '<!-- wp:convertkit/broadcasts {"backgroundColor":"' . $backgroundColor . '","textColor":"' . $textColor . '"} /-->',
+			)
+		);
 
-        // Wait for frontend web site to load.
-        $I->waitForElementVisible('body.page-template-default');
+		// Load the Page on the frontend site.
+		$I->amOnPage( '/convertkit-page-broadcasts-block-theme-color-params' );
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible( 'body.page-template-default' );
 
-        // Confirm that the block displays.
-        $I->seeBroadcastsOutput($I);
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-        // Confirm that our stylesheet loaded.
-        $I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="'.$_ENV['TEST_SITE_WP_URL'].'/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
+		// Confirm that the block displays.
+		$I->seeBroadcastsOutput( $I );
 
-        // Confirm that the chosen colors are applied as CSS styles.
-        $I->seeInSource('<div class="convertkit-broadcasts has-text-color has-'.$textColor.'-color has-background has-'.$backgroundColor.'-background-color"');
-    }
+		// Confirm that our stylesheet loaded.
+		$I->seeInSource( '<link rel="stylesheet" id="convertkit-broadcasts-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css' );
 
-    /**
-     * Test the Broadcasts block's hex color parameters works.
-     * 
-     * @since 1.9.7.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsBlockWithHexColorParameters(AcceptanceTester $I)
-    {
-        // Define colors.
-        $backgroundColor = '#ee1616';
-        $textColor = '#1212c0';
+		// Confirm that the chosen colors are applied as CSS styles.
+		$I->seeInSource( '<div class="convertkit-broadcasts has-text-color has-' . $textColor . '-color has-background has-' . $backgroundColor . '-background-color"' );
+	}
 
-        // It's tricky to interact with Gutenberg's color picker, so we programmatically create the Page
-        // instead to then confirm the color settings apply on the output.
-        // We don't need to test the color picker itself, as it's a Gutenberg supplied component, and our
-        // other Acceptance tests confirm that the block can be added in Gutenberg etc.
-        $I->havePageInDatabase(
-            [
-            'post_name'     => 'convertkit-page-broadcasts-block-hex-color-params',
-            'post_content'     => '<!-- wp:convertkit/broadcasts {"date_format":"m/d/Y","limit":3,"style":{"color":{"text":"'.$textColor.'","background":"'.$backgroundColor.'"}}} /-->',
-            ]
-        );
+	/**
+	 * Test the Broadcasts block's hex color parameters works.
+	 *
+	 * @since 1.9.7.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsBlockWithHexColorParameters( AcceptanceTester $I ) {
+		// Define colors.
+		$backgroundColor = '#ee1616';
+		$textColor       = '#1212c0';
 
-        // Load the Page on the frontend site.
-        $I->amOnPage('/convertkit-page-broadcasts-block-hex-color-params');
+		// It's tricky to interact with Gutenberg's color picker, so we programmatically create the Page
+		// instead to then confirm the color settings apply on the output.
+		// We don't need to test the color picker itself, as it's a Gutenberg supplied component, and our
+		// other Acceptance tests confirm that the block can be added in Gutenberg etc.
+		$I->havePageInDatabase(
+			array(
+				'post_name'    => 'convertkit-page-broadcasts-block-hex-color-params',
+				'post_content' => '<!-- wp:convertkit/broadcasts {"date_format":"m/d/Y","limit":3,"style":{"color":{"text":"' . $textColor . '","background":"' . $backgroundColor . '"}}} /-->',
+			)
+		);
 
-        // Wait for frontend web site to load.
-        $I->waitForElementVisible('body.page-template-default');
+		// Load the Page on the frontend site.
+		$I->amOnPage( '/convertkit-page-broadcasts-block-hex-color-params' );
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible( 'body.page-template-default' );
 
-        // Confirm that the block displays.
-        $I->seeBroadcastsOutput($I);
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-        // Confirm that our stylesheet loaded.
-        $I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="'.$_ENV['TEST_SITE_WP_URL'].'/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
+		// Confirm that the block displays.
+		$I->seeBroadcastsOutput( $I );
 
-        // Confirm that the chosen colors are applied as CSS styles.
-        $I->seeInSource('<div class="convertkit-broadcasts has-text-color has-background" style="color:'.$textColor.';background-color:'.$backgroundColor.'"');
-    }
+		// Confirm that our stylesheet loaded.
+		$I->seeInSource( '<link rel="stylesheet" id="convertkit-broadcasts-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css' );
 
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.7.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+		// Confirm that the chosen colors are applied as CSS styles.
+		$I->seeInSource( '<div class="convertkit-broadcasts has-text-color has-background" style="color:' . $textColor . ';background-color:' . $backgroundColor . '"' );
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.7.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
@@ -1,17 +1,17 @@
 <?php
 /**
  * Tests for the ConvertKit Broadcasts Gutenberg Block.
- * 
- * @since 	1.9.7.4
+ *
+ * @since   1.9.7.4
  */
 class PageBlockBroadcastsCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -22,10 +22,10 @@ class PageBlockBroadcastsCest
 
 	/**
 	 * Test the Broadcasts block works when using the default parameters.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsBlockWithDefaultParameters(AcceptanceTester $I)
 	{
@@ -45,15 +45,15 @@ class PageBlockBroadcastsCest
 		$I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
 
 		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
+		$I->seeNumberOfElements('li.convertkit-broadcast', [ 1, 10 ]);
 	}
 
 	/**
 	 * Test the Broadcasts block's date format parameter works.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsBlockWithDateFormatParameter(AcceptanceTester $I)
 	{
@@ -61,9 +61,14 @@ class PageBlockBroadcastsCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Date Format Param');
 
 		// Add block to Page, setting the date format.
-		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
-			'date_format' => [ 'select', 'Y-m-d' ],
-		]);
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			[
+				'date_format' => [ 'select', 'Y-m-d' ],
+			]
+		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -75,15 +80,15 @@ class PageBlockBroadcastsCest
 		$I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
 
 		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
+		$I->seeNumberOfElements('li.convertkit-broadcast', [ 1, 10 ]);
 	}
 
 	/**
 	 * Test the Broadcasts block's limit parameter works.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsBlockWithLimitParameter(AcceptanceTester $I)
 	{
@@ -91,9 +96,14 @@ class PageBlockBroadcastsCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Limit Param');
 
 		// Add block to Page, setting the limit.
-		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
-			'limit' => [ 'input', '2' ],
-		]);
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			[
+				'limit' => [ 'input', '2' ],
+			]
+		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -107,10 +117,10 @@ class PageBlockBroadcastsCest
 
 	/**
 	 * Test the Broadcasts block renders when the limit parameter is blank.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsBlockWithBlankLimitParameter(AcceptanceTester $I)
 	{
@@ -135,15 +145,15 @@ class PageBlockBroadcastsCest
 		$I->seeBroadcastsOutput($I);
 
 		// Confirm that the expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
+		$I->seeNumberOfElements('li.convertkit-broadcast', [ 1, 10 ]);
 	}
 
 	/**
 	 * Test the Broadcasts block's pagination works when enabled.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsBlockWithPaginationEnabled(AcceptanceTester $I)
 	{
@@ -151,10 +161,15 @@ class PageBlockBroadcastsCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Pagination');
 
 		// Add block to Page, setting the limit.
-		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
-			'limit' 	 				=> [ 'input', '1' ],
-			'.components-form-toggle' 	=> [ 'toggle', true ],
-		]);
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			[
+				'limit'                   => [ 'input', '1' ],
+				'.components-form-toggle' => [ 'toggle', true ],
+			]
+		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -165,10 +180,10 @@ class PageBlockBroadcastsCest
 
 	/**
 	 * Test the Broadcasts block's pagination labels work when defined.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsBlockWithPaginationLabelParameters(AcceptanceTester $I)
 	{
@@ -176,12 +191,17 @@ class PageBlockBroadcastsCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Pagination Labels');
 
 		// Add block to Page, setting the limit.
-		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
-			'limit' 	 		  		=> [ 'input', '1' ],
-			'.components-form-toggle' 	=> [ 'toggle', true ],
-			'paginate_label_prev' 		=> [ 'input', 'Newer' ],
-			'paginate_label_next' 		=> [ 'input', 'Older' ],
-		]);
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			[
+				'limit'                   => [ 'input', '1' ],
+				'.components-form-toggle' => [ 'toggle', true ],
+				'paginate_label_prev'     => [ 'input', 'Newer' ],
+				'paginate_label_next'     => [ 'input', 'Older' ],
+			]
+		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -192,25 +212,27 @@ class PageBlockBroadcastsCest
 
 	/**
 	 * Test the Broadcasts block's theme color parameters works.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsBlockWithThemeColorParameters(AcceptanceTester $I)
 	{
 		// Define colors.
 		$backgroundColor = 'white';
-		$textColor = 'purple';
+		$textColor       = 'purple';
 
 		// It's tricky to interact with Gutenberg's color picker, so we programmatically create the Page
 		// instead to then confirm the color settings apply on the output.
 		// We don't need to test the color picker itself, as it's a Gutenberg supplied component, and our
 		// other Acceptance tests confirm that the block can be added in Gutenberg etc.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-page-broadcasts-block-theme-color-params',
-			'post_content' 	=> '<!-- wp:convertkit/broadcasts {"backgroundColor":"'.$backgroundColor.'","textColor":"'.$textColor.'"} /-->',
-		]);
+		$I->havePageInDatabase(
+			[
+				'post_name'    => 'convertkit-page-broadcasts-block-theme-color-params',
+				'post_content' => '<!-- wp:convertkit/broadcasts {"backgroundColor":"' . $backgroundColor . '","textColor":"' . $textColor . '"} /-->',
+			]
+		);
 
 		// Load the Page on the frontend site.
 		$I->amOnPage('/convertkit-page-broadcasts-block-theme-color-params');
@@ -225,33 +247,35 @@ class PageBlockBroadcastsCest
 		$I->seeBroadcastsOutput($I);
 
 		// Confirm that our stylesheet loaded.
-		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="'.$_ENV['TEST_SITE_WP_URL'].'/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
+		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
 
 		// Confirm that the chosen colors are applied as CSS styles.
-		$I->seeInSource('<div class="convertkit-broadcasts has-text-color has-'.$textColor.'-color has-background has-'.$backgroundColor.'-background-color"');
+		$I->seeInSource('<div class="convertkit-broadcasts has-text-color has-' . $textColor . '-color has-background has-' . $backgroundColor . '-background-color"');
 	}
 
 	/**
 	 * Test the Broadcasts block's hex color parameters works.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsBlockWithHexColorParameters(AcceptanceTester $I)
 	{
 		// Define colors.
 		$backgroundColor = '#ee1616';
-		$textColor = '#1212c0';
+		$textColor       = '#1212c0';
 
 		// It's tricky to interact with Gutenberg's color picker, so we programmatically create the Page
 		// instead to then confirm the color settings apply on the output.
 		// We don't need to test the color picker itself, as it's a Gutenberg supplied component, and our
 		// other Acceptance tests confirm that the block can be added in Gutenberg etc.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-page-broadcasts-block-hex-color-params',
-			'post_content' 	=> '<!-- wp:convertkit/broadcasts {"date_format":"m/d/Y","limit":3,"style":{"color":{"text":"'.$textColor.'","background":"'.$backgroundColor.'"}}} /-->',
-		]);
+		$I->havePageInDatabase(
+			[
+				'post_name'    => 'convertkit-page-broadcasts-block-hex-color-params',
+				'post_content' => '<!-- wp:convertkit/broadcasts {"date_format":"m/d/Y","limit":3,"style":{"color":{"text":"' . $textColor . '","background":"' . $backgroundColor . '"}}} /-->',
+			]
+		);
 
 		// Load the Page on the frontend site.
 		$I->amOnPage('/convertkit-page-broadcasts-block-hex-color-params');
@@ -266,20 +290,20 @@ class PageBlockBroadcastsCest
 		$I->seeBroadcastsOutput($I);
 
 		// Confirm that our stylesheet loaded.
-		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="'.$_ENV['TEST_SITE_WP_URL'].'/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
+		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
 
 		// Confirm that the chosen colors are applied as CSS styles.
-		$I->seeInSource('<div class="convertkit-broadcasts has-text-color has-background" style="color:'.$textColor.';background-color:'.$backgroundColor.'"');
+		$I->seeInSource('<div class="convertkit-broadcasts has-text-color has-background" style="color:' . $textColor . ';background-color:' . $backgroundColor . '"');
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
@@ -1,303 +1,289 @@
 <?php
 /**
  * Tests for the ConvertKit Broadcasts Gutenberg Block.
- *
- * @since 1.9.7.4
+ * 
+ * @since 	1.9.7.4
  */
-class PageBlockBroadcastsCest {
-
+class PageBlockBroadcastsCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.7.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
-		$I->activateConvertKitPlugin( $I );
-		$I->setupConvertKitPlugin( $I );
-		$I->enableDebugLog( $I );
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
 	}
 
 	/**
 	 * Test the Broadcasts block works when using the default parameters.
-	 *
-	 * @since 1.9.7.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsBlockWithDefaultParameters( AcceptanceTester $I ) {
+	public function testBroadcastsBlockWithDefaultParameters(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Default Params' );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Default Params');
 
 		// Add block to Page.
-		$I->addGutenbergBlock( $I, 'ConvertKit Broadcasts', 'convertkit-broadcasts' );
+		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the block displays.
-		$I->seeBroadcastsOutput( $I );
+		$I->seeBroadcastsOutput($I);
 
 		// Confirm that the default date format is as expected.
-		$I->seeInSource( '<time datetime="2022-04-08">April 8, 2022</time>' );
+		$I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
 
 		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements( 'li.convertkit-broadcast', array( 1, 10 ) );
+		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
 	}
 
 	/**
 	 * Test the Broadcasts block's date format parameter works.
-	 *
-	 * @since 1.9.7.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsBlockWithDateFormatParameter( AcceptanceTester $I ) {
+	public function testBroadcastsBlockWithDateFormatParameter(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Date Format Param' );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Date Format Param');
 
 		// Add block to Page, setting the date format.
-		$I->addGutenbergBlock(
-			$I,
-			'ConvertKit Broadcasts',
-			'convertkit-broadcasts',
-			array(
-				'date_format' => array( 'select', 'Y-m-d' ),
-			)
-		);
+		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
+			'date_format' => [ 'select', 'Y-m-d' ],
+		]);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the block displays.
-		$I->seeBroadcastsOutput( $I );
+		$I->seeBroadcastsOutput($I);
 
 		// Confirm that the date format is as expected.
-		$I->seeInSource( '<time datetime="2022-04-08">2022-04-08</time>' );
+		$I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
 
 		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements( 'li.convertkit-broadcast', array( 1, 10 ) );
+		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
 	}
 
 	/**
 	 * Test the Broadcasts block's limit parameter works.
-	 *
-	 * @since 1.9.7.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsBlockWithLimitParameter( AcceptanceTester $I ) {
+	public function testBroadcastsBlockWithLimitParameter(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Limit Param' );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Limit Param');
 
 		// Add block to Page, setting the limit.
-		$I->addGutenbergBlock(
-			$I,
-			'ConvertKit Broadcasts',
-			'convertkit-broadcasts',
-			array(
-				'limit' => array( 'input', '2' ),
-			)
-		);
+		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
+			'limit' => [ 'input', '2' ],
+		]);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the block displays.
-		$I->seeBroadcastsOutput( $I );
+		$I->seeBroadcastsOutput($I);
 
 		// Confirm that the expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements( 'li.convertkit-broadcast', 2 );
+		$I->seeNumberOfElements('li.convertkit-broadcast', 2);
 	}
 
 	/**
 	 * Test the Broadcasts block renders when the limit parameter is blank.
-	 *
-	 * @since 1.9.7.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsBlockWithBlankLimitParameter( AcceptanceTester $I ) {
+	public function testBroadcastsBlockWithBlankLimitParameter(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Blank Limit Param' );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Blank Limit Param');
 
 		// Add block to Page.
-		$I->addGutenbergBlock( $I, 'ConvertKit Broadcasts', 'convertkit-broadcasts' );
+		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
 
 		// When the sidebar appears, blank the limit parameter as the user might, by pressing the backspace key twice.
-		$I->waitForElementVisible( '.interface-interface-skeleton__sidebar[aria-label="Editor settings"]' );
-		$I->pressKey( '#convertkit_broadcasts_limit', \Facebook\WebDriver\WebDriverKeys::BACKSPACE );
-		$I->pressKey( '#convertkit_broadcasts_limit', \Facebook\WebDriver\WebDriverKeys::BACKSPACE );
+		$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
+		$I->pressKey('#convertkit_broadcasts_limit', \Facebook\WebDriver\WebDriverKeys::BACKSPACE );
+		$I->pressKey('#convertkit_broadcasts_limit', \Facebook\WebDriver\WebDriverKeys::BACKSPACE );
 
 		// Confirm that the block did not encounter an error and fail to render.
-		$I->checkGutenbergBlockHasNoErrors( $I, 'ConvertKit Broadcasts' );
+		$I->checkGutenbergBlockHasNoErrors($I, 'ConvertKit Broadcasts');
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the block displays.
-		$I->seeBroadcastsOutput( $I );
+		$I->seeBroadcastsOutput($I);
 
 		// Confirm that the expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements( 'li.convertkit-broadcast', array( 1, 10 ) );
+		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
 	}
 
 	/**
 	 * Test the Broadcasts block's pagination works when enabled.
-	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsBlockWithPaginationEnabled( AcceptanceTester $I ) {
+	public function testBroadcastsBlockWithPaginationEnabled(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Pagination' );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Pagination');
 
 		// Add block to Page, setting the limit.
-		$I->addGutenbergBlock(
-			$I,
-			'ConvertKit Broadcasts',
-			'convertkit-broadcasts',
-			array(
-				'limit'                   => array( 'input', '1' ),
-				'.components-form-toggle' => array( 'toggle', true ),
-			)
-		);
+		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
+			'limit' 	 				=> [ 'input', '1' ],
+			'.components-form-toggle' 	=> [ 'toggle', true ],
+		]);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Test pagination.
-		$I->testBroadcastsPagination( $I, 'Previous', 'Next' );
+		$I->testBroadcastsPagination($I, 'Previous', 'Next');
 	}
 
 	/**
 	 * Test the Broadcasts block's pagination labels work when defined.
-	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsBlockWithPaginationLabelParameters( AcceptanceTester $I ) {
+	public function testBroadcastsBlockWithPaginationLabelParameters(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Pagination Labels' );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Pagination Labels');
 
 		// Add block to Page, setting the limit.
-		$I->addGutenbergBlock(
-			$I,
-			'ConvertKit Broadcasts',
-			'convertkit-broadcasts',
-			array(
-				'limit'                   => array( 'input', '1' ),
-				'.components-form-toggle' => array( 'toggle', true ),
-				'paginate_label_prev'     => array( 'input', 'Newer' ),
-				'paginate_label_next'     => array( 'input', 'Older' ),
-			)
-		);
+		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
+			'limit' 	 		  		=> [ 'input', '1' ],
+			'.components-form-toggle' 	=> [ 'toggle', true ],
+			'paginate_label_prev' 		=> [ 'input', 'Newer' ],
+			'paginate_label_next' 		=> [ 'input', 'Older' ],
+		]);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Test pagination.
-		$I->testBroadcastsPagination( $I, 'Older', 'Newer' );
+		$I->testBroadcastsPagination($I, 'Older', 'Newer');
 	}
 
 	/**
 	 * Test the Broadcasts block's theme color parameters works.
-	 *
-	 * @since 1.9.7.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsBlockWithThemeColorParameters( AcceptanceTester $I ) {
+	public function testBroadcastsBlockWithThemeColorParameters(AcceptanceTester $I)
+	{
 		// Define colors.
 		$backgroundColor = 'white';
-		$textColor       = 'purple';
+		$textColor = 'purple';
 
 		// It's tricky to interact with Gutenberg's color picker, so we programmatically create the Page
 		// instead to then confirm the color settings apply on the output.
 		// We don't need to test the color picker itself, as it's a Gutenberg supplied component, and our
 		// other Acceptance tests confirm that the block can be added in Gutenberg etc.
-		$I->havePageInDatabase(
-			array(
-				'post_name'    => 'convertkit-page-broadcasts-block-theme-color-params',
-				'post_content' => '<!-- wp:convertkit/broadcasts {"backgroundColor":"' . $backgroundColor . '","textColor":"' . $textColor . '"} /-->',
-			)
-		);
+		$I->havePageInDatabase([
+			'post_name' 	=> 'convertkit-page-broadcasts-block-theme-color-params',
+			'post_content' 	=> '<!-- wp:convertkit/broadcasts {"backgroundColor":"'.$backgroundColor.'","textColor":"'.$textColor.'"} /-->',
+		]);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage( '/convertkit-page-broadcasts-block-theme-color-params' );
+		$I->amOnPage('/convertkit-page-broadcasts-block-theme-color-params');
 
 		// Wait for frontend web site to load.
-		$I->waitForElementVisible( 'body.page-template-default' );
+		$I->waitForElementVisible('body.page-template-default');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the block displays.
-		$I->seeBroadcastsOutput( $I );
+		$I->seeBroadcastsOutput($I);
 
 		// Confirm that our stylesheet loaded.
-		$I->seeInSource( '<link rel="stylesheet" id="convertkit-broadcasts-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css' );
+		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="'.$_ENV['TEST_SITE_WP_URL'].'/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
 
 		// Confirm that the chosen colors are applied as CSS styles.
-		$I->seeInSource( '<div class="convertkit-broadcasts has-text-color has-' . $textColor . '-color has-background has-' . $backgroundColor . '-background-color"' );
+		$I->seeInSource('<div class="convertkit-broadcasts has-text-color has-'.$textColor.'-color has-background has-'.$backgroundColor.'-background-color"');
 	}
 
 	/**
 	 * Test the Broadcasts block's hex color parameters works.
-	 *
-	 * @since 1.9.7.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsBlockWithHexColorParameters( AcceptanceTester $I ) {
+	public function testBroadcastsBlockWithHexColorParameters(AcceptanceTester $I)
+	{
 		// Define colors.
 		$backgroundColor = '#ee1616';
-		$textColor       = '#1212c0';
+		$textColor = '#1212c0';
 
 		// It's tricky to interact with Gutenberg's color picker, so we programmatically create the Page
 		// instead to then confirm the color settings apply on the output.
 		// We don't need to test the color picker itself, as it's a Gutenberg supplied component, and our
 		// other Acceptance tests confirm that the block can be added in Gutenberg etc.
-		$I->havePageInDatabase(
-			array(
-				'post_name'    => 'convertkit-page-broadcasts-block-hex-color-params',
-				'post_content' => '<!-- wp:convertkit/broadcasts {"date_format":"m/d/Y","limit":3,"style":{"color":{"text":"' . $textColor . '","background":"' . $backgroundColor . '"}}} /-->',
-			)
-		);
+		$I->havePageInDatabase([
+			'post_name' 	=> 'convertkit-page-broadcasts-block-hex-color-params',
+			'post_content' 	=> '<!-- wp:convertkit/broadcasts {"date_format":"m/d/Y","limit":3,"style":{"color":{"text":"'.$textColor.'","background":"'.$backgroundColor.'"}}} /-->',
+		]);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage( '/convertkit-page-broadcasts-block-hex-color-params' );
+		$I->amOnPage('/convertkit-page-broadcasts-block-hex-color-params');
 
 		// Wait for frontend web site to load.
-		$I->waitForElementVisible( 'body.page-template-default' );
+		$I->waitForElementVisible('body.page-template-default');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the block displays.
-		$I->seeBroadcastsOutput( $I );
+		$I->seeBroadcastsOutput($I);
 
 		// Confirm that our stylesheet loaded.
-		$I->seeInSource( '<link rel="stylesheet" id="convertkit-broadcasts-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css' );
+		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="'.$_ENV['TEST_SITE_WP_URL'].'/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
 
 		// Confirm that the chosen colors are applied as CSS styles.
-		$I->seeInSource( '<div class="convertkit-broadcasts has-text-color has-background" style="color:' . $textColor . ';background-color:' . $backgroundColor . '"' );
+		$I->seeInSource('<div class="convertkit-broadcasts has-text-color has-background" style="color:'.$textColor.';background-color:'.$backgroundColor.'"');
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.7.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
@@ -2,288 +2,300 @@
 /**
  * Tests for the ConvertKit Broadcasts Gutenberg Block.
  * 
- * @since 	1.9.7.4
+ * @since 1.9.7.4
  */
 class PageBlockBroadcastsCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
-	}
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.7.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        $I->activateConvertKitPlugin($I);
+        $I->setupConvertKitPlugin($I);
+        $I->enableDebugLog($I);
+    }
 
-	/**
-	 * Test the Broadcasts block works when using the default parameters.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsBlockWithDefaultParameters(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Default Params');
+    /**
+     * Test the Broadcasts block works when using the default parameters.
+     * 
+     * @since 1.9.7.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsBlockWithDefaultParameters(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Default Params');
 
-		// Add block to Page.
-		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
+        // Add block to Page.
+        $I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Confirm that the block displays.
-		$I->seeBroadcastsOutput($I);
+        // Confirm that the block displays.
+        $I->seeBroadcastsOutput($I);
 
-		// Confirm that the default date format is as expected.
-		$I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
+        // Confirm that the default date format is as expected.
+        $I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
 
-		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
-	}
+        // Confirm that the default expected number of Broadcasts are displayed.
+        $I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
+    }
 
-	/**
-	 * Test the Broadcasts block's date format parameter works.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsBlockWithDateFormatParameter(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Date Format Param');
+    /**
+     * Test the Broadcasts block's date format parameter works.
+     * 
+     * @since 1.9.7.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsBlockWithDateFormatParameter(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Date Format Param');
 
-		// Add block to Page, setting the date format.
-		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
-			'date_format' => [ 'select', 'Y-m-d' ],
-		]);
+        // Add block to Page, setting the date format.
+        $I->addGutenbergBlock(
+            $I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
+            'date_format' => [ 'select', 'Y-m-d' ],
+            ]
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Confirm that the block displays.
-		$I->seeBroadcastsOutput($I);
+        // Confirm that the block displays.
+        $I->seeBroadcastsOutput($I);
 
-		// Confirm that the date format is as expected.
-		$I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
+        // Confirm that the date format is as expected.
+        $I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
 
-		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
-	}
+        // Confirm that the default expected number of Broadcasts are displayed.
+        $I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
+    }
 
-	/**
-	 * Test the Broadcasts block's limit parameter works.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsBlockWithLimitParameter(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Limit Param');
+    /**
+     * Test the Broadcasts block's limit parameter works.
+     * 
+     * @since 1.9.7.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsBlockWithLimitParameter(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Limit Param');
 
-		// Add block to Page, setting the limit.
-		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
-			'limit' => [ 'input', '2' ],
-		]);
+        // Add block to Page, setting the limit.
+        $I->addGutenbergBlock(
+            $I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
+            'limit' => [ 'input', '2' ],
+            ]
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Confirm that the block displays.
-		$I->seeBroadcastsOutput($I);
+        // Confirm that the block displays.
+        $I->seeBroadcastsOutput($I);
 
-		// Confirm that the expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', 2);
-	}
+        // Confirm that the expected number of Broadcasts are displayed.
+        $I->seeNumberOfElements('li.convertkit-broadcast', 2);
+    }
 
-	/**
-	 * Test the Broadcasts block renders when the limit parameter is blank.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsBlockWithBlankLimitParameter(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Blank Limit Param');
+    /**
+     * Test the Broadcasts block renders when the limit parameter is blank.
+     * 
+     * @since 1.9.7.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsBlockWithBlankLimitParameter(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Blank Limit Param');
 
-		// Add block to Page.
-		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
+        // Add block to Page.
+        $I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
 
-		// When the sidebar appears, blank the limit parameter as the user might, by pressing the backspace key twice.
-		$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
-		$I->pressKey('#convertkit_broadcasts_limit', \Facebook\WebDriver\WebDriverKeys::BACKSPACE );
-		$I->pressKey('#convertkit_broadcasts_limit', \Facebook\WebDriver\WebDriverKeys::BACKSPACE );
+        // When the sidebar appears, blank the limit parameter as the user might, by pressing the backspace key twice.
+        $I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
+        $I->pressKey('#convertkit_broadcasts_limit', \Facebook\WebDriver\WebDriverKeys::BACKSPACE);
+        $I->pressKey('#convertkit_broadcasts_limit', \Facebook\WebDriver\WebDriverKeys::BACKSPACE);
 
-		// Confirm that the block did not encounter an error and fail to render.
-		$I->checkGutenbergBlockHasNoErrors($I, 'ConvertKit Broadcasts');
+        // Confirm that the block did not encounter an error and fail to render.
+        $I->checkGutenbergBlockHasNoErrors($I, 'ConvertKit Broadcasts');
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Confirm that the block displays.
-		$I->seeBroadcastsOutput($I);
+        // Confirm that the block displays.
+        $I->seeBroadcastsOutput($I);
 
-		// Confirm that the expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
-	}
+        // Confirm that the expected number of Broadcasts are displayed.
+        $I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
+    }
 
-	/**
-	 * Test the Broadcasts block's pagination works when enabled.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsBlockWithPaginationEnabled(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Pagination');
+    /**
+     * Test the Broadcasts block's pagination works when enabled.
+     * 
+     * @since 1.9.7.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsBlockWithPaginationEnabled(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Pagination');
 
-		// Add block to Page, setting the limit.
-		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
-			'limit' 	 				=> [ 'input', '1' ],
-			'.components-form-toggle' 	=> [ 'toggle', true ],
-		]);
+        // Add block to Page, setting the limit.
+        $I->addGutenbergBlock(
+            $I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
+            'limit'                      => [ 'input', '1' ],
+            '.components-form-toggle'     => [ 'toggle', true ],
+            ]
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Previous', 'Next');
-	}
+        // Test pagination.
+        $I->testBroadcastsPagination($I, 'Previous', 'Next');
+    }
 
-	/**
-	 * Test the Broadcasts block's pagination labels work when defined.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsBlockWithPaginationLabelParameters(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Pagination Labels');
+    /**
+     * Test the Broadcasts block's pagination labels work when defined.
+     * 
+     * @since 1.9.7.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsBlockWithPaginationLabelParameters(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Pagination Labels');
 
-		// Add block to Page, setting the limit.
-		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
-			'limit' 	 		  		=> [ 'input', '1' ],
-			'.components-form-toggle' 	=> [ 'toggle', true ],
-			'paginate_label_prev' 		=> [ 'input', 'Newer' ],
-			'paginate_label_next' 		=> [ 'input', 'Older' ],
-		]);
+        // Add block to Page, setting the limit.
+        $I->addGutenbergBlock(
+            $I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
+            'limit'                        => [ 'input', '1' ],
+            '.components-form-toggle'     => [ 'toggle', true ],
+            'paginate_label_prev'         => [ 'input', 'Newer' ],
+            'paginate_label_next'         => [ 'input', 'Older' ],
+            ]
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Older', 'Newer');
-	}
+        // Test pagination.
+        $I->testBroadcastsPagination($I, 'Older', 'Newer');
+    }
 
-	/**
-	 * Test the Broadcasts block's theme color parameters works.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsBlockWithThemeColorParameters(AcceptanceTester $I)
-	{
-		// Define colors.
-		$backgroundColor = 'white';
-		$textColor = 'purple';
+    /**
+     * Test the Broadcasts block's theme color parameters works.
+     * 
+     * @since 1.9.7.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsBlockWithThemeColorParameters(AcceptanceTester $I)
+    {
+        // Define colors.
+        $backgroundColor = 'white';
+        $textColor = 'purple';
 
-		// It's tricky to interact with Gutenberg's color picker, so we programmatically create the Page
-		// instead to then confirm the color settings apply on the output.
-		// We don't need to test the color picker itself, as it's a Gutenberg supplied component, and our
-		// other Acceptance tests confirm that the block can be added in Gutenberg etc.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-page-broadcasts-block-theme-color-params',
-			'post_content' 	=> '<!-- wp:convertkit/broadcasts {"backgroundColor":"'.$backgroundColor.'","textColor":"'.$textColor.'"} /-->',
-		]);
+        // It's tricky to interact with Gutenberg's color picker, so we programmatically create the Page
+        // instead to then confirm the color settings apply on the output.
+        // We don't need to test the color picker itself, as it's a Gutenberg supplied component, and our
+        // other Acceptance tests confirm that the block can be added in Gutenberg etc.
+        $I->havePageInDatabase(
+            [
+            'post_name'     => 'convertkit-page-broadcasts-block-theme-color-params',
+            'post_content'     => '<!-- wp:convertkit/broadcasts {"backgroundColor":"'.$backgroundColor.'","textColor":"'.$textColor.'"} /-->',
+            ]
+        );
 
-		// Load the Page on the frontend site.
-		$I->amOnPage('/convertkit-page-broadcasts-block-theme-color-params');
+        // Load the Page on the frontend site.
+        $I->amOnPage('/convertkit-page-broadcasts-block-theme-color-params');
 
-		// Wait for frontend web site to load.
-		$I->waitForElementVisible('body.page-template-default');
+        // Wait for frontend web site to load.
+        $I->waitForElementVisible('body.page-template-default');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the block displays.
-		$I->seeBroadcastsOutput($I);
+        // Confirm that the block displays.
+        $I->seeBroadcastsOutput($I);
 
-		// Confirm that our stylesheet loaded.
-		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="'.$_ENV['TEST_SITE_WP_URL'].'/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
+        // Confirm that our stylesheet loaded.
+        $I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="'.$_ENV['TEST_SITE_WP_URL'].'/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
 
-		// Confirm that the chosen colors are applied as CSS styles.
-		$I->seeInSource('<div class="convertkit-broadcasts has-text-color has-'.$textColor.'-color has-background has-'.$backgroundColor.'-background-color"');
-	}
+        // Confirm that the chosen colors are applied as CSS styles.
+        $I->seeInSource('<div class="convertkit-broadcasts has-text-color has-'.$textColor.'-color has-background has-'.$backgroundColor.'-background-color"');
+    }
 
-	/**
-	 * Test the Broadcasts block's hex color parameters works.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsBlockWithHexColorParameters(AcceptanceTester $I)
-	{
-		// Define colors.
-		$backgroundColor = '#ee1616';
-		$textColor = '#1212c0';
+    /**
+     * Test the Broadcasts block's hex color parameters works.
+     * 
+     * @since 1.9.7.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsBlockWithHexColorParameters(AcceptanceTester $I)
+    {
+        // Define colors.
+        $backgroundColor = '#ee1616';
+        $textColor = '#1212c0';
 
-		// It's tricky to interact with Gutenberg's color picker, so we programmatically create the Page
-		// instead to then confirm the color settings apply on the output.
-		// We don't need to test the color picker itself, as it's a Gutenberg supplied component, and our
-		// other Acceptance tests confirm that the block can be added in Gutenberg etc.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-page-broadcasts-block-hex-color-params',
-			'post_content' 	=> '<!-- wp:convertkit/broadcasts {"date_format":"m/d/Y","limit":3,"style":{"color":{"text":"'.$textColor.'","background":"'.$backgroundColor.'"}}} /-->',
-		]);
+        // It's tricky to interact with Gutenberg's color picker, so we programmatically create the Page
+        // instead to then confirm the color settings apply on the output.
+        // We don't need to test the color picker itself, as it's a Gutenberg supplied component, and our
+        // other Acceptance tests confirm that the block can be added in Gutenberg etc.
+        $I->havePageInDatabase(
+            [
+            'post_name'     => 'convertkit-page-broadcasts-block-hex-color-params',
+            'post_content'     => '<!-- wp:convertkit/broadcasts {"date_format":"m/d/Y","limit":3,"style":{"color":{"text":"'.$textColor.'","background":"'.$backgroundColor.'"}}} /-->',
+            ]
+        );
 
-		// Load the Page on the frontend site.
-		$I->amOnPage('/convertkit-page-broadcasts-block-hex-color-params');
+        // Load the Page on the frontend site.
+        $I->amOnPage('/convertkit-page-broadcasts-block-hex-color-params');
 
-		// Wait for frontend web site to load.
-		$I->waitForElementVisible('body.page-template-default');
+        // Wait for frontend web site to load.
+        $I->waitForElementVisible('body.page-template-default');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the block displays.
-		$I->seeBroadcastsOutput($I);
+        // Confirm that the block displays.
+        $I->seeBroadcastsOutput($I);
 
-		// Confirm that our stylesheet loaded.
-		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="'.$_ENV['TEST_SITE_WP_URL'].'/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
+        // Confirm that our stylesheet loaded.
+        $I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="'.$_ENV['TEST_SITE_WP_URL'].'/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
 
-		// Confirm that the chosen colors are applied as CSS styles.
-		$I->seeInSource('<div class="convertkit-broadcasts has-text-color has-background" style="color:'.$textColor.';background-color:'.$backgroundColor.'"');
-	}
+        // Confirm that the chosen colors are applied as CSS styles.
+        $I->seeInSource('<div class="convertkit-broadcasts has-text-color has-background" style="color:'.$textColor.';background-color:'.$backgroundColor.'"');
+    }
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.7.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
@@ -2,437 +2,439 @@
 /**
  * Tests for the ConvertKit Form shortcode.
  * 
- * @since 	1.9.7.4
+ * @since 1.9.7.4
  */
 class PageShortcodeBroadcastsCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
-	}
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.7.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        $I->activateConvertKitPlugin($I);
+        $I->setupConvertKitPlugin($I);
+        $I->enableDebugLog($I);
+    }
 
-	/**
-	 * Test the [convertkit_broadcasts] shortcode works when using the default parameters,
-	 * using the Classic Editor (TinyMCE / Visual).
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsShortcodeInVisualEditorWithDefaultParameters(AcceptanceTester $I)
-	{
-		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor');
+    /**
+     * Test the [convertkit_broadcasts] shortcode works when using the default parameters,
+     * using the Classic Editor (TinyMCE / Visual).
+     * 
+     * @since 1.9.7.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsShortcodeInVisualEditorWithDefaultParameters(AcceptanceTester $I)
+    {
+        // Add a Page using the Classic Editor.
+        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor');
 
-		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
-		$I->addVisualEditorShortcode(
-			$I,
-			'ConvertKit Broadcasts',
-			'convertkit-broadcasts',
-			false,
-			'[convertkit_broadcasts date_format="F j, Y" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
-		);
+        // Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+        $I->addVisualEditorShortcode(
+            $I,
+            'ConvertKit Broadcasts',
+            'convertkit-broadcasts',
+            false,
+            '[convertkit_broadcasts date_format="F j, Y" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewClassicEditorPage($I);
 
-		// Confirm that the shortcode output displays.
-		$I->seeBroadcastsOutput($I);
+        // Confirm that the shortcode output displays.
+        $I->seeBroadcastsOutput($I);
 
-		// Confirm that the default date format is as expected.
-		$I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
+        // Confirm that the default date format is as expected.
+        $I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
 
-		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
-	}
+        // Confirm that the default expected number of Broadcasts are displayed.
+        $I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
+    }
 
-	/**
-	 * Test the [convertkit_broadcasts] shortcode works when specifying a non-default date format parameter,
-	 * using the Classic Editor (TinyMCE / Visual).
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsShortcodeInVisualEditorWithDateFormatParameter(AcceptanceTester $I)
-	{
-		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Date Format');
+    /**
+     * Test the [convertkit_broadcasts] shortcode works when specifying a non-default date format parameter,
+     * using the Classic Editor (TinyMCE / Visual).
+     * 
+     * @since 1.9.7.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsShortcodeInVisualEditorWithDateFormatParameter(AcceptanceTester $I)
+    {
+        // Add a Page using the Classic Editor.
+        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Date Format');
 
-		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
-		$I->addVisualEditorShortcode(
-			$I,
-			'ConvertKit Broadcasts',
-			'convertkit-broadcasts',
-			[
-				'date_format' => [ 'select', date('Y-m-d') ],
-			],
-			'[convertkit_broadcasts date_format="Y-m-d" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
-		);
+        // Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+        $I->addVisualEditorShortcode(
+            $I,
+            'ConvertKit Broadcasts',
+            'convertkit-broadcasts',
+            [
+            'date_format' => [ 'select', date('Y-m-d') ],
+            ],
+            '[convertkit_broadcasts date_format="Y-m-d" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewClassicEditorPage($I);
 
-		// Confirm that the shortcode output displays.
-		$I->seeBroadcastsOutput($I);
+        // Confirm that the shortcode output displays.
+        $I->seeBroadcastsOutput($I);
 
-		// Confirm that the default date format is as expected.
-		$I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
+        // Confirm that the default date format is as expected.
+        $I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
 
-		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
-	}
+        // Confirm that the default expected number of Broadcasts are displayed.
+        $I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
+    }
 
-	/**
-	 * Test the [convertkit_broadcasts] shortcode works when specifying a non-default limit parameter,
-	 * using the Classic Editor (TinyMCE / Visual).
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsShortcodeInVisualEditorWithLimitParameter(AcceptanceTester $I)
-	{
-		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Limit');
+    /**
+     * Test the [convertkit_broadcasts] shortcode works when specifying a non-default limit parameter,
+     * using the Classic Editor (TinyMCE / Visual).
+     * 
+     * @since 1.9.7.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsShortcodeInVisualEditorWithLimitParameter(AcceptanceTester $I)
+    {
+        // Add a Page using the Classic Editor.
+        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Limit');
 
-		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
-		$I->addVisualEditorShortcode(
-			$I,
-			'ConvertKit Broadcasts',
-			'convertkit-broadcasts',
-			[
-				'limit' => [ 'input', '2' ],
-			],
-			'[convertkit_broadcasts date_format="F j, Y" limit="2" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
-		);
+        // Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+        $I->addVisualEditorShortcode(
+            $I,
+            'ConvertKit Broadcasts',
+            'convertkit-broadcasts',
+            [
+            'limit' => [ 'input', '2' ],
+            ],
+            '[convertkit_broadcasts date_format="F j, Y" limit="2" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewClassicEditorPage($I);
 
-		// Confirm that the shortcode output displays.
-		$I->seeBroadcastsOutput($I);
+        // Confirm that the shortcode output displays.
+        $I->seeBroadcastsOutput($I);
 
-		// Confirm that the default date format is as expected.
-		$I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
+        // Confirm that the default date format is as expected.
+        $I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
 
-		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', 2);
-	}
+        // Confirm that the default expected number of Broadcasts are displayed.
+        $I->seeNumberOfElements('li.convertkit-broadcast', 2);
+    }
 
-	/**
-	 * Test the [convertkit_broadcasts] shortcode pagination works when enabled,
-	 * using the Classic Editor (TinyMCE / Visual).
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsShortcodeInVisualEditorWithPaginationEnabled(AcceptanceTester $I)
-	{
-		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Pagination');
+    /**
+     * Test the [convertkit_broadcasts] shortcode pagination works when enabled,
+     * using the Classic Editor (TinyMCE / Visual).
+     * 
+     * @since 1.9.7.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsShortcodeInVisualEditorWithPaginationEnabled(AcceptanceTester $I)
+    {
+        // Add a Page using the Classic Editor.
+        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Pagination');
 
-		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
-		$I->addVisualEditorShortcode(
-			$I,
-			'ConvertKit Broadcasts',
-			'convertkit-broadcasts',
-			[
-				'limit' 	=> [ 'input', '1' ],
-				'paginate' 	=> [ 'toggle', 'Yes' ],
-			],
-			'[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
-		);
+        // Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+        $I->addVisualEditorShortcode(
+            $I,
+            'ConvertKit Broadcasts',
+            'convertkit-broadcasts',
+            [
+            'limit'     => [ 'input', '1' ],
+            'paginate'     => [ 'toggle', 'Yes' ],
+            ],
+            '[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewClassicEditorPage($I);
 
-		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Previous', 'Next');
-	}
+        // Test pagination.
+        $I->testBroadcastsPagination($I, 'Previous', 'Next');
+    }
 
-	/**
-	 * Test the [convertkit_broadcasts] shortcode pagination works when enabled,
-	 * using the Classic Editor (TinyMCE / Visual).
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsShortcodeInVisualEditorWithPaginationLabelParameters(AcceptanceTester $I)
-	{
-		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Pagination Labels');
+    /**
+     * Test the [convertkit_broadcasts] shortcode pagination works when enabled,
+     * using the Classic Editor (TinyMCE / Visual).
+     * 
+     * @since 1.9.7.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsShortcodeInVisualEditorWithPaginationLabelParameters(AcceptanceTester $I)
+    {
+        // Add a Page using the Classic Editor.
+        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Pagination Labels');
 
-		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
-		$I->addVisualEditorShortcode(
-			$I,
-			'ConvertKit Broadcasts',
-			'convertkit-broadcasts',
-			[
-				'limit' 			  => [ 'input', '1' ],
-				'paginate' 			  => [ 'toggle', 'Yes' ],
-				'paginate_label_prev' => [ 'input', 'Newer' ],
-				'paginate_label_next' => [ 'input', 'Older' ],
-			],
-			'[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older"]'
-		);
+        // Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+        $I->addVisualEditorShortcode(
+            $I,
+            'ConvertKit Broadcasts',
+            'convertkit-broadcasts',
+            [
+            'limit'               => [ 'input', '1' ],
+            'paginate'               => [ 'toggle', 'Yes' ],
+            'paginate_label_prev' => [ 'input', 'Newer' ],
+            'paginate_label_next' => [ 'input', 'Older' ],
+            ],
+            '[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older"]'
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewClassicEditorPage($I);
 
-		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Older', 'Newer');
-	}
+        // Test pagination.
+        $I->testBroadcastsPagination($I, 'Older', 'Newer');
+    }
 
-	/**
-	 * Test the [convertkit_broadcasts] shortcode hex colors works when chosen,
-	 * using the Classic Editor (TinyMCE / Visual).
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsShortcodeInVisualEditorWithHexColorParameters(AcceptanceTester $I)
-	{
-		// Define colors.
-		$backgroundColor = '#ee1616';
-		$textColor = '#1212c0';
-		$linkColor = '#ffffff';
+    /**
+     * Test the [convertkit_broadcasts] shortcode hex colors works when chosen,
+     * using the Classic Editor (TinyMCE / Visual).
+     * 
+     * @since 1.9.8.5
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsShortcodeInVisualEditorWithHexColorParameters(AcceptanceTester $I)
+    {
+        // Define colors.
+        $backgroundColor = '#ee1616';
+        $textColor = '#1212c0';
+        $linkColor = '#ffffff';
 
-		// It's tricky to interact with WordPress's color picker, so we programmatically create the Page
-		// instead to then confirm the color settings apply on the output.
-		// We don't need to test the color picker itself, as it's a WordPress supplied component, and our
-		// other Acceptance tests confirm that the shortcode can be added in the Classic Editor.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-page-broadcasts-shortcode-hex-color-params',
-			'post_content' 	=> '[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older" link_color="'.$linkColor.'" background_color="'.$backgroundColor.'" text_color="'.$textColor.'"]'
-		]);
+        // It's tricky to interact with WordPress's color picker, so we programmatically create the Page
+        // instead to then confirm the color settings apply on the output.
+        // We don't need to test the color picker itself, as it's a WordPress supplied component, and our
+        // other Acceptance tests confirm that the shortcode can be added in the Classic Editor.
+        $I->havePageInDatabase(
+            [
+            'post_name'     => 'convertkit-page-broadcasts-shortcode-hex-color-params',
+            'post_content'     => '[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older" link_color="'.$linkColor.'" background_color="'.$backgroundColor.'" text_color="'.$textColor.'"]'
+            ]
+        );
 
-		// Load the Page on the frontend site.
-		$I->amOnPage('/convertkit-page-broadcasts-shortcode-hex-color-params');
+        // Load the Page on the frontend site.
+        $I->amOnPage('/convertkit-page-broadcasts-shortcode-hex-color-params');
 
-		// Wait for frontend web site to load.
-		$I->waitForElementVisible('body.page-template-default');
+        // Wait for frontend web site to load.
+        $I->waitForElementVisible('body.page-template-default');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the block displays.
-		$I->seeBroadcastsOutput($I);
+        // Confirm that the block displays.
+        $I->seeBroadcastsOutput($I);
 
-		// Confirm that our stylesheet loaded.
-		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="'.$_ENV['TEST_SITE_WP_URL'].'/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
+        // Confirm that our stylesheet loaded.
+        $I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="'.$_ENV['TEST_SITE_WP_URL'].'/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
 
-		// Confirm that the chosen colors are applied as CSS styles.
-		$I->seeInSource('<div class="convertkit-broadcasts has-text-color has-background" style="color:'.$textColor.';background-color:'.$backgroundColor.'"');
-		$I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:'.$linkColor.'"');
+        // Confirm that the chosen colors are applied as CSS styles.
+        $I->seeInSource('<div class="convertkit-broadcasts has-text-color has-background" style="color:'.$textColor.';background-color:'.$backgroundColor.'"');
+        $I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:'.$linkColor.'"');
 	
-		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Older', 'Newer');
+        // Test pagination.
+        $I->testBroadcastsPagination($I, 'Older', 'Newer');
 
-		// Confirm that link styles are still applied to refreshed data.
-		$I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:'.$linkColor.'"');
-	}
+        // Confirm that link styles are still applied to refreshed data.
+        $I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:'.$linkColor.'"');
+    }
 
-	/**
-	 * Test the [convertkit_broadcasts] shortcode works when using the default parameters,
-	 * using the Text Editor.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsShortcodeInTextEditorWithDefaultParameters(AcceptanceTester $I)
-	{
-		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor');
+    /**
+     * Test the [convertkit_broadcasts] shortcode works when using the default parameters,
+     * using the Text Editor.
+     * 
+     * @since 1.9.7.5
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsShortcodeInTextEditorWithDefaultParameters(AcceptanceTester $I)
+    {
+        // Add a Page using the Classic Editor.
+        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor');
 
-		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
-		$I->addTextEditorShortcode(
-			$I,
-			'ConvertKit Broadcasts',
-			'convertkit-broadcasts',
-			false,
-			'[convertkit_broadcasts date_format="F j, Y" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
-		);
+        // Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+        $I->addTextEditorShortcode(
+            $I,
+            'ConvertKit Broadcasts',
+            'convertkit-broadcasts',
+            false,
+            '[convertkit_broadcasts date_format="F j, Y" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewClassicEditorPage($I);
 
-		// Confirm that the shortcode output displays.
-		$I->seeBroadcastsOutput($I);
+        // Confirm that the shortcode output displays.
+        $I->seeBroadcastsOutput($I);
 
-		// Confirm that the default date format is as expected.
-		$I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
+        // Confirm that the default date format is as expected.
+        $I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
 
-		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
-	}
+        // Confirm that the default expected number of Broadcasts are displayed.
+        $I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
+    }
 
-	/**
-	 * Test the [convertkit_broadcasts] shortcode works when specifying a non-default date format parameter,
-	 * using the Text Editor.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsShortcodeInTextEditorWithDateFormatParameter(AcceptanceTester $I)
-	{
-		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor: Date Format');
+    /**
+     * Test the [convertkit_broadcasts] shortcode works when specifying a non-default date format parameter,
+     * using the Text Editor.
+     * 
+     * @since 1.9.7.5
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsShortcodeInTextEditorWithDateFormatParameter(AcceptanceTester $I)
+    {
+        // Add a Page using the Classic Editor.
+        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor: Date Format');
 
-		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
-		$I->addTextEditorShortcode(
-			$I,
-			'ConvertKit Broadcasts',
-			'convertkit-broadcasts',
-			[
-				'date_format' => [ 'select', date('Y-m-d') ],
-			],
-			'[convertkit_broadcasts date_format="Y-m-d" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
-		);
+        // Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+        $I->addTextEditorShortcode(
+            $I,
+            'ConvertKit Broadcasts',
+            'convertkit-broadcasts',
+            [
+            'date_format' => [ 'select', date('Y-m-d') ],
+            ],
+            '[convertkit_broadcasts date_format="Y-m-d" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewClassicEditorPage($I);
 
-		// Confirm that the shortcode output displays.
-		$I->seeBroadcastsOutput($I);
+        // Confirm that the shortcode output displays.
+        $I->seeBroadcastsOutput($I);
 
-		// Confirm that the default date format is as expected.
-		$I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
+        // Confirm that the default date format is as expected.
+        $I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
 
-		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
-	}
+        // Confirm that the default expected number of Broadcasts are displayed.
+        $I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
+    }
 
-	/**
-	 * Test the [convertkit_broadcasts] shortcode works when specifying a non-default limit parameter,
-	 * using the Text Editor.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsShortcodeInTextEditorWithLimitParameter(AcceptanceTester $I)
-	{
-		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor: Limit');
+    /**
+     * Test the [convertkit_broadcasts] shortcode works when specifying a non-default limit parameter,
+     * using the Text Editor.
+     * 
+     * @since 1.9.7.5
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsShortcodeInTextEditorWithLimitParameter(AcceptanceTester $I)
+    {
+        // Add a Page using the Classic Editor.
+        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor: Limit');
 
-		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
-		$I->addTextEditorShortcode(
-			$I,
-			'ConvertKit Broadcasts',
-			'convertkit-broadcasts',
-			[
-				'limit' => [ 'input', '2' ],
-			],
-			'[convertkit_broadcasts date_format="F j, Y" limit="2" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
-		);
+        // Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+        $I->addTextEditorShortcode(
+            $I,
+            'ConvertKit Broadcasts',
+            'convertkit-broadcasts',
+            [
+            'limit' => [ 'input', '2' ],
+            ],
+            '[convertkit_broadcasts date_format="F j, Y" limit="2" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewClassicEditorPage($I);
 
-		// Confirm that the shortcode output displays.
-		$I->seeBroadcastsOutput($I);
+        // Confirm that the shortcode output displays.
+        $I->seeBroadcastsOutput($I);
 
-		// Confirm that the default date format is as expected.
-		$I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
+        // Confirm that the default date format is as expected.
+        $I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
 
-		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', 2);
-	}
+        // Confirm that the default expected number of Broadcasts are displayed.
+        $I->seeNumberOfElements('li.convertkit-broadcast', 2);
+    }
 
-	/**
-	 * Test the [convertkit_broadcasts] shortcode pagination works when enabled,
-	 * using the Text Editor.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsShortcodeInTextEditorWithPaginationEnabled(AcceptanceTester $I)
-	{
-		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor: Pagination');
+    /**
+     * Test the [convertkit_broadcasts] shortcode pagination works when enabled,
+     * using the Text Editor.
+     * 
+     * @since 1.9.7.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsShortcodeInTextEditorWithPaginationEnabled(AcceptanceTester $I)
+    {
+        // Add a Page using the Classic Editor.
+        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor: Pagination');
 
-		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
-		$I->addTextEditorShortcode(
-			$I,
-			'ConvertKit Broadcasts',
-			'convertkit-broadcasts',
-			[
-				'limit' 	=> [ 'input', '1' ],
-				'paginate' 	=> [ 'toggle', 'Yes' ],
-			],
-			'[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
-		);
+        // Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+        $I->addTextEditorShortcode(
+            $I,
+            'ConvertKit Broadcasts',
+            'convertkit-broadcasts',
+            [
+            'limit'     => [ 'input', '1' ],
+            'paginate'     => [ 'toggle', 'Yes' ],
+            ],
+            '[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewClassicEditorPage($I);
 
-		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Previous', 'Next');
-	}
+        // Test pagination.
+        $I->testBroadcastsPagination($I, 'Previous', 'Next');
+    }
 
-	/**
-	 * Test the [convertkit_broadcasts] shortcode pagination works when enabled,
-	 * using the Text Editor.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsShortcodeInTextEditorWithPaginationLabelParameters(AcceptanceTester $I)
-	{
-		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor: Pagination Labels');
+    /**
+     * Test the [convertkit_broadcasts] shortcode pagination works when enabled,
+     * using the Text Editor.
+     * 
+     * @since 1.9.7.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsShortcodeInTextEditorWithPaginationLabelParameters(AcceptanceTester $I)
+    {
+        // Add a Page using the Classic Editor.
+        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor: Pagination Labels');
 
-		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
-		$I->addTextEditorShortcode(
-			$I,
-			'ConvertKit Broadcasts',
-			'convertkit-broadcasts',
-			[
-				'limit' 			  => [ 'input', '1' ],
-				'paginate' 			  => [ 'toggle', 'Yes' ],
-				'paginate_label_prev' => [ 'input', 'Newer' ],
-				'paginate_label_next' => [ 'input', 'Older' ],
-			],
-			'[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older"]'
-		);
+        // Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+        $I->addTextEditorShortcode(
+            $I,
+            'ConvertKit Broadcasts',
+            'convertkit-broadcasts',
+            [
+            'limit'               => [ 'input', '1' ],
+            'paginate'               => [ 'toggle', 'Yes' ],
+            'paginate_label_prev' => [ 'input', 'Newer' ],
+            'paginate_label_next' => [ 'input', 'Older' ],
+            ],
+            '[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older"]'
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewClassicEditorPage($I);
 
-		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Older', 'Newer');
-	}
+        // Test pagination.
+        $I->testBroadcastsPagination($I, 'Older', 'Newer');
+    }
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateThirdPartyPlugin($I, 'classic-editor');
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.7.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateThirdPartyPlugin($I, 'classic-editor');
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
@@ -1,440 +1,427 @@
 <?php
 /**
  * Tests for the ConvertKit Form shortcode.
- * 
+ *
  * @since 1.9.7.4
  */
-class PageShortcodeBroadcastsCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.7.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        $I->activateConvertKitPlugin($I);
-        $I->setupConvertKitPlugin($I);
-        $I->enableDebugLog($I);
-    }
+class PageShortcodeBroadcastsCest {
 
-    /**
-     * Test the [convertkit_broadcasts] shortcode works when using the default parameters,
-     * using the Classic Editor (TinyMCE / Visual).
-     * 
-     * @since 1.9.7.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsShortcodeInVisualEditorWithDefaultParameters(AcceptanceTester $I)
-    {
-        // Add a Page using the Classic Editor.
-        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor');
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.7.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		$I->activateConvertKitPlugin( $I );
+		$I->setupConvertKitPlugin( $I );
+		$I->enableDebugLog( $I );
+	}
 
-        // Add shortcode to Page, setting the Form setting to the value specified in the .env file.
-        $I->addVisualEditorShortcode(
-            $I,
-            'ConvertKit Broadcasts',
-            'convertkit-broadcasts',
-            false,
-            '[convertkit_broadcasts date_format="F j, Y" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
-        );
+	/**
+	 * Test the [convertkit_broadcasts] shortcode works when using the default parameters,
+	 * using the Classic Editor (TinyMCE / Visual).
+	 *
+	 * @since 1.9.7.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsShortcodeInVisualEditorWithDefaultParameters( AcceptanceTester $I ) {
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewClassicEditorPage($I);
+		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+		$I->addVisualEditorShortcode(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			false,
+			'[convertkit_broadcasts date_format="F j, Y" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+		);
 
-        // Confirm that the shortcode output displays.
-        $I->seeBroadcastsOutput($I);
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage( $I );
 
-        // Confirm that the default date format is as expected.
-        $I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
+		// Confirm that the shortcode output displays.
+		$I->seeBroadcastsOutput( $I );
 
-        // Confirm that the default expected number of Broadcasts are displayed.
-        $I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
-    }
+		// Confirm that the default date format is as expected.
+		$I->seeInSource( '<time datetime="2022-04-08">April 8, 2022</time>' );
 
-    /**
-     * Test the [convertkit_broadcasts] shortcode works when specifying a non-default date format parameter,
-     * using the Classic Editor (TinyMCE / Visual).
-     * 
-     * @since 1.9.7.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsShortcodeInVisualEditorWithDateFormatParameter(AcceptanceTester $I)
-    {
-        // Add a Page using the Classic Editor.
-        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Date Format');
+		// Confirm that the default expected number of Broadcasts are displayed.
+		$I->seeNumberOfElements( 'li.convertkit-broadcast', array( 1, 10 ) );
+	}
 
-        // Add shortcode to Page, setting the Form setting to the value specified in the .env file.
-        $I->addVisualEditorShortcode(
-            $I,
-            'ConvertKit Broadcasts',
-            'convertkit-broadcasts',
-            [
-            'date_format' => [ 'select', date('Y-m-d') ],
-            ],
-            '[convertkit_broadcasts date_format="Y-m-d" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
-        );
+	/**
+	 * Test the [convertkit_broadcasts] shortcode works when specifying a non-default date format parameter,
+	 * using the Classic Editor (TinyMCE / Visual).
+	 *
+	 * @since 1.9.7.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsShortcodeInVisualEditorWithDateFormatParameter( AcceptanceTester $I ) {
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Date Format' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewClassicEditorPage($I);
+		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+		$I->addVisualEditorShortcode(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			array(
+				'date_format' => array( 'select', date( 'Y-m-d' ) ),
+			),
+			'[convertkit_broadcasts date_format="Y-m-d" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+		);
 
-        // Confirm that the shortcode output displays.
-        $I->seeBroadcastsOutput($I);
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage( $I );
 
-        // Confirm that the default date format is as expected.
-        $I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
+		// Confirm that the shortcode output displays.
+		$I->seeBroadcastsOutput( $I );
 
-        // Confirm that the default expected number of Broadcasts are displayed.
-        $I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
-    }
+		// Confirm that the default date format is as expected.
+		$I->seeInSource( '<time datetime="2022-04-08">2022-04-08</time>' );
 
-    /**
-     * Test the [convertkit_broadcasts] shortcode works when specifying a non-default limit parameter,
-     * using the Classic Editor (TinyMCE / Visual).
-     * 
-     * @since 1.9.7.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsShortcodeInVisualEditorWithLimitParameter(AcceptanceTester $I)
-    {
-        // Add a Page using the Classic Editor.
-        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Limit');
+		// Confirm that the default expected number of Broadcasts are displayed.
+		$I->seeNumberOfElements( 'li.convertkit-broadcast', array( 1, 10 ) );
+	}
 
-        // Add shortcode to Page, setting the Form setting to the value specified in the .env file.
-        $I->addVisualEditorShortcode(
-            $I,
-            'ConvertKit Broadcasts',
-            'convertkit-broadcasts',
-            [
-            'limit' => [ 'input', '2' ],
-            ],
-            '[convertkit_broadcasts date_format="F j, Y" limit="2" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
-        );
+	/**
+	 * Test the [convertkit_broadcasts] shortcode works when specifying a non-default limit parameter,
+	 * using the Classic Editor (TinyMCE / Visual).
+	 *
+	 * @since 1.9.7.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsShortcodeInVisualEditorWithLimitParameter( AcceptanceTester $I ) {
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Limit' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewClassicEditorPage($I);
+		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+		$I->addVisualEditorShortcode(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			array(
+				'limit' => array( 'input', '2' ),
+			),
+			'[convertkit_broadcasts date_format="F j, Y" limit="2" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+		);
 
-        // Confirm that the shortcode output displays.
-        $I->seeBroadcastsOutput($I);
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage( $I );
 
-        // Confirm that the default date format is as expected.
-        $I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
+		// Confirm that the shortcode output displays.
+		$I->seeBroadcastsOutput( $I );
 
-        // Confirm that the default expected number of Broadcasts are displayed.
-        $I->seeNumberOfElements('li.convertkit-broadcast', 2);
-    }
+		// Confirm that the default date format is as expected.
+		$I->seeInSource( '<time datetime="2022-04-08">April 8, 2022</time>' );
 
-    /**
-     * Test the [convertkit_broadcasts] shortcode pagination works when enabled,
-     * using the Classic Editor (TinyMCE / Visual).
-     * 
-     * @since 1.9.7.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsShortcodeInVisualEditorWithPaginationEnabled(AcceptanceTester $I)
-    {
-        // Add a Page using the Classic Editor.
-        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Pagination');
+		// Confirm that the default expected number of Broadcasts are displayed.
+		$I->seeNumberOfElements( 'li.convertkit-broadcast', 2 );
+	}
 
-        // Add shortcode to Page, setting the Form setting to the value specified in the .env file.
-        $I->addVisualEditorShortcode(
-            $I,
-            'ConvertKit Broadcasts',
-            'convertkit-broadcasts',
-            [
-            'limit'     => [ 'input', '1' ],
-            'paginate'     => [ 'toggle', 'Yes' ],
-            ],
-            '[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
-        );
+	/**
+	 * Test the [convertkit_broadcasts] shortcode pagination works when enabled,
+	 * using the Classic Editor (TinyMCE / Visual).
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsShortcodeInVisualEditorWithPaginationEnabled( AcceptanceTester $I ) {
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Pagination' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewClassicEditorPage($I);
+		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+		$I->addVisualEditorShortcode(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			array(
+				'limit'    => array( 'input', '1' ),
+				'paginate' => array( 'toggle', 'Yes' ),
+			),
+			'[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
+		);
 
-        // Test pagination.
-        $I->testBroadcastsPagination($I, 'Previous', 'Next');
-    }
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage( $I );
 
-    /**
-     * Test the [convertkit_broadcasts] shortcode pagination works when enabled,
-     * using the Classic Editor (TinyMCE / Visual).
-     * 
-     * @since 1.9.7.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsShortcodeInVisualEditorWithPaginationLabelParameters(AcceptanceTester $I)
-    {
-        // Add a Page using the Classic Editor.
-        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Pagination Labels');
+		// Test pagination.
+		$I->testBroadcastsPagination( $I, 'Previous', 'Next' );
+	}
 
-        // Add shortcode to Page, setting the Form setting to the value specified in the .env file.
-        $I->addVisualEditorShortcode(
-            $I,
-            'ConvertKit Broadcasts',
-            'convertkit-broadcasts',
-            [
-            'limit'               => [ 'input', '1' ],
-            'paginate'               => [ 'toggle', 'Yes' ],
-            'paginate_label_prev' => [ 'input', 'Newer' ],
-            'paginate_label_next' => [ 'input', 'Older' ],
-            ],
-            '[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older"]'
-        );
+	/**
+	 * Test the [convertkit_broadcasts] shortcode pagination works when enabled,
+	 * using the Classic Editor (TinyMCE / Visual).
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsShortcodeInVisualEditorWithPaginationLabelParameters( AcceptanceTester $I ) {
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Pagination Labels' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewClassicEditorPage($I);
+		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+		$I->addVisualEditorShortcode(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			array(
+				'limit'               => array( 'input', '1' ),
+				'paginate'            => array( 'toggle', 'Yes' ),
+				'paginate_label_prev' => array( 'input', 'Newer' ),
+				'paginate_label_next' => array( 'input', 'Older' ),
+			),
+			'[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older"]'
+		);
 
-        // Test pagination.
-        $I->testBroadcastsPagination($I, 'Older', 'Newer');
-    }
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage( $I );
 
-    /**
-     * Test the [convertkit_broadcasts] shortcode hex colors works when chosen,
-     * using the Classic Editor (TinyMCE / Visual).
-     * 
-     * @since 1.9.8.5
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsShortcodeInVisualEditorWithHexColorParameters(AcceptanceTester $I)
-    {
-        // Define colors.
-        $backgroundColor = '#ee1616';
-        $textColor = '#1212c0';
-        $linkColor = '#ffffff';
+		// Test pagination.
+		$I->testBroadcastsPagination( $I, 'Older', 'Newer' );
+	}
 
-        // It's tricky to interact with WordPress's color picker, so we programmatically create the Page
-        // instead to then confirm the color settings apply on the output.
-        // We don't need to test the color picker itself, as it's a WordPress supplied component, and our
-        // other Acceptance tests confirm that the shortcode can be added in the Classic Editor.
-        $I->havePageInDatabase(
-            [
-            'post_name'     => 'convertkit-page-broadcasts-shortcode-hex-color-params',
-            'post_content'     => '[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older" link_color="'.$linkColor.'" background_color="'.$backgroundColor.'" text_color="'.$textColor.'"]'
-            ]
-        );
+	/**
+	 * Test the [convertkit_broadcasts] shortcode hex colors works when chosen,
+	 * using the Classic Editor (TinyMCE / Visual).
+	 *
+	 * @since 1.9.8.5
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsShortcodeInVisualEditorWithHexColorParameters( AcceptanceTester $I ) {
+		// Define colors.
+		$backgroundColor = '#ee1616';
+		$textColor       = '#1212c0';
+		$linkColor       = '#ffffff';
 
-        // Load the Page on the frontend site.
-        $I->amOnPage('/convertkit-page-broadcasts-shortcode-hex-color-params');
+		// It's tricky to interact with WordPress's color picker, so we programmatically create the Page
+		// instead to then confirm the color settings apply on the output.
+		// We don't need to test the color picker itself, as it's a WordPress supplied component, and our
+		// other Acceptance tests confirm that the shortcode can be added in the Classic Editor.
+		$I->havePageInDatabase(
+			array(
+				'post_name'    => 'convertkit-page-broadcasts-shortcode-hex-color-params',
+				'post_content' => '[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older" link_color="' . $linkColor . '" background_color="' . $backgroundColor . '" text_color="' . $textColor . '"]',
+			)
+		);
 
-        // Wait for frontend web site to load.
-        $I->waitForElementVisible('body.page-template-default');
+		// Load the Page on the frontend site.
+		$I->amOnPage( '/convertkit-page-broadcasts-shortcode-hex-color-params' );
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible( 'body.page-template-default' );
 
-        // Confirm that the block displays.
-        $I->seeBroadcastsOutput($I);
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-        // Confirm that our stylesheet loaded.
-        $I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="'.$_ENV['TEST_SITE_WP_URL'].'/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
+		// Confirm that the block displays.
+		$I->seeBroadcastsOutput( $I );
 
-        // Confirm that the chosen colors are applied as CSS styles.
-        $I->seeInSource('<div class="convertkit-broadcasts has-text-color has-background" style="color:'.$textColor.';background-color:'.$backgroundColor.'"');
-        $I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:'.$linkColor.'"');
-	
-        // Test pagination.
-        $I->testBroadcastsPagination($I, 'Older', 'Newer');
+		// Confirm that our stylesheet loaded.
+		$I->seeInSource( '<link rel="stylesheet" id="convertkit-broadcasts-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css' );
 
-        // Confirm that link styles are still applied to refreshed data.
-        $I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:'.$linkColor.'"');
-    }
+		// Confirm that the chosen colors are applied as CSS styles.
+		$I->seeInSource( '<div class="convertkit-broadcasts has-text-color has-background" style="color:' . $textColor . ';background-color:' . $backgroundColor . '"' );
+		$I->seeInSource( '<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:' . $linkColor . '"' );
 
-    /**
-     * Test the [convertkit_broadcasts] shortcode works when using the default parameters,
-     * using the Text Editor.
-     * 
-     * @since 1.9.7.5
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsShortcodeInTextEditorWithDefaultParameters(AcceptanceTester $I)
-    {
-        // Add a Page using the Classic Editor.
-        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor');
+		// Test pagination.
+		$I->testBroadcastsPagination( $I, 'Older', 'Newer' );
 
-        // Add shortcode to Page, setting the Form setting to the value specified in the .env file.
-        $I->addTextEditorShortcode(
-            $I,
-            'ConvertKit Broadcasts',
-            'convertkit-broadcasts',
-            false,
-            '[convertkit_broadcasts date_format="F j, Y" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
-        );
+		// Confirm that link styles are still applied to refreshed data.
+		$I->seeInSource( '<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:' . $linkColor . '"' );
+	}
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewClassicEditorPage($I);
+	/**
+	 * Test the [convertkit_broadcasts] shortcode works when using the default parameters,
+	 * using the Text Editor.
+	 *
+	 * @since 1.9.7.5
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsShortcodeInTextEditorWithDefaultParameters( AcceptanceTester $I ) {
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor' );
 
-        // Confirm that the shortcode output displays.
-        $I->seeBroadcastsOutput($I);
+		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+		$I->addTextEditorShortcode(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			false,
+			'[convertkit_broadcasts date_format="F j, Y" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+		);
 
-        // Confirm that the default date format is as expected.
-        $I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage( $I );
 
-        // Confirm that the default expected number of Broadcasts are displayed.
-        $I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
-    }
+		// Confirm that the shortcode output displays.
+		$I->seeBroadcastsOutput( $I );
 
-    /**
-     * Test the [convertkit_broadcasts] shortcode works when specifying a non-default date format parameter,
-     * using the Text Editor.
-     * 
-     * @since 1.9.7.5
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsShortcodeInTextEditorWithDateFormatParameter(AcceptanceTester $I)
-    {
-        // Add a Page using the Classic Editor.
-        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor: Date Format');
+		// Confirm that the default date format is as expected.
+		$I->seeInSource( '<time datetime="2022-04-08">April 8, 2022</time>' );
 
-        // Add shortcode to Page, setting the Form setting to the value specified in the .env file.
-        $I->addTextEditorShortcode(
-            $I,
-            'ConvertKit Broadcasts',
-            'convertkit-broadcasts',
-            [
-            'date_format' => [ 'select', date('Y-m-d') ],
-            ],
-            '[convertkit_broadcasts date_format="Y-m-d" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
-        );
+		// Confirm that the default expected number of Broadcasts are displayed.
+		$I->seeNumberOfElements( 'li.convertkit-broadcast', array( 1, 10 ) );
+	}
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewClassicEditorPage($I);
+	/**
+	 * Test the [convertkit_broadcasts] shortcode works when specifying a non-default date format parameter,
+	 * using the Text Editor.
+	 *
+	 * @since 1.9.7.5
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsShortcodeInTextEditorWithDateFormatParameter( AcceptanceTester $I ) {
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor: Date Format' );
 
-        // Confirm that the shortcode output displays.
-        $I->seeBroadcastsOutput($I);
+		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+		$I->addTextEditorShortcode(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			array(
+				'date_format' => array( 'select', date( 'Y-m-d' ) ),
+			),
+			'[convertkit_broadcasts date_format="Y-m-d" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+		);
 
-        // Confirm that the default date format is as expected.
-        $I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage( $I );
 
-        // Confirm that the default expected number of Broadcasts are displayed.
-        $I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
-    }
+		// Confirm that the shortcode output displays.
+		$I->seeBroadcastsOutput( $I );
 
-    /**
-     * Test the [convertkit_broadcasts] shortcode works when specifying a non-default limit parameter,
-     * using the Text Editor.
-     * 
-     * @since 1.9.7.5
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsShortcodeInTextEditorWithLimitParameter(AcceptanceTester $I)
-    {
-        // Add a Page using the Classic Editor.
-        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor: Limit');
+		// Confirm that the default date format is as expected.
+		$I->seeInSource( '<time datetime="2022-04-08">2022-04-08</time>' );
 
-        // Add shortcode to Page, setting the Form setting to the value specified in the .env file.
-        $I->addTextEditorShortcode(
-            $I,
-            'ConvertKit Broadcasts',
-            'convertkit-broadcasts',
-            [
-            'limit' => [ 'input', '2' ],
-            ],
-            '[convertkit_broadcasts date_format="F j, Y" limit="2" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
-        );
+		// Confirm that the default expected number of Broadcasts are displayed.
+		$I->seeNumberOfElements( 'li.convertkit-broadcast', array( 1, 10 ) );
+	}
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewClassicEditorPage($I);
+	/**
+	 * Test the [convertkit_broadcasts] shortcode works when specifying a non-default limit parameter,
+	 * using the Text Editor.
+	 *
+	 * @since 1.9.7.5
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsShortcodeInTextEditorWithLimitParameter( AcceptanceTester $I ) {
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor: Limit' );
 
-        // Confirm that the shortcode output displays.
-        $I->seeBroadcastsOutput($I);
+		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+		$I->addTextEditorShortcode(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			array(
+				'limit' => array( 'input', '2' ),
+			),
+			'[convertkit_broadcasts date_format="F j, Y" limit="2" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+		);
 
-        // Confirm that the default date format is as expected.
-        $I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage( $I );
 
-        // Confirm that the default expected number of Broadcasts are displayed.
-        $I->seeNumberOfElements('li.convertkit-broadcast', 2);
-    }
+		// Confirm that the shortcode output displays.
+		$I->seeBroadcastsOutput( $I );
 
-    /**
-     * Test the [convertkit_broadcasts] shortcode pagination works when enabled,
-     * using the Text Editor.
-     * 
-     * @since 1.9.7.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsShortcodeInTextEditorWithPaginationEnabled(AcceptanceTester $I)
-    {
-        // Add a Page using the Classic Editor.
-        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor: Pagination');
+		// Confirm that the default date format is as expected.
+		$I->seeInSource( '<time datetime="2022-04-08">April 8, 2022</time>' );
 
-        // Add shortcode to Page, setting the Form setting to the value specified in the .env file.
-        $I->addTextEditorShortcode(
-            $I,
-            'ConvertKit Broadcasts',
-            'convertkit-broadcasts',
-            [
-            'limit'     => [ 'input', '1' ],
-            'paginate'     => [ 'toggle', 'Yes' ],
-            ],
-            '[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
-        );
+		// Confirm that the default expected number of Broadcasts are displayed.
+		$I->seeNumberOfElements( 'li.convertkit-broadcast', 2 );
+	}
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewClassicEditorPage($I);
+	/**
+	 * Test the [convertkit_broadcasts] shortcode pagination works when enabled,
+	 * using the Text Editor.
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsShortcodeInTextEditorWithPaginationEnabled( AcceptanceTester $I ) {
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor: Pagination' );
 
-        // Test pagination.
-        $I->testBroadcastsPagination($I, 'Previous', 'Next');
-    }
+		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+		$I->addTextEditorShortcode(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			array(
+				'limit'    => array( 'input', '1' ),
+				'paginate' => array( 'toggle', 'Yes' ),
+			),
+			'[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
+		);
 
-    /**
-     * Test the [convertkit_broadcasts] shortcode pagination works when enabled,
-     * using the Text Editor.
-     * 
-     * @since 1.9.7.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsShortcodeInTextEditorWithPaginationLabelParameters(AcceptanceTester $I)
-    {
-        // Add a Page using the Classic Editor.
-        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor: Pagination Labels');
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage( $I );
 
-        // Add shortcode to Page, setting the Form setting to the value specified in the .env file.
-        $I->addTextEditorShortcode(
-            $I,
-            'ConvertKit Broadcasts',
-            'convertkit-broadcasts',
-            [
-            'limit'               => [ 'input', '1' ],
-            'paginate'               => [ 'toggle', 'Yes' ],
-            'paginate_label_prev' => [ 'input', 'Newer' ],
-            'paginate_label_next' => [ 'input', 'Older' ],
-            ],
-            '[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older"]'
-        );
+		// Test pagination.
+		$I->testBroadcastsPagination( $I, 'Previous', 'Next' );
+	}
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewClassicEditorPage($I);
+	/**
+	 * Test the [convertkit_broadcasts] shortcode pagination works when enabled,
+	 * using the Text Editor.
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsShortcodeInTextEditorWithPaginationLabelParameters( AcceptanceTester $I ) {
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor: Pagination Labels' );
 
-        // Test pagination.
-        $I->testBroadcastsPagination($I, 'Older', 'Newer');
-    }
+		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+		$I->addTextEditorShortcode(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			array(
+				'limit'               => array( 'input', '1' ),
+				'paginate'            => array( 'toggle', 'Yes' ),
+				'paginate_label_prev' => array( 'input', 'Newer' ),
+				'paginate_label_next' => array( 'input', 'Older' ),
+			),
+			'[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older"]'
+		);
 
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.7.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateThirdPartyPlugin($I, 'classic-editor');
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage( $I );
+
+		// Test pagination.
+		$I->testBroadcastsPagination( $I, 'Older', 'Newer' );
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.7.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateThirdPartyPlugin( $I, 'classic-editor' );
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
@@ -1,35 +1,37 @@
 <?php
 /**
  * Tests for the ConvertKit Form shortcode.
- *
- * @since 1.9.7.4
+ * 
+ * @since 	1.9.7.4
  */
-class PageShortcodeBroadcastsCest {
-
+class PageShortcodeBroadcastsCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.7.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
-		$I->activateConvertKitPlugin( $I );
-		$I->setupConvertKitPlugin( $I );
-		$I->enableDebugLog( $I );
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
 	}
 
 	/**
 	 * Test the [convertkit_broadcasts] shortcode works when using the default parameters,
 	 * using the Classic Editor (TinyMCE / Visual).
-	 *
-	 * @since 1.9.7.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsShortcodeInVisualEditorWithDefaultParameters( AcceptanceTester $I ) {
+	public function testBroadcastsShortcodeInVisualEditorWithDefaultParameters(AcceptanceTester $I)
+	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor' );
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor');
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
@@ -41,216 +43,220 @@ class PageShortcodeBroadcastsCest {
 		);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage( $I );
+		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the shortcode output displays.
-		$I->seeBroadcastsOutput( $I );
+		$I->seeBroadcastsOutput($I);
 
 		// Confirm that the default date format is as expected.
-		$I->seeInSource( '<time datetime="2022-04-08">April 8, 2022</time>' );
+		$I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
 
 		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements( 'li.convertkit-broadcast', array( 1, 10 ) );
+		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
 	}
 
 	/**
 	 * Test the [convertkit_broadcasts] shortcode works when specifying a non-default date format parameter,
 	 * using the Classic Editor (TinyMCE / Visual).
-	 *
-	 * @since 1.9.7.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsShortcodeInVisualEditorWithDateFormatParameter( AcceptanceTester $I ) {
+	public function testBroadcastsShortcodeInVisualEditorWithDateFormatParameter(AcceptanceTester $I)
+	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Date Format' );
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Date Format');
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
 			'ConvertKit Broadcasts',
 			'convertkit-broadcasts',
-			array(
-				'date_format' => array( 'select', date( 'Y-m-d' ) ),
-			),
+			[
+				'date_format' => [ 'select', date('Y-m-d') ],
+			],
 			'[convertkit_broadcasts date_format="Y-m-d" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage( $I );
+		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the shortcode output displays.
-		$I->seeBroadcastsOutput( $I );
+		$I->seeBroadcastsOutput($I);
 
 		// Confirm that the default date format is as expected.
-		$I->seeInSource( '<time datetime="2022-04-08">2022-04-08</time>' );
+		$I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
 
 		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements( 'li.convertkit-broadcast', array( 1, 10 ) );
+		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
 	}
 
 	/**
 	 * Test the [convertkit_broadcasts] shortcode works when specifying a non-default limit parameter,
 	 * using the Classic Editor (TinyMCE / Visual).
-	 *
-	 * @since 1.9.7.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsShortcodeInVisualEditorWithLimitParameter( AcceptanceTester $I ) {
+	public function testBroadcastsShortcodeInVisualEditorWithLimitParameter(AcceptanceTester $I)
+	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Limit' );
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Limit');
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
 			'ConvertKit Broadcasts',
 			'convertkit-broadcasts',
-			array(
-				'limit' => array( 'input', '2' ),
-			),
+			[
+				'limit' => [ 'input', '2' ],
+			],
 			'[convertkit_broadcasts date_format="F j, Y" limit="2" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage( $I );
+		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the shortcode output displays.
-		$I->seeBroadcastsOutput( $I );
+		$I->seeBroadcastsOutput($I);
 
 		// Confirm that the default date format is as expected.
-		$I->seeInSource( '<time datetime="2022-04-08">April 8, 2022</time>' );
+		$I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
 
 		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements( 'li.convertkit-broadcast', 2 );
+		$I->seeNumberOfElements('li.convertkit-broadcast', 2);
 	}
 
 	/**
 	 * Test the [convertkit_broadcasts] shortcode pagination works when enabled,
 	 * using the Classic Editor (TinyMCE / Visual).
-	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsShortcodeInVisualEditorWithPaginationEnabled( AcceptanceTester $I ) {
+	public function testBroadcastsShortcodeInVisualEditorWithPaginationEnabled(AcceptanceTester $I)
+	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Pagination' );
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Pagination');
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
 			'ConvertKit Broadcasts',
 			'convertkit-broadcasts',
-			array(
-				'limit'    => array( 'input', '1' ),
-				'paginate' => array( 'toggle', 'Yes' ),
-			),
+			[
+				'limit' 	=> [ 'input', '1' ],
+				'paginate' 	=> [ 'toggle', 'Yes' ],
+			],
 			'[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage( $I );
+		$I->publishAndViewClassicEditorPage($I);
 
 		// Test pagination.
-		$I->testBroadcastsPagination( $I, 'Previous', 'Next' );
+		$I->testBroadcastsPagination($I, 'Previous', 'Next');
 	}
 
 	/**
 	 * Test the [convertkit_broadcasts] shortcode pagination works when enabled,
 	 * using the Classic Editor (TinyMCE / Visual).
-	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsShortcodeInVisualEditorWithPaginationLabelParameters( AcceptanceTester $I ) {
+	public function testBroadcastsShortcodeInVisualEditorWithPaginationLabelParameters(AcceptanceTester $I)
+	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Pagination Labels' );
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Pagination Labels');
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
 			'ConvertKit Broadcasts',
 			'convertkit-broadcasts',
-			array(
-				'limit'               => array( 'input', '1' ),
-				'paginate'            => array( 'toggle', 'Yes' ),
-				'paginate_label_prev' => array( 'input', 'Newer' ),
-				'paginate_label_next' => array( 'input', 'Older' ),
-			),
+			[
+				'limit' 			  => [ 'input', '1' ],
+				'paginate' 			  => [ 'toggle', 'Yes' ],
+				'paginate_label_prev' => [ 'input', 'Newer' ],
+				'paginate_label_next' => [ 'input', 'Older' ],
+			],
 			'[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older"]'
 		);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage( $I );
+		$I->publishAndViewClassicEditorPage($I);
 
 		// Test pagination.
-		$I->testBroadcastsPagination( $I, 'Older', 'Newer' );
+		$I->testBroadcastsPagination($I, 'Older', 'Newer');
 	}
 
 	/**
 	 * Test the [convertkit_broadcasts] shortcode hex colors works when chosen,
 	 * using the Classic Editor (TinyMCE / Visual).
-	 *
-	 * @since 1.9.8.5
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsShortcodeInVisualEditorWithHexColorParameters( AcceptanceTester $I ) {
+	public function testBroadcastsShortcodeInVisualEditorWithHexColorParameters(AcceptanceTester $I)
+	{
 		// Define colors.
 		$backgroundColor = '#ee1616';
-		$textColor       = '#1212c0';
-		$linkColor       = '#ffffff';
+		$textColor = '#1212c0';
+		$linkColor = '#ffffff';
 
 		// It's tricky to interact with WordPress's color picker, so we programmatically create the Page
 		// instead to then confirm the color settings apply on the output.
 		// We don't need to test the color picker itself, as it's a WordPress supplied component, and our
 		// other Acceptance tests confirm that the shortcode can be added in the Classic Editor.
-		$I->havePageInDatabase(
-			array(
-				'post_name'    => 'convertkit-page-broadcasts-shortcode-hex-color-params',
-				'post_content' => '[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older" link_color="' . $linkColor . '" background_color="' . $backgroundColor . '" text_color="' . $textColor . '"]',
-			)
-		);
+		$I->havePageInDatabase([
+			'post_name' 	=> 'convertkit-page-broadcasts-shortcode-hex-color-params',
+			'post_content' 	=> '[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older" link_color="'.$linkColor.'" background_color="'.$backgroundColor.'" text_color="'.$textColor.'"]'
+		]);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage( '/convertkit-page-broadcasts-shortcode-hex-color-params' );
+		$I->amOnPage('/convertkit-page-broadcasts-shortcode-hex-color-params');
 
 		// Wait for frontend web site to load.
-		$I->waitForElementVisible( 'body.page-template-default' );
+		$I->waitForElementVisible('body.page-template-default');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the block displays.
-		$I->seeBroadcastsOutput( $I );
+		$I->seeBroadcastsOutput($I);
 
 		// Confirm that our stylesheet loaded.
-		$I->seeInSource( '<link rel="stylesheet" id="convertkit-broadcasts-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css' );
+		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="'.$_ENV['TEST_SITE_WP_URL'].'/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
 
 		// Confirm that the chosen colors are applied as CSS styles.
-		$I->seeInSource( '<div class="convertkit-broadcasts has-text-color has-background" style="color:' . $textColor . ';background-color:' . $backgroundColor . '"' );
-		$I->seeInSource( '<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:' . $linkColor . '"' );
-
+		$I->seeInSource('<div class="convertkit-broadcasts has-text-color has-background" style="color:'.$textColor.';background-color:'.$backgroundColor.'"');
+		$I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:'.$linkColor.'"');
+	
 		// Test pagination.
-		$I->testBroadcastsPagination( $I, 'Older', 'Newer' );
+		$I->testBroadcastsPagination($I, 'Older', 'Newer');
 
 		// Confirm that link styles are still applied to refreshed data.
-		$I->seeInSource( '<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:' . $linkColor . '"' );
+		$I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:'.$linkColor.'"');
 	}
 
 	/**
 	 * Test the [convertkit_broadcasts] shortcode works when using the default parameters,
 	 * using the Text Editor.
-	 *
-	 * @since 1.9.7.5
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsShortcodeInTextEditorWithDefaultParameters( AcceptanceTester $I ) {
+	public function testBroadcastsShortcodeInTextEditorWithDefaultParameters(AcceptanceTester $I)
+	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor' );
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor');
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
@@ -262,166 +268,171 @@ class PageShortcodeBroadcastsCest {
 		);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage( $I );
+		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the shortcode output displays.
-		$I->seeBroadcastsOutput( $I );
+		$I->seeBroadcastsOutput($I);
 
 		// Confirm that the default date format is as expected.
-		$I->seeInSource( '<time datetime="2022-04-08">April 8, 2022</time>' );
+		$I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
 
 		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements( 'li.convertkit-broadcast', array( 1, 10 ) );
+		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
 	}
 
 	/**
 	 * Test the [convertkit_broadcasts] shortcode works when specifying a non-default date format parameter,
 	 * using the Text Editor.
-	 *
-	 * @since 1.9.7.5
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsShortcodeInTextEditorWithDateFormatParameter( AcceptanceTester $I ) {
+	public function testBroadcastsShortcodeInTextEditorWithDateFormatParameter(AcceptanceTester $I)
+	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor: Date Format' );
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor: Date Format');
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
 			'ConvertKit Broadcasts',
 			'convertkit-broadcasts',
-			array(
-				'date_format' => array( 'select', date( 'Y-m-d' ) ),
-			),
+			[
+				'date_format' => [ 'select', date('Y-m-d') ],
+			],
 			'[convertkit_broadcasts date_format="Y-m-d" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage( $I );
+		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the shortcode output displays.
-		$I->seeBroadcastsOutput( $I );
+		$I->seeBroadcastsOutput($I);
 
 		// Confirm that the default date format is as expected.
-		$I->seeInSource( '<time datetime="2022-04-08">2022-04-08</time>' );
+		$I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
 
 		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements( 'li.convertkit-broadcast', array( 1, 10 ) );
+		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
 	}
 
 	/**
 	 * Test the [convertkit_broadcasts] shortcode works when specifying a non-default limit parameter,
 	 * using the Text Editor.
-	 *
-	 * @since 1.9.7.5
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsShortcodeInTextEditorWithLimitParameter( AcceptanceTester $I ) {
+	public function testBroadcastsShortcodeInTextEditorWithLimitParameter(AcceptanceTester $I)
+	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor: Limit' );
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor: Limit');
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
 			'ConvertKit Broadcasts',
 			'convertkit-broadcasts',
-			array(
-				'limit' => array( 'input', '2' ),
-			),
+			[
+				'limit' => [ 'input', '2' ],
+			],
 			'[convertkit_broadcasts date_format="F j, Y" limit="2" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage( $I );
+		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the shortcode output displays.
-		$I->seeBroadcastsOutput( $I );
+		$I->seeBroadcastsOutput($I);
 
 		// Confirm that the default date format is as expected.
-		$I->seeInSource( '<time datetime="2022-04-08">April 8, 2022</time>' );
+		$I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
 
 		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements( 'li.convertkit-broadcast', 2 );
+		$I->seeNumberOfElements('li.convertkit-broadcast', 2);
 	}
 
 	/**
 	 * Test the [convertkit_broadcasts] shortcode pagination works when enabled,
 	 * using the Text Editor.
-	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsShortcodeInTextEditorWithPaginationEnabled( AcceptanceTester $I ) {
+	public function testBroadcastsShortcodeInTextEditorWithPaginationEnabled(AcceptanceTester $I)
+	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor: Pagination' );
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor: Pagination');
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
 			'ConvertKit Broadcasts',
 			'convertkit-broadcasts',
-			array(
-				'limit'    => array( 'input', '1' ),
-				'paginate' => array( 'toggle', 'Yes' ),
-			),
+			[
+				'limit' 	=> [ 'input', '1' ],
+				'paginate' 	=> [ 'toggle', 'Yes' ],
+			],
 			'[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage( $I );
+		$I->publishAndViewClassicEditorPage($I);
 
 		// Test pagination.
-		$I->testBroadcastsPagination( $I, 'Previous', 'Next' );
+		$I->testBroadcastsPagination($I, 'Previous', 'Next');
 	}
 
 	/**
 	 * Test the [convertkit_broadcasts] shortcode pagination works when enabled,
 	 * using the Text Editor.
-	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsShortcodeInTextEditorWithPaginationLabelParameters( AcceptanceTester $I ) {
+	public function testBroadcastsShortcodeInTextEditorWithPaginationLabelParameters(AcceptanceTester $I)
+	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor: Pagination Labels' );
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor: Pagination Labels');
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
 			'ConvertKit Broadcasts',
 			'convertkit-broadcasts',
-			array(
-				'limit'               => array( 'input', '1' ),
-				'paginate'            => array( 'toggle', 'Yes' ),
-				'paginate_label_prev' => array( 'input', 'Newer' ),
-				'paginate_label_next' => array( 'input', 'Older' ),
-			),
+			[
+				'limit' 			  => [ 'input', '1' ],
+				'paginate' 			  => [ 'toggle', 'Yes' ],
+				'paginate_label_prev' => [ 'input', 'Newer' ],
+				'paginate_label_next' => [ 'input', 'Older' ],
+			],
 			'[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older"]'
 		);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage( $I );
+		$I->publishAndViewClassicEditorPage($I);
 
 		// Test pagination.
-		$I->testBroadcastsPagination( $I, 'Older', 'Newer' );
+		$I->testBroadcastsPagination($I, 'Older', 'Newer');
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.7.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateThirdPartyPlugin( $I, 'classic-editor' );
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateThirdPartyPlugin($I, 'classic-editor');
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
@@ -37,7 +37,6 @@ class PageShortcodeBroadcastsCest
 		$I->addVisualEditorShortcode(
 			$I,
 			'ConvertKit Broadcasts',
-			'convertkit-broadcasts',
 			false,
 			'[convertkit_broadcasts date_format="F j, Y" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
@@ -72,7 +71,6 @@ class PageShortcodeBroadcastsCest
 		$I->addVisualEditorShortcode(
 			$I,
 			'ConvertKit Broadcasts',
-			'convertkit-broadcasts',
 			[
 				'date_format' => [ 'select', date('Y-m-d') ],
 			],
@@ -109,7 +107,6 @@ class PageShortcodeBroadcastsCest
 		$I->addVisualEditorShortcode(
 			$I,
 			'ConvertKit Broadcasts',
-			'convertkit-broadcasts',
 			[
 				'limit' => [ 'input', '2' ],
 			],
@@ -146,7 +143,6 @@ class PageShortcodeBroadcastsCest
 		$I->addVisualEditorShortcode(
 			$I,
 			'ConvertKit Broadcasts',
-			'convertkit-broadcasts',
 			[
 				'limit'    => [ 'input', '1' ],
 				'paginate' => [ 'toggle', 'Yes' ],
@@ -178,7 +174,6 @@ class PageShortcodeBroadcastsCest
 		$I->addVisualEditorShortcode(
 			$I,
 			'ConvertKit Broadcasts',
-			'convertkit-broadcasts',
 			[
 				'limit'               => [ 'input', '1' ],
 				'paginate'            => [ 'toggle', 'Yes' ],
@@ -263,7 +258,6 @@ class PageShortcodeBroadcastsCest
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
-			'ConvertKit Broadcasts',
 			'convertkit-broadcasts',
 			false,
 			'[convertkit_broadcasts date_format="F j, Y" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
@@ -298,7 +292,6 @@ class PageShortcodeBroadcastsCest
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
-			'ConvertKit Broadcasts',
 			'convertkit-broadcasts',
 			[
 				'date_format' => [ 'select', date('Y-m-d') ],
@@ -335,7 +328,6 @@ class PageShortcodeBroadcastsCest
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
-			'ConvertKit Broadcasts',
 			'convertkit-broadcasts',
 			[
 				'limit' => [ 'input', '2' ],
@@ -372,7 +364,6 @@ class PageShortcodeBroadcastsCest
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
-			'ConvertKit Broadcasts',
 			'convertkit-broadcasts',
 			[
 				'limit'    => [ 'input', '1' ],
@@ -404,7 +395,6 @@ class PageShortcodeBroadcastsCest
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
-			'ConvertKit Broadcasts',
 			'convertkit-broadcasts',
 			[
 				'limit'               => [ 'input', '1' ],

--- a/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
@@ -1,17 +1,17 @@
 <?php
 /**
  * Tests for the ConvertKit Form shortcode.
- * 
- * @since 	1.9.7.4
+ *
+ * @since   1.9.7.4
  */
 class PageShortcodeBroadcastsCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -23,10 +23,10 @@ class PageShortcodeBroadcastsCest
 	/**
 	 * Test the [convertkit_broadcasts] shortcode works when using the default parameters,
 	 * using the Classic Editor (TinyMCE / Visual).
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsShortcodeInVisualEditorWithDefaultParameters(AcceptanceTester $I)
 	{
@@ -52,16 +52,16 @@ class PageShortcodeBroadcastsCest
 		$I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
 
 		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
+		$I->seeNumberOfElements('li.convertkit-broadcast', [ 1, 10 ]);
 	}
 
 	/**
 	 * Test the [convertkit_broadcasts] shortcode works when specifying a non-default date format parameter,
 	 * using the Classic Editor (TinyMCE / Visual).
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsShortcodeInVisualEditorWithDateFormatParameter(AcceptanceTester $I)
 	{
@@ -89,16 +89,16 @@ class PageShortcodeBroadcastsCest
 		$I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
 
 		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
+		$I->seeNumberOfElements('li.convertkit-broadcast', [ 1, 10 ]);
 	}
 
 	/**
 	 * Test the [convertkit_broadcasts] shortcode works when specifying a non-default limit parameter,
 	 * using the Classic Editor (TinyMCE / Visual).
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsShortcodeInVisualEditorWithLimitParameter(AcceptanceTester $I)
 	{
@@ -132,10 +132,10 @@ class PageShortcodeBroadcastsCest
 	/**
 	 * Test the [convertkit_broadcasts] shortcode pagination works when enabled,
 	 * using the Classic Editor (TinyMCE / Visual).
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsShortcodeInVisualEditorWithPaginationEnabled(AcceptanceTester $I)
 	{
@@ -148,8 +148,8 @@ class PageShortcodeBroadcastsCest
 			'ConvertKit Broadcasts',
 			'convertkit-broadcasts',
 			[
-				'limit' 	=> [ 'input', '1' ],
-				'paginate' 	=> [ 'toggle', 'Yes' ],
+				'limit'    => [ 'input', '1' ],
+				'paginate' => [ 'toggle', 'Yes' ],
 			],
 			'[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
@@ -164,10 +164,10 @@ class PageShortcodeBroadcastsCest
 	/**
 	 * Test the [convertkit_broadcasts] shortcode pagination works when enabled,
 	 * using the Classic Editor (TinyMCE / Visual).
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsShortcodeInVisualEditorWithPaginationLabelParameters(AcceptanceTester $I)
 	{
@@ -180,8 +180,8 @@ class PageShortcodeBroadcastsCest
 			'ConvertKit Broadcasts',
 			'convertkit-broadcasts',
 			[
-				'limit' 			  => [ 'input', '1' ],
-				'paginate' 			  => [ 'toggle', 'Yes' ],
+				'limit'               => [ 'input', '1' ],
+				'paginate'            => [ 'toggle', 'Yes' ],
 				'paginate_label_prev' => [ 'input', 'Newer' ],
 				'paginate_label_next' => [ 'input', 'Older' ],
 			],
@@ -198,26 +198,28 @@ class PageShortcodeBroadcastsCest
 	/**
 	 * Test the [convertkit_broadcasts] shortcode hex colors works when chosen,
 	 * using the Classic Editor (TinyMCE / Visual).
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsShortcodeInVisualEditorWithHexColorParameters(AcceptanceTester $I)
 	{
 		// Define colors.
 		$backgroundColor = '#ee1616';
-		$textColor = '#1212c0';
-		$linkColor = '#ffffff';
+		$textColor       = '#1212c0';
+		$linkColor       = '#ffffff';
 
 		// It's tricky to interact with WordPress's color picker, so we programmatically create the Page
 		// instead to then confirm the color settings apply on the output.
 		// We don't need to test the color picker itself, as it's a WordPress supplied component, and our
 		// other Acceptance tests confirm that the shortcode can be added in the Classic Editor.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-page-broadcasts-shortcode-hex-color-params',
-			'post_content' 	=> '[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older" link_color="'.$linkColor.'" background_color="'.$backgroundColor.'" text_color="'.$textColor.'"]'
-		]);
+		$I->havePageInDatabase(
+			[
+				'post_name'    => 'convertkit-page-broadcasts-shortcode-hex-color-params',
+				'post_content' => '[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older" link_color="' . $linkColor . '" background_color="' . $backgroundColor . '" text_color="' . $textColor . '"]',
+			]
+		);
 
 		// Load the Page on the frontend site.
 		$I->amOnPage('/convertkit-page-broadcasts-shortcode-hex-color-params');
@@ -232,26 +234,26 @@ class PageShortcodeBroadcastsCest
 		$I->seeBroadcastsOutput($I);
 
 		// Confirm that our stylesheet loaded.
-		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="'.$_ENV['TEST_SITE_WP_URL'].'/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
+		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
 
 		// Confirm that the chosen colors are applied as CSS styles.
-		$I->seeInSource('<div class="convertkit-broadcasts has-text-color has-background" style="color:'.$textColor.';background-color:'.$backgroundColor.'"');
-		$I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:'.$linkColor.'"');
-	
+		$I->seeInSource('<div class="convertkit-broadcasts has-text-color has-background" style="color:' . $textColor . ';background-color:' . $backgroundColor . '"');
+		$I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:' . $linkColor . '"');
+
 		// Test pagination.
 		$I->testBroadcastsPagination($I, 'Older', 'Newer');
 
 		// Confirm that link styles are still applied to refreshed data.
-		$I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:'.$linkColor.'"');
+		$I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:' . $linkColor . '"');
 	}
 
 	/**
 	 * Test the [convertkit_broadcasts] shortcode works when using the default parameters,
 	 * using the Text Editor.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsShortcodeInTextEditorWithDefaultParameters(AcceptanceTester $I)
 	{
@@ -277,16 +279,16 @@ class PageShortcodeBroadcastsCest
 		$I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
 
 		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
+		$I->seeNumberOfElements('li.convertkit-broadcast', [ 1, 10 ]);
 	}
 
 	/**
 	 * Test the [convertkit_broadcasts] shortcode works when specifying a non-default date format parameter,
 	 * using the Text Editor.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsShortcodeInTextEditorWithDateFormatParameter(AcceptanceTester $I)
 	{
@@ -314,16 +316,16 @@ class PageShortcodeBroadcastsCest
 		$I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
 
 		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
+		$I->seeNumberOfElements('li.convertkit-broadcast', [ 1, 10 ]);
 	}
 
 	/**
 	 * Test the [convertkit_broadcasts] shortcode works when specifying a non-default limit parameter,
 	 * using the Text Editor.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsShortcodeInTextEditorWithLimitParameter(AcceptanceTester $I)
 	{
@@ -357,10 +359,10 @@ class PageShortcodeBroadcastsCest
 	/**
 	 * Test the [convertkit_broadcasts] shortcode pagination works when enabled,
 	 * using the Text Editor.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsShortcodeInTextEditorWithPaginationEnabled(AcceptanceTester $I)
 	{
@@ -373,8 +375,8 @@ class PageShortcodeBroadcastsCest
 			'ConvertKit Broadcasts',
 			'convertkit-broadcasts',
 			[
-				'limit' 	=> [ 'input', '1' ],
-				'paginate' 	=> [ 'toggle', 'Yes' ],
+				'limit'    => [ 'input', '1' ],
+				'paginate' => [ 'toggle', 'Yes' ],
 			],
 			'[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
@@ -389,10 +391,10 @@ class PageShortcodeBroadcastsCest
 	/**
 	 * Test the [convertkit_broadcasts] shortcode pagination works when enabled,
 	 * using the Text Editor.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsShortcodeInTextEditorWithPaginationLabelParameters(AcceptanceTester $I)
 	{
@@ -405,8 +407,8 @@ class PageShortcodeBroadcastsCest
 			'ConvertKit Broadcasts',
 			'convertkit-broadcasts',
 			[
-				'limit' 			  => [ 'input', '1' ],
-				'paginate' 			  => [ 'toggle', 'Yes' ],
+				'limit'               => [ 'input', '1' ],
+				'paginate'            => [ 'toggle', 'Yes' ],
 				'paginate_label_prev' => [ 'input', 'Newer' ],
 				'paginate_label_next' => [ 'input', 'Older' ],
 			],
@@ -424,10 +426,10 @@ class PageShortcodeBroadcastsCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/broadcasts/WidgetBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/WidgetBroadcastsCest.php
@@ -1,187 +1,192 @@
 <?php
 /**
  * Tests for the ConvertKit Broadcasts block when used as a widget.
- * 
+ *
  * A widget area is typically defined by a Theme in a shared area, such as a sidebar or footer.
- * 
+ *
  * @since 1.9.8.2
  */
-class WidgetBroadcastsCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.8.2
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        $I->activateConvertKitPlugin($I);
-        $I->setupConvertKitPlugin($I);
-        $I->enableDebugLog($I);
+class WidgetBroadcastsCest {
 
-        // Activate an older WordPress Theme that supports Widgets.
-        $I->useTheme('twentytwentyone');
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.8.2
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		$I->activateConvertKitPlugin( $I );
+		$I->setupConvertKitPlugin( $I );
+		$I->enableDebugLog( $I );
 
-        // Create a Post, so that the home page does not display the 404 template,
-        // which never includes widgets.
-        $I->havePostInDatabase(
-            [
-            'post_title'    => 'Widget Tests',
-            'post_type'        => 'post',
-            'post_status'    => 'publish',
-            'post_excerpt'  => 'Widget Tests',
-            'post_content'  => 'Widget Tests',    
-            ]
-        );
-    }
+		// Activate an older WordPress Theme that supports Widgets.
+		$I->useTheme( 'twentytwentyone' );
 
-    /**
-     * Test the Broadcasts block works when using the default parameters.
-     * 
-     * @since 1.9.8.2
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsBlockWidgetWithDefaultParameters(AcceptanceTester $I)
-    {
-        // Add block widget.
-        $I->addBlockWidget($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
+		// Create a Post, so that the home page does not display the 404 template,
+		// which never includes widgets.
+		$I->havePostInDatabase(
+			array(
+				'post_title'   => 'Widget Tests',
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_excerpt' => 'Widget Tests',
+				'post_content' => 'Widget Tests',
+			)
+		);
+	}
 
-        // View the home page.
-        $I->amOnPage('/');
+	/**
+	 * Test the Broadcasts block works when using the default parameters.
+	 *
+	 * @since 1.9.8.2
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsBlockWidgetWithDefaultParameters( AcceptanceTester $I ) {
+		// Add block widget.
+		$I->addBlockWidget( $I, 'ConvertKit Broadcasts', 'convertkit-broadcasts' );
 
-        // Confirm that the block displays.
-        $I->seeBroadcastsOutput($I);
+		// View the home page.
+		$I->amOnPage( '/' );
 
-        // Confirm that the default date format is as expected.
-        $I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
+		// Confirm that the block displays.
+		$I->seeBroadcastsOutput( $I );
 
-        // Confirm that the default expected number of Broadcasts are displayed.
-        $I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
-    }
+		// Confirm that the default date format is as expected.
+		$I->seeInSource( '<time datetime="2022-04-08">April 8, 2022</time>' );
 
-    /**
-     * Test the Broadcasts block's date format parameter works.
-     * 
-     * @since 1.9.8.2
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsBlockWidgetWithDateFormatParameter(AcceptanceTester $I)
-    {
-        // Add block widget.
-        $I->addBlockWidget(
-            $I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
-            'date_format' => [ 'select', 'Y-m-d' ],
-            ]
-        );
+		// Confirm that the default expected number of Broadcasts are displayed.
+		$I->seeNumberOfElements( 'li.convertkit-broadcast', array( 1, 10 ) );
+	}
 
-        // View the home page.
-        $I->amOnPage('/');
+	/**
+	 * Test the Broadcasts block's date format parameter works.
+	 *
+	 * @since 1.9.8.2
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsBlockWidgetWithDateFormatParameter( AcceptanceTester $I ) {
+		// Add block widget.
+		$I->addBlockWidget(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			array(
+				'date_format' => array( 'select', 'Y-m-d' ),
+			)
+		);
 
-        // Confirm that the block displays.
-        $I->seeBroadcastsOutput($I);
+		// View the home page.
+		$I->amOnPage( '/' );
 
-        // Confirm that the date format is as expected.
-        $I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
+		// Confirm that the block displays.
+		$I->seeBroadcastsOutput( $I );
 
-        // Confirm that the default expected number of Broadcasts are displayed.
-        $I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
-    }
+		// Confirm that the date format is as expected.
+		$I->seeInSource( '<time datetime="2022-04-08">2022-04-08</time>' );
 
-    /**
-     * Test the Broadcasts block's limit parameter works.
-     * 
-     * @since 1.9.8.2
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsBlockWidgetWithLimitParameter(AcceptanceTester $I)
-    {
-        // Add block widget.
-        $I->addBlockWidget(
-            $I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
-            'limit' => [ 'input', '2' ],
-            ]
-        );
+		// Confirm that the default expected number of Broadcasts are displayed.
+		$I->seeNumberOfElements( 'li.convertkit-broadcast', array( 1, 10 ) );
+	}
 
-        // View the home page.
-        $I->amOnPage('/');
+	/**
+	 * Test the Broadcasts block's limit parameter works.
+	 *
+	 * @since 1.9.8.2
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsBlockWidgetWithLimitParameter( AcceptanceTester $I ) {
+		// Add block widget.
+		$I->addBlockWidget(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			array(
+				'limit' => array( 'input', '2' ),
+			)
+		);
 
-        // Confirm that the block displays.
-        $I->seeBroadcastsOutput($I);
+		// View the home page.
+		$I->amOnPage( '/' );
 
-        // Confirm that the expected number of Broadcasts are displayed.
-        $I->seeNumberOfElements('li.convertkit-broadcast', 2);
-    }
+		// Confirm that the block displays.
+		$I->seeBroadcastsOutput( $I );
 
-    /**
-     * Test the Broadcasts block's pagination works when enabled.
-     * 
-     * @since 1.9.8.2
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsBlockWidgetWithPaginationEnabled(AcceptanceTester $I)
-    {
-        // Add block widget.
-        $I->addBlockWidget(
-            $I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
-            '.components-form-toggle'     => [ 'toggle', true ],
-            'limit'                     => [ 'input', '1' ],
-            ]
-        );
+		// Confirm that the expected number of Broadcasts are displayed.
+		$I->seeNumberOfElements( 'li.convertkit-broadcast', 2 );
+	}
 
-        // View the home page.
-        $I->amOnPage('/');
+	/**
+	 * Test the Broadcasts block's pagination works when enabled.
+	 *
+	 * @since 1.9.8.2
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsBlockWidgetWithPaginationEnabled( AcceptanceTester $I ) {
+		// Add block widget.
+		$I->addBlockWidget(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			array(
+				'.components-form-toggle' => array( 'toggle', true ),
+				'limit'                   => array( 'input', '1' ),
+			)
+		);
 
-        // Test pagination.
-        $I->testBroadcastsPagination($I, 'Previous', 'Next');
-    }
+		// View the home page.
+		$I->amOnPage( '/' );
 
-    /**
-     * Test the Broadcasts block's pagination labels work when defined.
-     * 
-     * @since 1.9.8.2
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsBlockWithPaginationLabelParameters(AcceptanceTester $I)
-    {
-        // Add block widget.
-        $I->addBlockWidget(
-            $I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
-            '.components-form-toggle'     => [ 'toggle', true ],
-            'limit'                        => [ 'input', '1' ],
-            'paginate_label_prev'         => [ 'input', 'Newer' ],
-            'paginate_label_next'         => [ 'input', 'Older' ],
-            ]
-        );
+		// Test pagination.
+		$I->testBroadcastsPagination( $I, 'Previous', 'Next' );
+	}
 
-        // View the home page.
-        $I->amOnPage('/');
+	/**
+	 * Test the Broadcasts block's pagination labels work when defined.
+	 *
+	 * @since 1.9.8.2
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsBlockWithPaginationLabelParameters( AcceptanceTester $I ) {
+		// Add block widget.
+		$I->addBlockWidget(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			array(
+				'.components-form-toggle' => array( 'toggle', true ),
+				'limit'                   => array( 'input', '1' ),
+				'paginate_label_prev'     => array( 'input', 'Newer' ),
+				'paginate_label_next'     => array( 'input', 'Older' ),
+			)
+		);
 
-        // Test pagination.
-        $I->testBroadcastsPagination($I, 'Older', 'Newer');
-    }
+		// View the home page.
+		$I->amOnPage( '/' );
 
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.8.2
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        // Activate the current theme.
-        $I->useTheme('twentytwentytwo');
-        $I->resetWidgets($I);
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+		// Test pagination.
+		$I->testBroadcastsPagination( $I, 'Older', 'Newer' );
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.8.2
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		// Activate the current theme.
+		$I->useTheme( 'twentytwentytwo' );
+		$I->resetWidgets( $I );
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/broadcasts/WidgetBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/WidgetBroadcastsCest.php
@@ -1,192 +1,177 @@
 <?php
 /**
  * Tests for the ConvertKit Broadcasts block when used as a widget.
- *
+ * 
  * A widget area is typically defined by a Theme in a shared area, such as a sidebar or footer.
- *
- * @since 1.9.8.2
+ * 
+ * @since 	1.9.8.2
  */
-class WidgetBroadcastsCest {
-
+class WidgetBroadcastsCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.8.2
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
-		$I->activateConvertKitPlugin( $I );
-		$I->setupConvertKitPlugin( $I );
-		$I->enableDebugLog( $I );
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
 
 		// Activate an older WordPress Theme that supports Widgets.
-		$I->useTheme( 'twentytwentyone' );
+		$I->useTheme('twentytwentyone');
 
 		// Create a Post, so that the home page does not display the 404 template,
 		// which never includes widgets.
-		$I->havePostInDatabase(
-			array(
-				'post_title'   => 'Widget Tests',
-				'post_type'    => 'post',
-				'post_status'  => 'publish',
-				'post_excerpt' => 'Widget Tests',
-				'post_content' => 'Widget Tests',
-			)
-		);
+		$I->havePostInDatabase([
+			'post_title'	=> 'Widget Tests',
+			'post_type'		=> 'post',
+			'post_status'	=> 'publish',
+			'post_excerpt'  => 'Widget Tests',
+			'post_content'  => 'Widget Tests',	
+		]);
 	}
 
 	/**
 	 * Test the Broadcasts block works when using the default parameters.
-	 *
-	 * @since 1.9.8.2
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsBlockWidgetWithDefaultParameters( AcceptanceTester $I ) {
+	public function testBroadcastsBlockWidgetWithDefaultParameters(AcceptanceTester $I)
+	{
 		// Add block widget.
-		$I->addBlockWidget( $I, 'ConvertKit Broadcasts', 'convertkit-broadcasts' );
+		$I->addBlockWidget($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
 
 		// View the home page.
-		$I->amOnPage( '/' );
+		$I->amOnPage('/');
 
 		// Confirm that the block displays.
-		$I->seeBroadcastsOutput( $I );
+		$I->seeBroadcastsOutput($I);
 
 		// Confirm that the default date format is as expected.
-		$I->seeInSource( '<time datetime="2022-04-08">April 8, 2022</time>' );
+		$I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
 
 		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements( 'li.convertkit-broadcast', array( 1, 10 ) );
+		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
 	}
 
 	/**
 	 * Test the Broadcasts block's date format parameter works.
-	 *
-	 * @since 1.9.8.2
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsBlockWidgetWithDateFormatParameter( AcceptanceTester $I ) {
+	public function testBroadcastsBlockWidgetWithDateFormatParameter(AcceptanceTester $I)
+	{
 		// Add block widget.
-		$I->addBlockWidget(
-			$I,
-			'ConvertKit Broadcasts',
-			'convertkit-broadcasts',
-			array(
-				'date_format' => array( 'select', 'Y-m-d' ),
-			)
-		);
+		$I->addBlockWidget($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
+			'date_format' => [ 'select', 'Y-m-d' ],
+		]);
 
 		// View the home page.
-		$I->amOnPage( '/' );
+		$I->amOnPage('/');
 
 		// Confirm that the block displays.
-		$I->seeBroadcastsOutput( $I );
+		$I->seeBroadcastsOutput($I);
 
 		// Confirm that the date format is as expected.
-		$I->seeInSource( '<time datetime="2022-04-08">2022-04-08</time>' );
+		$I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
 
 		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements( 'li.convertkit-broadcast', array( 1, 10 ) );
+		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
 	}
 
 	/**
 	 * Test the Broadcasts block's limit parameter works.
-	 *
-	 * @since 1.9.8.2
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsBlockWidgetWithLimitParameter( AcceptanceTester $I ) {
+	public function testBroadcastsBlockWidgetWithLimitParameter(AcceptanceTester $I)
+	{
 		// Add block widget.
-		$I->addBlockWidget(
-			$I,
-			'ConvertKit Broadcasts',
-			'convertkit-broadcasts',
-			array(
-				'limit' => array( 'input', '2' ),
-			)
-		);
+		$I->addBlockWidget($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
+			'limit' => [ 'input', '2' ],
+		]);
 
 		// View the home page.
-		$I->amOnPage( '/' );
+		$I->amOnPage('/');
 
 		// Confirm that the block displays.
-		$I->seeBroadcastsOutput( $I );
+		$I->seeBroadcastsOutput($I);
 
 		// Confirm that the expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements( 'li.convertkit-broadcast', 2 );
+		$I->seeNumberOfElements('li.convertkit-broadcast', 2);
 	}
 
 	/**
 	 * Test the Broadcasts block's pagination works when enabled.
-	 *
-	 * @since 1.9.8.2
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsBlockWidgetWithPaginationEnabled( AcceptanceTester $I ) {
+	public function testBroadcastsBlockWidgetWithPaginationEnabled(AcceptanceTester $I)
+	{
 		// Add block widget.
-		$I->addBlockWidget(
-			$I,
-			'ConvertKit Broadcasts',
-			'convertkit-broadcasts',
-			array(
-				'.components-form-toggle' => array( 'toggle', true ),
-				'limit'                   => array( 'input', '1' ),
-			)
-		);
+		$I->addBlockWidget($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
+			'.components-form-toggle' 	=> [ 'toggle', true ],
+			'limit' 					=> [ 'input', '1' ],
+		]);
 
 		// View the home page.
-		$I->amOnPage( '/' );
+		$I->amOnPage('/');
 
 		// Test pagination.
-		$I->testBroadcastsPagination( $I, 'Previous', 'Next' );
+		$I->testBroadcastsPagination($I, 'Previous', 'Next');
 	}
 
 	/**
 	 * Test the Broadcasts block's pagination labels work when defined.
-	 *
-	 * @since 1.9.8.2
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsBlockWithPaginationLabelParameters( AcceptanceTester $I ) {
+	public function testBroadcastsBlockWithPaginationLabelParameters(AcceptanceTester $I)
+	{
 		// Add block widget.
-		$I->addBlockWidget(
-			$I,
-			'ConvertKit Broadcasts',
-			'convertkit-broadcasts',
-			array(
-				'.components-form-toggle' => array( 'toggle', true ),
-				'limit'                   => array( 'input', '1' ),
-				'paginate_label_prev'     => array( 'input', 'Newer' ),
-				'paginate_label_next'     => array( 'input', 'Older' ),
-			)
-		);
+		$I->addBlockWidget($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
+			'.components-form-toggle' 	=> [ 'toggle', true ],
+			'limit' 	 		  		=> [ 'input', '1' ],
+			'paginate_label_prev' 		=> [ 'input', 'Newer' ],
+			'paginate_label_next' 		=> [ 'input', 'Older' ],
+		]);
 
 		// View the home page.
-		$I->amOnPage( '/' );
+		$I->amOnPage('/');
 
 		// Test pagination.
-		$I->testBroadcastsPagination( $I, 'Older', 'Newer' );
+		$I->testBroadcastsPagination($I, 'Older', 'Newer');
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.8.2
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
+	public function _passed(AcceptanceTester $I)
+	{
 		// Activate the current theme.
-		$I->useTheme( 'twentytwentytwo' );
-		$I->resetWidgets( $I );
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+		$I->useTheme('twentytwentytwo');
+		$I->resetWidgets($I);
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/broadcasts/WidgetBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/WidgetBroadcastsCest.php
@@ -1,19 +1,19 @@
 <?php
 /**
  * Tests for the ConvertKit Broadcasts block when used as a widget.
- * 
+ *
  * A widget area is typically defined by a Theme in a shared area, such as a sidebar or footer.
- * 
- * @since 	1.9.8.2
+ *
+ * @since   1.9.8.2
  */
 class WidgetBroadcastsCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.8.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -26,21 +26,23 @@ class WidgetBroadcastsCest
 
 		// Create a Post, so that the home page does not display the 404 template,
 		// which never includes widgets.
-		$I->havePostInDatabase([
-			'post_title'	=> 'Widget Tests',
-			'post_type'		=> 'post',
-			'post_status'	=> 'publish',
-			'post_excerpt'  => 'Widget Tests',
-			'post_content'  => 'Widget Tests',	
-		]);
+		$I->havePostInDatabase(
+			[
+				'post_title'   => 'Widget Tests',
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_excerpt' => 'Widget Tests',
+				'post_content' => 'Widget Tests',
+			]
+		);
 	}
 
 	/**
 	 * Test the Broadcasts block works when using the default parameters.
-	 * 
-	 * @since 	1.9.8.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsBlockWidgetWithDefaultParameters(AcceptanceTester $I)
 	{
@@ -57,22 +59,27 @@ class WidgetBroadcastsCest
 		$I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
 
 		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
+		$I->seeNumberOfElements('li.convertkit-broadcast', [ 1, 10 ]);
 	}
 
 	/**
 	 * Test the Broadcasts block's date format parameter works.
-	 * 
-	 * @since 	1.9.8.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsBlockWidgetWithDateFormatParameter(AcceptanceTester $I)
 	{
 		// Add block widget.
-		$I->addBlockWidget($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
-			'date_format' => [ 'select', 'Y-m-d' ],
-		]);
+		$I->addBlockWidget(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			[
+				'date_format' => [ 'select', 'Y-m-d' ],
+			]
+		);
 
 		// View the home page.
 		$I->amOnPage('/');
@@ -84,22 +91,27 @@ class WidgetBroadcastsCest
 		$I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
 
 		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
+		$I->seeNumberOfElements('li.convertkit-broadcast', [ 1, 10 ]);
 	}
 
 	/**
 	 * Test the Broadcasts block's limit parameter works.
-	 * 
-	 * @since 	1.9.8.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsBlockWidgetWithLimitParameter(AcceptanceTester $I)
 	{
 		// Add block widget.
-		$I->addBlockWidget($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
-			'limit' => [ 'input', '2' ],
-		]);
+		$I->addBlockWidget(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			[
+				'limit' => [ 'input', '2' ],
+			]
+		);
 
 		// View the home page.
 		$I->amOnPage('/');
@@ -113,18 +125,23 @@ class WidgetBroadcastsCest
 
 	/**
 	 * Test the Broadcasts block's pagination works when enabled.
-	 * 
-	 * @since 	1.9.8.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsBlockWidgetWithPaginationEnabled(AcceptanceTester $I)
 	{
 		// Add block widget.
-		$I->addBlockWidget($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
-			'.components-form-toggle' 	=> [ 'toggle', true ],
-			'limit' 					=> [ 'input', '1' ],
-		]);
+		$I->addBlockWidget(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			[
+				'.components-form-toggle' => [ 'toggle', true ],
+				'limit'                   => [ 'input', '1' ],
+			]
+		);
 
 		// View the home page.
 		$I->amOnPage('/');
@@ -135,20 +152,25 @@ class WidgetBroadcastsCest
 
 	/**
 	 * Test the Broadcasts block's pagination labels work when defined.
-	 * 
-	 * @since 	1.9.8.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsBlockWithPaginationLabelParameters(AcceptanceTester $I)
 	{
 		// Add block widget.
-		$I->addBlockWidget($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
-			'.components-form-toggle' 	=> [ 'toggle', true ],
-			'limit' 	 		  		=> [ 'input', '1' ],
-			'paginate_label_prev' 		=> [ 'input', 'Newer' ],
-			'paginate_label_next' 		=> [ 'input', 'Older' ],
-		]);
+		$I->addBlockWidget(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			[
+				'.components-form-toggle' => [ 'toggle', true ],
+				'limit'                   => [ 'input', '1' ],
+				'paginate_label_prev'     => [ 'input', 'Newer' ],
+				'paginate_label_next'     => [ 'input', 'Older' ],
+			]
+		);
 
 		// View the home page.
 		$I->amOnPage('/');
@@ -161,10 +183,10 @@ class WidgetBroadcastsCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.8.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/broadcasts/WidgetBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/WidgetBroadcastsCest.php
@@ -4,174 +4,184 @@
  * 
  * A widget area is typically defined by a Theme in a shared area, such as a sidebar or footer.
  * 
- * @since 	1.9.8.2
+ * @since 1.9.8.2
  */
 class WidgetBroadcastsCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.8.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.8.2
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        $I->activateConvertKitPlugin($I);
+        $I->setupConvertKitPlugin($I);
+        $I->enableDebugLog($I);
 
-		// Activate an older WordPress Theme that supports Widgets.
-		$I->useTheme('twentytwentyone');
+        // Activate an older WordPress Theme that supports Widgets.
+        $I->useTheme('twentytwentyone');
 
-		// Create a Post, so that the home page does not display the 404 template,
-		// which never includes widgets.
-		$I->havePostInDatabase([
-			'post_title'	=> 'Widget Tests',
-			'post_type'		=> 'post',
-			'post_status'	=> 'publish',
-			'post_excerpt'  => 'Widget Tests',
-			'post_content'  => 'Widget Tests',	
-		]);
-	}
+        // Create a Post, so that the home page does not display the 404 template,
+        // which never includes widgets.
+        $I->havePostInDatabase(
+            [
+            'post_title'    => 'Widget Tests',
+            'post_type'        => 'post',
+            'post_status'    => 'publish',
+            'post_excerpt'  => 'Widget Tests',
+            'post_content'  => 'Widget Tests',    
+            ]
+        );
+    }
 
-	/**
-	 * Test the Broadcasts block works when using the default parameters.
-	 * 
-	 * @since 	1.9.8.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsBlockWidgetWithDefaultParameters(AcceptanceTester $I)
-	{
-		// Add block widget.
-		$I->addBlockWidget($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
+    /**
+     * Test the Broadcasts block works when using the default parameters.
+     * 
+     * @since 1.9.8.2
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsBlockWidgetWithDefaultParameters(AcceptanceTester $I)
+    {
+        // Add block widget.
+        $I->addBlockWidget($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
 
-		// View the home page.
-		$I->amOnPage('/');
+        // View the home page.
+        $I->amOnPage('/');
 
-		// Confirm that the block displays.
-		$I->seeBroadcastsOutput($I);
+        // Confirm that the block displays.
+        $I->seeBroadcastsOutput($I);
 
-		// Confirm that the default date format is as expected.
-		$I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
+        // Confirm that the default date format is as expected.
+        $I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
 
-		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
-	}
+        // Confirm that the default expected number of Broadcasts are displayed.
+        $I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
+    }
 
-	/**
-	 * Test the Broadcasts block's date format parameter works.
-	 * 
-	 * @since 	1.9.8.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsBlockWidgetWithDateFormatParameter(AcceptanceTester $I)
-	{
-		// Add block widget.
-		$I->addBlockWidget($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
-			'date_format' => [ 'select', 'Y-m-d' ],
-		]);
+    /**
+     * Test the Broadcasts block's date format parameter works.
+     * 
+     * @since 1.9.8.2
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsBlockWidgetWithDateFormatParameter(AcceptanceTester $I)
+    {
+        // Add block widget.
+        $I->addBlockWidget(
+            $I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
+            'date_format' => [ 'select', 'Y-m-d' ],
+            ]
+        );
 
-		// View the home page.
-		$I->amOnPage('/');
+        // View the home page.
+        $I->amOnPage('/');
 
-		// Confirm that the block displays.
-		$I->seeBroadcastsOutput($I);
+        // Confirm that the block displays.
+        $I->seeBroadcastsOutput($I);
 
-		// Confirm that the date format is as expected.
-		$I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
+        // Confirm that the date format is as expected.
+        $I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
 
-		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
-	}
+        // Confirm that the default expected number of Broadcasts are displayed.
+        $I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
+    }
 
-	/**
-	 * Test the Broadcasts block's limit parameter works.
-	 * 
-	 * @since 	1.9.8.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsBlockWidgetWithLimitParameter(AcceptanceTester $I)
-	{
-		// Add block widget.
-		$I->addBlockWidget($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
-			'limit' => [ 'input', '2' ],
-		]);
+    /**
+     * Test the Broadcasts block's limit parameter works.
+     * 
+     * @since 1.9.8.2
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsBlockWidgetWithLimitParameter(AcceptanceTester $I)
+    {
+        // Add block widget.
+        $I->addBlockWidget(
+            $I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
+            'limit' => [ 'input', '2' ],
+            ]
+        );
 
-		// View the home page.
-		$I->amOnPage('/');
+        // View the home page.
+        $I->amOnPage('/');
 
-		// Confirm that the block displays.
-		$I->seeBroadcastsOutput($I);
+        // Confirm that the block displays.
+        $I->seeBroadcastsOutput($I);
 
-		// Confirm that the expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', 2);
-	}
+        // Confirm that the expected number of Broadcasts are displayed.
+        $I->seeNumberOfElements('li.convertkit-broadcast', 2);
+    }
 
-	/**
-	 * Test the Broadcasts block's pagination works when enabled.
-	 * 
-	 * @since 	1.9.8.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsBlockWidgetWithPaginationEnabled(AcceptanceTester $I)
-	{
-		// Add block widget.
-		$I->addBlockWidget($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
-			'.components-form-toggle' 	=> [ 'toggle', true ],
-			'limit' 					=> [ 'input', '1' ],
-		]);
+    /**
+     * Test the Broadcasts block's pagination works when enabled.
+     * 
+     * @since 1.9.8.2
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsBlockWidgetWithPaginationEnabled(AcceptanceTester $I)
+    {
+        // Add block widget.
+        $I->addBlockWidget(
+            $I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
+            '.components-form-toggle'     => [ 'toggle', true ],
+            'limit'                     => [ 'input', '1' ],
+            ]
+        );
 
-		// View the home page.
-		$I->amOnPage('/');
+        // View the home page.
+        $I->amOnPage('/');
 
-		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Previous', 'Next');
-	}
+        // Test pagination.
+        $I->testBroadcastsPagination($I, 'Previous', 'Next');
+    }
 
-	/**
-	 * Test the Broadcasts block's pagination labels work when defined.
-	 * 
-	 * @since 	1.9.8.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsBlockWithPaginationLabelParameters(AcceptanceTester $I)
-	{
-		// Add block widget.
-		$I->addBlockWidget($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
-			'.components-form-toggle' 	=> [ 'toggle', true ],
-			'limit' 	 		  		=> [ 'input', '1' ],
-			'paginate_label_prev' 		=> [ 'input', 'Newer' ],
-			'paginate_label_next' 		=> [ 'input', 'Older' ],
-		]);
+    /**
+     * Test the Broadcasts block's pagination labels work when defined.
+     * 
+     * @since 1.9.8.2
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsBlockWithPaginationLabelParameters(AcceptanceTester $I)
+    {
+        // Add block widget.
+        $I->addBlockWidget(
+            $I, 'ConvertKit Broadcasts', 'convertkit-broadcasts', [
+            '.components-form-toggle'     => [ 'toggle', true ],
+            'limit'                        => [ 'input', '1' ],
+            'paginate_label_prev'         => [ 'input', 'Newer' ],
+            'paginate_label_next'         => [ 'input', 'Older' ],
+            ]
+        );
 
-		// View the home page.
-		$I->amOnPage('/');
+        // View the home page.
+        $I->amOnPage('/');
 
-		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Older', 'Newer');
-	}
+        // Test pagination.
+        $I->testBroadcastsPagination($I, 'Older', 'Newer');
+    }
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.8.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		// Activate the current theme.
-		$I->useTheme('twentytwentytwo');
-		$I->resetWidgets($I);
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.8.2
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        // Activate the current theme.
+        $I->useTheme('twentytwentytwo');
+        $I->resetWidgets($I);
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/forms/PageBlockFormCest.php
+++ b/tests/acceptance/forms/PageBlockFormCest.php
@@ -2,246 +2,270 @@
 /**
  * Tests for the ConvertKit Form's Gutenberg Block.
  * 
- * @since 	1.9.6
+ * @since 1.9.6
  */
 class PageBlockFormCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
-	}
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        $I->activateConvertKitPlugin($I);
+        $I->setupConvertKitPlugin($I);
+        $I->enableDebugLog($I);
+    }
 
-	/**
-	 * Test the Form block works when a valid Form is selected.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testFormBlockWithValidFormParameter(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Form Param');
+    /**
+     * Test the Form block works when a valid Form is selected.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testFormBlockWithValidFormParameter(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Form Param');
 
-		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'None' ],
-		]);
+        // Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'form' => [ 'select2', 'None' ],
+            ]
+        );
 
-		// Add block to Page, setting the Form setting to the value specified in the .env file.
-		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form', [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
-		]);
+        // Add block to Page, setting the Form setting to the value specified in the .env file.
+        $I->addGutenbergBlock(
+            $I, 'ConvertKit Form', 'convertkit-form', [
+            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+            ]
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Confirm that the ConvertKit Form is displayed.
-		$I->seeElementInDOM('form[data-sv-form]');
-	}
+        // Confirm that the ConvertKit Form is displayed.
+        $I->seeElementInDOM('form[data-sv-form]');
+    }
 
-	/**
-	 * Test the Form block works when a valid Legacy Form is selected.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testFormBlockWithValidLegacyFormParameter(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Legacy Form: Block: Valid Form Param');
+    /**
+     * Test the Form block works when a valid Legacy Form is selected.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testFormBlockWithValidLegacyFormParameter(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Legacy Form: Block: Valid Form Param');
 
-		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'None' ],
-		]);
+        // Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'form' => [ 'select2', 'None' ],
+            ]
+        );
 		
-		// Add block to Page, setting the Form setting to the value specified in the .env file.
-		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form', [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ]
-		]);
+        // Add block to Page, setting the Form setting to the value specified in the .env file.
+        $I->addGutenbergBlock(
+            $I, 'ConvertKit Form', 'convertkit-form', [
+            'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ]
+            ]
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Confirm that the ConvertKit Form is displayed.
-		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
-	}
+        // Confirm that the ConvertKit Form is displayed.
+        $I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
+    }
 
-	/**
-	 * Test the Form block displays a message explaining why the block cannot be previewed
-	 * in the Gutenberg editor when a valid Modal Form is selected.
-	 * 
-	 * @since 	1.9.6.9
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testFormBlockWithValidModalFormParameter(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Modal Form Param');
+    /**
+     * Test the Form block displays a message explaining why the block cannot be previewed
+     * in the Gutenberg editor when a valid Modal Form is selected.
+     * 
+     * @since 1.9.6.9
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testFormBlockWithValidModalFormParameter(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Modal Form Param');
 
-		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'None' ],
-		]);
+        // Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'form' => [ 'select2', 'None' ],
+            ]
+        );
 
-		// Add block to Page, setting the Form setting to the value specified in the .env file.
-		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form', [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ]
-		]);
+        // Add block to Page, setting the Form setting to the value specified in the .env file.
+        $I->addGutenbergBlock(
+            $I, 'ConvertKit Form', 'convertkit-form', [
+            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ]
+            ]
+        );
 
-		// Switch to iframe preview for the Form block.
-		$I->switchToIFrame('iframe[class="components-sandbox"]');
+        // Switch to iframe preview for the Form block.
+        $I->switchToIFrame('iframe[class="components-sandbox"]');
 
-		// Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
-		// site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
-		$I->see('Modal form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . '" selected. View on the frontend site to see the modal form.');
+        // Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
+        // site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
+        $I->see('Modal form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . '" selected. View on the frontend site to see the modal form.');
 
-		// Switch back to main window.
-		$I->switchToIFrame();
+        // Switch back to main window.
+        $I->switchToIFrame();
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Confirm that the ConvertKit Form is displayed.
-		$I->seeElementInDOM('form[data-sv-form]');
-	}
+        // Confirm that the ConvertKit Form is displayed.
+        $I->seeElementInDOM('form[data-sv-form]');
+    }
 
-	/**
-	 * Test the Form block displays a message explaining why the block cannot be previewed
-	 * in the Gutenberg editor when a valid Slide In Form is selected.
-	 * 
-	 * @since 	1.9.6.9
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testFormBlockWithValidSlideInFormParameter(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Slide In Form Param');
+    /**
+     * Test the Form block displays a message explaining why the block cannot be previewed
+     * in the Gutenberg editor when a valid Slide In Form is selected.
+     * 
+     * @since 1.9.6.9
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testFormBlockWithValidSlideInFormParameter(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Slide In Form Param');
 
-		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'None' ],
-		]);
+        // Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'form' => [ 'select2', 'None' ],
+            ]
+        );
 
-		// Add block to Page, setting the Form setting to the value specified in the .env file.
-		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form', [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] ]
-		]);
+        // Add block to Page, setting the Form setting to the value specified in the .env file.
+        $I->addGutenbergBlock(
+            $I, 'ConvertKit Form', 'convertkit-form', [
+            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] ]
+            ]
+        );
 
-		// Switch to iframe preview for the Form block.
-		$I->switchToIFrame('iframe[class="components-sandbox"]');
+        // Switch to iframe preview for the Form block.
+        $I->switchToIFrame('iframe[class="components-sandbox"]');
 
-		// Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
-		// site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
-		$I->see('Slide in form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] . '" selected. View on the frontend site to see the slide in form.');
+        // Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
+        // site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
+        $I->see('Slide in form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] . '" selected. View on the frontend site to see the slide in form.');
 
-		// Switch back to main window.
-		$I->switchToIFrame();
+        // Switch back to main window.
+        $I->switchToIFrame();
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Confirm that the ConvertKit Form is displayed.
-		$I->seeElementInDOM('form[data-sv-form]');
-	}
+        // Confirm that the ConvertKit Form is displayed.
+        $I->seeElementInDOM('form[data-sv-form]');
+    }
 
-	/**
-	 * Test the Form block displays a message explaining why the block cannot be previewed
-	 * in the Gutenberg editor when a valid Sticky Bar Form is selected.
-	 * 
-	 * @since 	1.9.6.9
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testFormBlockWithValidStickyBarFormParameter(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Sticky Bar Form Param');
+    /**
+     * Test the Form block displays a message explaining why the block cannot be previewed
+     * in the Gutenberg editor when a valid Sticky Bar Form is selected.
+     * 
+     * @since 1.9.6.9
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testFormBlockWithValidStickyBarFormParameter(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Sticky Bar Form Param');
 
-		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'None' ],
-		]);
+        // Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'form' => [ 'select2', 'None' ],
+            ]
+        );
 
-		// Add block to Page, setting the Form setting to the value specified in the .env file.
-		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form', [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ]
-		]);
+        // Add block to Page, setting the Form setting to the value specified in the .env file.
+        $I->addGutenbergBlock(
+            $I, 'ConvertKit Form', 'convertkit-form', [
+            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ]
+            ]
+        );
 
-		// Switch to iframe preview for the Form block.
-		$I->switchToIFrame('iframe[class="components-sandbox"]');
+        // Switch to iframe preview for the Form block.
+        $I->switchToIFrame('iframe[class="components-sandbox"]');
 
-		// Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
-		// site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
-		$I->see('Sticky bar form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] . '" selected. View on the frontend site to see the sticky bar form.');
+        // Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
+        // site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
+        $I->see('Sticky bar form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] . '" selected. View on the frontend site to see the sticky bar form.');
 
-		// Switch back to main window.
-		$I->switchToIFrame();
+        // Switch back to main window.
+        $I->switchToIFrame();
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Confirm that the ConvertKit Form is displayed.
-		$I->seeElementInDOM('form[data-sv-form]');
-	}
+        // Confirm that the ConvertKit Form is displayed.
+        $I->seeElementInDOM('form[data-sv-form]');
+    }
 
-	/**
-	 * Test the Form block works when no Form is selected.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testFormBlockWithNoFormParameter(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Sticky Bar Form Param');
+    /**
+     * Test the Form block works when no Form is selected.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testFormBlockWithNoFormParameter(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Sticky Bar Form Param');
 
-		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'None' ],
-		]);
+        // Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'form' => [ 'select2', 'None' ],
+            ]
+        );
 
-		// Add block to Page.
-		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form');
+        // Add block to Page.
+        $I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form');
 
-		// Confirm that the Form block displays instructions to the user on how to select a Form.
-		$I->see('Select a Form using the Form option in the Gutenberg sidebar.', [
-			'css' => '.convertkit-no-content',
-		]);
+        // Confirm that the Form block displays instructions to the user on how to select a Form.
+        $I->see(
+            'Select a Form using the Form option in the Gutenberg sidebar.', [
+            'css' => '.convertkit-no-content',
+            ]
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Confirm that no ConvertKit Form is displayed.
-		$I->dontSeeElementInDOM('form[data-sv-form]');
-	}
+        // Confirm that no ConvertKit Form is displayed.
+        $I->dontSeeElementInDOM('form[data-sv-form]');
+    }
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/forms/PageBlockFormCest.php
+++ b/tests/acceptance/forms/PageBlockFormCest.php
@@ -1,271 +1,291 @@
 <?php
 /**
  * Tests for the ConvertKit Form's Gutenberg Block.
- * 
+ *
  * @since 1.9.6
  */
-class PageBlockFormCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        $I->activateConvertKitPlugin($I);
-        $I->setupConvertKitPlugin($I);
-        $I->enableDebugLog($I);
-    }
+class PageBlockFormCest {
 
-    /**
-     * Test the Form block works when a valid Form is selected.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testFormBlockWithValidFormParameter(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Form Param');
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		$I->activateConvertKitPlugin( $I );
+		$I->setupConvertKitPlugin( $I );
+		$I->enableDebugLog( $I );
+	}
 
-        // Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'form' => [ 'select2', 'None' ],
-            ]
-        );
+	/**
+	 * Test the Form block works when a valid Form is selected.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testFormBlockWithValidFormParameter( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Form: Block: Valid Form Param' );
 
-        // Add block to Page, setting the Form setting to the value specified in the .env file.
-        $I->addGutenbergBlock(
-            $I, 'ConvertKit Form', 'convertkit-form', [
-            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
-            ]
-        );
+		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'form' => array( 'select2', 'None' ),
+			)
+		);
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
+		// Add block to Page, setting the Form setting to the value specified in the .env file.
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			array(
+				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
+			)
+		);
 
-        // Confirm that the ConvertKit Form is displayed.
-        $I->seeElementInDOM('form[data-sv-form]');
-    }
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
 
-    /**
-     * Test the Form block works when a valid Legacy Form is selected.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testFormBlockWithValidLegacyFormParameter(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Legacy Form: Block: Valid Form Param');
+		// Confirm that the ConvertKit Form is displayed.
+		$I->seeElementInDOM( 'form[data-sv-form]' );
+	}
 
-        // Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'form' => [ 'select2', 'None' ],
-            ]
-        );
-		
-        // Add block to Page, setting the Form setting to the value specified in the .env file.
-        $I->addGutenbergBlock(
-            $I, 'ConvertKit Form', 'convertkit-form', [
-            'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ]
-            ]
-        );
+	/**
+	 * Test the Form block works when a valid Legacy Form is selected.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testFormBlockWithValidLegacyFormParameter( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Legacy Form: Block: Valid Form Param' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
+		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'form' => array( 'select2', 'None' ),
+			)
+		);
 
-        // Confirm that the ConvertKit Form is displayed.
-        $I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
-    }
+		// Add block to Page, setting the Form setting to the value specified in the .env file.
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			array(
+				'form' => array( 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ),
+			)
+		);
 
-    /**
-     * Test the Form block displays a message explaining why the block cannot be previewed
-     * in the Gutenberg editor when a valid Modal Form is selected.
-     * 
-     * @since 1.9.6.9
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testFormBlockWithValidModalFormParameter(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Modal Form Param');
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
 
-        // Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'form' => [ 'select2', 'None' ],
-            ]
-        );
+		// Confirm that the ConvertKit Form is displayed.
+		$I->seeInSource( '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">' );
+	}
 
-        // Add block to Page, setting the Form setting to the value specified in the .env file.
-        $I->addGutenbergBlock(
-            $I, 'ConvertKit Form', 'convertkit-form', [
-            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ]
-            ]
-        );
+	/**
+	 * Test the Form block displays a message explaining why the block cannot be previewed
+	 * in the Gutenberg editor when a valid Modal Form is selected.
+	 *
+	 * @since 1.9.6.9
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testFormBlockWithValidModalFormParameter( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Form: Block: Valid Modal Form Param' );
 
-        // Switch to iframe preview for the Form block.
-        $I->switchToIFrame('iframe[class="components-sandbox"]');
+		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'form' => array( 'select2', 'None' ),
+			)
+		);
 
-        // Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
-        // site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
-        $I->see('Modal form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . '" selected. View on the frontend site to see the modal form.');
+		// Add block to Page, setting the Form setting to the value specified in the .env file.
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			array(
+				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ),
+			)
+		);
 
-        // Switch back to main window.
-        $I->switchToIFrame();
+		// Switch to iframe preview for the Form block.
+		$I->switchToIFrame( 'iframe[class="components-sandbox"]' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
+		// Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
+		// site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
+		$I->see( 'Modal form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . '" selected. View on the frontend site to see the modal form.' );
 
-        // Confirm that the ConvertKit Form is displayed.
-        $I->seeElementInDOM('form[data-sv-form]');
-    }
+		// Switch back to main window.
+		$I->switchToIFrame();
 
-    /**
-     * Test the Form block displays a message explaining why the block cannot be previewed
-     * in the Gutenberg editor when a valid Slide In Form is selected.
-     * 
-     * @since 1.9.6.9
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testFormBlockWithValidSlideInFormParameter(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Slide In Form Param');
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
 
-        // Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'form' => [ 'select2', 'None' ],
-            ]
-        );
+		// Confirm that the ConvertKit Form is displayed.
+		$I->seeElementInDOM( 'form[data-sv-form]' );
+	}
 
-        // Add block to Page, setting the Form setting to the value specified in the .env file.
-        $I->addGutenbergBlock(
-            $I, 'ConvertKit Form', 'convertkit-form', [
-            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] ]
-            ]
-        );
+	/**
+	 * Test the Form block displays a message explaining why the block cannot be previewed
+	 * in the Gutenberg editor when a valid Slide In Form is selected.
+	 *
+	 * @since 1.9.6.9
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testFormBlockWithValidSlideInFormParameter( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Form: Block: Valid Slide In Form Param' );
 
-        // Switch to iframe preview for the Form block.
-        $I->switchToIFrame('iframe[class="components-sandbox"]');
+		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'form' => array( 'select2', 'None' ),
+			)
+		);
 
-        // Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
-        // site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
-        $I->see('Slide in form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] . '" selected. View on the frontend site to see the slide in form.');
+		// Add block to Page, setting the Form setting to the value specified in the .env file.
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			array(
+				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] ),
+			)
+		);
 
-        // Switch back to main window.
-        $I->switchToIFrame();
+		// Switch to iframe preview for the Form block.
+		$I->switchToIFrame( 'iframe[class="components-sandbox"]' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
+		// Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
+		// site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
+		$I->see( 'Slide in form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] . '" selected. View on the frontend site to see the slide in form.' );
 
-        // Confirm that the ConvertKit Form is displayed.
-        $I->seeElementInDOM('form[data-sv-form]');
-    }
+		// Switch back to main window.
+		$I->switchToIFrame();
 
-    /**
-     * Test the Form block displays a message explaining why the block cannot be previewed
-     * in the Gutenberg editor when a valid Sticky Bar Form is selected.
-     * 
-     * @since 1.9.6.9
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testFormBlockWithValidStickyBarFormParameter(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Sticky Bar Form Param');
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
 
-        // Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'form' => [ 'select2', 'None' ],
-            ]
-        );
+		// Confirm that the ConvertKit Form is displayed.
+		$I->seeElementInDOM( 'form[data-sv-form]' );
+	}
 
-        // Add block to Page, setting the Form setting to the value specified in the .env file.
-        $I->addGutenbergBlock(
-            $I, 'ConvertKit Form', 'convertkit-form', [
-            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ]
-            ]
-        );
+	/**
+	 * Test the Form block displays a message explaining why the block cannot be previewed
+	 * in the Gutenberg editor when a valid Sticky Bar Form is selected.
+	 *
+	 * @since 1.9.6.9
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testFormBlockWithValidStickyBarFormParameter( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Form: Block: Valid Sticky Bar Form Param' );
 
-        // Switch to iframe preview for the Form block.
-        $I->switchToIFrame('iframe[class="components-sandbox"]');
+		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'form' => array( 'select2', 'None' ),
+			)
+		);
 
-        // Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
-        // site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
-        $I->see('Sticky bar form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] . '" selected. View on the frontend site to see the sticky bar form.');
+		// Add block to Page, setting the Form setting to the value specified in the .env file.
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			array(
+				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ),
+			)
+		);
 
-        // Switch back to main window.
-        $I->switchToIFrame();
+		// Switch to iframe preview for the Form block.
+		$I->switchToIFrame( 'iframe[class="components-sandbox"]' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
+		// Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
+		// site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
+		$I->see( 'Sticky bar form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] . '" selected. View on the frontend site to see the sticky bar form.' );
 
-        // Confirm that the ConvertKit Form is displayed.
-        $I->seeElementInDOM('form[data-sv-form]');
-    }
+		// Switch back to main window.
+		$I->switchToIFrame();
 
-    /**
-     * Test the Form block works when no Form is selected.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testFormBlockWithNoFormParameter(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Sticky Bar Form Param');
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
 
-        // Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'form' => [ 'select2', 'None' ],
-            ]
-        );
+		// Confirm that the ConvertKit Form is displayed.
+		$I->seeElementInDOM( 'form[data-sv-form]' );
+	}
 
-        // Add block to Page.
-        $I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form');
+	/**
+	 * Test the Form block works when no Form is selected.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testFormBlockWithNoFormParameter( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Form: Block: Valid Sticky Bar Form Param' );
 
-        // Confirm that the Form block displays instructions to the user on how to select a Form.
-        $I->see(
-            'Select a Form using the Form option in the Gutenberg sidebar.', [
-            'css' => '.convertkit-no-content',
-            ]
-        );
+		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'form' => array( 'select2', 'None' ),
+			)
+		);
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
+		// Add block to Page.
+		$I->addGutenbergBlock( $I, 'ConvertKit Form', 'convertkit-form' );
 
-        // Confirm that no ConvertKit Form is displayed.
-        $I->dontSeeElementInDOM('form[data-sv-form]');
-    }
+		// Confirm that the Form block displays instructions to the user on how to select a Form.
+		$I->see(
+			'Select a Form using the Form option in the Gutenberg sidebar.',
+			array(
+				'css' => '.convertkit-no-content',
+			)
+		);
 
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
+
+		// Confirm that no ConvertKit Form is displayed.
+		$I->dontSeeElementInDOM( 'form[data-sv-form]' );
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/forms/PageBlockFormCest.php
+++ b/tests/acceptance/forms/PageBlockFormCest.php
@@ -1,17 +1,17 @@
 <?php
 /**
  * Tests for the ConvertKit Form's Gutenberg Block.
- * 
- * @since 	1.9.6
+ *
+ * @since   1.9.6
  */
 class PageBlockFormCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -22,10 +22,10 @@ class PageBlockFormCest
 
 	/**
 	 * Test the Form block works when a valid Form is selected.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testFormBlockWithValidFormParameter(AcceptanceTester $I)
 	{
@@ -33,14 +33,23 @@ class PageBlockFormCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Form Param');
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'None' ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
 
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
-		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form', [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
-		]);
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+			]
+		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -51,10 +60,10 @@ class PageBlockFormCest
 
 	/**
 	 * Test the Form block works when a valid Legacy Form is selected.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testFormBlockWithValidLegacyFormParameter(AcceptanceTester $I)
 	{
@@ -62,14 +71,23 @@ class PageBlockFormCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Legacy Form: Block: Valid Form Param');
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'None' ],
-		]);
-		
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
+
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
-		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form', [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ]
-		]);
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
+			]
+		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -81,10 +99,10 @@ class PageBlockFormCest
 	/**
 	 * Test the Form block displays a message explaining why the block cannot be previewed
 	 * in the Gutenberg editor when a valid Modal Form is selected.
-	 * 
-	 * @since 	1.9.6.9
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.9
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testFormBlockWithValidModalFormParameter(AcceptanceTester $I)
 	{
@@ -92,14 +110,23 @@ class PageBlockFormCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Modal Form Param');
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'None' ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
 
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
-		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form', [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ]
-		]);
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
+			]
+		);
 
 		// Switch to iframe preview for the Form block.
 		$I->switchToIFrame('iframe[class="components-sandbox"]');
@@ -121,10 +148,10 @@ class PageBlockFormCest
 	/**
 	 * Test the Form block displays a message explaining why the block cannot be previewed
 	 * in the Gutenberg editor when a valid Slide In Form is selected.
-	 * 
-	 * @since 	1.9.6.9
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.9
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testFormBlockWithValidSlideInFormParameter(AcceptanceTester $I)
 	{
@@ -132,14 +159,23 @@ class PageBlockFormCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Slide In Form Param');
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'None' ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
 
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
-		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form', [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] ]
-		]);
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] ],
+			]
+		);
 
 		// Switch to iframe preview for the Form block.
 		$I->switchToIFrame('iframe[class="components-sandbox"]');
@@ -161,10 +197,10 @@ class PageBlockFormCest
 	/**
 	 * Test the Form block displays a message explaining why the block cannot be previewed
 	 * in the Gutenberg editor when a valid Sticky Bar Form is selected.
-	 * 
-	 * @since 	1.9.6.9
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.9
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testFormBlockWithValidStickyBarFormParameter(AcceptanceTester $I)
 	{
@@ -172,14 +208,23 @@ class PageBlockFormCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Sticky Bar Form Param');
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'None' ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
 
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
-		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form', [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ]
-		]);
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ],
+			]
+		);
 
 		// Switch to iframe preview for the Form block.
 		$I->switchToIFrame('iframe[class="components-sandbox"]');
@@ -200,10 +245,10 @@ class PageBlockFormCest
 
 	/**
 	 * Test the Form block works when no Form is selected.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testFormBlockWithNoFormParameter(AcceptanceTester $I)
 	{
@@ -211,17 +256,24 @@ class PageBlockFormCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Sticky Bar Form Param');
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'None' ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
 
 		// Add block to Page.
 		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form');
 
 		// Confirm that the Form block displays instructions to the user on how to select a Form.
-		$I->see('Select a Form using the Form option in the Gutenberg sidebar.', [
-			'css' => '.convertkit-no-content',
-		]);
+		$I->see(
+			'Select a Form using the Form option in the Gutenberg sidebar.',
+			[
+				'css' => '.convertkit-no-content',
+			]
+		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -234,10 +286,10 @@ class PageBlockFormCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/forms/PageBlockFormCest.php
+++ b/tests/acceptance/forms/PageBlockFormCest.php
@@ -1,291 +1,247 @@
 <?php
 /**
  * Tests for the ConvertKit Form's Gutenberg Block.
- *
- * @since 1.9.6
+ * 
+ * @since 	1.9.6
  */
-class PageBlockFormCest {
-
+class PageBlockFormCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
-		$I->activateConvertKitPlugin( $I );
-		$I->setupConvertKitPlugin( $I );
-		$I->enableDebugLog( $I );
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
 	}
 
 	/**
 	 * Test the Form block works when a valid Form is selected.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testFormBlockWithValidFormParameter( AcceptanceTester $I ) {
+	public function testFormBlockWithValidFormParameter(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Form: Block: Valid Form Param' );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Form Param');
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'form' => array( 'select2', 'None' ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'None' ],
+		]);
 
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
-		$I->addGutenbergBlock(
-			$I,
-			'ConvertKit Form',
-			'convertkit-form',
-			array(
-				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
-			)
-		);
+		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form', [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+		]);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the ConvertKit Form is displayed.
-		$I->seeElementInDOM( 'form[data-sv-form]' );
+		$I->seeElementInDOM('form[data-sv-form]');
 	}
 
 	/**
 	 * Test the Form block works when a valid Legacy Form is selected.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testFormBlockWithValidLegacyFormParameter( AcceptanceTester $I ) {
+	public function testFormBlockWithValidLegacyFormParameter(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Legacy Form: Block: Valid Form Param' );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Legacy Form: Block: Valid Form Param');
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'form' => array( 'select2', 'None' ),
-			)
-		);
-
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'None' ],
+		]);
+		
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
-		$I->addGutenbergBlock(
-			$I,
-			'ConvertKit Form',
-			'convertkit-form',
-			array(
-				'form' => array( 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ),
-			)
-		);
+		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form', [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ]
+		]);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the ConvertKit Form is displayed.
-		$I->seeInSource( '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">' );
+		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
 	}
 
 	/**
 	 * Test the Form block displays a message explaining why the block cannot be previewed
 	 * in the Gutenberg editor when a valid Modal Form is selected.
-	 *
-	 * @since 1.9.6.9
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.9
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testFormBlockWithValidModalFormParameter( AcceptanceTester $I ) {
+	public function testFormBlockWithValidModalFormParameter(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Form: Block: Valid Modal Form Param' );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Modal Form Param');
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'form' => array( 'select2', 'None' ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'None' ],
+		]);
 
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
-		$I->addGutenbergBlock(
-			$I,
-			'ConvertKit Form',
-			'convertkit-form',
-			array(
-				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ),
-			)
-		);
+		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form', [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ]
+		]);
 
 		// Switch to iframe preview for the Form block.
-		$I->switchToIFrame( 'iframe[class="components-sandbox"]' );
+		$I->switchToIFrame('iframe[class="components-sandbox"]');
 
 		// Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
 		// site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
-		$I->see( 'Modal form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . '" selected. View on the frontend site to see the modal form.' );
+		$I->see('Modal form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . '" selected. View on the frontend site to see the modal form.');
 
 		// Switch back to main window.
 		$I->switchToIFrame();
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the ConvertKit Form is displayed.
-		$I->seeElementInDOM( 'form[data-sv-form]' );
+		$I->seeElementInDOM('form[data-sv-form]');
 	}
 
 	/**
 	 * Test the Form block displays a message explaining why the block cannot be previewed
 	 * in the Gutenberg editor when a valid Slide In Form is selected.
-	 *
-	 * @since 1.9.6.9
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.9
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testFormBlockWithValidSlideInFormParameter( AcceptanceTester $I ) {
+	public function testFormBlockWithValidSlideInFormParameter(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Form: Block: Valid Slide In Form Param' );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Slide In Form Param');
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'form' => array( 'select2', 'None' ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'None' ],
+		]);
 
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
-		$I->addGutenbergBlock(
-			$I,
-			'ConvertKit Form',
-			'convertkit-form',
-			array(
-				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] ),
-			)
-		);
+		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form', [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] ]
+		]);
 
 		// Switch to iframe preview for the Form block.
-		$I->switchToIFrame( 'iframe[class="components-sandbox"]' );
+		$I->switchToIFrame('iframe[class="components-sandbox"]');
 
 		// Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
 		// site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
-		$I->see( 'Slide in form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] . '" selected. View on the frontend site to see the slide in form.' );
+		$I->see('Slide in form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] . '" selected. View on the frontend site to see the slide in form.');
 
 		// Switch back to main window.
 		$I->switchToIFrame();
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the ConvertKit Form is displayed.
-		$I->seeElementInDOM( 'form[data-sv-form]' );
+		$I->seeElementInDOM('form[data-sv-form]');
 	}
 
 	/**
 	 * Test the Form block displays a message explaining why the block cannot be previewed
 	 * in the Gutenberg editor when a valid Sticky Bar Form is selected.
-	 *
-	 * @since 1.9.6.9
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.9
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testFormBlockWithValidStickyBarFormParameter( AcceptanceTester $I ) {
+	public function testFormBlockWithValidStickyBarFormParameter(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Form: Block: Valid Sticky Bar Form Param' );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Sticky Bar Form Param');
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'form' => array( 'select2', 'None' ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'None' ],
+		]);
 
 		// Add block to Page, setting the Form setting to the value specified in the .env file.
-		$I->addGutenbergBlock(
-			$I,
-			'ConvertKit Form',
-			'convertkit-form',
-			array(
-				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ),
-			)
-		);
+		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form', [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ]
+		]);
 
 		// Switch to iframe preview for the Form block.
-		$I->switchToIFrame( 'iframe[class="components-sandbox"]' );
+		$I->switchToIFrame('iframe[class="components-sandbox"]');
 
 		// Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
 		// site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
-		$I->see( 'Sticky bar form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] . '" selected. View on the frontend site to see the sticky bar form.' );
+		$I->see('Sticky bar form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] . '" selected. View on the frontend site to see the sticky bar form.');
 
 		// Switch back to main window.
 		$I->switchToIFrame();
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the ConvertKit Form is displayed.
-		$I->seeElementInDOM( 'form[data-sv-form]' );
+		$I->seeElementInDOM('form[data-sv-form]');
 	}
 
 	/**
 	 * Test the Form block works when no Form is selected.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testFormBlockWithNoFormParameter( AcceptanceTester $I ) {
+	public function testFormBlockWithNoFormParameter(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Form: Block: Valid Sticky Bar Form Param' );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Sticky Bar Form Param');
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'form' => array( 'select2', 'None' ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'None' ],
+		]);
 
 		// Add block to Page.
-		$I->addGutenbergBlock( $I, 'ConvertKit Form', 'convertkit-form' );
+		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form');
 
 		// Confirm that the Form block displays instructions to the user on how to select a Form.
-		$I->see(
-			'Select a Form using the Form option in the Gutenberg sidebar.',
-			array(
-				'css' => '.convertkit-no-content',
-			)
-		);
+		$I->see('Select a Form using the Form option in the Gutenberg sidebar.', [
+			'css' => '.convertkit-no-content',
+		]);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that no ConvertKit Form is displayed.
-		$I->dontSeeElementInDOM( 'form[data-sv-form]' );
+		$I->dontSeeElementInDOM('form[data-sv-form]');
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/forms/PageFormCest.php
+++ b/tests/acceptance/forms/PageFormCest.php
@@ -1,528 +1,477 @@
 <?php
 /**
  * Tests for ConvertKit Forms on WordPress Pages.
- *
- * @since 1.9.6
+ * 
+ * @since 	1.9.6
  */
-class PageFormCest {
-
+class PageFormCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
+	public function _before(AcceptanceTester $I)
+	{
 		// Activate and Setup ConvertKit plugin
-		$I->activateConvertKitPlugin( $I );
-		$I->setupConvertKitPlugin( $I );
-		$I->enableDebugLog( $I );
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
 	}
 
 	/**
 	 * Test that the Pages > Add New screen has expected a11y output, such as label[for].
-	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAccessibility( AcceptanceTester $I ) {
+	public function testAccessibility(AcceptanceTester $I)
+	{
 		// Navigate to Post Type (e.g. Pages / Posts) > Add New
-		$I->amOnAdminPage( 'post-new.php?post_type=page' );
+		$I->amOnAdminPage('post-new.php?post_type=page');
 
 		// Confirm that settings have label[for] attributes.
-		$I->seeInSource( '<label for="wp-convertkit-form">' );
-		$I->seeInSource( '<label for="wp-convertkit-landing_page">' );
-		$I->seeInSource( '<label for="wp-convertkit-tag">' );
+		$I->seeInSource('<label for="wp-convertkit-form">');
+		$I->seeInSource('<label for="wp-convertkit-landing_page">');
+		$I->seeInSource('<label for="wp-convertkit-tag">');
 	}
 
 	/**
 	 * Test that the 'Default' option for the Default Form setting in the Plugin Settings works when
 	 * creating and viewing a new WordPress Page, and there is no Default Form specified in the Plugin
 	 * settings.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewPageUsingDefaultFormWithNoDefaultFormSpecifiedInPlugin( AcceptanceTester $I ) {
+	public function testAddNewPageUsingDefaultFormWithNoDefaultFormSpecifiedInPlugin(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Form: Default: None' );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Default: None');
 
 		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'form' => array( 'select2', 'Default' ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'Default' ],
+		]);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that no ConvertKit Form is displayed.
-		$I->dontSeeElementInDOM( 'form[data-sv-form]' );
+		$I->dontSeeElementInDOM('form[data-sv-form]');
 	}
 
 	/**
 	 * Test that the Default Form specified in the Plugin Settings works when
 	 * creating and viewing a new WordPress Page.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewPageUsingDefaultForm( AcceptanceTester $I ) {
+	public function testAddNewPageUsingDefaultForm(AcceptanceTester $I)
+	{
 		// Specify the Default Form in the Plugin Settings.
-		$defaultFormID = $I->setupConvertKitPluginDefaultForm( $I );
+		$defaultFormID = $I->setupConvertKitPluginDefaultForm($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Form: Default' );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Default');
 
 		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'form' => array( 'select2', 'Default' ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'Default' ],
+		]);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the ConvertKit Default Form displays.
-		$I->seeElementInDOM( 'form[data-sv-form="' . $defaultFormID . '"]' );
+		$I->seeElementInDOM('form[data-sv-form="' . $defaultFormID . '"]');
 	}
 
 	/**
 	 * Test that the Default Legacy Form specified in the Plugin Settings works when
 	 * creating and viewing a new WordPress Page.
-	 *
-	 * @since 1.9.6.3
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewPageUsingDefaultLegacyForm( AcceptanceTester $I ) {
+	public function testAddNewPageUsingDefaultLegacyForm(AcceptanceTester $I)
+	{
 		// Specify the Default Legacy Form in the Plugin Settings.
-		$defaultLegacyFormID = $I->setupConvertKitPluginDefaultLegacyForm( $I );
+		$defaultLegacyFormID = $I->setupConvertKitPluginDefaultLegacyForm($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Form: Legacy: Default' );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Legacy: Default');
 
 		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'form' => array( 'select2', 'Default' ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'Default' ],
+		]);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the ConvertKit Default Legacy Form displays.
-		$I->seeInSource( '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $defaultLegacyFormID . '/subscribe" data-remote="true">' );
+		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $defaultLegacyFormID . '/subscribe" data-remote="true">');
 	}
 
 	/**
 	 * Test that 'None' Form specified in the Page Settings works when
 	 * creating and viewing a new WordPress Page.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewPageUsingNoForm( AcceptanceTester $I ) {
+	public function testAddNewPageUsingNoForm(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Form: None' );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: None');
 
 		// Configure metabox's Form setting = None.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'form' => array( 'select2', 'None' ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'None' ],
+		]);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that no ConvertKit Form is displayed.
-		$I->dontSeeElementInDOM( 'form[data-sv-form]' );
+		$I->dontSeeElementInDOM('form[data-sv-form]');
 	}
 
 	/**
 	 * Test that the Form specified in the Page Settings works when
 	 * creating and viewing a new WordPress Page.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewPageUsingDefinedForm( AcceptanceTester $I ) {
+	public function testAddNewPageUsingDefinedForm(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME']);
 
 		// Configure metabox's Form setting = None.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'form' => array( 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+		]);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the ConvertKit Form displays.
-		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 	}
 
 	/**
 	 * Test that the Legacy Form specified in the Page Settings works when
 	 * creating and viewing a new WordPress Page.
-	 *
-	 * @since 1.9.6.3
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewPageUsingDefinedLegacyForm( AcceptanceTester $I ) {
+	public function testAddNewPageUsingDefinedLegacyForm(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
 
 		// Configure metabox's Form setting = None.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'form' => array( 'select2', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
+		]);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the ConvertKit Legacy Form displays.
-		$I->seeInSource( '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">' );
+		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
 	}
 
 	/**
 	 * Test that the Default Form for Pages displays when an invalid Form ID is specified
 	 * for a Page.
-	 *
+	 * 
 	 * Whilst the on screen options won't permit selecting an invalid Form ID, a Page might
 	 * have an invalid Form ID because:
 	 * - the form belongs to another ConvertKit account (i.e. API credentials were changed in the Plugin, but this Page's specified Form was not changed)
 	 * - the form was deleted from the ConvertKit account.
-	 *
-	 * @since 1.9.7.2
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewPageUsingInvalidDefinedForm( AcceptanceTester $I ) {
+	public function testAddNewPageUsingInvalidDefinedForm(AcceptanceTester $I)
+	{
 		// Setup the Default Form for Pages and Posts.
-		$I->setupConvertKitPluginDefaultForm( $I );
+		$I->setupConvertKitPluginDefaultForm($I);
 
 		// Create Page, with an invalid Form ID, as if it were created prior to API credentials being changed and/or
 		// a Form being deleted in ConvertKit.
-		$pageID = $I->havePostInDatabase(
-			array(
-				'post_type'  => 'page',
-				'post_title' => 'ConvertKit: Page: Form: Specific: Invalid',
-				'meta_input' => array(
-					'_wp_convertkit_post_meta' => array(
-						'form'         => '11111',
-						'landing_page' => '',
-						'tag'          => '',
-					),
-				),
-			)
-		);
+		$pageID = $I->havePostInDatabase([
+			'post_type' 	=> 'page',
+			'post_title' 	=> 'ConvertKit: Page: Form: Specific: Invalid',
+			'meta_input'	=> [
+				'_wp_convertkit_post_meta' => [
+					'form'         => '11111',
+					'landing_page' => '',
+					'tag'          => '',
+				]
+			],
+		]);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage( '/?p=' . $pageID );
+		$I->amOnPage('/?p='.$pageID);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the invalid ConvertKit Form does not display.
-		$I->dontSeeElementInDOM( 'form[data-sv-form="11111"]' );
+		$I->dontSeeElementInDOM('form[data-sv-form="11111"]');
 
 		// Confirm that the Default Form for Pages does display as a fallback.
-		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 	}
 
 	/**
 	 * Test that the Default Form for Pages displays when the Default option is chosen via
 	 * WordPress' Quick Edit functionality.
-	 *
-	 * @since 1.9.8.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testQuickEditUsingDefaultForm( AcceptanceTester $I ) {
+	public function testQuickEditUsingDefaultForm(AcceptanceTester $I)
+	{
 		// Specify the Default Form in the Plugin Settings.
-		$I->setupConvertKitPluginDefaultForm( $I );
+		$I->setupConvertKitPluginDefaultForm($I);
 
 		// Programmatically create a Page.
-		$pageID = $I->havePostInDatabase(
-			array(
-				'post_type'  => 'page',
-				'post_title' => 'ConvertKit: Page: Form: Default: Quick Edit',
-			)
-		);
+		$pageID = $I->havePostInDatabase([
+			'post_type' 	=> 'page',
+			'post_title' 	=> 'ConvertKit: Page: Form: Default: Quick Edit',
+		]);
 
 		// Quick Edit the Page in the Pages WP_List_Table.
-		$I->quickEdit(
-			$I,
-			'page',
-			$pageID,
-			array(
-				'form' => array( 'select', 'Default' ),
-			)
-		);
+		$I->quickEdit($I, 'page', $pageID, [
+			'form' => [ 'select', 'Default' ],
+		]);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage( '/?p=' . $pageID );
+		$I->amOnPage('/?p='.$pageID);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the ConvertKit Default Form displays.
-		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 	}
 
 	/**
 	 * Test that the defined form displays when chosen via
 	 * WordPress' Quick Edit functionality.
-	 *
-	 * @since 1.9.8.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testQuickEditUsingDefinedForm( AcceptanceTester $I ) {
+	public function testQuickEditUsingDefinedForm(AcceptanceTester $I)
+	{
 		// Programmatically create a Page.
-		$pageID = $I->havePostInDatabase(
-			array(
-				'post_type'  => 'page',
-				'post_title' => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
-			)
-		);
+		$pageID = $I->havePostInDatabase([
+			'post_type' 	=> 'page',
+			'post_title' 	=> 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
+		]);
 
 		// Quick Edit the Page in the Pages WP_List_Table.
-		$I->quickEdit(
-			$I,
-			'page',
-			$pageID,
-			array(
-				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
-			)
-		);
+		$I->quickEdit($I, 'page', $pageID, [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+		]);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage( '/?p=' . $pageID );
+		$I->amOnPage('/?p='.$pageID);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the ConvertKit Default Form displays.
-		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 	}
 
 	/**
 	 * Test that the Default Form for Pages displays when the Default option is chosen via
 	 * WordPress' Bulk Edit functionality.
-	 *
-	 * @since 1.9.8.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBulkEditUsingDefaultForm( AcceptanceTester $I ) {
+	public function testBulkEditUsingDefaultForm(AcceptanceTester $I)
+	{
 		// Specify the Default Form in the Plugin Settings.
-		$I->setupConvertKitPluginDefaultForm( $I );
+		$I->setupConvertKitPluginDefaultForm($I);
 
 		// Programmatically create two Pages.
 		$pageIDs = array(
-			$I->havePostInDatabase(
-				array(
-					'post_type'  => 'page',
-					'post_title' => 'ConvertKit: Page: Form: Default: Bulk Edit #1',
-				)
-			),
-			$I->havePostInDatabase(
-				array(
-					'post_type'  => 'page',
-					'post_title' => 'ConvertKit: Page: Form: Default: Bulk Edit #2',
-				)
-			),
+			$I->havePostInDatabase([
+				'post_type' 	=> 'page',
+				'post_title' 	=> 'ConvertKit: Page: Form: Default: Bulk Edit #1',
+			]),
+			$I->havePostInDatabase([
+				'post_type' 	=> 'page',
+				'post_title' 	=> 'ConvertKit: Page: Form: Default: Bulk Edit #2',
+			])
 		);
 
 		// Bulk Edit the Pages in the Pages WP_List_Table.
-		$I->bulkEdit(
-			$I,
-			'page',
-			$pageIDs,
-			array(
-				'form' => array( 'select', 'Default' ),
-			)
-		);
+		$I->bulkEdit($I, 'page', $pageIDs, [
+			'form' => [ 'select', 'Default' ],
+		]);
 
 		// Iterate through Pages to run frontend tests.
-		foreach ( $pageIDs as $pageID ) {
+		foreach($pageIDs as $pageID) {
 			// Load Page on the frontend site.
-			$I->amOnPage( '/?p=' . $pageID );
+			$I->amOnPage('/?p='.$pageID);
 
 			// Check that no PHP warnings or notices were output.
-			$I->checkNoWarningsAndNoticesOnScreen( $I );
+			$I->checkNoWarningsAndNoticesOnScreen($I);
 
 			// Confirm that the ConvertKit Default Form displays.
-			$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+			$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 		}
 	}
 
 	/**
 	 * Test that the defined form displays when chosen via
 	 * WordPress' Bulk Edit functionality.
-	 *
-	 * @since 1.9.8.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBulkEditUsingDefinedForm( AcceptanceTester $I ) {
+	public function testBulkEditUsingDefinedForm(AcceptanceTester $I)
+	{
 		// Programmatically create two Pages.
 		$pageIDs = array(
-			$I->havePostInDatabase(
-				array(
-					'post_type'  => 'page',
-					'post_title' => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
-				)
-			),
-			$I->havePostInDatabase(
-				array(
-					'post_type'  => 'page',
-					'post_title' => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
-				)
-			),
+			$I->havePostInDatabase([
+				'post_type' 	=> 'page',
+				'post_title' 	=> 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
+			]),
+			$I->havePostInDatabase([
+				'post_type' 	=> 'page',
+				'post_title' 	=> 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
+			])
 		);
 
 		// Bulk Edit the Pages in the Pages WP_List_Table.
-		$I->bulkEdit(
-			$I,
-			'page',
-			$pageIDs,
-			array(
-				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
-			)
-		);
+		$I->bulkEdit($I, 'page', $pageIDs, [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+		]);
 
 		// Iterate through Pages to run frontend tests.
-		foreach ( $pageIDs as $pageID ) {
+		foreach($pageIDs as $pageID) {
 			// Load Page on the frontend site.
-			$I->amOnPage( '/?p=' . $pageID );
+			$I->amOnPage('/?p='.$pageID);
 
 			// Check that no PHP warnings or notices were output.
-			$I->checkNoWarningsAndNoticesOnScreen( $I );
+			$I->checkNoWarningsAndNoticesOnScreen($I);
 
 			// Confirm that the ConvertKit Form displays.
-			$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+			$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 		}
 	}
 
 	/**
 	 * Test that the existing settings are honored and not changed
 	 * when the Bulk Edit options are set to 'No Change'.
-	 *
-	 * @since 1.9.8.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBulkEditWithNoChanges( AcceptanceTester $I ) {
+	public function testBulkEditWithNoChanges(AcceptanceTester $I)
+	{
 		// Programmatically create two Pages with a defined form.
 		$pageIDs = array(
-			$I->havePostInDatabase(
-				array(
-					'post_type'  => 'page',
-					'post_title' => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #1',
-					'meta_input' => array(
-						'_wp_convertkit_post_meta' => array(
-							'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
-							'landing_page' => '',
-							'tag'          => '',
-						),
-					),
-				)
-			),
-			$I->havePostInDatabase(
-				array(
-					'post_type'  => 'page',
-					'post_title' => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
-					'meta_input' => array(
-						'_wp_convertkit_post_meta' => array(
-							'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
-							'landing_page' => '',
-							'tag'          => '',
-						),
-					),
-				)
-			),
+			$I->havePostInDatabase([
+				'post_type' 	=> 'page',
+				'post_title' 	=> 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #1',
+				'meta_input'	=> [
+					'_wp_convertkit_post_meta' => [
+						'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
+						'landing_page' => '',
+						'tag'          => '',
+					]
+				],
+			]),
+			$I->havePostInDatabase([
+				'post_type' 	=> 'page',
+				'post_title' 	=> 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
+				'meta_input'	=> [
+					'_wp_convertkit_post_meta' => [
+						'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
+						'landing_page' => '',
+						'tag'          => '',
+					]
+				],
+			])
 		);
 
 		// Bulk Edit the Pages in the Pages WP_List_Table.
-		$I->bulkEdit(
-			$I,
-			'page',
-			$pageIDs,
-			array(
-				'form' => array( 'select', '— No Change —' ),
-			)
-		);
+		$I->bulkEdit($I, 'page', $pageIDs, [
+			'form' => [ 'select', '— No Change —' ],
+		]);
 
 		// Iterate through Pages to run frontend tests.
-		foreach ( $pageIDs as $pageID ) {
+		foreach($pageIDs as $pageID) {
 			// Load Page on the frontend site.
-			$I->amOnPage( '/?p=' . $pageID );
+			$I->amOnPage('/?p='.$pageID);
 
 			// Check that no PHP warnings or notices were output.
-			$I->checkNoWarningsAndNoticesOnScreen( $I );
+			$I->checkNoWarningsAndNoticesOnScreen($I);
 
 			// Confirm that the ConvertKit Form displays.
-			$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+			$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 		}
 	}
 
 	/**
 	 * Test that the Bulk Edit fields do not display when a search on a WP_List_Table
 	 * returns no results.
-	 *
-	 * @since 1.9.8.1
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.1
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBulkEditFieldsHiddenWhenNoPagesFound( AcceptanceTester $I ) {
+	public function testBulkEditFieldsHiddenWhenNoPagesFound(AcceptanceTester $I)
+	{
 		// Emulate the user searching for Pages with a query string that yields no results.
-		$I->amOnAdminPage( 'edit.php?post_type=page&s=nothing' );
+		$I->amOnAdminPage('edit.php?post_type=page&s=nothing');
 
 		// Confirm that the Bulk Edit fields do not display.
-		$I->dontSeeElement( '#convertkit-bulk-edit' );
+		$I->dontSeeElement('#convertkit-bulk-edit');
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/forms/PageFormCest.php
+++ b/tests/acceptance/forms/PageFormCest.php
@@ -1,517 +1,528 @@
 <?php
 /**
  * Tests for ConvertKit Forms on WordPress Pages.
- * 
+ *
  * @since 1.9.6
  */
-class PageFormCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        // Activate and Setup ConvertKit plugin
-        $I->activateConvertKitPlugin($I);
-        $I->setupConvertKitPlugin($I);
-        $I->enableDebugLog($I);
-    }
-
-    /**
-     * Test that the Pages > Add New screen has expected a11y output, such as label[for].
-     * 
-     * @since 1.9.7.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAccessibility(AcceptanceTester $I)
-    {
-        // Navigate to Post Type (e.g. Pages / Posts) > Add New
-        $I->amOnAdminPage('post-new.php?post_type=page');
-
-        // Confirm that settings have label[for] attributes.
-        $I->seeInSource('<label for="wp-convertkit-form">');
-        $I->seeInSource('<label for="wp-convertkit-landing_page">');
-        $I->seeInSource('<label for="wp-convertkit-tag">');
-    }
-
-    /**
-     * Test that the 'Default' option for the Default Form setting in the Plugin Settings works when
-     * creating and viewing a new WordPress Page, and there is no Default Form specified in the Plugin
-     * settings.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewPageUsingDefaultFormWithNoDefaultFormSpecifiedInPlugin(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Default: None');
-
-        // Configure metabox's Form setting = Default.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'form' => [ 'select2', 'Default' ],
-            ]
-        );
-
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
-
-        // Confirm that no ConvertKit Form is displayed.
-        $I->dontSeeElementInDOM('form[data-sv-form]');
-    }
-
-    /**
-     * Test that the Default Form specified in the Plugin Settings works when
-     * creating and viewing a new WordPress Page.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewPageUsingDefaultForm(AcceptanceTester $I)
-    {
-        // Specify the Default Form in the Plugin Settings.
-        $defaultFormID = $I->setupConvertKitPluginDefaultForm($I);
-
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Default');
-
-        // Configure metabox's Form setting = Default.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'form' => [ 'select2', 'Default' ],
-            ]
-        );
-
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
-
-        // Confirm that the ConvertKit Default Form displays.
-        $I->seeElementInDOM('form[data-sv-form="' . $defaultFormID . '"]');
-    }
-
-    /**
-     * Test that the Default Legacy Form specified in the Plugin Settings works when
-     * creating and viewing a new WordPress Page.
-     * 
-     * @since 1.9.6.3
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewPageUsingDefaultLegacyForm(AcceptanceTester $I)
-    {
-        // Specify the Default Legacy Form in the Plugin Settings.
-        $defaultLegacyFormID = $I->setupConvertKitPluginDefaultLegacyForm($I);
-
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Legacy: Default');
-
-        // Configure metabox's Form setting = Default.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'form' => [ 'select2', 'Default' ],
-            ]
-        );
-
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
-
-        // Confirm that the ConvertKit Default Legacy Form displays.
-        $I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $defaultLegacyFormID . '/subscribe" data-remote="true">');
-    }
-
-    /**
-     * Test that 'None' Form specified in the Page Settings works when
-     * creating and viewing a new WordPress Page.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewPageUsingNoForm(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: None');
-
-        // Configure metabox's Form setting = None.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'form' => [ 'select2', 'None' ],
-            ]
-        );
-
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
-
-        // Confirm that no ConvertKit Form is displayed.
-        $I->dontSeeElementInDOM('form[data-sv-form]');
-    }
-
-    /**
-     * Test that the Form specified in the Page Settings works when
-     * creating and viewing a new WordPress Page.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewPageUsingDefinedForm(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME']);
-
-        // Configure metabox's Form setting = None.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-            ]
-        );
-
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
-
-        // Confirm that the ConvertKit Form displays.
-        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-    }
-
-    /**
-     * Test that the Legacy Form specified in the Page Settings works when
-     * creating and viewing a new WordPress Page.
-     * 
-     * @since 1.9.6.3
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewPageUsingDefinedLegacyForm(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
-
-        // Configure metabox's Form setting = None.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'form' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
-            ]
-        );
-
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
-
-        // Confirm that the ConvertKit Legacy Form displays.
-        $I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
-    }
-
-    /**
-     * Test that the Default Form for Pages displays when an invalid Form ID is specified
-     * for a Page.
-     * 
-     * Whilst the on screen options won't permit selecting an invalid Form ID, a Page might
-     * have an invalid Form ID because:
-     * - the form belongs to another ConvertKit account (i.e. API credentials were changed in the Plugin, but this Page's specified Form was not changed)
-     * - the form was deleted from the ConvertKit account.
-     * 
-     * @since 1.9.7.2
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewPageUsingInvalidDefinedForm(AcceptanceTester $I)
-    {
-        // Setup the Default Form for Pages and Posts.
-        $I->setupConvertKitPluginDefaultForm($I);
-
-        // Create Page, with an invalid Form ID, as if it were created prior to API credentials being changed and/or
-        // a Form being deleted in ConvertKit.
-        $pageID = $I->havePostInDatabase(
-            [
-            'post_type'     => 'page',
-            'post_title'     => 'ConvertKit: Page: Form: Specific: Invalid',
-            'meta_input'    => [
-            '_wp_convertkit_post_meta' => [
-            'form'         => '11111',
-            'landing_page' => '',
-            'tag'          => '',
-            ]
-            ],
-            ]
-        );
-
-        // Load the Page on the frontend site.
-        $I->amOnPage('/?p='.$pageID);
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Confirm that the invalid ConvertKit Form does not display.
-        $I->dontSeeElementInDOM('form[data-sv-form="11111"]');
-
-        // Confirm that the Default Form for Pages does display as a fallback.
-        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-    }
-
-    /**
-     * Test that the Default Form for Pages displays when the Default option is chosen via
-     * WordPress' Quick Edit functionality.
-     * 
-     * @since 1.9.8.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testQuickEditUsingDefaultForm(AcceptanceTester $I)
-    {
-        // Specify the Default Form in the Plugin Settings.
-        $I->setupConvertKitPluginDefaultForm($I);
-
-        // Programmatically create a Page.
-        $pageID = $I->havePostInDatabase(
-            [
-            'post_type'     => 'page',
-            'post_title'     => 'ConvertKit: Page: Form: Default: Quick Edit',
-            ]
-        );
-
-        // Quick Edit the Page in the Pages WP_List_Table.
-        $I->quickEdit(
-            $I, 'page', $pageID, [
-            'form' => [ 'select', 'Default' ],
-            ]
-        );
-
-        // Load the Page on the frontend site.
-        $I->amOnPage('/?p='.$pageID);
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Confirm that the ConvertKit Default Form displays.
-        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-    }
-
-    /**
-     * Test that the defined form displays when chosen via
-     * WordPress' Quick Edit functionality.
-     * 
-     * @since 1.9.8.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testQuickEditUsingDefinedForm(AcceptanceTester $I)
-    {
-        // Programmatically create a Page.
-        $pageID = $I->havePostInDatabase(
-            [
-            'post_type'     => 'page',
-            'post_title'     => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
-            ]
-        );
-
-        // Quick Edit the Page in the Pages WP_List_Table.
-        $I->quickEdit(
-            $I, 'page', $pageID, [
-            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-            ]
-        );
-
-        // Load the Page on the frontend site.
-        $I->amOnPage('/?p='.$pageID);
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Confirm that the ConvertKit Default Form displays.
-        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-    }
-
-    /**
-     * Test that the Default Form for Pages displays when the Default option is chosen via
-     * WordPress' Bulk Edit functionality.
-     * 
-     * @since 1.9.8.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBulkEditUsingDefaultForm(AcceptanceTester $I)
-    {
-        // Specify the Default Form in the Plugin Settings.
-        $I->setupConvertKitPluginDefaultForm($I);
-
-        // Programmatically create two Pages.
-        $pageIDs = array(
-        $I->havePostInDatabase(
-            [
-            'post_type'     => 'page',
-            'post_title'     => 'ConvertKit: Page: Form: Default: Bulk Edit #1',
-            ]
-        ),
-        $I->havePostInDatabase(
-            [
-            'post_type'     => 'page',
-            'post_title'     => 'ConvertKit: Page: Form: Default: Bulk Edit #2',
-            ]
-        )
-        );
-
-        // Bulk Edit the Pages in the Pages WP_List_Table.
-        $I->bulkEdit(
-            $I, 'page', $pageIDs, [
-            'form' => [ 'select', 'Default' ],
-            ]
-        );
-
-        // Iterate through Pages to run frontend tests.
-        foreach ($pageIDs as $pageID) {
-            // Load Page on the frontend site.
-            $I->amOnPage('/?p='.$pageID);
-
-            // Check that no PHP warnings or notices were output.
-            $I->checkNoWarningsAndNoticesOnScreen($I);
-
-            // Confirm that the ConvertKit Default Form displays.
-            $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-        }
-    }
-
-    /**
-     * Test that the defined form displays when chosen via
-     * WordPress' Bulk Edit functionality.
-     * 
-     * @since 1.9.8.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBulkEditUsingDefinedForm(AcceptanceTester $I)
-    {
-        // Programmatically create two Pages.
-        $pageIDs = array(
-        $I->havePostInDatabase(
-            [
-            'post_type'     => 'page',
-            'post_title'     => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
-            ]
-        ),
-        $I->havePostInDatabase(
-            [
-            'post_type'     => 'page',
-            'post_title'     => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
-            ]
-        )
-        );
-
-        // Bulk Edit the Pages in the Pages WP_List_Table.
-        $I->bulkEdit(
-            $I, 'page', $pageIDs, [
-            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-            ]
-        );
-
-        // Iterate through Pages to run frontend tests.
-        foreach ($pageIDs as $pageID) {
-            // Load Page on the frontend site.
-            $I->amOnPage('/?p='.$pageID);
-
-            // Check that no PHP warnings or notices were output.
-            $I->checkNoWarningsAndNoticesOnScreen($I);
-
-            // Confirm that the ConvertKit Form displays.
-            $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-        }
-    }
-
-    /**
-     * Test that the existing settings are honored and not changed
-     * when the Bulk Edit options are set to 'No Change'.
-     * 
-     * @since 1.9.8.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBulkEditWithNoChanges(AcceptanceTester $I)
-    {
-        // Programmatically create two Pages with a defined form.
-        $pageIDs = array(
-        $I->havePostInDatabase(
-            [
-            'post_type'     => 'page',
-            'post_title'     => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #1',
-            'meta_input'    => [
-            '_wp_convertkit_post_meta' => [
-            'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
-            'landing_page' => '',
-            'tag'          => '',
-            ]
-            ],
-            ]
-        ),
-        $I->havePostInDatabase(
-            [
-            'post_type'     => 'page',
-            'post_title'     => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
-            'meta_input'    => [
-            '_wp_convertkit_post_meta' => [
-            'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
-            'landing_page' => '',
-            'tag'          => '',
-            ]
-            ],
-            ]
-        )
-        );
-
-        // Bulk Edit the Pages in the Pages WP_List_Table.
-        $I->bulkEdit(
-            $I, 'page', $pageIDs, [
-            'form' => [ 'select', '— No Change —' ],
-            ]
-        );
-
-        // Iterate through Pages to run frontend tests.
-        foreach ($pageIDs as $pageID) {
-            // Load Page on the frontend site.
-            $I->amOnPage('/?p='.$pageID);
-
-            // Check that no PHP warnings or notices were output.
-            $I->checkNoWarningsAndNoticesOnScreen($I);
-
-            // Confirm that the ConvertKit Form displays.
-            $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-        }
-    }
-
-    /**
-     * Test that the Bulk Edit fields do not display when a search on a WP_List_Table
-     * returns no results.
-     * 
-     * @since 1.9.8.1
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBulkEditFieldsHiddenWhenNoPagesFound(AcceptanceTester $I)
-    {
-        // Emulate the user searching for Pages with a query string that yields no results.
-        $I->amOnAdminPage('edit.php?post_type=page&s=nothing');
-
-        // Confirm that the Bulk Edit fields do not display.
-        $I->dontSeeElement('#convertkit-bulk-edit');
-    }
-
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+class PageFormCest {
+
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		// Activate and Setup ConvertKit plugin
+		$I->activateConvertKitPlugin( $I );
+		$I->setupConvertKitPlugin( $I );
+		$I->enableDebugLog( $I );
+	}
+
+	/**
+	 * Test that the Pages > Add New screen has expected a11y output, such as label[for].
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAccessibility( AcceptanceTester $I ) {
+		// Navigate to Post Type (e.g. Pages / Posts) > Add New
+		$I->amOnAdminPage( 'post-new.php?post_type=page' );
+
+		// Confirm that settings have label[for] attributes.
+		$I->seeInSource( '<label for="wp-convertkit-form">' );
+		$I->seeInSource( '<label for="wp-convertkit-landing_page">' );
+		$I->seeInSource( '<label for="wp-convertkit-tag">' );
+	}
+
+	/**
+	 * Test that the 'Default' option for the Default Form setting in the Plugin Settings works when
+	 * creating and viewing a new WordPress Page, and there is no Default Form specified in the Plugin
+	 * settings.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewPageUsingDefaultFormWithNoDefaultFormSpecifiedInPlugin( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Form: Default: None' );
+
+		// Configure metabox's Form setting = Default.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'form' => array( 'select2', 'Default' ),
+			)
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
+
+		// Confirm that no ConvertKit Form is displayed.
+		$I->dontSeeElementInDOM( 'form[data-sv-form]' );
+	}
+
+	/**
+	 * Test that the Default Form specified in the Plugin Settings works when
+	 * creating and viewing a new WordPress Page.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewPageUsingDefaultForm( AcceptanceTester $I ) {
+		// Specify the Default Form in the Plugin Settings.
+		$defaultFormID = $I->setupConvertKitPluginDefaultForm( $I );
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Form: Default' );
+
+		// Configure metabox's Form setting = Default.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'form' => array( 'select2', 'Default' ),
+			)
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
+
+		// Confirm that the ConvertKit Default Form displays.
+		$I->seeElementInDOM( 'form[data-sv-form="' . $defaultFormID . '"]' );
+	}
+
+	/**
+	 * Test that the Default Legacy Form specified in the Plugin Settings works when
+	 * creating and viewing a new WordPress Page.
+	 *
+	 * @since 1.9.6.3
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewPageUsingDefaultLegacyForm( AcceptanceTester $I ) {
+		// Specify the Default Legacy Form in the Plugin Settings.
+		$defaultLegacyFormID = $I->setupConvertKitPluginDefaultLegacyForm( $I );
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Form: Legacy: Default' );
+
+		// Configure metabox's Form setting = Default.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'form' => array( 'select2', 'Default' ),
+			)
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
+
+		// Confirm that the ConvertKit Default Legacy Form displays.
+		$I->seeInSource( '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $defaultLegacyFormID . '/subscribe" data-remote="true">' );
+	}
+
+	/**
+	 * Test that 'None' Form specified in the Page Settings works when
+	 * creating and viewing a new WordPress Page.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewPageUsingNoForm( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Form: None' );
+
+		// Configure metabox's Form setting = None.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'form' => array( 'select2', 'None' ),
+			)
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
+
+		// Confirm that no ConvertKit Form is displayed.
+		$I->dontSeeElementInDOM( 'form[data-sv-form]' );
+	}
+
+	/**
+	 * Test that the Form specified in the Page Settings works when
+	 * creating and viewing a new WordPress Page.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewPageUsingDefinedForm( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] );
+
+		// Configure metabox's Form setting = None.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'form' => array( 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
+			)
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
+
+		// Confirm that the ConvertKit Form displays.
+		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+	}
+
+	/**
+	 * Test that the Legacy Form specified in the Page Settings works when
+	 * creating and viewing a new WordPress Page.
+	 *
+	 * @since 1.9.6.3
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewPageUsingDefinedLegacyForm( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] );
+
+		// Configure metabox's Form setting = None.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'form' => array( 'select2', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ),
+			)
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
+
+		// Confirm that the ConvertKit Legacy Form displays.
+		$I->seeInSource( '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">' );
+	}
+
+	/**
+	 * Test that the Default Form for Pages displays when an invalid Form ID is specified
+	 * for a Page.
+	 *
+	 * Whilst the on screen options won't permit selecting an invalid Form ID, a Page might
+	 * have an invalid Form ID because:
+	 * - the form belongs to another ConvertKit account (i.e. API credentials were changed in the Plugin, but this Page's specified Form was not changed)
+	 * - the form was deleted from the ConvertKit account.
+	 *
+	 * @since 1.9.7.2
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewPageUsingInvalidDefinedForm( AcceptanceTester $I ) {
+		// Setup the Default Form for Pages and Posts.
+		$I->setupConvertKitPluginDefaultForm( $I );
+
+		// Create Page, with an invalid Form ID, as if it were created prior to API credentials being changed and/or
+		// a Form being deleted in ConvertKit.
+		$pageID = $I->havePostInDatabase(
+			array(
+				'post_type'  => 'page',
+				'post_title' => 'ConvertKit: Page: Form: Specific: Invalid',
+				'meta_input' => array(
+					'_wp_convertkit_post_meta' => array(
+						'form'         => '11111',
+						'landing_page' => '',
+						'tag'          => '',
+					),
+				),
+			)
+		);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage( '/?p=' . $pageID );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Confirm that the invalid ConvertKit Form does not display.
+		$I->dontSeeElementInDOM( 'form[data-sv-form="11111"]' );
+
+		// Confirm that the Default Form for Pages does display as a fallback.
+		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+	}
+
+	/**
+	 * Test that the Default Form for Pages displays when the Default option is chosen via
+	 * WordPress' Quick Edit functionality.
+	 *
+	 * @since 1.9.8.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testQuickEditUsingDefaultForm( AcceptanceTester $I ) {
+		// Specify the Default Form in the Plugin Settings.
+		$I->setupConvertKitPluginDefaultForm( $I );
+
+		// Programmatically create a Page.
+		$pageID = $I->havePostInDatabase(
+			array(
+				'post_type'  => 'page',
+				'post_title' => 'ConvertKit: Page: Form: Default: Quick Edit',
+			)
+		);
+
+		// Quick Edit the Page in the Pages WP_List_Table.
+		$I->quickEdit(
+			$I,
+			'page',
+			$pageID,
+			array(
+				'form' => array( 'select', 'Default' ),
+			)
+		);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage( '/?p=' . $pageID );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Confirm that the ConvertKit Default Form displays.
+		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+	}
+
+	/**
+	 * Test that the defined form displays when chosen via
+	 * WordPress' Quick Edit functionality.
+	 *
+	 * @since 1.9.8.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testQuickEditUsingDefinedForm( AcceptanceTester $I ) {
+		// Programmatically create a Page.
+		$pageID = $I->havePostInDatabase(
+			array(
+				'post_type'  => 'page',
+				'post_title' => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
+			)
+		);
+
+		// Quick Edit the Page in the Pages WP_List_Table.
+		$I->quickEdit(
+			$I,
+			'page',
+			$pageID,
+			array(
+				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
+			)
+		);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage( '/?p=' . $pageID );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Confirm that the ConvertKit Default Form displays.
+		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+	}
+
+	/**
+	 * Test that the Default Form for Pages displays when the Default option is chosen via
+	 * WordPress' Bulk Edit functionality.
+	 *
+	 * @since 1.9.8.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBulkEditUsingDefaultForm( AcceptanceTester $I ) {
+		// Specify the Default Form in the Plugin Settings.
+		$I->setupConvertKitPluginDefaultForm( $I );
+
+		// Programmatically create two Pages.
+		$pageIDs = array(
+			$I->havePostInDatabase(
+				array(
+					'post_type'  => 'page',
+					'post_title' => 'ConvertKit: Page: Form: Default: Bulk Edit #1',
+				)
+			),
+			$I->havePostInDatabase(
+				array(
+					'post_type'  => 'page',
+					'post_title' => 'ConvertKit: Page: Form: Default: Bulk Edit #2',
+				)
+			),
+		);
+
+		// Bulk Edit the Pages in the Pages WP_List_Table.
+		$I->bulkEdit(
+			$I,
+			'page',
+			$pageIDs,
+			array(
+				'form' => array( 'select', 'Default' ),
+			)
+		);
+
+		// Iterate through Pages to run frontend tests.
+		foreach ( $pageIDs as $pageID ) {
+			// Load Page on the frontend site.
+			$I->amOnPage( '/?p=' . $pageID );
+
+			// Check that no PHP warnings or notices were output.
+			$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+			// Confirm that the ConvertKit Default Form displays.
+			$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		}
+	}
+
+	/**
+	 * Test that the defined form displays when chosen via
+	 * WordPress' Bulk Edit functionality.
+	 *
+	 * @since 1.9.8.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBulkEditUsingDefinedForm( AcceptanceTester $I ) {
+		// Programmatically create two Pages.
+		$pageIDs = array(
+			$I->havePostInDatabase(
+				array(
+					'post_type'  => 'page',
+					'post_title' => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
+				)
+			),
+			$I->havePostInDatabase(
+				array(
+					'post_type'  => 'page',
+					'post_title' => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
+				)
+			),
+		);
+
+		// Bulk Edit the Pages in the Pages WP_List_Table.
+		$I->bulkEdit(
+			$I,
+			'page',
+			$pageIDs,
+			array(
+				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
+			)
+		);
+
+		// Iterate through Pages to run frontend tests.
+		foreach ( $pageIDs as $pageID ) {
+			// Load Page on the frontend site.
+			$I->amOnPage( '/?p=' . $pageID );
+
+			// Check that no PHP warnings or notices were output.
+			$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+			// Confirm that the ConvertKit Form displays.
+			$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		}
+	}
+
+	/**
+	 * Test that the existing settings are honored and not changed
+	 * when the Bulk Edit options are set to 'No Change'.
+	 *
+	 * @since 1.9.8.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBulkEditWithNoChanges( AcceptanceTester $I ) {
+		// Programmatically create two Pages with a defined form.
+		$pageIDs = array(
+			$I->havePostInDatabase(
+				array(
+					'post_type'  => 'page',
+					'post_title' => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #1',
+					'meta_input' => array(
+						'_wp_convertkit_post_meta' => array(
+							'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
+							'landing_page' => '',
+							'tag'          => '',
+						),
+					),
+				)
+			),
+			$I->havePostInDatabase(
+				array(
+					'post_type'  => 'page',
+					'post_title' => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
+					'meta_input' => array(
+						'_wp_convertkit_post_meta' => array(
+							'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
+							'landing_page' => '',
+							'tag'          => '',
+						),
+					),
+				)
+			),
+		);
+
+		// Bulk Edit the Pages in the Pages WP_List_Table.
+		$I->bulkEdit(
+			$I,
+			'page',
+			$pageIDs,
+			array(
+				'form' => array( 'select', '— No Change —' ),
+			)
+		);
+
+		// Iterate through Pages to run frontend tests.
+		foreach ( $pageIDs as $pageID ) {
+			// Load Page on the frontend site.
+			$I->amOnPage( '/?p=' . $pageID );
+
+			// Check that no PHP warnings or notices were output.
+			$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+			// Confirm that the ConvertKit Form displays.
+			$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		}
+	}
+
+	/**
+	 * Test that the Bulk Edit fields do not display when a search on a WP_List_Table
+	 * returns no results.
+	 *
+	 * @since 1.9.8.1
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBulkEditFieldsHiddenWhenNoPagesFound( AcceptanceTester $I ) {
+		// Emulate the user searching for Pages with a query string that yields no results.
+		$I->amOnAdminPage( 'edit.php?post_type=page&s=nothing' );
+
+		// Confirm that the Bulk Edit fields do not display.
+		$I->dontSeeElement( '#convertkit-bulk-edit' );
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/forms/PageFormCest.php
+++ b/tests/acceptance/forms/PageFormCest.php
@@ -1,21 +1,21 @@
 <?php
 /**
  * Tests for ConvertKit Forms on WordPress Pages.
- * 
- * @since 	1.9.6
+ *
+ * @since   1.9.6
  */
 class PageFormCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
-		// Activate and Setup ConvertKit plugin
+		// Activate and Setup ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
 		$I->enableDebugLog($I);
@@ -23,14 +23,14 @@ class PageFormCest
 
 	/**
 	 * Test that the Pages > Add New screen has expected a11y output, such as label[for].
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAccessibility(AcceptanceTester $I)
 	{
-		// Navigate to Post Type (e.g. Pages / Posts) > Add New
+		// Navigate to Post Type (e.g. Pages / Posts) > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=page');
 
 		// Confirm that settings have label[for] attributes.
@@ -43,10 +43,10 @@ class PageFormCest
 	 * Test that the 'Default' option for the Default Form setting in the Plugin Settings works when
 	 * creating and viewing a new WordPress Page, and there is no Default Form specified in the Plugin
 	 * settings.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewPageUsingDefaultFormWithNoDefaultFormSpecifiedInPlugin(AcceptanceTester $I)
 	{
@@ -54,9 +54,13 @@ class PageFormCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Default: None');
 
 		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'Default' ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'Default' ],
+			]
+		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -68,10 +72,10 @@ class PageFormCest
 	/**
 	 * Test that the Default Form specified in the Plugin Settings works when
 	 * creating and viewing a new WordPress Page.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewPageUsingDefaultForm(AcceptanceTester $I)
 	{
@@ -82,9 +86,13 @@ class PageFormCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Default');
 
 		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'Default' ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'Default' ],
+			]
+		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -96,10 +104,10 @@ class PageFormCest
 	/**
 	 * Test that the Default Legacy Form specified in the Plugin Settings works when
 	 * creating and viewing a new WordPress Page.
-	 * 
-	 * @since 	1.9.6.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewPageUsingDefaultLegacyForm(AcceptanceTester $I)
 	{
@@ -110,9 +118,13 @@ class PageFormCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Legacy: Default');
 
 		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'Default' ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'Default' ],
+			]
+		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -124,10 +136,10 @@ class PageFormCest
 	/**
 	 * Test that 'None' Form specified in the Page Settings works when
 	 * creating and viewing a new WordPress Page.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewPageUsingNoForm(AcceptanceTester $I)
 	{
@@ -135,9 +147,13 @@ class PageFormCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: None');
 
 		// Configure metabox's Form setting = None.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'None' ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -149,10 +165,10 @@ class PageFormCest
 	/**
 	 * Test that the Form specified in the Page Settings works when
 	 * creating and viewing a new WordPress Page.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewPageUsingDefinedForm(AcceptanceTester $I)
 	{
@@ -160,9 +176,13 @@ class PageFormCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME']);
 
 		// Configure metabox's Form setting = None.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+			]
+		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -174,10 +194,10 @@ class PageFormCest
 	/**
 	 * Test that the Legacy Form specified in the Page Settings works when
 	 * creating and viewing a new WordPress Page.
-	 * 
-	 * @since 	1.9.6.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewPageUsingDefinedLegacyForm(AcceptanceTester $I)
 	{
@@ -185,9 +205,13 @@ class PageFormCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
 
 		// Configure metabox's Form setting = None.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
+			]
+		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -199,15 +223,15 @@ class PageFormCest
 	/**
 	 * Test that the Default Form for Pages displays when an invalid Form ID is specified
 	 * for a Page.
-	 * 
+	 *
 	 * Whilst the on screen options won't permit selecting an invalid Form ID, a Page might
 	 * have an invalid Form ID because:
 	 * - the form belongs to another ConvertKit account (i.e. API credentials were changed in the Plugin, but this Page's specified Form was not changed)
 	 * - the form was deleted from the ConvertKit account.
-	 * 
-	 * @since 	1.9.7.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewPageUsingInvalidDefinedForm(AcceptanceTester $I)
 	{
@@ -216,20 +240,22 @@ class PageFormCest
 
 		// Create Page, with an invalid Form ID, as if it were created prior to API credentials being changed and/or
 		// a Form being deleted in ConvertKit.
-		$pageID = $I->havePostInDatabase([
-			'post_type' 	=> 'page',
-			'post_title' 	=> 'ConvertKit: Page: Form: Specific: Invalid',
-			'meta_input'	=> [
-				'_wp_convertkit_post_meta' => [
-					'form'         => '11111',
-					'landing_page' => '',
-					'tag'          => '',
-				]
-			],
-		]);
+		$pageID = $I->havePostInDatabase(
+			[
+				'post_type'  => 'page',
+				'post_title' => 'ConvertKit: Page: Form: Specific: Invalid',
+				'meta_input' => [
+					'_wp_convertkit_post_meta' => [
+						'form'         => '11111',
+						'landing_page' => '',
+						'tag'          => '',
+					],
+				],
+			]
+		);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage('/?p='.$pageID);
+		$I->amOnPage('/?p=' . $pageID);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -244,10 +270,10 @@ class PageFormCest
 	/**
 	 * Test that the Default Form for Pages displays when the Default option is chosen via
 	 * WordPress' Quick Edit functionality.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testQuickEditUsingDefaultForm(AcceptanceTester $I)
 	{
@@ -255,18 +281,25 @@ class PageFormCest
 		$I->setupConvertKitPluginDefaultForm($I);
 
 		// Programmatically create a Page.
-		$pageID = $I->havePostInDatabase([
-			'post_type' 	=> 'page',
-			'post_title' 	=> 'ConvertKit: Page: Form: Default: Quick Edit',
-		]);
+		$pageID = $I->havePostInDatabase(
+			[
+				'post_type'  => 'page',
+				'post_title' => 'ConvertKit: Page: Form: Default: Quick Edit',
+			]
+		);
 
 		// Quick Edit the Page in the Pages WP_List_Table.
-		$I->quickEdit($I, 'page', $pageID, [
-			'form' => [ 'select', 'Default' ],
-		]);
+		$I->quickEdit(
+			$I,
+			'page',
+			$pageID,
+			[
+				'form' => [ 'select', 'Default' ],
+			]
+		);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage('/?p='.$pageID);
+		$I->amOnPage('/?p=' . $pageID);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -278,26 +311,33 @@ class PageFormCest
 	/**
 	 * Test that the defined form displays when chosen via
 	 * WordPress' Quick Edit functionality.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testQuickEditUsingDefinedForm(AcceptanceTester $I)
 	{
 		// Programmatically create a Page.
-		$pageID = $I->havePostInDatabase([
-			'post_type' 	=> 'page',
-			'post_title' 	=> 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
-		]);
+		$pageID = $I->havePostInDatabase(
+			[
+				'post_type'  => 'page',
+				'post_title' => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
+			]
+		);
 
 		// Quick Edit the Page in the Pages WP_List_Table.
-		$I->quickEdit($I, 'page', $pageID, [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-		]);
+		$I->quickEdit(
+			$I,
+			'page',
+			$pageID,
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+			]
+		);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage('/?p='.$pageID);
+		$I->amOnPage('/?p=' . $pageID);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -309,10 +349,10 @@ class PageFormCest
 	/**
 	 * Test that the Default Form for Pages displays when the Default option is chosen via
 	 * WordPress' Bulk Edit functionality.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBulkEditUsingDefaultForm(AcceptanceTester $I)
 	{
@@ -321,25 +361,34 @@ class PageFormCest
 
 		// Programmatically create two Pages.
 		$pageIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'page',
-				'post_title' 	=> 'ConvertKit: Page: Form: Default: Bulk Edit #1',
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'page',
-				'post_title' 	=> 'ConvertKit: Page: Form: Default: Bulk Edit #2',
-			])
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'page',
+					'post_title' => 'ConvertKit: Page: Form: Default: Bulk Edit #1',
+				]
+			),
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'page',
+					'post_title' => 'ConvertKit: Page: Form: Default: Bulk Edit #2',
+				]
+			),
 		);
 
 		// Bulk Edit the Pages in the Pages WP_List_Table.
-		$I->bulkEdit($I, 'page', $pageIDs, [
-			'form' => [ 'select', 'Default' ],
-		]);
+		$I->bulkEdit(
+			$I,
+			'page',
+			$pageIDs,
+			[
+				'form' => [ 'select', 'Default' ],
+			]
+		);
 
 		// Iterate through Pages to run frontend tests.
-		foreach($pageIDs as $pageID) {
+		foreach ($pageIDs as $pageID) {
 			// Load Page on the frontend site.
-			$I->amOnPage('/?p='.$pageID);
+			$I->amOnPage('/?p=' . $pageID);
 
 			// Check that no PHP warnings or notices were output.
 			$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -352,34 +401,43 @@ class PageFormCest
 	/**
 	 * Test that the defined form displays when chosen via
 	 * WordPress' Bulk Edit functionality.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBulkEditUsingDefinedForm(AcceptanceTester $I)
 	{
 		// Programmatically create two Pages.
 		$pageIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'page',
-				'post_title' 	=> 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'page',
-				'post_title' 	=> 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
-			])
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'page',
+					'post_title' => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
+				]
+			),
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'page',
+					'post_title' => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
+				]
+			),
 		);
 
 		// Bulk Edit the Pages in the Pages WP_List_Table.
-		$I->bulkEdit($I, 'page', $pageIDs, [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-		]);
+		$I->bulkEdit(
+			$I,
+			'page',
+			$pageIDs,
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+			]
+		);
 
 		// Iterate through Pages to run frontend tests.
-		foreach($pageIDs as $pageID) {
+		foreach ($pageIDs as $pageID) {
 			// Load Page on the frontend site.
-			$I->amOnPage('/?p='.$pageID);
+			$I->amOnPage('/?p=' . $pageID);
 
 			// Check that no PHP warnings or notices were output.
 			$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -392,48 +450,57 @@ class PageFormCest
 	/**
 	 * Test that the existing settings are honored and not changed
 	 * when the Bulk Edit options are set to 'No Change'.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBulkEditWithNoChanges(AcceptanceTester $I)
 	{
 		// Programmatically create two Pages with a defined form.
 		$pageIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'page',
-				'post_title' 	=> 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #1',
-				'meta_input'	=> [
-					'_wp_convertkit_post_meta' => [
-						'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
-						'landing_page' => '',
-						'tag'          => '',
-					]
-				],
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'page',
-				'post_title' 	=> 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
-				'meta_input'	=> [
-					'_wp_convertkit_post_meta' => [
-						'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
-						'landing_page' => '',
-						'tag'          => '',
-					]
-				],
-			])
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'page',
+					'post_title' => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #1',
+					'meta_input' => [
+						'_wp_convertkit_post_meta' => [
+							'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
+							'landing_page' => '',
+							'tag'          => '',
+						],
+					],
+				]
+			),
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'page',
+					'post_title' => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
+					'meta_input' => [
+						'_wp_convertkit_post_meta' => [
+							'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
+							'landing_page' => '',
+							'tag'          => '',
+						],
+					],
+				]
+			),
 		);
 
 		// Bulk Edit the Pages in the Pages WP_List_Table.
-		$I->bulkEdit($I, 'page', $pageIDs, [
-			'form' => [ 'select', '— No Change —' ],
-		]);
+		$I->bulkEdit(
+			$I,
+			'page',
+			$pageIDs,
+			[
+				'form' => [ 'select', '— No Change —' ],
+			]
+		);
 
 		// Iterate through Pages to run frontend tests.
-		foreach($pageIDs as $pageID) {
+		foreach ($pageIDs as $pageID) {
 			// Load Page on the frontend site.
-			$I->amOnPage('/?p='.$pageID);
+			$I->amOnPage('/?p=' . $pageID);
 
 			// Check that no PHP warnings or notices were output.
 			$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -446,10 +513,10 @@ class PageFormCest
 	/**
 	 * Test that the Bulk Edit fields do not display when a search on a WP_List_Table
 	 * returns no results.
-	 * 
-	 * @since 	1.9.8.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBulkEditFieldsHiddenWhenNoPagesFound(AcceptanceTester $I)
 	{
@@ -464,10 +531,10 @@ class PageFormCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/forms/PageFormCest.php
+++ b/tests/acceptance/forms/PageFormCest.php
@@ -2,476 +2,516 @@
 /**
  * Tests for ConvertKit Forms on WordPress Pages.
  * 
- * @since 	1.9.6
+ * @since 1.9.6
  */
 class PageFormCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		// Activate and Setup ConvertKit plugin
-		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
-	}
-
-	/**
-	 * Test that the Pages > Add New screen has expected a11y output, such as label[for].
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAccessibility(AcceptanceTester $I)
-	{
-		// Navigate to Post Type (e.g. Pages / Posts) > Add New
-		$I->amOnAdminPage('post-new.php?post_type=page');
-
-		// Confirm that settings have label[for] attributes.
-		$I->seeInSource('<label for="wp-convertkit-form">');
-		$I->seeInSource('<label for="wp-convertkit-landing_page">');
-		$I->seeInSource('<label for="wp-convertkit-tag">');
-	}
-
-	/**
-	 * Test that the 'Default' option for the Default Form setting in the Plugin Settings works when
-	 * creating and viewing a new WordPress Page, and there is no Default Form specified in the Plugin
-	 * settings.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewPageUsingDefaultFormWithNoDefaultFormSpecifiedInPlugin(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Default: None');
-
-		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'Default' ],
-		]);
-
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
-
-		// Confirm that no ConvertKit Form is displayed.
-		$I->dontSeeElementInDOM('form[data-sv-form]');
-	}
-
-	/**
-	 * Test that the Default Form specified in the Plugin Settings works when
-	 * creating and viewing a new WordPress Page.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewPageUsingDefaultForm(AcceptanceTester $I)
-	{
-		// Specify the Default Form in the Plugin Settings.
-		$defaultFormID = $I->setupConvertKitPluginDefaultForm($I);
-
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Default');
-
-		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'Default' ],
-		]);
-
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
-
-		// Confirm that the ConvertKit Default Form displays.
-		$I->seeElementInDOM('form[data-sv-form="' . $defaultFormID . '"]');
-	}
-
-	/**
-	 * Test that the Default Legacy Form specified in the Plugin Settings works when
-	 * creating and viewing a new WordPress Page.
-	 * 
-	 * @since 	1.9.6.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewPageUsingDefaultLegacyForm(AcceptanceTester $I)
-	{
-		// Specify the Default Legacy Form in the Plugin Settings.
-		$defaultLegacyFormID = $I->setupConvertKitPluginDefaultLegacyForm($I);
-
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Legacy: Default');
-
-		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'Default' ],
-		]);
-
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
-
-		// Confirm that the ConvertKit Default Legacy Form displays.
-		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $defaultLegacyFormID . '/subscribe" data-remote="true">');
-	}
-
-	/**
-	 * Test that 'None' Form specified in the Page Settings works when
-	 * creating and viewing a new WordPress Page.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewPageUsingNoForm(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: None');
-
-		// Configure metabox's Form setting = None.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'None' ],
-		]);
-
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
-
-		// Confirm that no ConvertKit Form is displayed.
-		$I->dontSeeElementInDOM('form[data-sv-form]');
-	}
-
-	/**
-	 * Test that the Form specified in the Page Settings works when
-	 * creating and viewing a new WordPress Page.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewPageUsingDefinedForm(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME']);
-
-		// Configure metabox's Form setting = None.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-		]);
-
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
-
-		// Confirm that the ConvertKit Form displays.
-		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-	}
-
-	/**
-	 * Test that the Legacy Form specified in the Page Settings works when
-	 * creating and viewing a new WordPress Page.
-	 * 
-	 * @since 	1.9.6.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewPageUsingDefinedLegacyForm(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
-
-		// Configure metabox's Form setting = None.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
-		]);
-
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
-
-		// Confirm that the ConvertKit Legacy Form displays.
-		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
-	}
-
-	/**
-	 * Test that the Default Form for Pages displays when an invalid Form ID is specified
-	 * for a Page.
-	 * 
-	 * Whilst the on screen options won't permit selecting an invalid Form ID, a Page might
-	 * have an invalid Form ID because:
-	 * - the form belongs to another ConvertKit account (i.e. API credentials were changed in the Plugin, but this Page's specified Form was not changed)
-	 * - the form was deleted from the ConvertKit account.
-	 * 
-	 * @since 	1.9.7.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewPageUsingInvalidDefinedForm(AcceptanceTester $I)
-	{
-		// Setup the Default Form for Pages and Posts.
-		$I->setupConvertKitPluginDefaultForm($I);
-
-		// Create Page, with an invalid Form ID, as if it were created prior to API credentials being changed and/or
-		// a Form being deleted in ConvertKit.
-		$pageID = $I->havePostInDatabase([
-			'post_type' 	=> 'page',
-			'post_title' 	=> 'ConvertKit: Page: Form: Specific: Invalid',
-			'meta_input'	=> [
-				'_wp_convertkit_post_meta' => [
-					'form'         => '11111',
-					'landing_page' => '',
-					'tag'          => '',
-				]
-			],
-		]);
-
-		// Load the Page on the frontend site.
-		$I->amOnPage('/?p='.$pageID);
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm that the invalid ConvertKit Form does not display.
-		$I->dontSeeElementInDOM('form[data-sv-form="11111"]');
-
-		// Confirm that the Default Form for Pages does display as a fallback.
-		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-	}
-
-	/**
-	 * Test that the Default Form for Pages displays when the Default option is chosen via
-	 * WordPress' Quick Edit functionality.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testQuickEditUsingDefaultForm(AcceptanceTester $I)
-	{
-		// Specify the Default Form in the Plugin Settings.
-		$I->setupConvertKitPluginDefaultForm($I);
-
-		// Programmatically create a Page.
-		$pageID = $I->havePostInDatabase([
-			'post_type' 	=> 'page',
-			'post_title' 	=> 'ConvertKit: Page: Form: Default: Quick Edit',
-		]);
-
-		// Quick Edit the Page in the Pages WP_List_Table.
-		$I->quickEdit($I, 'page', $pageID, [
-			'form' => [ 'select', 'Default' ],
-		]);
-
-		// Load the Page on the frontend site.
-		$I->amOnPage('/?p='.$pageID);
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm that the ConvertKit Default Form displays.
-		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-	}
-
-	/**
-	 * Test that the defined form displays when chosen via
-	 * WordPress' Quick Edit functionality.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testQuickEditUsingDefinedForm(AcceptanceTester $I)
-	{
-		// Programmatically create a Page.
-		$pageID = $I->havePostInDatabase([
-			'post_type' 	=> 'page',
-			'post_title' 	=> 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
-		]);
-
-		// Quick Edit the Page in the Pages WP_List_Table.
-		$I->quickEdit($I, 'page', $pageID, [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-		]);
-
-		// Load the Page on the frontend site.
-		$I->amOnPage('/?p='.$pageID);
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm that the ConvertKit Default Form displays.
-		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-	}
-
-	/**
-	 * Test that the Default Form for Pages displays when the Default option is chosen via
-	 * WordPress' Bulk Edit functionality.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBulkEditUsingDefaultForm(AcceptanceTester $I)
-	{
-		// Specify the Default Form in the Plugin Settings.
-		$I->setupConvertKitPluginDefaultForm($I);
-
-		// Programmatically create two Pages.
-		$pageIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'page',
-				'post_title' 	=> 'ConvertKit: Page: Form: Default: Bulk Edit #1',
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'page',
-				'post_title' 	=> 'ConvertKit: Page: Form: Default: Bulk Edit #2',
-			])
-		);
-
-		// Bulk Edit the Pages in the Pages WP_List_Table.
-		$I->bulkEdit($I, 'page', $pageIDs, [
-			'form' => [ 'select', 'Default' ],
-		]);
-
-		// Iterate through Pages to run frontend tests.
-		foreach($pageIDs as $pageID) {
-			// Load Page on the frontend site.
-			$I->amOnPage('/?p='.$pageID);
-
-			// Check that no PHP warnings or notices were output.
-			$I->checkNoWarningsAndNoticesOnScreen($I);
-
-			// Confirm that the ConvertKit Default Form displays.
-			$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-		}
-	}
-
-	/**
-	 * Test that the defined form displays when chosen via
-	 * WordPress' Bulk Edit functionality.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBulkEditUsingDefinedForm(AcceptanceTester $I)
-	{
-		// Programmatically create two Pages.
-		$pageIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'page',
-				'post_title' 	=> 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'page',
-				'post_title' 	=> 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
-			])
-		);
-
-		// Bulk Edit the Pages in the Pages WP_List_Table.
-		$I->bulkEdit($I, 'page', $pageIDs, [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-		]);
-
-		// Iterate through Pages to run frontend tests.
-		foreach($pageIDs as $pageID) {
-			// Load Page on the frontend site.
-			$I->amOnPage('/?p='.$pageID);
-
-			// Check that no PHP warnings or notices were output.
-			$I->checkNoWarningsAndNoticesOnScreen($I);
-
-			// Confirm that the ConvertKit Form displays.
-			$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-		}
-	}
-
-	/**
-	 * Test that the existing settings are honored and not changed
-	 * when the Bulk Edit options are set to 'No Change'.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBulkEditWithNoChanges(AcceptanceTester $I)
-	{
-		// Programmatically create two Pages with a defined form.
-		$pageIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'page',
-				'post_title' 	=> 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #1',
-				'meta_input'	=> [
-					'_wp_convertkit_post_meta' => [
-						'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
-						'landing_page' => '',
-						'tag'          => '',
-					]
-				],
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'page',
-				'post_title' 	=> 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
-				'meta_input'	=> [
-					'_wp_convertkit_post_meta' => [
-						'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
-						'landing_page' => '',
-						'tag'          => '',
-					]
-				],
-			])
-		);
-
-		// Bulk Edit the Pages in the Pages WP_List_Table.
-		$I->bulkEdit($I, 'page', $pageIDs, [
-			'form' => [ 'select', '— No Change —' ],
-		]);
-
-		// Iterate through Pages to run frontend tests.
-		foreach($pageIDs as $pageID) {
-			// Load Page on the frontend site.
-			$I->amOnPage('/?p='.$pageID);
-
-			// Check that no PHP warnings or notices were output.
-			$I->checkNoWarningsAndNoticesOnScreen($I);
-
-			// Confirm that the ConvertKit Form displays.
-			$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-		}
-	}
-
-	/**
-	 * Test that the Bulk Edit fields do not display when a search on a WP_List_Table
-	 * returns no results.
-	 * 
-	 * @since 	1.9.8.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBulkEditFieldsHiddenWhenNoPagesFound(AcceptanceTester $I)
-	{
-		// Emulate the user searching for Pages with a query string that yields no results.
-		$I->amOnAdminPage('edit.php?post_type=page&s=nothing');
-
-		// Confirm that the Bulk Edit fields do not display.
-		$I->dontSeeElement('#convertkit-bulk-edit');
-	}
-
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        // Activate and Setup ConvertKit plugin
+        $I->activateConvertKitPlugin($I);
+        $I->setupConvertKitPlugin($I);
+        $I->enableDebugLog($I);
+    }
+
+    /**
+     * Test that the Pages > Add New screen has expected a11y output, such as label[for].
+     * 
+     * @since 1.9.7.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAccessibility(AcceptanceTester $I)
+    {
+        // Navigate to Post Type (e.g. Pages / Posts) > Add New
+        $I->amOnAdminPage('post-new.php?post_type=page');
+
+        // Confirm that settings have label[for] attributes.
+        $I->seeInSource('<label for="wp-convertkit-form">');
+        $I->seeInSource('<label for="wp-convertkit-landing_page">');
+        $I->seeInSource('<label for="wp-convertkit-tag">');
+    }
+
+    /**
+     * Test that the 'Default' option for the Default Form setting in the Plugin Settings works when
+     * creating and viewing a new WordPress Page, and there is no Default Form specified in the Plugin
+     * settings.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewPageUsingDefaultFormWithNoDefaultFormSpecifiedInPlugin(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Default: None');
+
+        // Configure metabox's Form setting = Default.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'form' => [ 'select2', 'Default' ],
+            ]
+        );
+
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
+
+        // Confirm that no ConvertKit Form is displayed.
+        $I->dontSeeElementInDOM('form[data-sv-form]');
+    }
+
+    /**
+     * Test that the Default Form specified in the Plugin Settings works when
+     * creating and viewing a new WordPress Page.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewPageUsingDefaultForm(AcceptanceTester $I)
+    {
+        // Specify the Default Form in the Plugin Settings.
+        $defaultFormID = $I->setupConvertKitPluginDefaultForm($I);
+
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Default');
+
+        // Configure metabox's Form setting = Default.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'form' => [ 'select2', 'Default' ],
+            ]
+        );
+
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
+
+        // Confirm that the ConvertKit Default Form displays.
+        $I->seeElementInDOM('form[data-sv-form="' . $defaultFormID . '"]');
+    }
+
+    /**
+     * Test that the Default Legacy Form specified in the Plugin Settings works when
+     * creating and viewing a new WordPress Page.
+     * 
+     * @since 1.9.6.3
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewPageUsingDefaultLegacyForm(AcceptanceTester $I)
+    {
+        // Specify the Default Legacy Form in the Plugin Settings.
+        $defaultLegacyFormID = $I->setupConvertKitPluginDefaultLegacyForm($I);
+
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Legacy: Default');
+
+        // Configure metabox's Form setting = Default.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'form' => [ 'select2', 'Default' ],
+            ]
+        );
+
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
+
+        // Confirm that the ConvertKit Default Legacy Form displays.
+        $I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $defaultLegacyFormID . '/subscribe" data-remote="true">');
+    }
+
+    /**
+     * Test that 'None' Form specified in the Page Settings works when
+     * creating and viewing a new WordPress Page.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewPageUsingNoForm(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: None');
+
+        // Configure metabox's Form setting = None.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'form' => [ 'select2', 'None' ],
+            ]
+        );
+
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
+
+        // Confirm that no ConvertKit Form is displayed.
+        $I->dontSeeElementInDOM('form[data-sv-form]');
+    }
+
+    /**
+     * Test that the Form specified in the Page Settings works when
+     * creating and viewing a new WordPress Page.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewPageUsingDefinedForm(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME']);
+
+        // Configure metabox's Form setting = None.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+            ]
+        );
+
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
+
+        // Confirm that the ConvertKit Form displays.
+        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+    }
+
+    /**
+     * Test that the Legacy Form specified in the Page Settings works when
+     * creating and viewing a new WordPress Page.
+     * 
+     * @since 1.9.6.3
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewPageUsingDefinedLegacyForm(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
+
+        // Configure metabox's Form setting = None.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'form' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
+            ]
+        );
+
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
+
+        // Confirm that the ConvertKit Legacy Form displays.
+        $I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
+    }
+
+    /**
+     * Test that the Default Form for Pages displays when an invalid Form ID is specified
+     * for a Page.
+     * 
+     * Whilst the on screen options won't permit selecting an invalid Form ID, a Page might
+     * have an invalid Form ID because:
+     * - the form belongs to another ConvertKit account (i.e. API credentials were changed in the Plugin, but this Page's specified Form was not changed)
+     * - the form was deleted from the ConvertKit account.
+     * 
+     * @since 1.9.7.2
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewPageUsingInvalidDefinedForm(AcceptanceTester $I)
+    {
+        // Setup the Default Form for Pages and Posts.
+        $I->setupConvertKitPluginDefaultForm($I);
+
+        // Create Page, with an invalid Form ID, as if it were created prior to API credentials being changed and/or
+        // a Form being deleted in ConvertKit.
+        $pageID = $I->havePostInDatabase(
+            [
+            'post_type'     => 'page',
+            'post_title'     => 'ConvertKit: Page: Form: Specific: Invalid',
+            'meta_input'    => [
+            '_wp_convertkit_post_meta' => [
+            'form'         => '11111',
+            'landing_page' => '',
+            'tag'          => '',
+            ]
+            ],
+            ]
+        );
+
+        // Load the Page on the frontend site.
+        $I->amOnPage('/?p='.$pageID);
+
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
+
+        // Confirm that the invalid ConvertKit Form does not display.
+        $I->dontSeeElementInDOM('form[data-sv-form="11111"]');
+
+        // Confirm that the Default Form for Pages does display as a fallback.
+        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+    }
+
+    /**
+     * Test that the Default Form for Pages displays when the Default option is chosen via
+     * WordPress' Quick Edit functionality.
+     * 
+     * @since 1.9.8.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testQuickEditUsingDefaultForm(AcceptanceTester $I)
+    {
+        // Specify the Default Form in the Plugin Settings.
+        $I->setupConvertKitPluginDefaultForm($I);
+
+        // Programmatically create a Page.
+        $pageID = $I->havePostInDatabase(
+            [
+            'post_type'     => 'page',
+            'post_title'     => 'ConvertKit: Page: Form: Default: Quick Edit',
+            ]
+        );
+
+        // Quick Edit the Page in the Pages WP_List_Table.
+        $I->quickEdit(
+            $I, 'page', $pageID, [
+            'form' => [ 'select', 'Default' ],
+            ]
+        );
+
+        // Load the Page on the frontend site.
+        $I->amOnPage('/?p='.$pageID);
+
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
+
+        // Confirm that the ConvertKit Default Form displays.
+        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+    }
+
+    /**
+     * Test that the defined form displays when chosen via
+     * WordPress' Quick Edit functionality.
+     * 
+     * @since 1.9.8.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testQuickEditUsingDefinedForm(AcceptanceTester $I)
+    {
+        // Programmatically create a Page.
+        $pageID = $I->havePostInDatabase(
+            [
+            'post_type'     => 'page',
+            'post_title'     => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
+            ]
+        );
+
+        // Quick Edit the Page in the Pages WP_List_Table.
+        $I->quickEdit(
+            $I, 'page', $pageID, [
+            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+            ]
+        );
+
+        // Load the Page on the frontend site.
+        $I->amOnPage('/?p='.$pageID);
+
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
+
+        // Confirm that the ConvertKit Default Form displays.
+        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+    }
+
+    /**
+     * Test that the Default Form for Pages displays when the Default option is chosen via
+     * WordPress' Bulk Edit functionality.
+     * 
+     * @since 1.9.8.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBulkEditUsingDefaultForm(AcceptanceTester $I)
+    {
+        // Specify the Default Form in the Plugin Settings.
+        $I->setupConvertKitPluginDefaultForm($I);
+
+        // Programmatically create two Pages.
+        $pageIDs = array(
+        $I->havePostInDatabase(
+            [
+            'post_type'     => 'page',
+            'post_title'     => 'ConvertKit: Page: Form: Default: Bulk Edit #1',
+            ]
+        ),
+        $I->havePostInDatabase(
+            [
+            'post_type'     => 'page',
+            'post_title'     => 'ConvertKit: Page: Form: Default: Bulk Edit #2',
+            ]
+        )
+        );
+
+        // Bulk Edit the Pages in the Pages WP_List_Table.
+        $I->bulkEdit(
+            $I, 'page', $pageIDs, [
+            'form' => [ 'select', 'Default' ],
+            ]
+        );
+
+        // Iterate through Pages to run frontend tests.
+        foreach($pageIDs as $pageID) {
+            // Load Page on the frontend site.
+            $I->amOnPage('/?p='.$pageID);
+
+            // Check that no PHP warnings or notices were output.
+            $I->checkNoWarningsAndNoticesOnScreen($I);
+
+            // Confirm that the ConvertKit Default Form displays.
+            $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+        }
+    }
+
+    /**
+     * Test that the defined form displays when chosen via
+     * WordPress' Bulk Edit functionality.
+     * 
+     * @since 1.9.8.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBulkEditUsingDefinedForm(AcceptanceTester $I)
+    {
+        // Programmatically create two Pages.
+        $pageIDs = array(
+        $I->havePostInDatabase(
+            [
+            'post_type'     => 'page',
+            'post_title'     => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
+            ]
+        ),
+        $I->havePostInDatabase(
+            [
+            'post_type'     => 'page',
+            'post_title'     => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
+            ]
+        )
+        );
+
+        // Bulk Edit the Pages in the Pages WP_List_Table.
+        $I->bulkEdit(
+            $I, 'page', $pageIDs, [
+            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+            ]
+        );
+
+        // Iterate through Pages to run frontend tests.
+        foreach($pageIDs as $pageID) {
+            // Load Page on the frontend site.
+            $I->amOnPage('/?p='.$pageID);
+
+            // Check that no PHP warnings or notices were output.
+            $I->checkNoWarningsAndNoticesOnScreen($I);
+
+            // Confirm that the ConvertKit Form displays.
+            $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+        }
+    }
+
+    /**
+     * Test that the existing settings are honored and not changed
+     * when the Bulk Edit options are set to 'No Change'.
+     * 
+     * @since 1.9.8.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBulkEditWithNoChanges(AcceptanceTester $I)
+    {
+        // Programmatically create two Pages with a defined form.
+        $pageIDs = array(
+        $I->havePostInDatabase(
+            [
+            'post_type'     => 'page',
+            'post_title'     => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #1',
+            'meta_input'    => [
+            '_wp_convertkit_post_meta' => [
+            'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
+            'landing_page' => '',
+            'tag'          => '',
+            ]
+            ],
+            ]
+        ),
+        $I->havePostInDatabase(
+            [
+            'post_type'     => 'page',
+            'post_title'     => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
+            'meta_input'    => [
+            '_wp_convertkit_post_meta' => [
+            'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
+            'landing_page' => '',
+            'tag'          => '',
+            ]
+            ],
+            ]
+        )
+        );
+
+        // Bulk Edit the Pages in the Pages WP_List_Table.
+        $I->bulkEdit(
+            $I, 'page', $pageIDs, [
+            'form' => [ 'select', '— No Change —' ],
+            ]
+        );
+
+        // Iterate through Pages to run frontend tests.
+        foreach($pageIDs as $pageID) {
+            // Load Page on the frontend site.
+            $I->amOnPage('/?p='.$pageID);
+
+            // Check that no PHP warnings or notices were output.
+            $I->checkNoWarningsAndNoticesOnScreen($I);
+
+            // Confirm that the ConvertKit Form displays.
+            $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+        }
+    }
+
+    /**
+     * Test that the Bulk Edit fields do not display when a search on a WP_List_Table
+     * returns no results.
+     * 
+     * @since 1.9.8.1
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBulkEditFieldsHiddenWhenNoPagesFound(AcceptanceTester $I)
+    {
+        // Emulate the user searching for Pages with a query string that yields no results.
+        $I->amOnAdminPage('edit.php?post_type=page&s=nothing');
+
+        // Confirm that the Bulk Edit fields do not display.
+        $I->dontSeeElement('#convertkit-bulk-edit');
+    }
+
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/forms/PageFormCest.php
+++ b/tests/acceptance/forms/PageFormCest.php
@@ -365,7 +365,7 @@ class PageFormCest
         );
 
         // Iterate through Pages to run frontend tests.
-        foreach($pageIDs as $pageID) {
+        foreach ($pageIDs as $pageID) {
             // Load Page on the frontend site.
             $I->amOnPage('/?p='.$pageID);
 
@@ -411,7 +411,7 @@ class PageFormCest
         );
 
         // Iterate through Pages to run frontend tests.
-        foreach($pageIDs as $pageID) {
+        foreach ($pageIDs as $pageID) {
             // Load Page on the frontend site.
             $I->amOnPage('/?p='.$pageID);
 
@@ -471,7 +471,7 @@ class PageFormCest
         );
 
         // Iterate through Pages to run frontend tests.
-        foreach($pageIDs as $pageID) {
+        foreach ($pageIDs as $pageID) {
             // Load Page on the frontend site.
             $I->amOnPage('/?p='.$pageID);
 

--- a/tests/acceptance/forms/PageNoFormCest.php
+++ b/tests/acceptance/forms/PageNoFormCest.php
@@ -1,67 +1,64 @@
 <?php
 /**
  * Tests for WordPress Pages when no ConvertKit Forms exist in the ConvertKit account.
- * 
+ *
  * @since 1.9.6.1
  */
-class PageNoFormCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.6.1
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        // Activate and Setup ConvertKit plugin
-        $I->activateConvertKitPlugin($I);
-        $I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
-        $I->enableDebugLog($I);
-		
-        // Navigate to Pages > Add New
-        $I->amOnAdminPage('post-new.php?post_type=page');
+class PageNoFormCest {
 
-        // Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
-        $I->maybeCloseGutenbergWelcomeModal($I);
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.6.1
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		// Activate and Setup ConvertKit plugin
+		$I->activateConvertKitPlugin( $I );
+		$I->setupConvertKitPlugin( $I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA'] );
+		$I->enableDebugLog( $I );
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-    }
+		// Navigate to Pages > Add New
+		$I->amOnAdminPage( 'post-new.php?post_type=page' );
 
-    /**
-     * Test that UTM parameters are included in links displayed in the metabox for the user to sign in to
-     * their ConvertKit account.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testUTMParametersExist(AcceptanceTester $I)
-    {
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
+		$I->maybeCloseGutenbergWelcomeModal( $I );
 
-        // Check that the metabox is displayed.
-        $I->seeElementInDOM('#wp-convertkit-meta-box');
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+	}
 
-        // Confirm that UTM parameters exist for the 'sign in to ConvertKit' link.
-        $I->seeInSource('<a href="https://app.convertkit.com/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">sign in to ConvertKit</a>');
-    }
+	/**
+	 * Test that UTM parameters are included in links displayed in the metabox for the user to sign in to
+	 * their ConvertKit account.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testUTMParametersExist( AcceptanceTester $I ) {
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+		// Check that the metabox is displayed.
+		$I->seeElementInDOM( '#wp-convertkit-meta-box' );
+
+		// Confirm that UTM parameters exist for the 'sign in to ConvertKit' link.
+		$I->seeInSource( '<a href="https://app.convertkit.com/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">sign in to ConvertKit</a>' );
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/forms/PageNoFormCest.php
+++ b/tests/acceptance/forms/PageNoFormCest.php
@@ -1,29 +1,29 @@
 <?php
 /**
  * Tests for WordPress Pages when no ConvertKit Forms exist in the ConvertKit account.
- * 
- * @since 	1.9.6.1
+ *
+ * @since   1.9.6.1
  */
 class PageNoFormCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
-		// Activate and Setup ConvertKit plugin
+		// Activate and Setup ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
 		$I->enableDebugLog($I);
-		
-		// Navigate to Pages > Add New
+
+		// Navigate to Pages > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=page');
 
-		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
+		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed.
 		$I->maybeCloseGutenbergWelcomeModal($I);
 
 		// Check that no PHP warnings or notices were output.
@@ -33,10 +33,10 @@ class PageNoFormCest
 	/**
 	 * Test that UTM parameters are included in links displayed in the metabox for the user to sign in to
 	 * their ConvertKit account.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testUTMParametersExist(AcceptanceTester $I)
 	{
@@ -54,10 +54,10 @@ class PageNoFormCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/forms/PageNoFormCest.php
+++ b/tests/acceptance/forms/PageNoFormCest.php
@@ -1,64 +1,67 @@
 <?php
 /**
  * Tests for WordPress Pages when no ConvertKit Forms exist in the ConvertKit account.
- *
- * @since 1.9.6.1
+ * 
+ * @since 	1.9.6.1
  */
-class PageNoFormCest {
-
+class PageNoFormCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.6.1
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.1
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
+	public function _before(AcceptanceTester $I)
+	{
 		// Activate and Setup ConvertKit plugin
-		$I->activateConvertKitPlugin( $I );
-		$I->setupConvertKitPlugin( $I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA'] );
-		$I->enableDebugLog( $I );
-
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
+		$I->enableDebugLog($I);
+		
 		// Navigate to Pages > Add New
-		$I->amOnAdminPage( 'post-new.php?post_type=page' );
+		$I->amOnAdminPage('post-new.php?post_type=page');
 
 		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
-		$I->maybeCloseGutenbergWelcomeModal( $I );
+		$I->maybeCloseGutenbergWelcomeModal($I);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 	}
 
 	/**
 	 * Test that UTM parameters are included in links displayed in the metabox for the user to sign in to
 	 * their ConvertKit account.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testUTMParametersExist( AcceptanceTester $I ) {
+	public function testUTMParametersExist(AcceptanceTester $I)
+	{
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check that the metabox is displayed.
-		$I->seeElementInDOM( '#wp-convertkit-meta-box' );
+		$I->seeElementInDOM('#wp-convertkit-meta-box');
 
 		// Confirm that UTM parameters exist for the 'sign in to ConvertKit' link.
-		$I->seeInSource( '<a href="https://app.convertkit.com/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">sign in to ConvertKit</a>' );
+		$I->seeInSource('<a href="https://app.convertkit.com/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">sign in to ConvertKit</a>');
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/forms/PageNoFormCest.php
+++ b/tests/acceptance/forms/PageNoFormCest.php
@@ -2,66 +2,66 @@
 /**
  * Tests for WordPress Pages when no ConvertKit Forms exist in the ConvertKit account.
  * 
- * @since 	1.9.6.1
+ * @since 1.9.6.1
  */
 class PageNoFormCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		// Activate and Setup ConvertKit plugin
-		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
-		$I->enableDebugLog($I);
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.6.1
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        // Activate and Setup ConvertKit plugin
+        $I->activateConvertKitPlugin($I);
+        $I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
+        $I->enableDebugLog($I);
 		
-		// Navigate to Pages > Add New
-		$I->amOnAdminPage('post-new.php?post_type=page');
+        // Navigate to Pages > Add New
+        $I->amOnAdminPage('post-new.php?post_type=page');
 
-		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
-		$I->maybeCloseGutenbergWelcomeModal($I);
+        // Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
+        $I->maybeCloseGutenbergWelcomeModal($I);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-	}
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
+    }
 
-	/**
-	 * Test that UTM parameters are included in links displayed in the metabox for the user to sign in to
-	 * their ConvertKit account.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testUTMParametersExist(AcceptanceTester $I)
-	{
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+    /**
+     * Test that UTM parameters are included in links displayed in the metabox for the user to sign in to
+     * their ConvertKit account.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testUTMParametersExist(AcceptanceTester $I)
+    {
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Check that the metabox is displayed.
-		$I->seeElementInDOM('#wp-convertkit-meta-box');
+        // Check that the metabox is displayed.
+        $I->seeElementInDOM('#wp-convertkit-meta-box');
 
-		// Confirm that UTM parameters exist for the 'sign in to ConvertKit' link.
-		$I->seeInSource('<a href="https://app.convertkit.com/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">sign in to ConvertKit</a>');
-	}
+        // Confirm that UTM parameters exist for the 'sign in to ConvertKit' link.
+        $I->seeInSource('<a href="https://app.convertkit.com/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">sign in to ConvertKit</a>');
+    }
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/forms/PageShortcodeFormCest.php
+++ b/tests/acceptance/forms/PageShortcodeFormCest.php
@@ -2,303 +2,323 @@
 /**
  * Tests for the ConvertKit Form shortcode.
  * 
- * @since 	1.9.6
+ * @since 1.9.6
  */
 class PageShortcodeFormCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
-	}
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        $I->activateConvertKitPlugin($I);
+        $I->setupConvertKitPlugin($I);
+        $I->enableDebugLog($I);
+    }
 
-	/**
-	 * Test the [convertkit_form] shortcode works when a valid Form ID is specified,
-	 * using the Classic Editor (TinyMCE / Visual).
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testFormShortcodeInVisualEditorWithValidFormParameter(AcceptanceTester $I)
-	{
-		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Form: Shortcode: Visual Editor');
+    /**
+     * Test the [convertkit_form] shortcode works when a valid Form ID is specified,
+     * using the Classic Editor (TinyMCE / Visual).
+     * 
+     * @since 1.9.7.5
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testFormShortcodeInVisualEditorWithValidFormParameter(AcceptanceTester $I)
+    {
+        // Add a Page using the Classic Editor.
+        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Form: Shortcode: Visual Editor');
 
-		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'None' ],
-		]);
+        // Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'form' => [ 'select2', 'None' ],
+            ]
+        );
 
-		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
-		$I->addVisualEditorShortcode(
-			$I,
-			'ConvertKit Form',
-			'convertkit-form',
-			[
-				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
-			],
-			'[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]'
-		);
+        // Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+        $I->addVisualEditorShortcode(
+            $I,
+            'ConvertKit Form',
+            'convertkit-form',
+            [
+            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+            ],
+            '[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]'
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewClassicEditorPage($I);
 
-		// Confirm that the ConvertKit Form is displayed.
-		$I->seeElementInDOM('form[data-sv-form]');
-	}
+        // Confirm that the ConvertKit Form is displayed.
+        $I->seeElementInDOM('form[data-sv-form]');
+    }
 
-	/**
-	 * Test the [convertkit_form] shortcode works when a valid Form ID is specified,
-	 * using the Text Editor.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testFormShortcodeInTextEditorWithValidFormParameter(AcceptanceTester $I)
-	{
-		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Form: Shortcode: Text Editor');
+    /**
+     * Test the [convertkit_form] shortcode works when a valid Form ID is specified,
+     * using the Text Editor.
+     * 
+     * @since 1.9.7.5
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testFormShortcodeInTextEditorWithValidFormParameter(AcceptanceTester $I)
+    {
+        // Add a Page using the Classic Editor.
+        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Form: Shortcode: Text Editor');
 
-		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'None' ],
-		]);
+        // Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'form' => [ 'select2', 'None' ],
+            ]
+        );
 
-		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
-		$I->addTextEditorShortcode(
-			$I,
-			'ConvertKit Form',
-			'convertkit-form',
-			[
-				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
-			],
-			'[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]'
-		);
+        // Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+        $I->addTextEditorShortcode(
+            $I,
+            'ConvertKit Form',
+            'convertkit-form',
+            [
+            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+            ],
+            '[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]'
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewClassicEditorPage($I);
 
-		// Confirm that the ConvertKit Form is displayed.
-		$I->seeElementInDOM('form[data-sv-form]');
-	}
+        // Confirm that the ConvertKit Form is displayed.
+        $I->seeElementInDOM('form[data-sv-form]');
+    }
 
-	/**
-	 * Test the [convertkit form] shortcode does not output errors when an invalid Form ID is specified.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testFormShortcodeWithInvalidFormParameter(AcceptanceTester $I)
-	{
-		// Create Page with Shortcode.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-form-shortcode-invalid-form-param',
-			'post_content' 	=> '[convertkit form=1]',
-		]);
+    /**
+     * Test the [convertkit form] shortcode does not output errors when an invalid Form ID is specified.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testFormShortcodeWithInvalidFormParameter(AcceptanceTester $I)
+    {
+        // Create Page with Shortcode.
+        $I->havePageInDatabase(
+            [
+            'post_name'     => 'convertkit-form-shortcode-invalid-form-param',
+            'post_content'     => '[convertkit form=1]',
+            ]
+        );
 
-		// Load the Page on the frontend site.
-		$I->amOnPage('/convertkit-form-shortcode-invalid-form-param');
+        // Load the Page on the frontend site.
+        $I->amOnPage('/convertkit-form-shortcode-invalid-form-param');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the ConvertKit Form is not displayed.
-		$I->dontSeeElementInDOM('form[data-sv-form]');
-	}
+        // Confirm that the ConvertKit Form is not displayed.
+        $I->dontSeeElementInDOM('form[data-sv-form]');
+    }
 
-	/**
-	 * Test the [convertkit id] shortcode works when a valid Form ID is specified.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testFormShortcodeWithValidIDParameter(AcceptanceTester $I)
-	{
-		// Create Page with Shortcode.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-form-shortcode-valid-id-param',
-			'post_content' 	=> '[convertkit id=' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']',
-		]);
+    /**
+     * Test the [convertkit id] shortcode works when a valid Form ID is specified.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testFormShortcodeWithValidIDParameter(AcceptanceTester $I)
+    {
+        // Create Page with Shortcode.
+        $I->havePageInDatabase(
+            [
+            'post_name'     => 'convertkit-form-shortcode-valid-id-param',
+            'post_content'     => '[convertkit id=' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']',
+            ]
+        );
 
-		// Load the Page on the frontend site.
-		$I->amOnPage('/convertkit-form-shortcode-valid-id-param');
+        // Load the Page on the frontend site.
+        $I->amOnPage('/convertkit-form-shortcode-valid-id-param');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the ConvertKit Form is displayed.
-		$I->seeElementInDOM('form[data-sv-form]');
-	}
+        // Confirm that the ConvertKit Form is displayed.
+        $I->seeElementInDOM('form[data-sv-form]');
+    }
 
-	/**
-	 * Test the [convertkit form] shortcode does not output errors when an invalid Form ID is specified.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testFormShortcodeWithInvalidIDParameter(AcceptanceTester $I)
-	{
-		// Create Page with Shortcode.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-form-shortcode-invalid-id-param',
-			'post_content' 	=> '[convertkit id=1]',
-		]);
+    /**
+     * Test the [convertkit form] shortcode does not output errors when an invalid Form ID is specified.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testFormShortcodeWithInvalidIDParameter(AcceptanceTester $I)
+    {
+        // Create Page with Shortcode.
+        $I->havePageInDatabase(
+            [
+            'post_name'     => 'convertkit-form-shortcode-invalid-id-param',
+            'post_content'     => '[convertkit id=1]',
+            ]
+        );
 
-		// Load the Page on the frontend site.
-		$I->amOnPage('/convertkit-form-shortcode-invalid-id-param');
+        // Load the Page on the frontend site.
+        $I->amOnPage('/convertkit-form-shortcode-invalid-id-param');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the ConvertKit Form is not displayed.
-		$I->dontSeeElementInDOM('form[data-sv-form]');
-	}
+        // Confirm that the ConvertKit Form is not displayed.
+        $I->dontSeeElementInDOM('form[data-sv-form]');
+    }
 
-	/**
-	 * Test the [convertkit form] shortcode works when a valid Form ID is specified,
-	 * but the Form ID does not exist in the options table.
-	 * 
-	 * This emulates when a ConvertKit User has:
-	 * - added a new ConvertKit Form to their account at https://app.convertkit.com/
-	 * - copied the ConvertKit Form Shortcode at https://app.convertkit.com/
-	 * - pasted the ConvertKit Form Shortcode into a new WordPress Page
-	 * - not navigated to Settings > ConvertKit to refresh the Plugin's Form Resources.
-	 * 
-	 * @since 	1.9.6.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testFormShortcodeWhenFormDoesNotExistInPluginFormResources(AcceptanceTester $I)
-	{
-		// Update the Form Resource option table value to only contain a dummy Form with an ID
-		// that does not match the shortcode Form's ID.
-		$I->haveOptionInDatabase('convertkit_forms', [
-			1234 => [
-				'id' => 1234,
-				'uid' => 1234,
-				'embed_js' => 'fake',
-			],
-		]);
+    /**
+     * Test the [convertkit form] shortcode works when a valid Form ID is specified,
+     * but the Form ID does not exist in the options table.
+     * 
+     * This emulates when a ConvertKit User has:
+     * - added a new ConvertKit Form to their account at https://app.convertkit.com/
+     * - copied the ConvertKit Form Shortcode at https://app.convertkit.com/
+     * - pasted the ConvertKit Form Shortcode into a new WordPress Page
+     * - not navigated to Settings > ConvertKit to refresh the Plugin's Form Resources.
+     * 
+     * @since 1.9.6.2
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testFormShortcodeWhenFormDoesNotExistInPluginFormResources(AcceptanceTester $I)
+    {
+        // Update the Form Resource option table value to only contain a dummy Form with an ID
+        // that does not match the shortcode Form's ID.
+        $I->haveOptionInDatabase(
+            'convertkit_forms', [
+            1234 => [
+            'id' => 1234,
+            'uid' => 1234,
+            'embed_js' => 'fake',
+            ],
+            ]
+        );
 
-		// Create Page with Shortcode.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-form-shortcode-no-form-resources',
-			'post_content' 	=> '[convertkit form=' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']',
-		]);
+        // Create Page with Shortcode.
+        $I->havePageInDatabase(
+            [
+            'post_name'     => 'convertkit-form-shortcode-no-form-resources',
+            'post_content'     => '[convertkit form=' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']',
+            ]
+        );
 
-		// Load the Page on the frontend site.
-		$I->amOnPage('/convertkit-form-shortcode-no-form-resources');
+        // Load the Page on the frontend site.
+        $I->amOnPage('/convertkit-form-shortcode-no-form-resources');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the ConvertKit Form is displayed.
-		$I->seeElementInDOM('form[data-sv-form]');
-	}
+        // Confirm that the ConvertKit Form is displayed.
+        $I->seeElementInDOM('form[data-sv-form]');
+    }
 
-	/**
-	 * Test the [convertkit form] shortcode works when a valid Legacy Form ID is specified.
-	 * 
-	 * @since 	1.9.6.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testFormShortcodeWithValidLegacyFormParameter(AcceptanceTester $I)
-	{
-		// Create Page with Shortcode.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-form-shortcode-valid-legacy-form-param',
-			'post_content' 	=> '[convertkit form=' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']',
-		]);
+    /**
+     * Test the [convertkit form] shortcode works when a valid Legacy Form ID is specified.
+     * 
+     * @since 1.9.6.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testFormShortcodeWithValidLegacyFormParameter(AcceptanceTester $I)
+    {
+        // Create Page with Shortcode.
+        $I->havePageInDatabase(
+            [
+            'post_name'     => 'convertkit-form-shortcode-valid-legacy-form-param',
+            'post_content'     => '[convertkit form=' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']',
+            ]
+        );
 
-		// Load the Page on the frontend site.
-		$I->amOnPage('/convertkit-form-shortcode-valid-legacy-form-param');
+        // Load the Page on the frontend site.
+        $I->amOnPage('/convertkit-form-shortcode-valid-legacy-form-param');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the ConvertKit Default Legacy Form displays.
-		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
-	}
+        // Confirm that the ConvertKit Default Legacy Form displays.
+        $I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
+    }
 
-	/**
-	 * Test the [convertkit id] shortcode works when a valid Legacy Form ID is specified.
-	 * 
-	 * @since 	1.9.6.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testFormShortcodeWithValidLegacyIDParameter(AcceptanceTester $I)
-	{
-		// Create Page with Shortcode.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-form-shortcode-valid-legacy-id-param',
-			'post_content' 	=> '[convertkit id=' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']',
-		]);
+    /**
+     * Test the [convertkit id] shortcode works when a valid Legacy Form ID is specified.
+     * 
+     * @since 1.9.6.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testFormShortcodeWithValidLegacyIDParameter(AcceptanceTester $I)
+    {
+        // Create Page with Shortcode.
+        $I->havePageInDatabase(
+            [
+            'post_name'     => 'convertkit-form-shortcode-valid-legacy-id-param',
+            'post_content'     => '[convertkit id=' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']',
+            ]
+        );
 
-		// Load the Page on the frontend site.
-		$I->amOnPage('/convertkit-form-shortcode-valid-legacy-id-param');
+        // Load the Page on the frontend site.
+        $I->amOnPage('/convertkit-form-shortcode-valid-legacy-id-param');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the ConvertKit Default Legacy Form displays.
-		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
-	}
+        // Confirm that the ConvertKit Default Legacy Form displays.
+        $I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
+    }
 
-	/**
-	 * Test the [convertkit form] shortcode, as supplied by app.convertkit.com, works when a valid Legacy Form ID is specified.
-	 * The shortcode form's number / ID differs from the ID given to us in the API.
-	 * For example, a Legacy Form ID might be 470099, but the ConvertKit app says to use the shortcode [convertkit form=5281783]).
-	 * 
-	 * @since 	1.9.6.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testFormShortcodeWithValidLegacyFormShortcodeFromConvertKitApp(AcceptanceTester $I)
-	{
-		// Create Page with Shortcode.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-form-shortcode-valid-legacy-form-shortcode-from-convertkit-app',
-			'post_content' 	=> $_ENV['CONVERTKIT_API_LEGACY_FORM_SHORTCODE'],
-		]);
+    /**
+     * Test the [convertkit form] shortcode, as supplied by app.convertkit.com, works when a valid Legacy Form ID is specified.
+     * The shortcode form's number / ID differs from the ID given to us in the API.
+     * For example, a Legacy Form ID might be 470099, but the ConvertKit app says to use the shortcode [convertkit form=5281783]).
+     * 
+     * @since 1.9.6.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testFormShortcodeWithValidLegacyFormShortcodeFromConvertKitApp(AcceptanceTester $I)
+    {
+        // Create Page with Shortcode.
+        $I->havePageInDatabase(
+            [
+            'post_name'     => 'convertkit-form-shortcode-valid-legacy-form-shortcode-from-convertkit-app',
+            'post_content'     => $_ENV['CONVERTKIT_API_LEGACY_FORM_SHORTCODE'],
+            ]
+        );
 
-		// Load the Page on the frontend site.
-		$I->amOnPage('/convertkit-form-shortcode-valid-legacy-form-shortcode-from-convertkit-app');
+        // Load the Page on the frontend site.
+        $I->amOnPage('/convertkit-form-shortcode-valid-legacy-form-shortcode-from-convertkit-app');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the ConvertKit Default Legacy Form displays.
-		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
-	}
+        // Confirm that the ConvertKit Default Legacy Form displays.
+        $I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
+    }
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateThirdPartyPlugin($I, 'classic-editor');
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateThirdPartyPlugin($I, 'classic-editor');
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/forms/PageShortcodeFormCest.php
+++ b/tests/acceptance/forms/PageShortcodeFormCest.php
@@ -1,324 +1,318 @@
 <?php
 /**
  * Tests for the ConvertKit Form shortcode.
- * 
+ *
  * @since 1.9.6
  */
-class PageShortcodeFormCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        $I->activateConvertKitPlugin($I);
-        $I->setupConvertKitPlugin($I);
-        $I->enableDebugLog($I);
-    }
+class PageShortcodeFormCest {
 
-    /**
-     * Test the [convertkit_form] shortcode works when a valid Form ID is specified,
-     * using the Classic Editor (TinyMCE / Visual).
-     * 
-     * @since 1.9.7.5
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testFormShortcodeInVisualEditorWithValidFormParameter(AcceptanceTester $I)
-    {
-        // Add a Page using the Classic Editor.
-        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Form: Shortcode: Visual Editor');
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		$I->activateConvertKitPlugin( $I );
+		$I->setupConvertKitPlugin( $I );
+		$I->enableDebugLog( $I );
+	}
 
-        // Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'form' => [ 'select2', 'None' ],
-            ]
-        );
+	/**
+	 * Test the [convertkit_form] shortcode works when a valid Form ID is specified,
+	 * using the Classic Editor (TinyMCE / Visual).
+	 *
+	 * @since 1.9.7.5
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testFormShortcodeInVisualEditorWithValidFormParameter( AcceptanceTester $I ) {
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Form: Shortcode: Visual Editor' );
 
-        // Add shortcode to Page, setting the Form setting to the value specified in the .env file.
-        $I->addVisualEditorShortcode(
-            $I,
-            'ConvertKit Form',
-            'convertkit-form',
-            [
-            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
-            ],
-            '[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]'
-        );
+		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'form' => array( 'select2', 'None' ),
+			)
+		);
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewClassicEditorPage($I);
+		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+		$I->addVisualEditorShortcode(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			array(
+				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
+			),
+			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
+		);
 
-        // Confirm that the ConvertKit Form is displayed.
-        $I->seeElementInDOM('form[data-sv-form]');
-    }
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage( $I );
 
-    /**
-     * Test the [convertkit_form] shortcode works when a valid Form ID is specified,
-     * using the Text Editor.
-     * 
-     * @since 1.9.7.5
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testFormShortcodeInTextEditorWithValidFormParameter(AcceptanceTester $I)
-    {
-        // Add a Page using the Classic Editor.
-        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Form: Shortcode: Text Editor');
+		// Confirm that the ConvertKit Form is displayed.
+		$I->seeElementInDOM( 'form[data-sv-form]' );
+	}
 
-        // Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'form' => [ 'select2', 'None' ],
-            ]
-        );
+	/**
+	 * Test the [convertkit_form] shortcode works when a valid Form ID is specified,
+	 * using the Text Editor.
+	 *
+	 * @since 1.9.7.5
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testFormShortcodeInTextEditorWithValidFormParameter( AcceptanceTester $I ) {
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Form: Shortcode: Text Editor' );
 
-        // Add shortcode to Page, setting the Form setting to the value specified in the .env file.
-        $I->addTextEditorShortcode(
-            $I,
-            'ConvertKit Form',
-            'convertkit-form',
-            [
-            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
-            ],
-            '[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]'
-        );
+		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'form' => array( 'select2', 'None' ),
+			)
+		);
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewClassicEditorPage($I);
+		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+		$I->addTextEditorShortcode(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			array(
+				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
+			),
+			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
+		);
 
-        // Confirm that the ConvertKit Form is displayed.
-        $I->seeElementInDOM('form[data-sv-form]');
-    }
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage( $I );
 
-    /**
-     * Test the [convertkit form] shortcode does not output errors when an invalid Form ID is specified.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testFormShortcodeWithInvalidFormParameter(AcceptanceTester $I)
-    {
-        // Create Page with Shortcode.
-        $I->havePageInDatabase(
-            [
-            'post_name'     => 'convertkit-form-shortcode-invalid-form-param',
-            'post_content'     => '[convertkit form=1]',
-            ]
-        );
+		// Confirm that the ConvertKit Form is displayed.
+		$I->seeElementInDOM( 'form[data-sv-form]' );
+	}
 
-        // Load the Page on the frontend site.
-        $I->amOnPage('/convertkit-form-shortcode-invalid-form-param');
+	/**
+	 * Test the [convertkit form] shortcode does not output errors when an invalid Form ID is specified.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testFormShortcodeWithInvalidFormParameter( AcceptanceTester $I ) {
+		// Create Page with Shortcode.
+		$I->havePageInDatabase(
+			array(
+				'post_name'    => 'convertkit-form-shortcode-invalid-form-param',
+				'post_content' => '[convertkit form=1]',
+			)
+		);
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Load the Page on the frontend site.
+		$I->amOnPage( '/convertkit-form-shortcode-invalid-form-param' );
 
-        // Confirm that the ConvertKit Form is not displayed.
-        $I->dontSeeElementInDOM('form[data-sv-form]');
-    }
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-    /**
-     * Test the [convertkit id] shortcode works when a valid Form ID is specified.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testFormShortcodeWithValidIDParameter(AcceptanceTester $I)
-    {
-        // Create Page with Shortcode.
-        $I->havePageInDatabase(
-            [
-            'post_name'     => 'convertkit-form-shortcode-valid-id-param',
-            'post_content'     => '[convertkit id=' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']',
-            ]
-        );
+		// Confirm that the ConvertKit Form is not displayed.
+		$I->dontSeeElementInDOM( 'form[data-sv-form]' );
+	}
 
-        // Load the Page on the frontend site.
-        $I->amOnPage('/convertkit-form-shortcode-valid-id-param');
+	/**
+	 * Test the [convertkit id] shortcode works when a valid Form ID is specified.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testFormShortcodeWithValidIDParameter( AcceptanceTester $I ) {
+		// Create Page with Shortcode.
+		$I->havePageInDatabase(
+			array(
+				'post_name'    => 'convertkit-form-shortcode-valid-id-param',
+				'post_content' => '[convertkit id=' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']',
+			)
+		);
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Load the Page on the frontend site.
+		$I->amOnPage( '/convertkit-form-shortcode-valid-id-param' );
 
-        // Confirm that the ConvertKit Form is displayed.
-        $I->seeElementInDOM('form[data-sv-form]');
-    }
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-    /**
-     * Test the [convertkit form] shortcode does not output errors when an invalid Form ID is specified.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testFormShortcodeWithInvalidIDParameter(AcceptanceTester $I)
-    {
-        // Create Page with Shortcode.
-        $I->havePageInDatabase(
-            [
-            'post_name'     => 'convertkit-form-shortcode-invalid-id-param',
-            'post_content'     => '[convertkit id=1]',
-            ]
-        );
+		// Confirm that the ConvertKit Form is displayed.
+		$I->seeElementInDOM( 'form[data-sv-form]' );
+	}
 
-        // Load the Page on the frontend site.
-        $I->amOnPage('/convertkit-form-shortcode-invalid-id-param');
+	/**
+	 * Test the [convertkit form] shortcode does not output errors when an invalid Form ID is specified.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testFormShortcodeWithInvalidIDParameter( AcceptanceTester $I ) {
+		// Create Page with Shortcode.
+		$I->havePageInDatabase(
+			array(
+				'post_name'    => 'convertkit-form-shortcode-invalid-id-param',
+				'post_content' => '[convertkit id=1]',
+			)
+		);
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Load the Page on the frontend site.
+		$I->amOnPage( '/convertkit-form-shortcode-invalid-id-param' );
 
-        // Confirm that the ConvertKit Form is not displayed.
-        $I->dontSeeElementInDOM('form[data-sv-form]');
-    }
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-    /**
-     * Test the [convertkit form] shortcode works when a valid Form ID is specified,
-     * but the Form ID does not exist in the options table.
-     * 
-     * This emulates when a ConvertKit User has:
-     * - added a new ConvertKit Form to their account at https://app.convertkit.com/
-     * - copied the ConvertKit Form Shortcode at https://app.convertkit.com/
-     * - pasted the ConvertKit Form Shortcode into a new WordPress Page
-     * - not navigated to Settings > ConvertKit to refresh the Plugin's Form Resources.
-     * 
-     * @since 1.9.6.2
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testFormShortcodeWhenFormDoesNotExistInPluginFormResources(AcceptanceTester $I)
-    {
-        // Update the Form Resource option table value to only contain a dummy Form with an ID
-        // that does not match the shortcode Form's ID.
-        $I->haveOptionInDatabase(
-            'convertkit_forms', [
-            1234 => [
-            'id' => 1234,
-            'uid' => 1234,
-            'embed_js' => 'fake',
-            ],
-            ]
-        );
+		// Confirm that the ConvertKit Form is not displayed.
+		$I->dontSeeElementInDOM( 'form[data-sv-form]' );
+	}
 
-        // Create Page with Shortcode.
-        $I->havePageInDatabase(
-            [
-            'post_name'     => 'convertkit-form-shortcode-no-form-resources',
-            'post_content'     => '[convertkit form=' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']',
-            ]
-        );
+	/**
+	 * Test the [convertkit form] shortcode works when a valid Form ID is specified,
+	 * but the Form ID does not exist in the options table.
+	 *
+	 * This emulates when a ConvertKit User has:
+	 * - added a new ConvertKit Form to their account at https://app.convertkit.com/
+	 * - copied the ConvertKit Form Shortcode at https://app.convertkit.com/
+	 * - pasted the ConvertKit Form Shortcode into a new WordPress Page
+	 * - not navigated to Settings > ConvertKit to refresh the Plugin's Form Resources.
+	 *
+	 * @since 1.9.6.2
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testFormShortcodeWhenFormDoesNotExistInPluginFormResources( AcceptanceTester $I ) {
+		// Update the Form Resource option table value to only contain a dummy Form with an ID
+		// that does not match the shortcode Form's ID.
+		$I->haveOptionInDatabase(
+			'convertkit_forms',
+			array(
+				1234 => array(
+					'id'       => 1234,
+					'uid'      => 1234,
+					'embed_js' => 'fake',
+				),
+			)
+		);
 
-        // Load the Page on the frontend site.
-        $I->amOnPage('/convertkit-form-shortcode-no-form-resources');
+		// Create Page with Shortcode.
+		$I->havePageInDatabase(
+			array(
+				'post_name'    => 'convertkit-form-shortcode-no-form-resources',
+				'post_content' => '[convertkit form=' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']',
+			)
+		);
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Load the Page on the frontend site.
+		$I->amOnPage( '/convertkit-form-shortcode-no-form-resources' );
 
-        // Confirm that the ConvertKit Form is displayed.
-        $I->seeElementInDOM('form[data-sv-form]');
-    }
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-    /**
-     * Test the [convertkit form] shortcode works when a valid Legacy Form ID is specified.
-     * 
-     * @since 1.9.6.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testFormShortcodeWithValidLegacyFormParameter(AcceptanceTester $I)
-    {
-        // Create Page with Shortcode.
-        $I->havePageInDatabase(
-            [
-            'post_name'     => 'convertkit-form-shortcode-valid-legacy-form-param',
-            'post_content'     => '[convertkit form=' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']',
-            ]
-        );
+		// Confirm that the ConvertKit Form is displayed.
+		$I->seeElementInDOM( 'form[data-sv-form]' );
+	}
 
-        // Load the Page on the frontend site.
-        $I->amOnPage('/convertkit-form-shortcode-valid-legacy-form-param');
+	/**
+	 * Test the [convertkit form] shortcode works when a valid Legacy Form ID is specified.
+	 *
+	 * @since 1.9.6.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testFormShortcodeWithValidLegacyFormParameter( AcceptanceTester $I ) {
+		// Create Page with Shortcode.
+		$I->havePageInDatabase(
+			array(
+				'post_name'    => 'convertkit-form-shortcode-valid-legacy-form-param',
+				'post_content' => '[convertkit form=' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']',
+			)
+		);
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Load the Page on the frontend site.
+		$I->amOnPage( '/convertkit-form-shortcode-valid-legacy-form-param' );
 
-        // Confirm that the ConvertKit Default Legacy Form displays.
-        $I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
-    }
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-    /**
-     * Test the [convertkit id] shortcode works when a valid Legacy Form ID is specified.
-     * 
-     * @since 1.9.6.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testFormShortcodeWithValidLegacyIDParameter(AcceptanceTester $I)
-    {
-        // Create Page with Shortcode.
-        $I->havePageInDatabase(
-            [
-            'post_name'     => 'convertkit-form-shortcode-valid-legacy-id-param',
-            'post_content'     => '[convertkit id=' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']',
-            ]
-        );
+		// Confirm that the ConvertKit Default Legacy Form displays.
+		$I->seeInSource( '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">' );
+	}
 
-        // Load the Page on the frontend site.
-        $I->amOnPage('/convertkit-form-shortcode-valid-legacy-id-param');
+	/**
+	 * Test the [convertkit id] shortcode works when a valid Legacy Form ID is specified.
+	 *
+	 * @since 1.9.6.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testFormShortcodeWithValidLegacyIDParameter( AcceptanceTester $I ) {
+		// Create Page with Shortcode.
+		$I->havePageInDatabase(
+			array(
+				'post_name'    => 'convertkit-form-shortcode-valid-legacy-id-param',
+				'post_content' => '[convertkit id=' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']',
+			)
+		);
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Load the Page on the frontend site.
+		$I->amOnPage( '/convertkit-form-shortcode-valid-legacy-id-param' );
 
-        // Confirm that the ConvertKit Default Legacy Form displays.
-        $I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
-    }
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-    /**
-     * Test the [convertkit form] shortcode, as supplied by app.convertkit.com, works when a valid Legacy Form ID is specified.
-     * The shortcode form's number / ID differs from the ID given to us in the API.
-     * For example, a Legacy Form ID might be 470099, but the ConvertKit app says to use the shortcode [convertkit form=5281783]).
-     * 
-     * @since 1.9.6.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testFormShortcodeWithValidLegacyFormShortcodeFromConvertKitApp(AcceptanceTester $I)
-    {
-        // Create Page with Shortcode.
-        $I->havePageInDatabase(
-            [
-            'post_name'     => 'convertkit-form-shortcode-valid-legacy-form-shortcode-from-convertkit-app',
-            'post_content'     => $_ENV['CONVERTKIT_API_LEGACY_FORM_SHORTCODE'],
-            ]
-        );
+		// Confirm that the ConvertKit Default Legacy Form displays.
+		$I->seeInSource( '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">' );
+	}
 
-        // Load the Page on the frontend site.
-        $I->amOnPage('/convertkit-form-shortcode-valid-legacy-form-shortcode-from-convertkit-app');
+	/**
+	 * Test the [convertkit form] shortcode, as supplied by app.convertkit.com, works when a valid Legacy Form ID is specified.
+	 * The shortcode form's number / ID differs from the ID given to us in the API.
+	 * For example, a Legacy Form ID might be 470099, but the ConvertKit app says to use the shortcode [convertkit form=5281783]).
+	 *
+	 * @since 1.9.6.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testFormShortcodeWithValidLegacyFormShortcodeFromConvertKitApp( AcceptanceTester $I ) {
+		// Create Page with Shortcode.
+		$I->havePageInDatabase(
+			array(
+				'post_name'    => 'convertkit-form-shortcode-valid-legacy-form-shortcode-from-convertkit-app',
+				'post_content' => $_ENV['CONVERTKIT_API_LEGACY_FORM_SHORTCODE'],
+			)
+		);
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Load the Page on the frontend site.
+		$I->amOnPage( '/convertkit-form-shortcode-valid-legacy-form-shortcode-from-convertkit-app' );
 
-        // Confirm that the ConvertKit Default Legacy Form displays.
-        $I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
-    }
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateThirdPartyPlugin($I, 'classic-editor');
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+		// Confirm that the ConvertKit Default Legacy Form displays.
+		$I->seeInSource( '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">' );
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateThirdPartyPlugin( $I, 'classic-editor' );
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/forms/PageShortcodeFormCest.php
+++ b/tests/acceptance/forms/PageShortcodeFormCest.php
@@ -1,17 +1,17 @@
 <?php
 /**
  * Tests for the ConvertKit Form shortcode.
- * 
- * @since 	1.9.6
+ *
+ * @since   1.9.6
  */
 class PageShortcodeFormCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -23,10 +23,10 @@ class PageShortcodeFormCest
 	/**
 	 * Test the [convertkit_form] shortcode works when a valid Form ID is specified,
 	 * using the Classic Editor (TinyMCE / Visual).
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testFormShortcodeInVisualEditorWithValidFormParameter(AcceptanceTester $I)
 	{
@@ -34,9 +34,13 @@ class PageShortcodeFormCest
 		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Form: Shortcode: Visual Editor');
 
 		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'None' ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
@@ -44,9 +48,9 @@ class PageShortcodeFormCest
 			'ConvertKit Form',
 			'convertkit-form',
 			[
-				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			],
-			'[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]'
+			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -59,10 +63,10 @@ class PageShortcodeFormCest
 	/**
 	 * Test the [convertkit_form] shortcode works when a valid Form ID is specified,
 	 * using the Text Editor.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testFormShortcodeInTextEditorWithValidFormParameter(AcceptanceTester $I)
 	{
@@ -70,9 +74,13 @@ class PageShortcodeFormCest
 		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Form: Shortcode: Text Editor');
 
 		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'None' ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
@@ -80,9 +88,9 @@ class PageShortcodeFormCest
 			'ConvertKit Form',
 			'convertkit-form',
 			[
-				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			],
-			'[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]'
+			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -94,18 +102,20 @@ class PageShortcodeFormCest
 
 	/**
 	 * Test the [convertkit form] shortcode does not output errors when an invalid Form ID is specified.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testFormShortcodeWithInvalidFormParameter(AcceptanceTester $I)
 	{
 		// Create Page with Shortcode.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-form-shortcode-invalid-form-param',
-			'post_content' 	=> '[convertkit form=1]',
-		]);
+		$I->havePageInDatabase(
+			[
+				'post_name'    => 'convertkit-form-shortcode-invalid-form-param',
+				'post_content' => '[convertkit form=1]',
+			]
+		);
 
 		// Load the Page on the frontend site.
 		$I->amOnPage('/convertkit-form-shortcode-invalid-form-param');
@@ -119,18 +129,20 @@ class PageShortcodeFormCest
 
 	/**
 	 * Test the [convertkit id] shortcode works when a valid Form ID is specified.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testFormShortcodeWithValidIDParameter(AcceptanceTester $I)
 	{
 		// Create Page with Shortcode.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-form-shortcode-valid-id-param',
-			'post_content' 	=> '[convertkit id=' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']',
-		]);
+		$I->havePageInDatabase(
+			[
+				'post_name'    => 'convertkit-form-shortcode-valid-id-param',
+				'post_content' => '[convertkit id=' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']',
+			]
+		);
 
 		// Load the Page on the frontend site.
 		$I->amOnPage('/convertkit-form-shortcode-valid-id-param');
@@ -144,18 +156,20 @@ class PageShortcodeFormCest
 
 	/**
 	 * Test the [convertkit form] shortcode does not output errors when an invalid Form ID is specified.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testFormShortcodeWithInvalidIDParameter(AcceptanceTester $I)
 	{
 		// Create Page with Shortcode.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-form-shortcode-invalid-id-param',
-			'post_content' 	=> '[convertkit id=1]',
-		]);
+		$I->havePageInDatabase(
+			[
+				'post_name'    => 'convertkit-form-shortcode-invalid-id-param',
+				'post_content' => '[convertkit id=1]',
+			]
+		);
 
 		// Load the Page on the frontend site.
 		$I->amOnPage('/convertkit-form-shortcode-invalid-id-param');
@@ -170,34 +184,39 @@ class PageShortcodeFormCest
 	/**
 	 * Test the [convertkit form] shortcode works when a valid Form ID is specified,
 	 * but the Form ID does not exist in the options table.
-	 * 
+	 *
 	 * This emulates when a ConvertKit User has:
 	 * - added a new ConvertKit Form to their account at https://app.convertkit.com/
 	 * - copied the ConvertKit Form Shortcode at https://app.convertkit.com/
 	 * - pasted the ConvertKit Form Shortcode into a new WordPress Page
 	 * - not navigated to Settings > ConvertKit to refresh the Plugin's Form Resources.
-	 * 
-	 * @since 	1.9.6.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testFormShortcodeWhenFormDoesNotExistInPluginFormResources(AcceptanceTester $I)
 	{
 		// Update the Form Resource option table value to only contain a dummy Form with an ID
 		// that does not match the shortcode Form's ID.
-		$I->haveOptionInDatabase('convertkit_forms', [
-			1234 => [
-				'id' => 1234,
-				'uid' => 1234,
-				'embed_js' => 'fake',
-			],
-		]);
+		$I->haveOptionInDatabase(
+			'convertkit_forms',
+			[
+				1234 => [
+					'id'       => 1234,
+					'uid'      => 1234,
+					'embed_js' => 'fake',
+				],
+			]
+		);
 
 		// Create Page with Shortcode.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-form-shortcode-no-form-resources',
-			'post_content' 	=> '[convertkit form=' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']',
-		]);
+		$I->havePageInDatabase(
+			[
+				'post_name'    => 'convertkit-form-shortcode-no-form-resources',
+				'post_content' => '[convertkit form=' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']',
+			]
+		);
 
 		// Load the Page on the frontend site.
 		$I->amOnPage('/convertkit-form-shortcode-no-form-resources');
@@ -211,18 +230,20 @@ class PageShortcodeFormCest
 
 	/**
 	 * Test the [convertkit form] shortcode works when a valid Legacy Form ID is specified.
-	 * 
-	 * @since 	1.9.6.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testFormShortcodeWithValidLegacyFormParameter(AcceptanceTester $I)
 	{
 		// Create Page with Shortcode.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-form-shortcode-valid-legacy-form-param',
-			'post_content' 	=> '[convertkit form=' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']',
-		]);
+		$I->havePageInDatabase(
+			[
+				'post_name'    => 'convertkit-form-shortcode-valid-legacy-form-param',
+				'post_content' => '[convertkit form=' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']',
+			]
+		);
 
 		// Load the Page on the frontend site.
 		$I->amOnPage('/convertkit-form-shortcode-valid-legacy-form-param');
@@ -236,18 +257,20 @@ class PageShortcodeFormCest
 
 	/**
 	 * Test the [convertkit id] shortcode works when a valid Legacy Form ID is specified.
-	 * 
-	 * @since 	1.9.6.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testFormShortcodeWithValidLegacyIDParameter(AcceptanceTester $I)
 	{
 		// Create Page with Shortcode.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-form-shortcode-valid-legacy-id-param',
-			'post_content' 	=> '[convertkit id=' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']',
-		]);
+		$I->havePageInDatabase(
+			[
+				'post_name'    => 'convertkit-form-shortcode-valid-legacy-id-param',
+				'post_content' => '[convertkit id=' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']',
+			]
+		);
 
 		// Load the Page on the frontend site.
 		$I->amOnPage('/convertkit-form-shortcode-valid-legacy-id-param');
@@ -263,18 +286,20 @@ class PageShortcodeFormCest
 	 * Test the [convertkit form] shortcode, as supplied by app.convertkit.com, works when a valid Legacy Form ID is specified.
 	 * The shortcode form's number / ID differs from the ID given to us in the API.
 	 * For example, a Legacy Form ID might be 470099, but the ConvertKit app says to use the shortcode [convertkit form=5281783]).
-	 * 
-	 * @since 	1.9.6.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testFormShortcodeWithValidLegacyFormShortcodeFromConvertKitApp(AcceptanceTester $I)
 	{
 		// Create Page with Shortcode.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-form-shortcode-valid-legacy-form-shortcode-from-convertkit-app',
-			'post_content' 	=> $_ENV['CONVERTKIT_API_LEGACY_FORM_SHORTCODE'],
-		]);
+		$I->havePageInDatabase(
+			[
+				'post_name'    => 'convertkit-form-shortcode-valid-legacy-form-shortcode-from-convertkit-app',
+				'post_content' => $_ENV['CONVERTKIT_API_LEGACY_FORM_SHORTCODE'],
+			]
+		);
 
 		// Load the Page on the frontend site.
 		$I->amOnPage('/convertkit-form-shortcode-valid-legacy-form-shortcode-from-convertkit-app');
@@ -290,10 +315,10 @@ class PageShortcodeFormCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/forms/PageShortcodeFormCest.php
+++ b/tests/acceptance/forms/PageShortcodeFormCest.php
@@ -46,7 +46,6 @@ class PageShortcodeFormCest
 		$I->addVisualEditorShortcode(
 			$I,
 			'ConvertKit Form',
-			'convertkit-form',
 			[
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			],
@@ -85,7 +84,6 @@ class PageShortcodeFormCest
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
-			'ConvertKit Form',
 			'convertkit-form',
 			[
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],

--- a/tests/acceptance/forms/PageShortcodeFormCest.php
+++ b/tests/acceptance/forms/PageShortcodeFormCest.php
@@ -1,318 +1,304 @@
 <?php
 /**
  * Tests for the ConvertKit Form shortcode.
- *
- * @since 1.9.6
+ * 
+ * @since 	1.9.6
  */
-class PageShortcodeFormCest {
-
+class PageShortcodeFormCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
-		$I->activateConvertKitPlugin( $I );
-		$I->setupConvertKitPlugin( $I );
-		$I->enableDebugLog( $I );
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
 	}
 
 	/**
 	 * Test the [convertkit_form] shortcode works when a valid Form ID is specified,
 	 * using the Classic Editor (TinyMCE / Visual).
-	 *
-	 * @since 1.9.7.5
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testFormShortcodeInVisualEditorWithValidFormParameter( AcceptanceTester $I ) {
+	public function testFormShortcodeInVisualEditorWithValidFormParameter(AcceptanceTester $I)
+	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Form: Shortcode: Visual Editor' );
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Form: Shortcode: Visual Editor');
 
 		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'form' => array( 'select2', 'None' ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'None' ],
+		]);
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
 			'ConvertKit Form',
 			'convertkit-form',
-			array(
-				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
-			),
-			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+			],
+			'[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]'
 		);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage( $I );
+		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the ConvertKit Form is displayed.
-		$I->seeElementInDOM( 'form[data-sv-form]' );
+		$I->seeElementInDOM('form[data-sv-form]');
 	}
 
 	/**
 	 * Test the [convertkit_form] shortcode works when a valid Form ID is specified,
 	 * using the Text Editor.
-	 *
-	 * @since 1.9.7.5
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testFormShortcodeInTextEditorWithValidFormParameter( AcceptanceTester $I ) {
+	public function testFormShortcodeInTextEditorWithValidFormParameter(AcceptanceTester $I)
+	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Form: Shortcode: Text Editor' );
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Form: Shortcode: Text Editor');
 
 		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'form' => array( 'select2', 'None' ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'None' ],
+		]);
 
 		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
 			'ConvertKit Form',
 			'convertkit-form',
-			array(
-				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
-			),
-			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+			],
+			'[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]'
 		);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage( $I );
+		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the ConvertKit Form is displayed.
-		$I->seeElementInDOM( 'form[data-sv-form]' );
+		$I->seeElementInDOM('form[data-sv-form]');
 	}
 
 	/**
 	 * Test the [convertkit form] shortcode does not output errors when an invalid Form ID is specified.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testFormShortcodeWithInvalidFormParameter( AcceptanceTester $I ) {
+	public function testFormShortcodeWithInvalidFormParameter(AcceptanceTester $I)
+	{
 		// Create Page with Shortcode.
-		$I->havePageInDatabase(
-			array(
-				'post_name'    => 'convertkit-form-shortcode-invalid-form-param',
-				'post_content' => '[convertkit form=1]',
-			)
-		);
+		$I->havePageInDatabase([
+			'post_name' 	=> 'convertkit-form-shortcode-invalid-form-param',
+			'post_content' 	=> '[convertkit form=1]',
+		]);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage( '/convertkit-form-shortcode-invalid-form-param' );
+		$I->amOnPage('/convertkit-form-shortcode-invalid-form-param');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the ConvertKit Form is not displayed.
-		$I->dontSeeElementInDOM( 'form[data-sv-form]' );
+		$I->dontSeeElementInDOM('form[data-sv-form]');
 	}
 
 	/**
 	 * Test the [convertkit id] shortcode works when a valid Form ID is specified.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testFormShortcodeWithValidIDParameter( AcceptanceTester $I ) {
+	public function testFormShortcodeWithValidIDParameter(AcceptanceTester $I)
+	{
 		// Create Page with Shortcode.
-		$I->havePageInDatabase(
-			array(
-				'post_name'    => 'convertkit-form-shortcode-valid-id-param',
-				'post_content' => '[convertkit id=' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']',
-			)
-		);
+		$I->havePageInDatabase([
+			'post_name' 	=> 'convertkit-form-shortcode-valid-id-param',
+			'post_content' 	=> '[convertkit id=' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']',
+		]);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage( '/convertkit-form-shortcode-valid-id-param' );
+		$I->amOnPage('/convertkit-form-shortcode-valid-id-param');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the ConvertKit Form is displayed.
-		$I->seeElementInDOM( 'form[data-sv-form]' );
+		$I->seeElementInDOM('form[data-sv-form]');
 	}
 
 	/**
 	 * Test the [convertkit form] shortcode does not output errors when an invalid Form ID is specified.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testFormShortcodeWithInvalidIDParameter( AcceptanceTester $I ) {
+	public function testFormShortcodeWithInvalidIDParameter(AcceptanceTester $I)
+	{
 		// Create Page with Shortcode.
-		$I->havePageInDatabase(
-			array(
-				'post_name'    => 'convertkit-form-shortcode-invalid-id-param',
-				'post_content' => '[convertkit id=1]',
-			)
-		);
+		$I->havePageInDatabase([
+			'post_name' 	=> 'convertkit-form-shortcode-invalid-id-param',
+			'post_content' 	=> '[convertkit id=1]',
+		]);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage( '/convertkit-form-shortcode-invalid-id-param' );
+		$I->amOnPage('/convertkit-form-shortcode-invalid-id-param');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the ConvertKit Form is not displayed.
-		$I->dontSeeElementInDOM( 'form[data-sv-form]' );
+		$I->dontSeeElementInDOM('form[data-sv-form]');
 	}
 
 	/**
 	 * Test the [convertkit form] shortcode works when a valid Form ID is specified,
 	 * but the Form ID does not exist in the options table.
-	 *
+	 * 
 	 * This emulates when a ConvertKit User has:
 	 * - added a new ConvertKit Form to their account at https://app.convertkit.com/
 	 * - copied the ConvertKit Form Shortcode at https://app.convertkit.com/
 	 * - pasted the ConvertKit Form Shortcode into a new WordPress Page
 	 * - not navigated to Settings > ConvertKit to refresh the Plugin's Form Resources.
-	 *
-	 * @since 1.9.6.2
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testFormShortcodeWhenFormDoesNotExistInPluginFormResources( AcceptanceTester $I ) {
+	public function testFormShortcodeWhenFormDoesNotExistInPluginFormResources(AcceptanceTester $I)
+	{
 		// Update the Form Resource option table value to only contain a dummy Form with an ID
 		// that does not match the shortcode Form's ID.
-		$I->haveOptionInDatabase(
-			'convertkit_forms',
-			array(
-				1234 => array(
-					'id'       => 1234,
-					'uid'      => 1234,
-					'embed_js' => 'fake',
-				),
-			)
-		);
+		$I->haveOptionInDatabase('convertkit_forms', [
+			1234 => [
+				'id' => 1234,
+				'uid' => 1234,
+				'embed_js' => 'fake',
+			],
+		]);
 
 		// Create Page with Shortcode.
-		$I->havePageInDatabase(
-			array(
-				'post_name'    => 'convertkit-form-shortcode-no-form-resources',
-				'post_content' => '[convertkit form=' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']',
-			)
-		);
+		$I->havePageInDatabase([
+			'post_name' 	=> 'convertkit-form-shortcode-no-form-resources',
+			'post_content' 	=> '[convertkit form=' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']',
+		]);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage( '/convertkit-form-shortcode-no-form-resources' );
+		$I->amOnPage('/convertkit-form-shortcode-no-form-resources');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the ConvertKit Form is displayed.
-		$I->seeElementInDOM( 'form[data-sv-form]' );
+		$I->seeElementInDOM('form[data-sv-form]');
 	}
 
 	/**
 	 * Test the [convertkit form] shortcode works when a valid Legacy Form ID is specified.
-	 *
-	 * @since 1.9.6.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testFormShortcodeWithValidLegacyFormParameter( AcceptanceTester $I ) {
+	public function testFormShortcodeWithValidLegacyFormParameter(AcceptanceTester $I)
+	{
 		// Create Page with Shortcode.
-		$I->havePageInDatabase(
-			array(
-				'post_name'    => 'convertkit-form-shortcode-valid-legacy-form-param',
-				'post_content' => '[convertkit form=' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']',
-			)
-		);
+		$I->havePageInDatabase([
+			'post_name' 	=> 'convertkit-form-shortcode-valid-legacy-form-param',
+			'post_content' 	=> '[convertkit form=' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']',
+		]);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage( '/convertkit-form-shortcode-valid-legacy-form-param' );
+		$I->amOnPage('/convertkit-form-shortcode-valid-legacy-form-param');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the ConvertKit Default Legacy Form displays.
-		$I->seeInSource( '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">' );
+		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
 	}
 
 	/**
 	 * Test the [convertkit id] shortcode works when a valid Legacy Form ID is specified.
-	 *
-	 * @since 1.9.6.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testFormShortcodeWithValidLegacyIDParameter( AcceptanceTester $I ) {
+	public function testFormShortcodeWithValidLegacyIDParameter(AcceptanceTester $I)
+	{
 		// Create Page with Shortcode.
-		$I->havePageInDatabase(
-			array(
-				'post_name'    => 'convertkit-form-shortcode-valid-legacy-id-param',
-				'post_content' => '[convertkit id=' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']',
-			)
-		);
+		$I->havePageInDatabase([
+			'post_name' 	=> 'convertkit-form-shortcode-valid-legacy-id-param',
+			'post_content' 	=> '[convertkit id=' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']',
+		]);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage( '/convertkit-form-shortcode-valid-legacy-id-param' );
+		$I->amOnPage('/convertkit-form-shortcode-valid-legacy-id-param');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the ConvertKit Default Legacy Form displays.
-		$I->seeInSource( '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">' );
+		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
 	}
 
 	/**
 	 * Test the [convertkit form] shortcode, as supplied by app.convertkit.com, works when a valid Legacy Form ID is specified.
 	 * The shortcode form's number / ID differs from the ID given to us in the API.
 	 * For example, a Legacy Form ID might be 470099, but the ConvertKit app says to use the shortcode [convertkit form=5281783]).
-	 *
-	 * @since 1.9.6.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testFormShortcodeWithValidLegacyFormShortcodeFromConvertKitApp( AcceptanceTester $I ) {
+	public function testFormShortcodeWithValidLegacyFormShortcodeFromConvertKitApp(AcceptanceTester $I)
+	{
 		// Create Page with Shortcode.
-		$I->havePageInDatabase(
-			array(
-				'post_name'    => 'convertkit-form-shortcode-valid-legacy-form-shortcode-from-convertkit-app',
-				'post_content' => $_ENV['CONVERTKIT_API_LEGACY_FORM_SHORTCODE'],
-			)
-		);
+		$I->havePageInDatabase([
+			'post_name' 	=> 'convertkit-form-shortcode-valid-legacy-form-shortcode-from-convertkit-app',
+			'post_content' 	=> $_ENV['CONVERTKIT_API_LEGACY_FORM_SHORTCODE'],
+		]);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage( '/convertkit-form-shortcode-valid-legacy-form-shortcode-from-convertkit-app' );
+		$I->amOnPage('/convertkit-form-shortcode-valid-legacy-form-shortcode-from-convertkit-app');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the ConvertKit Default Legacy Form displays.
-		$I->seeInSource( '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">' );
+		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateThirdPartyPlugin( $I, 'classic-editor' );
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateThirdPartyPlugin($I, 'classic-editor');
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/forms/PostFormCest.php
+++ b/tests/acceptance/forms/PostFormCest.php
@@ -1,625 +1,636 @@
 <?php
 /**
  * Tests for ConvertKit Forms on WordPress Posts.
- * 
+ *
  * @since 1.9.6
  */
-class PostFormCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        // Activate and Setup ConvertKit plugin
-        $I->activateConvertKitPlugin($I);
-        $I->setupConvertKitPlugin($I);
-        $I->enableDebugLog($I);
-    }
-
-    /**
-     * Test that the Posts > Add New screen has expected a11y output, such as label[for].
-     * 
-     * @since 1.9.7.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAccessibility(AcceptanceTester $I)
-    {
-        // Navigate to Post Type (e.g. Pages / Posts) > Add New
-        $I->amOnAdminPage('post-new.php?post_type=post');
-
-        // Confirm that settings have label[for] attributes.
-        $I->seeInSource('<label for="wp-convertkit-form">');
-        $I->seeInSource('<label for="wp-convertkit-tag">');
-    }
-
-    /**
-     * Test that the 'Default' option for the Default Form setting in the Plugin Settings works when
-     * creating and viewing a new WordPress Post, and there is no Default Form specified in the Plugin
-     * settings.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewPostUsingDefaultFormWithNoDefaultFormSpecifiedInPlugin(AcceptanceTester $I)
-    {
-        // Add a Post using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: Default: None');
-
-        // Configure metabox's Form setting = Default.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'form' => [ 'select2', 'Default' ],
-            ]
-        );
-
-        // Publish and view the Post on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
-
-        // Confirm that no ConvertKit Form is displayed.
-        $I->dontSeeElementInDOM('form[data-sv-form]');
-    }
-
-    /**
-     * Test that the Default Form specified in the Plugin Settings works when
-     * creating and viewing a new WordPress Post.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewPostUsingDefaultForm(AcceptanceTester $I)
-    {
-        // Specify the Default Form in the Plugin Settings.
-        $defaultFormID = $I->setupConvertKitPluginDefaultForm($I);
-
-        // Add a Post using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: Default');
-
-        // Configure metabox's Form setting = Default.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'form' => [ 'select2', 'Default' ],
-            ]
-        );
-
-        // Publish and view the Post on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
-
-        // Confirm that the ConvertKit Default Form displays.
-        $I->seeElementInDOM('form[data-sv-form="' . $defaultFormID . '"]');
-    }
-
-    /**
-     * Test that the Default Legacy Form specified in the Plugin Settings works when
-     * creating and viewing a new WordPress Post.
-     * 
-     * @since 1.9.6.3
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewPostUsingDefaultLegacyForm(AcceptanceTester $I)
-    {
-        // Specify the Default Legacy Form in the Plugin Settings.
-        $defaultLegacyFormID = $I->setupConvertKitPluginDefaultLegacyForm($I);
-
-        // Add a Post using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: Legacy: Default');
-
-        // Configure metabox's Form setting = Default.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'form' => [ 'select2', 'Default' ],
-            ]
-        );
-
-        // Publish and view the Post on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
-
-        // Confirm that the ConvertKit Default Legacy Form displays.
-        $I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $defaultLegacyFormID . '/subscribe" data-remote="true">');
-    }
-
-    /**
-     * Test that 'None' Form specified in the Post Settings works when
-     * creating and viewing a new WordPress Post.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewPostUsingNoForm(AcceptanceTester $I)
-    {
-        // Add a Post using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: None');
-
-        // Configure metabox's Form setting = None.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'form' => [ 'select2', 'None' ],
-            ]
-        );
-
-        // Publish and view the Post on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
-
-        // Confirm that no ConvertKit Form is displayed.
-        $I->dontSeeElementInDOM('form[data-sv-form]');
-    }
-
-    /**
-     * Test that the Form specified in the Post Settings works when
-     * creating and viewing a new WordPress Post.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewPostUsingDefinedForm(AcceptanceTester $I)
-    {
-        // Add a Post using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME']);
-
-        // Configure metabox's Form setting = None.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-            ]
-        );
-
-        // Publish and view the Post on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
-
-        // Confirm that the ConvertKit Form displays.
-        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-    }
-
-    /**
-     * Test that the Legacy Form specified in the Post Settings works when
-     * creating and viewing a new WordPress Post.
-     * 
-     * @since 1.9.6.3
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewPostUsingDefinedLegacyForm(AcceptanceTester $I)
-    {
-        // Add a Post using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
-
-        // Configure metabox's Form setting = None.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'form' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
-            ]
-        );
-
-        // Publish and view the Post on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
-
-        // Confirm that the ConvertKit Legacy Form displays.
-        $I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
-    }
-
-    /**
-     * Test that the Default Form for Posts displays when an invalid Form ID is specified
-     * for a Post.
-     * 
-     * Whilst the on screen options won't permit selecting an invalid Form ID, a Post might
-     * have an invalid Form ID because:
-     * - the form belongs to another ConvertKit account (i.e. API credentials were changed in the Plugin, but this Post's specified Form was not changed)
-     * - the form was deleted from the ConvertKit account.
-     * 
-     * @since 1.9.7.2
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewPostUsingInvalidDefinedForm(AcceptanceTester $I)
-    {
-        // Setup the Default Form for Pages and Posts.
-        $I->setupConvertKitPluginDefaultForm($I);
-
-        // Create Post, with an invalid Form ID, as if it were created prior to API credentials being changed and/or
-        // a Form being deleted in ConvertKit.
-        $postID = $I->havePostInDatabase(
-            [
-            'post_type'     => 'post',
-            'post_title'     => 'ConvertKit: Post: Form: Specific: Invalid',
-            'meta_input'    => [
-            '_wp_convertkit_post_meta' => [
-            'form'         => '11111',
-            'landing_page' => '',
-            'tag'          => '',
-            ]
-            ],
-            ]
-        );
-
-        // Load the Post on the frontend site.
-        $I->amOnPage('/?p='.$postID);
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Confirm that the invalid ConvertKit Form does not display.
-        $I->dontSeeElementInDOM('form[data-sv-form="11111"]');
-
-        // Confirm that the Default Form for Posts does display as a fallback.
-        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-    }
-
-    /**
-     * Test that the Form specified in the Category assigned to the WordPress Post is used when the WordPress Post
-     * is set to use the Default Form.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewPostUsingDefaultFormWithCategoryFormSpecified(AcceptanceTester $I)
-    {
-        // Create Category.
-        $termID = $I->haveTermInDatabase('ConvertKit', 'category');
-        $termID = $termID[0];
-		
-        // Create Post, assigned to ConvertKit Category.
-        $postID = $I->havePostInDatabase(
-            [
-            'post_type'     => 'post',
-            'post_title'     => 'ConvertKit Form inherited from ConvertKit Category',
-            'tax_input' => [
-            [ 'category' => $termID ],
-            ],
-            ]
-        );
-
-        // Edit the Term, defining a Form.
-        $I->amOnAdminPage('term.php?taxonomy=category&tag_ID=' . $termID);
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Check that the Form option is displayed.
-        $I->seeElementInDOM('#wp-convertkit-form');
-
-        // Change Form to value specified in the .env file.
-        $I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
-
-        // Click Update
-        $I->click('Update');
-
-        // Check that the update succeeded.
-        $I->seeElementInDOM('div.notice-success');
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Load the Post on the frontend site
-        $I->amOnPage('/?p=' . $postID);
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Confirm that the ConvertKit Form displays.
-        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-    }
-
-    /**
-     * Test that the Default Form specified at Plugin level for Posts displays when:
-     * - A Category was created with ConvertKit Form = 'None' when 1.9.5.2 or earlier of the Plugin was activated,
-     * - The WordPress Post is set to use the Default Form,
-     * - A Default Form is set in the Plugin settings.
-     * 
-     * 1.9.5.2 and earlier stored the 'None' option as 'default' for Categories, meaning that the Post (or Plugin) default form
-     * should be used. 
-     * 
-     * 1.9.6.0 and later changed the value to 0 for Categories, bringing it in line with the Post Form's 'None'
-     * setting.
-     * 
-     * @since 1.9.7.3
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewPostUsingDefaultFormWithCategoryCreatedBefore1960(AcceptanceTester $I)
-    {
-        // Setup Default Forms.
-        $I->setupConvertKitPluginDefaultForm($I);
-
-        // Create Category as if it were created / edited when the ConvertKit Plugin < 1.9.6.0
-        // was active.
-        $termID = $I->haveTermInDatabase(
-            'ConvertKit 1.9.5.2 and earlier', 'category', [
-            'meta' => [
-            'ck_default_form' => 'default', // Emulate how 1.9.5.2 and earlier store this setting.
-            ],
-            ] 
-        );
-        $termID = $termID[0];
-		
-        // Create Post, assigned to Category.
-        $postID = $I->havePostInDatabase(
-            [
-            'post_type'     => 'post',
-            'post_title'     => 'ConvertKit: Default Form: Category Created before 1.9.6.0',
-            'tax_input' => [
-            [ 'category' => $termID ],
-            ],
-            ]
-        );
-
-        // Load the Post on the frontend site.
-        $I->amOnPage('/?p=' . $postID);
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Confirm that the ConvertKit Form displays as defined in the Plugin Settings.
-        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-    }
-
-    /**
-     * Test that the Default Form for Pages displays when the Default option is chosen via
-     * WordPress' Quick Edit functionality.
-     * 
-     * @since 1.9.8.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testQuickEditUsingDefaultForm(AcceptanceTester $I)
-    {
-        // Specify the Default Form in the Plugin Settings.
-        $I->setupConvertKitPluginDefaultForm($I);
-
-        // Programmatically create a Post.
-        $postID = $I->havePostInDatabase(
-            [
-            'post_type'     => 'post',
-            'post_title'     => 'ConvertKit: Post: Form: Default: Quick Edit',
-            ]
-        );
-
-        // Quick Edit the Post in the Posts WP_List_Table.
-        $I->quickEdit(
-            $I, 'post', $postID, [
-            'form' => [ 'select', 'Default' ],
-            ]
-        );
-
-        // Load the Post on the frontend site.
-        $I->amOnPage('/?p='.$postID);
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Confirm that the ConvertKit Default Form displays.
-        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-    }
-
-    /**
-     * Test that the defined form displays when chosen via
-     * WordPress' Quick Edit functionality.
-     * 
-     * @since 1.9.8.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testQuickEditUsingDefinedForm(AcceptanceTester $I)
-    {
-        // Programmatically create a Post.
-        $postID = $I->havePostInDatabase(
-            [
-            'post_type'     => 'post',
-            'post_title'     => 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
-            ]
-        );
-
-        // Quick Edit the Post in the Posts WP_List_Table.
-        $I->quickEdit(
-            $I, 'post', $postID, [
-            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-            ]
-        );
-
-        // Load the Post on the frontend site.
-        $I->amOnPage('/?p='.$postID);
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Confirm that the ConvertKit Default Form displays.
-        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-    }
-
-    /**
-     * Test that the Default Form for Posts displays when the Default option is chosen via
-     * WordPress' Bulk Edit functionality.
-     * 
-     * @since 1.9.8.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBulkEditUsingDefaultForm(AcceptanceTester $I)
-    {
-        // Specify the Default Form in the Plugin Settings.
-        $I->setupConvertKitPluginDefaultForm($I);
-
-        // Programmatically create two Posts.
-        $postIDs = array(
-        $I->havePostInDatabase(
-            [
-            'post_type'     => 'post',
-            'post_title'     => 'ConvertKit: Post: Form: Default: Bulk Edit #1',
-            ]
-        ),
-        $I->havePostInDatabase(
-            [
-            'post_type'     => 'post',
-            'post_title'     => 'ConvertKit: Post: Form: Default: Bulk Edit #2',
-            ]
-        )
-        );
-
-        // Bulk Edit the Posts in the Posts WP_List_Table.
-        $I->bulkEdit(
-            $I, 'post', $postIDs, [
-            'form' => [ 'select', 'Default' ],
-            ]
-        );
-
-        // Iterate through Posts to run frontend tests.
-        foreach ($postIDs as $postID) {
-            // Load Post on the frontend site.
-            $I->amOnPage('/?p='.$postID);
-
-            // Check that no PHP warnings or notices were output.
-            $I->checkNoWarningsAndNoticesOnScreen($I);
-
-            // Confirm that the ConvertKit Default Form displays.
-            $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-        }
-    }
-
-    /**
-     * Test that the defined form displays when chosen via
-     * WordPress' Bulk Edit functionality.
-     * 
-     * @since 1.9.8.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBulkEditUsingDefinedForm(AcceptanceTester $I)
-    {
-        // Programmatically create two Posts.
-        $postIDs = array(
-        $I->havePostInDatabase(
-            [
-            'post_type'     => 'post',
-            'post_title'     => 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
-            ]
-        ),
-        $I->havePostInDatabase(
-            [
-            'post_type'     => 'post',
-            'post_title'     => 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
-            ]
-        )
-        );
-
-        // Bulk Edit the Posts in the Posts WP_List_Table.
-        $I->bulkEdit(
-            $I, 'post', $postIDs, [
-            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-            ]
-        );
-
-        // Iterate through Posts to run frontend tests.
-        foreach ($postIDs as $postID) {
-            // Load Post on the frontend site.
-            $I->amOnPage('/?p='.$postID);
-
-            // Check that no PHP warnings or notices were output.
-            $I->checkNoWarningsAndNoticesOnScreen($I);
-
-            // Confirm that the ConvertKit Form displays.
-            $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-        }
-    }
-
-    /**
-     * Test that the existing settings are honored and not changed
-     * when the Bulk Edit options are set to 'No Change'.
-     * 
-     * @since 1.9.8.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBulkEditWithNoChanges(AcceptanceTester $I)
-    {
-        // Programmatically create two Posts with a defined form.
-        $postIDs = array(
-        $I->havePostInDatabase(
-            [
-            'post_type'     => 'post',
-            'post_title'     => 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #1',
-            'meta_input'    => [
-            '_wp_convertkit_post_meta' => [
-            'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
-            'landing_page' => '',
-            'tag'          => '',
-            ]
-            ],
-            ]
-        ),
-        $I->havePostInDatabase(
-            [
-            'post_type'     => 'post',
-            'post_title'     => 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
-            'meta_input'    => [
-            '_wp_convertkit_post_meta' => [
-            'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
-            'landing_page' => '',
-            'tag'          => '',
-            ]
-            ],
-            ]
-        )
-        );
-
-        // Bulk Edit the Posts in the Posts WP_List_Table.
-        $I->bulkEdit(
-            $I, 'post', $postIDs, [
-            'form' => [ 'select', '— No Change —' ],
-            ]
-        );
-
-        // Iterate through Posts to run frontend tests.
-        foreach ($postIDs as $postID) {
-            // Load Post on the frontend site.
-            $I->amOnPage('/?p='.$postID);
-
-            // Check that no PHP warnings or notices were output.
-            $I->checkNoWarningsAndNoticesOnScreen($I);
-
-            // Confirm that the ConvertKit Form displays.
-            $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-        }
-    }
-
-    /**
-     * Test that the Bulk Edit fields do not display when a search on a WP_List_Table
-     * returns no results.
-     * 
-     * @since 1.9.8.1
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBulkEditFieldsHiddenWhenNoPostsFound(AcceptanceTester $I)
-    {
-        // Emulate the user searching for Posts with a query string that yields no results.
-        $I->amOnAdminPage('edit.php?post_type=post&s=nothing');
-
-        // Confirm that the Bulk Edit fields do not display.
-        $I->dontSeeElement('#convertkit-bulk-edit');
-    }
-
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+class PostFormCest {
+
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		// Activate and Setup ConvertKit plugin
+		$I->activateConvertKitPlugin( $I );
+		$I->setupConvertKitPlugin( $I );
+		$I->enableDebugLog( $I );
+	}
+
+	/**
+	 * Test that the Posts > Add New screen has expected a11y output, such as label[for].
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAccessibility( AcceptanceTester $I ) {
+		// Navigate to Post Type (e.g. Pages / Posts) > Add New
+		$I->amOnAdminPage( 'post-new.php?post_type=post' );
+
+		// Confirm that settings have label[for] attributes.
+		$I->seeInSource( '<label for="wp-convertkit-form">' );
+		$I->seeInSource( '<label for="wp-convertkit-tag">' );
+	}
+
+	/**
+	 * Test that the 'Default' option for the Default Form setting in the Plugin Settings works when
+	 * creating and viewing a new WordPress Post, and there is no Default Form specified in the Plugin
+	 * settings.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewPostUsingDefaultFormWithNoDefaultFormSpecifiedInPlugin( AcceptanceTester $I ) {
+		// Add a Post using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'post', 'ConvertKit: Post: Form: Default: None' );
+
+		// Configure metabox's Form setting = Default.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'form' => array( 'select2', 'Default' ),
+			)
+		);
+
+		// Publish and view the Post on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
+
+		// Confirm that no ConvertKit Form is displayed.
+		$I->dontSeeElementInDOM( 'form[data-sv-form]' );
+	}
+
+	/**
+	 * Test that the Default Form specified in the Plugin Settings works when
+	 * creating and viewing a new WordPress Post.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewPostUsingDefaultForm( AcceptanceTester $I ) {
+		// Specify the Default Form in the Plugin Settings.
+		$defaultFormID = $I->setupConvertKitPluginDefaultForm( $I );
+
+		// Add a Post using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'post', 'ConvertKit: Post: Form: Default' );
+
+		// Configure metabox's Form setting = Default.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'form' => array( 'select2', 'Default' ),
+			)
+		);
+
+		// Publish and view the Post on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
+
+		// Confirm that the ConvertKit Default Form displays.
+		$I->seeElementInDOM( 'form[data-sv-form="' . $defaultFormID . '"]' );
+	}
+
+	/**
+	 * Test that the Default Legacy Form specified in the Plugin Settings works when
+	 * creating and viewing a new WordPress Post.
+	 *
+	 * @since 1.9.6.3
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewPostUsingDefaultLegacyForm( AcceptanceTester $I ) {
+		// Specify the Default Legacy Form in the Plugin Settings.
+		$defaultLegacyFormID = $I->setupConvertKitPluginDefaultLegacyForm( $I );
+
+		// Add a Post using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'post', 'ConvertKit: Post: Form: Legacy: Default' );
+
+		// Configure metabox's Form setting = Default.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'form' => array( 'select2', 'Default' ),
+			)
+		);
+
+		// Publish and view the Post on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
+
+		// Confirm that the ConvertKit Default Legacy Form displays.
+		$I->seeInSource( '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $defaultLegacyFormID . '/subscribe" data-remote="true">' );
+	}
+
+	/**
+	 * Test that 'None' Form specified in the Post Settings works when
+	 * creating and viewing a new WordPress Post.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewPostUsingNoForm( AcceptanceTester $I ) {
+		// Add a Post using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'post', 'ConvertKit: Post: Form: None' );
+
+		// Configure metabox's Form setting = None.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'form' => array( 'select2', 'None' ),
+			)
+		);
+
+		// Publish and view the Post on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
+
+		// Confirm that no ConvertKit Form is displayed.
+		$I->dontSeeElementInDOM( 'form[data-sv-form]' );
+	}
+
+	/**
+	 * Test that the Form specified in the Post Settings works when
+	 * creating and viewing a new WordPress Post.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewPostUsingDefinedForm( AcceptanceTester $I ) {
+		// Add a Post using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'post', 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] );
+
+		// Configure metabox's Form setting = None.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'form' => array( 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
+			)
+		);
+
+		// Publish and view the Post on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
+
+		// Confirm that the ConvertKit Form displays.
+		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+	}
+
+	/**
+	 * Test that the Legacy Form specified in the Post Settings works when
+	 * creating and viewing a new WordPress Post.
+	 *
+	 * @since 1.9.6.3
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewPostUsingDefinedLegacyForm( AcceptanceTester $I ) {
+		// Add a Post using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'post', 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] );
+
+		// Configure metabox's Form setting = None.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'form' => array( 'select2', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ),
+			)
+		);
+
+		// Publish and view the Post on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
+
+		// Confirm that the ConvertKit Legacy Form displays.
+		$I->seeInSource( '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">' );
+	}
+
+	/**
+	 * Test that the Default Form for Posts displays when an invalid Form ID is specified
+	 * for a Post.
+	 *
+	 * Whilst the on screen options won't permit selecting an invalid Form ID, a Post might
+	 * have an invalid Form ID because:
+	 * - the form belongs to another ConvertKit account (i.e. API credentials were changed in the Plugin, but this Post's specified Form was not changed)
+	 * - the form was deleted from the ConvertKit account.
+	 *
+	 * @since 1.9.7.2
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewPostUsingInvalidDefinedForm( AcceptanceTester $I ) {
+		// Setup the Default Form for Pages and Posts.
+		$I->setupConvertKitPluginDefaultForm( $I );
+
+		// Create Post, with an invalid Form ID, as if it were created prior to API credentials being changed and/or
+		// a Form being deleted in ConvertKit.
+		$postID = $I->havePostInDatabase(
+			array(
+				'post_type'  => 'post',
+				'post_title' => 'ConvertKit: Post: Form: Specific: Invalid',
+				'meta_input' => array(
+					'_wp_convertkit_post_meta' => array(
+						'form'         => '11111',
+						'landing_page' => '',
+						'tag'          => '',
+					),
+				),
+			)
+		);
+
+		// Load the Post on the frontend site.
+		$I->amOnPage( '/?p=' . $postID );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Confirm that the invalid ConvertKit Form does not display.
+		$I->dontSeeElementInDOM( 'form[data-sv-form="11111"]' );
+
+		// Confirm that the Default Form for Posts does display as a fallback.
+		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+	}
+
+	/**
+	 * Test that the Form specified in the Category assigned to the WordPress Post is used when the WordPress Post
+	 * is set to use the Default Form.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewPostUsingDefaultFormWithCategoryFormSpecified( AcceptanceTester $I ) {
+		// Create Category.
+		$termID = $I->haveTermInDatabase( 'ConvertKit', 'category' );
+		$termID = $termID[0];
+
+		// Create Post, assigned to ConvertKit Category.
+		$postID = $I->havePostInDatabase(
+			array(
+				'post_type'  => 'post',
+				'post_title' => 'ConvertKit Form inherited from ConvertKit Category',
+				'tax_input'  => array(
+					array( 'category' => $termID ),
+				),
+			)
+		);
+
+		// Edit the Term, defining a Form.
+		$I->amOnAdminPage( 'term.php?taxonomy=category&tag_ID=' . $termID );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Check that the Form option is displayed.
+		$I->seeElementInDOM( '#wp-convertkit-form' );
+
+		// Change Form to value specified in the .env file.
+		$I->fillSelect2Field( $I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+
+		// Click Update
+		$I->click( 'Update' );
+
+		// Check that the update succeeded.
+		$I->seeElementInDOM( 'div.notice-success' );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Load the Post on the frontend site
+		$I->amOnPage( '/?p=' . $postID );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Confirm that the ConvertKit Form displays.
+		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+	}
+
+	/**
+	 * Test that the Default Form specified at Plugin level for Posts displays when:
+	 * - A Category was created with ConvertKit Form = 'None' when 1.9.5.2 or earlier of the Plugin was activated,
+	 * - The WordPress Post is set to use the Default Form,
+	 * - A Default Form is set in the Plugin settings.
+	 *
+	 * 1.9.5.2 and earlier stored the 'None' option as 'default' for Categories, meaning that the Post (or Plugin) default form
+	 * should be used.
+	 *
+	 * 1.9.6.0 and later changed the value to 0 for Categories, bringing it in line with the Post Form's 'None'
+	 * setting.
+	 *
+	 * @since 1.9.7.3
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewPostUsingDefaultFormWithCategoryCreatedBefore1960( AcceptanceTester $I ) {
+		// Setup Default Forms.
+		$I->setupConvertKitPluginDefaultForm( $I );
+
+		// Create Category as if it were created / edited when the ConvertKit Plugin < 1.9.6.0
+		// was active.
+		$termID = $I->haveTermInDatabase(
+			'ConvertKit 1.9.5.2 and earlier',
+			'category',
+			array(
+				'meta' => array(
+					'ck_default_form' => 'default', // Emulate how 1.9.5.2 and earlier store this setting.
+				),
+			)
+		);
+		$termID = $termID[0];
+
+		// Create Post, assigned to Category.
+		$postID = $I->havePostInDatabase(
+			array(
+				'post_type'  => 'post',
+				'post_title' => 'ConvertKit: Default Form: Category Created before 1.9.6.0',
+				'tax_input'  => array(
+					array( 'category' => $termID ),
+				),
+			)
+		);
+
+		// Load the Post on the frontend site.
+		$I->amOnPage( '/?p=' . $postID );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Confirm that the ConvertKit Form displays as defined in the Plugin Settings.
+		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+	}
+
+	/**
+	 * Test that the Default Form for Pages displays when the Default option is chosen via
+	 * WordPress' Quick Edit functionality.
+	 *
+	 * @since 1.9.8.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testQuickEditUsingDefaultForm( AcceptanceTester $I ) {
+		// Specify the Default Form in the Plugin Settings.
+		$I->setupConvertKitPluginDefaultForm( $I );
+
+		// Programmatically create a Post.
+		$postID = $I->havePostInDatabase(
+			array(
+				'post_type'  => 'post',
+				'post_title' => 'ConvertKit: Post: Form: Default: Quick Edit',
+			)
+		);
+
+		// Quick Edit the Post in the Posts WP_List_Table.
+		$I->quickEdit(
+			$I,
+			'post',
+			$postID,
+			array(
+				'form' => array( 'select', 'Default' ),
+			)
+		);
+
+		// Load the Post on the frontend site.
+		$I->amOnPage( '/?p=' . $postID );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Confirm that the ConvertKit Default Form displays.
+		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+	}
+
+	/**
+	 * Test that the defined form displays when chosen via
+	 * WordPress' Quick Edit functionality.
+	 *
+	 * @since 1.9.8.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testQuickEditUsingDefinedForm( AcceptanceTester $I ) {
+		// Programmatically create a Post.
+		$postID = $I->havePostInDatabase(
+			array(
+				'post_type'  => 'post',
+				'post_title' => 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
+			)
+		);
+
+		// Quick Edit the Post in the Posts WP_List_Table.
+		$I->quickEdit(
+			$I,
+			'post',
+			$postID,
+			array(
+				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
+			)
+		);
+
+		// Load the Post on the frontend site.
+		$I->amOnPage( '/?p=' . $postID );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Confirm that the ConvertKit Default Form displays.
+		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+	}
+
+	/**
+	 * Test that the Default Form for Posts displays when the Default option is chosen via
+	 * WordPress' Bulk Edit functionality.
+	 *
+	 * @since 1.9.8.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBulkEditUsingDefaultForm( AcceptanceTester $I ) {
+		// Specify the Default Form in the Plugin Settings.
+		$I->setupConvertKitPluginDefaultForm( $I );
+
+		// Programmatically create two Posts.
+		$postIDs = array(
+			$I->havePostInDatabase(
+				array(
+					'post_type'  => 'post',
+					'post_title' => 'ConvertKit: Post: Form: Default: Bulk Edit #1',
+				)
+			),
+			$I->havePostInDatabase(
+				array(
+					'post_type'  => 'post',
+					'post_title' => 'ConvertKit: Post: Form: Default: Bulk Edit #2',
+				)
+			),
+		);
+
+		// Bulk Edit the Posts in the Posts WP_List_Table.
+		$I->bulkEdit(
+			$I,
+			'post',
+			$postIDs,
+			array(
+				'form' => array( 'select', 'Default' ),
+			)
+		);
+
+		// Iterate through Posts to run frontend tests.
+		foreach ( $postIDs as $postID ) {
+			// Load Post on the frontend site.
+			$I->amOnPage( '/?p=' . $postID );
+
+			// Check that no PHP warnings or notices were output.
+			$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+			// Confirm that the ConvertKit Default Form displays.
+			$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		}
+	}
+
+	/**
+	 * Test that the defined form displays when chosen via
+	 * WordPress' Bulk Edit functionality.
+	 *
+	 * @since 1.9.8.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBulkEditUsingDefinedForm( AcceptanceTester $I ) {
+		// Programmatically create two Posts.
+		$postIDs = array(
+			$I->havePostInDatabase(
+				array(
+					'post_type'  => 'post',
+					'post_title' => 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
+				)
+			),
+			$I->havePostInDatabase(
+				array(
+					'post_type'  => 'post',
+					'post_title' => 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
+				)
+			),
+		);
+
+		// Bulk Edit the Posts in the Posts WP_List_Table.
+		$I->bulkEdit(
+			$I,
+			'post',
+			$postIDs,
+			array(
+				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
+			)
+		);
+
+		// Iterate through Posts to run frontend tests.
+		foreach ( $postIDs as $postID ) {
+			// Load Post on the frontend site.
+			$I->amOnPage( '/?p=' . $postID );
+
+			// Check that no PHP warnings or notices were output.
+			$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+			// Confirm that the ConvertKit Form displays.
+			$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		}
+	}
+
+	/**
+	 * Test that the existing settings are honored and not changed
+	 * when the Bulk Edit options are set to 'No Change'.
+	 *
+	 * @since 1.9.8.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBulkEditWithNoChanges( AcceptanceTester $I ) {
+		// Programmatically create two Posts with a defined form.
+		$postIDs = array(
+			$I->havePostInDatabase(
+				array(
+					'post_type'  => 'post',
+					'post_title' => 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #1',
+					'meta_input' => array(
+						'_wp_convertkit_post_meta' => array(
+							'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
+							'landing_page' => '',
+							'tag'          => '',
+						),
+					),
+				)
+			),
+			$I->havePostInDatabase(
+				array(
+					'post_type'  => 'post',
+					'post_title' => 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
+					'meta_input' => array(
+						'_wp_convertkit_post_meta' => array(
+							'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
+							'landing_page' => '',
+							'tag'          => '',
+						),
+					),
+				)
+			),
+		);
+
+		// Bulk Edit the Posts in the Posts WP_List_Table.
+		$I->bulkEdit(
+			$I,
+			'post',
+			$postIDs,
+			array(
+				'form' => array( 'select', '— No Change —' ),
+			)
+		);
+
+		// Iterate through Posts to run frontend tests.
+		foreach ( $postIDs as $postID ) {
+			// Load Post on the frontend site.
+			$I->amOnPage( '/?p=' . $postID );
+
+			// Check that no PHP warnings or notices were output.
+			$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+			// Confirm that the ConvertKit Form displays.
+			$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		}
+	}
+
+	/**
+	 * Test that the Bulk Edit fields do not display when a search on a WP_List_Table
+	 * returns no results.
+	 *
+	 * @since 1.9.8.1
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBulkEditFieldsHiddenWhenNoPostsFound( AcceptanceTester $I ) {
+		// Emulate the user searching for Posts with a query string that yields no results.
+		$I->amOnAdminPage( 'edit.php?post_type=post&s=nothing' );
+
+		// Confirm that the Bulk Edit fields do not display.
+		$I->dontSeeElement( '#convertkit-bulk-edit' );
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/forms/PostFormCest.php
+++ b/tests/acceptance/forms/PostFormCest.php
@@ -1,636 +1,579 @@
 <?php
 /**
  * Tests for ConvertKit Forms on WordPress Posts.
- *
- * @since 1.9.6
+ * 
+ * @since 	1.9.6
  */
-class PostFormCest {
-
+class PostFormCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
+	public function _before(AcceptanceTester $I)
+	{
 		// Activate and Setup ConvertKit plugin
-		$I->activateConvertKitPlugin( $I );
-		$I->setupConvertKitPlugin( $I );
-		$I->enableDebugLog( $I );
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
 	}
 
 	/**
 	 * Test that the Posts > Add New screen has expected a11y output, such as label[for].
-	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAccessibility( AcceptanceTester $I ) {
+	public function testAccessibility(AcceptanceTester $I)
+	{
 		// Navigate to Post Type (e.g. Pages / Posts) > Add New
-		$I->amOnAdminPage( 'post-new.php?post_type=post' );
+		$I->amOnAdminPage('post-new.php?post_type=post');
 
 		// Confirm that settings have label[for] attributes.
-		$I->seeInSource( '<label for="wp-convertkit-form">' );
-		$I->seeInSource( '<label for="wp-convertkit-tag">' );
+		$I->seeInSource('<label for="wp-convertkit-form">');
+		$I->seeInSource('<label for="wp-convertkit-tag">');
 	}
 
 	/**
 	 * Test that the 'Default' option for the Default Form setting in the Plugin Settings works when
 	 * creating and viewing a new WordPress Post, and there is no Default Form specified in the Plugin
 	 * settings.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewPostUsingDefaultFormWithNoDefaultFormSpecifiedInPlugin( AcceptanceTester $I ) {
+	public function testAddNewPostUsingDefaultFormWithNoDefaultFormSpecifiedInPlugin(AcceptanceTester $I)
+	{
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'post', 'ConvertKit: Post: Form: Default: None' );
+		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: Default: None');
 
 		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'form' => array( 'select2', 'Default' ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'Default' ],
+		]);
 
 		// Publish and view the Post on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that no ConvertKit Form is displayed.
-		$I->dontSeeElementInDOM( 'form[data-sv-form]' );
+		$I->dontSeeElementInDOM('form[data-sv-form]');
 	}
 
 	/**
 	 * Test that the Default Form specified in the Plugin Settings works when
 	 * creating and viewing a new WordPress Post.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewPostUsingDefaultForm( AcceptanceTester $I ) {
+	public function testAddNewPostUsingDefaultForm(AcceptanceTester $I)
+	{
 		// Specify the Default Form in the Plugin Settings.
-		$defaultFormID = $I->setupConvertKitPluginDefaultForm( $I );
+		$defaultFormID = $I->setupConvertKitPluginDefaultForm($I);
 
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'post', 'ConvertKit: Post: Form: Default' );
+		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: Default');
 
 		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'form' => array( 'select2', 'Default' ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'Default' ],
+		]);
 
 		// Publish and view the Post on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the ConvertKit Default Form displays.
-		$I->seeElementInDOM( 'form[data-sv-form="' . $defaultFormID . '"]' );
+		$I->seeElementInDOM('form[data-sv-form="' . $defaultFormID . '"]');
 	}
 
 	/**
 	 * Test that the Default Legacy Form specified in the Plugin Settings works when
 	 * creating and viewing a new WordPress Post.
-	 *
-	 * @since 1.9.6.3
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewPostUsingDefaultLegacyForm( AcceptanceTester $I ) {
+	public function testAddNewPostUsingDefaultLegacyForm(AcceptanceTester $I)
+	{
 		// Specify the Default Legacy Form in the Plugin Settings.
-		$defaultLegacyFormID = $I->setupConvertKitPluginDefaultLegacyForm( $I );
+		$defaultLegacyFormID = $I->setupConvertKitPluginDefaultLegacyForm($I);
 
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'post', 'ConvertKit: Post: Form: Legacy: Default' );
+		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: Legacy: Default');
 
 		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'form' => array( 'select2', 'Default' ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'Default' ],
+		]);
 
 		// Publish and view the Post on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the ConvertKit Default Legacy Form displays.
-		$I->seeInSource( '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $defaultLegacyFormID . '/subscribe" data-remote="true">' );
+		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $defaultLegacyFormID . '/subscribe" data-remote="true">');
 	}
 
 	/**
 	 * Test that 'None' Form specified in the Post Settings works when
 	 * creating and viewing a new WordPress Post.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewPostUsingNoForm( AcceptanceTester $I ) {
+	public function testAddNewPostUsingNoForm(AcceptanceTester $I)
+	{
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'post', 'ConvertKit: Post: Form: None' );
+		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: None');
 
 		// Configure metabox's Form setting = None.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'form' => array( 'select2', 'None' ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'None' ],
+		]);
 
 		// Publish and view the Post on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that no ConvertKit Form is displayed.
-		$I->dontSeeElementInDOM( 'form[data-sv-form]' );
+		$I->dontSeeElementInDOM('form[data-sv-form]');
 	}
 
 	/**
 	 * Test that the Form specified in the Post Settings works when
 	 * creating and viewing a new WordPress Post.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewPostUsingDefinedForm( AcceptanceTester $I ) {
+	public function testAddNewPostUsingDefinedForm(AcceptanceTester $I)
+	{
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'post', 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] );
+		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME']);
 
 		// Configure metabox's Form setting = None.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'form' => array( 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+		]);
 
 		// Publish and view the Post on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the ConvertKit Form displays.
-		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 	}
 
 	/**
 	 * Test that the Legacy Form specified in the Post Settings works when
 	 * creating and viewing a new WordPress Post.
-	 *
-	 * @since 1.9.6.3
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewPostUsingDefinedLegacyForm( AcceptanceTester $I ) {
+	public function testAddNewPostUsingDefinedLegacyForm(AcceptanceTester $I)
+	{
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'post', 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] );
+		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
 
 		// Configure metabox's Form setting = None.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'form' => array( 'select2', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
+		]);
 
 		// Publish and view the Post on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the ConvertKit Legacy Form displays.
-		$I->seeInSource( '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">' );
+		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
 	}
 
 	/**
 	 * Test that the Default Form for Posts displays when an invalid Form ID is specified
 	 * for a Post.
-	 *
+	 * 
 	 * Whilst the on screen options won't permit selecting an invalid Form ID, a Post might
 	 * have an invalid Form ID because:
 	 * - the form belongs to another ConvertKit account (i.e. API credentials were changed in the Plugin, but this Post's specified Form was not changed)
 	 * - the form was deleted from the ConvertKit account.
-	 *
-	 * @since 1.9.7.2
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewPostUsingInvalidDefinedForm( AcceptanceTester $I ) {
+	public function testAddNewPostUsingInvalidDefinedForm(AcceptanceTester $I)
+	{
 		// Setup the Default Form for Pages and Posts.
-		$I->setupConvertKitPluginDefaultForm( $I );
+		$I->setupConvertKitPluginDefaultForm($I);
 
 		// Create Post, with an invalid Form ID, as if it were created prior to API credentials being changed and/or
 		// a Form being deleted in ConvertKit.
-		$postID = $I->havePostInDatabase(
-			array(
-				'post_type'  => 'post',
-				'post_title' => 'ConvertKit: Post: Form: Specific: Invalid',
-				'meta_input' => array(
-					'_wp_convertkit_post_meta' => array(
-						'form'         => '11111',
-						'landing_page' => '',
-						'tag'          => '',
-					),
-				),
-			)
-		);
+		$postID = $I->havePostInDatabase([
+			'post_type' 	=> 'post',
+			'post_title' 	=> 'ConvertKit: Post: Form: Specific: Invalid',
+			'meta_input'	=> [
+				'_wp_convertkit_post_meta' => [
+					'form'         => '11111',
+					'landing_page' => '',
+					'tag'          => '',
+				]
+			],
+		]);
 
 		// Load the Post on the frontend site.
-		$I->amOnPage( '/?p=' . $postID );
+		$I->amOnPage('/?p='.$postID);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the invalid ConvertKit Form does not display.
-		$I->dontSeeElementInDOM( 'form[data-sv-form="11111"]' );
+		$I->dontSeeElementInDOM('form[data-sv-form="11111"]');
 
 		// Confirm that the Default Form for Posts does display as a fallback.
-		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 	}
 
 	/**
 	 * Test that the Form specified in the Category assigned to the WordPress Post is used when the WordPress Post
 	 * is set to use the Default Form.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewPostUsingDefaultFormWithCategoryFormSpecified( AcceptanceTester $I ) {
+	public function testAddNewPostUsingDefaultFormWithCategoryFormSpecified(AcceptanceTester $I)
+	{
 		// Create Category.
 		$termID = $I->haveTermInDatabase( 'ConvertKit', 'category' );
 		$termID = $termID[0];
-
+		
 		// Create Post, assigned to ConvertKit Category.
-		$postID = $I->havePostInDatabase(
-			array(
-				'post_type'  => 'post',
-				'post_title' => 'ConvertKit Form inherited from ConvertKit Category',
-				'tax_input'  => array(
-					array( 'category' => $termID ),
-				),
-			)
-		);
+		$postID = $I->havePostInDatabase([
+			'post_type' 	=> 'post',
+			'post_title' 	=> 'ConvertKit Form inherited from ConvertKit Category',
+			'tax_input' => [
+				[ 'category' => $termID ],
+			],
+		]);
 
 		// Edit the Term, defining a Form.
-		$I->amOnAdminPage( 'term.php?taxonomy=category&tag_ID=' . $termID );
+		$I->amOnAdminPage('term.php?taxonomy=category&tag_ID=' . $termID);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check that the Form option is displayed.
-		$I->seeElementInDOM( '#wp-convertkit-form' );
+		$I->seeElementInDOM('#wp-convertkit-form');
 
 		// Change Form to value specified in the .env file.
-		$I->fillSelect2Field( $I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
 		// Click Update
-		$I->click( 'Update' );
+		$I->click('Update');
 
 		// Check that the update succeeded.
-		$I->seeElementInDOM( 'div.notice-success' );
+		$I->seeElementInDOM('div.notice-success');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Load the Post on the frontend site
-		$I->amOnPage( '/?p=' . $postID );
+		$I->amOnPage('/?p=' . $postID);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the ConvertKit Form displays.
-		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 	}
 
-	/**
+  	/**
 	 * Test that the Default Form specified at Plugin level for Posts displays when:
 	 * - A Category was created with ConvertKit Form = 'None' when 1.9.5.2 or earlier of the Plugin was activated,
 	 * - The WordPress Post is set to use the Default Form,
 	 * - A Default Form is set in the Plugin settings.
-	 *
+	 * 
 	 * 1.9.5.2 and earlier stored the 'None' option as 'default' for Categories, meaning that the Post (or Plugin) default form
-	 * should be used.
-	 *
+	 * should be used. 
+	 * 
 	 * 1.9.6.0 and later changed the value to 0 for Categories, bringing it in line with the Post Form's 'None'
 	 * setting.
-	 *
-	 * @since 1.9.7.3
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewPostUsingDefaultFormWithCategoryCreatedBefore1960( AcceptanceTester $I ) {
+	public function testAddNewPostUsingDefaultFormWithCategoryCreatedBefore1960(AcceptanceTester $I)
+	{
 		// Setup Default Forms.
-		$I->setupConvertKitPluginDefaultForm( $I );
+		$I->setupConvertKitPluginDefaultForm($I);
 
 		// Create Category as if it were created / edited when the ConvertKit Plugin < 1.9.6.0
 		// was active.
-		$termID = $I->haveTermInDatabase(
-			'ConvertKit 1.9.5.2 and earlier',
-			'category',
-			array(
-				'meta' => array(
-					'ck_default_form' => 'default', // Emulate how 1.9.5.2 and earlier store this setting.
-				),
-			)
-		);
+		$termID = $I->haveTermInDatabase( 'ConvertKit 1.9.5.2 and earlier', 'category', [
+			'meta' => [
+				'ck_default_form' => 'default', // Emulate how 1.9.5.2 and earlier store this setting.
+			],
+		] );
 		$termID = $termID[0];
-
+		
 		// Create Post, assigned to Category.
-		$postID = $I->havePostInDatabase(
-			array(
-				'post_type'  => 'post',
-				'post_title' => 'ConvertKit: Default Form: Category Created before 1.9.6.0',
-				'tax_input'  => array(
-					array( 'category' => $termID ),
-				),
-			)
-		);
+		$postID = $I->havePostInDatabase([
+			'post_type' 	=> 'post',
+			'post_title' 	=> 'ConvertKit: Default Form: Category Created before 1.9.6.0',
+			'tax_input' => [
+				[ 'category' => $termID ],
+			],
+		]);
 
 		// Load the Post on the frontend site.
-		$I->amOnPage( '/?p=' . $postID );
+		$I->amOnPage('/?p=' . $postID);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the ConvertKit Form displays as defined in the Plugin Settings.
-		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 	}
 
 	/**
 	 * Test that the Default Form for Pages displays when the Default option is chosen via
 	 * WordPress' Quick Edit functionality.
-	 *
-	 * @since 1.9.8.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testQuickEditUsingDefaultForm( AcceptanceTester $I ) {
+	public function testQuickEditUsingDefaultForm(AcceptanceTester $I)
+	{
 		// Specify the Default Form in the Plugin Settings.
-		$I->setupConvertKitPluginDefaultForm( $I );
+		$I->setupConvertKitPluginDefaultForm($I);
 
 		// Programmatically create a Post.
-		$postID = $I->havePostInDatabase(
-			array(
-				'post_type'  => 'post',
-				'post_title' => 'ConvertKit: Post: Form: Default: Quick Edit',
-			)
-		);
+		$postID = $I->havePostInDatabase([
+			'post_type' 	=> 'post',
+			'post_title' 	=> 'ConvertKit: Post: Form: Default: Quick Edit',
+		]);
 
 		// Quick Edit the Post in the Posts WP_List_Table.
-		$I->quickEdit(
-			$I,
-			'post',
-			$postID,
-			array(
-				'form' => array( 'select', 'Default' ),
-			)
-		);
+		$I->quickEdit($I, 'post', $postID, [
+			'form' => [ 'select', 'Default' ],
+		]);
 
 		// Load the Post on the frontend site.
-		$I->amOnPage( '/?p=' . $postID );
+		$I->amOnPage('/?p='.$postID);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the ConvertKit Default Form displays.
-		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 	}
 
 	/**
 	 * Test that the defined form displays when chosen via
 	 * WordPress' Quick Edit functionality.
-	 *
-	 * @since 1.9.8.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testQuickEditUsingDefinedForm( AcceptanceTester $I ) {
+	public function testQuickEditUsingDefinedForm(AcceptanceTester $I)
+	{
 		// Programmatically create a Post.
-		$postID = $I->havePostInDatabase(
-			array(
-				'post_type'  => 'post',
-				'post_title' => 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
-			)
-		);
+		$postID = $I->havePostInDatabase([
+			'post_type' 	=> 'post',
+			'post_title' 	=> 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
+		]);
 
 		// Quick Edit the Post in the Posts WP_List_Table.
-		$I->quickEdit(
-			$I,
-			'post',
-			$postID,
-			array(
-				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
-			)
-		);
+		$I->quickEdit($I, 'post', $postID, [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+		]);
 
 		// Load the Post on the frontend site.
-		$I->amOnPage( '/?p=' . $postID );
+		$I->amOnPage('/?p='.$postID);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the ConvertKit Default Form displays.
-		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 	}
 
 	/**
 	 * Test that the Default Form for Posts displays when the Default option is chosen via
 	 * WordPress' Bulk Edit functionality.
-	 *
-	 * @since 1.9.8.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBulkEditUsingDefaultForm( AcceptanceTester $I ) {
+	public function testBulkEditUsingDefaultForm(AcceptanceTester $I)
+	{
 		// Specify the Default Form in the Plugin Settings.
-		$I->setupConvertKitPluginDefaultForm( $I );
+		$I->setupConvertKitPluginDefaultForm($I);
 
 		// Programmatically create two Posts.
 		$postIDs = array(
-			$I->havePostInDatabase(
-				array(
-					'post_type'  => 'post',
-					'post_title' => 'ConvertKit: Post: Form: Default: Bulk Edit #1',
-				)
-			),
-			$I->havePostInDatabase(
-				array(
-					'post_type'  => 'post',
-					'post_title' => 'ConvertKit: Post: Form: Default: Bulk Edit #2',
-				)
-			),
+			$I->havePostInDatabase([
+				'post_type' 	=> 'post',
+				'post_title' 	=> 'ConvertKit: Post: Form: Default: Bulk Edit #1',
+			]),
+			$I->havePostInDatabase([
+				'post_type' 	=> 'post',
+				'post_title' 	=> 'ConvertKit: Post: Form: Default: Bulk Edit #2',
+			])
 		);
 
 		// Bulk Edit the Posts in the Posts WP_List_Table.
-		$I->bulkEdit(
-			$I,
-			'post',
-			$postIDs,
-			array(
-				'form' => array( 'select', 'Default' ),
-			)
-		);
+		$I->bulkEdit($I, 'post', $postIDs, [
+			'form' => [ 'select', 'Default' ],
+		]);
 
 		// Iterate through Posts to run frontend tests.
-		foreach ( $postIDs as $postID ) {
+		foreach($postIDs as $postID) {
 			// Load Post on the frontend site.
-			$I->amOnPage( '/?p=' . $postID );
+			$I->amOnPage('/?p='.$postID);
 
 			// Check that no PHP warnings or notices were output.
-			$I->checkNoWarningsAndNoticesOnScreen( $I );
+			$I->checkNoWarningsAndNoticesOnScreen($I);
 
 			// Confirm that the ConvertKit Default Form displays.
-			$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+			$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 		}
 	}
 
 	/**
 	 * Test that the defined form displays when chosen via
 	 * WordPress' Bulk Edit functionality.
-	 *
-	 * @since 1.9.8.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBulkEditUsingDefinedForm( AcceptanceTester $I ) {
+	public function testBulkEditUsingDefinedForm(AcceptanceTester $I)
+	{
 		// Programmatically create two Posts.
 		$postIDs = array(
-			$I->havePostInDatabase(
-				array(
-					'post_type'  => 'post',
-					'post_title' => 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
-				)
-			),
-			$I->havePostInDatabase(
-				array(
-					'post_type'  => 'post',
-					'post_title' => 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
-				)
-			),
+			$I->havePostInDatabase([
+				'post_type' 	=> 'post',
+				'post_title' 	=> 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
+			]),
+			$I->havePostInDatabase([
+				'post_type' 	=> 'post',
+				'post_title' 	=> 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
+			])
 		);
 
 		// Bulk Edit the Posts in the Posts WP_List_Table.
-		$I->bulkEdit(
-			$I,
-			'post',
-			$postIDs,
-			array(
-				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
-			)
-		);
+		$I->bulkEdit($I, 'post', $postIDs, [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+		]);
 
 		// Iterate through Posts to run frontend tests.
-		foreach ( $postIDs as $postID ) {
+		foreach($postIDs as $postID) {
 			// Load Post on the frontend site.
-			$I->amOnPage( '/?p=' . $postID );
+			$I->amOnPage('/?p='.$postID);
 
 			// Check that no PHP warnings or notices were output.
-			$I->checkNoWarningsAndNoticesOnScreen( $I );
+			$I->checkNoWarningsAndNoticesOnScreen($I);
 
 			// Confirm that the ConvertKit Form displays.
-			$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+			$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 		}
 	}
 
 	/**
 	 * Test that the existing settings are honored and not changed
 	 * when the Bulk Edit options are set to 'No Change'.
-	 *
-	 * @since 1.9.8.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBulkEditWithNoChanges( AcceptanceTester $I ) {
+	public function testBulkEditWithNoChanges(AcceptanceTester $I)
+	{
 		// Programmatically create two Posts with a defined form.
 		$postIDs = array(
-			$I->havePostInDatabase(
-				array(
-					'post_type'  => 'post',
-					'post_title' => 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #1',
-					'meta_input' => array(
-						'_wp_convertkit_post_meta' => array(
-							'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
-							'landing_page' => '',
-							'tag'          => '',
-						),
-					),
-				)
-			),
-			$I->havePostInDatabase(
-				array(
-					'post_type'  => 'post',
-					'post_title' => 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
-					'meta_input' => array(
-						'_wp_convertkit_post_meta' => array(
-							'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
-							'landing_page' => '',
-							'tag'          => '',
-						),
-					),
-				)
-			),
+			$I->havePostInDatabase([
+				'post_type' 	=> 'post',
+				'post_title' 	=> 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #1',
+				'meta_input'	=> [
+					'_wp_convertkit_post_meta' => [
+						'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
+						'landing_page' => '',
+						'tag'          => '',
+					]
+				],
+			]),
+			$I->havePostInDatabase([
+				'post_type' 	=> 'post',
+				'post_title' 	=> 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
+				'meta_input'	=> [
+					'_wp_convertkit_post_meta' => [
+						'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
+						'landing_page' => '',
+						'tag'          => '',
+					]
+				],
+			])
 		);
 
 		// Bulk Edit the Posts in the Posts WP_List_Table.
-		$I->bulkEdit(
-			$I,
-			'post',
-			$postIDs,
-			array(
-				'form' => array( 'select', '— No Change —' ),
-			)
-		);
+		$I->bulkEdit($I, 'post', $postIDs, [
+			'form' => [ 'select', '— No Change —' ],
+		]);
 
 		// Iterate through Posts to run frontend tests.
-		foreach ( $postIDs as $postID ) {
+		foreach($postIDs as $postID) {
 			// Load Post on the frontend site.
-			$I->amOnPage( '/?p=' . $postID );
+			$I->amOnPage('/?p='.$postID);
 
 			// Check that no PHP warnings or notices were output.
-			$I->checkNoWarningsAndNoticesOnScreen( $I );
+			$I->checkNoWarningsAndNoticesOnScreen($I);
 
 			// Confirm that the ConvertKit Form displays.
-			$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+			$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 		}
 	}
 
 	/**
 	 * Test that the Bulk Edit fields do not display when a search on a WP_List_Table
 	 * returns no results.
-	 *
-	 * @since 1.9.8.1
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.1
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBulkEditFieldsHiddenWhenNoPostsFound( AcceptanceTester $I ) {
+	public function testBulkEditFieldsHiddenWhenNoPostsFound(AcceptanceTester $I)
+	{
 		// Emulate the user searching for Posts with a query string that yields no results.
-		$I->amOnAdminPage( 'edit.php?post_type=post&s=nothing' );
+		$I->amOnAdminPage('edit.php?post_type=post&s=nothing');
 
 		// Confirm that the Bulk Edit fields do not display.
-		$I->dontSeeElement( '#convertkit-bulk-edit' );
+		$I->dontSeeElement('#convertkit-bulk-edit');
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/forms/PostFormCest.php
+++ b/tests/acceptance/forms/PostFormCest.php
@@ -2,578 +2,624 @@
 /**
  * Tests for ConvertKit Forms on WordPress Posts.
  * 
- * @since 	1.9.6
+ * @since 1.9.6
  */
 class PostFormCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		// Activate and Setup ConvertKit plugin
-		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
-	}
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        // Activate and Setup ConvertKit plugin
+        $I->activateConvertKitPlugin($I);
+        $I->setupConvertKitPlugin($I);
+        $I->enableDebugLog($I);
+    }
 
-	/**
-	 * Test that the Posts > Add New screen has expected a11y output, such as label[for].
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAccessibility(AcceptanceTester $I)
-	{
-		// Navigate to Post Type (e.g. Pages / Posts) > Add New
-		$I->amOnAdminPage('post-new.php?post_type=post');
+    /**
+     * Test that the Posts > Add New screen has expected a11y output, such as label[for].
+     * 
+     * @since 1.9.7.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAccessibility(AcceptanceTester $I)
+    {
+        // Navigate to Post Type (e.g. Pages / Posts) > Add New
+        $I->amOnAdminPage('post-new.php?post_type=post');
 
-		// Confirm that settings have label[for] attributes.
-		$I->seeInSource('<label for="wp-convertkit-form">');
-		$I->seeInSource('<label for="wp-convertkit-tag">');
-	}
+        // Confirm that settings have label[for] attributes.
+        $I->seeInSource('<label for="wp-convertkit-form">');
+        $I->seeInSource('<label for="wp-convertkit-tag">');
+    }
 
-	/**
-	 * Test that the 'Default' option for the Default Form setting in the Plugin Settings works when
-	 * creating and viewing a new WordPress Post, and there is no Default Form specified in the Plugin
-	 * settings.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewPostUsingDefaultFormWithNoDefaultFormSpecifiedInPlugin(AcceptanceTester $I)
-	{
-		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: Default: None');
+    /**
+     * Test that the 'Default' option for the Default Form setting in the Plugin Settings works when
+     * creating and viewing a new WordPress Post, and there is no Default Form specified in the Plugin
+     * settings.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewPostUsingDefaultFormWithNoDefaultFormSpecifiedInPlugin(AcceptanceTester $I)
+    {
+        // Add a Post using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: Default: None');
 
-		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'Default' ],
-		]);
+        // Configure metabox's Form setting = Default.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'form' => [ 'select2', 'Default' ],
+            ]
+        );
 
-		// Publish and view the Post on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Post on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Confirm that no ConvertKit Form is displayed.
-		$I->dontSeeElementInDOM('form[data-sv-form]');
-	}
+        // Confirm that no ConvertKit Form is displayed.
+        $I->dontSeeElementInDOM('form[data-sv-form]');
+    }
 
-	/**
-	 * Test that the Default Form specified in the Plugin Settings works when
-	 * creating and viewing a new WordPress Post.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewPostUsingDefaultForm(AcceptanceTester $I)
-	{
-		// Specify the Default Form in the Plugin Settings.
-		$defaultFormID = $I->setupConvertKitPluginDefaultForm($I);
+    /**
+     * Test that the Default Form specified in the Plugin Settings works when
+     * creating and viewing a new WordPress Post.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewPostUsingDefaultForm(AcceptanceTester $I)
+    {
+        // Specify the Default Form in the Plugin Settings.
+        $defaultFormID = $I->setupConvertKitPluginDefaultForm($I);
 
-		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: Default');
+        // Add a Post using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: Default');
 
-		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'Default' ],
-		]);
+        // Configure metabox's Form setting = Default.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'form' => [ 'select2', 'Default' ],
+            ]
+        );
 
-		// Publish and view the Post on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Post on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Confirm that the ConvertKit Default Form displays.
-		$I->seeElementInDOM('form[data-sv-form="' . $defaultFormID . '"]');
-	}
+        // Confirm that the ConvertKit Default Form displays.
+        $I->seeElementInDOM('form[data-sv-form="' . $defaultFormID . '"]');
+    }
 
-	/**
-	 * Test that the Default Legacy Form specified in the Plugin Settings works when
-	 * creating and viewing a new WordPress Post.
-	 * 
-	 * @since 	1.9.6.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewPostUsingDefaultLegacyForm(AcceptanceTester $I)
-	{
-		// Specify the Default Legacy Form in the Plugin Settings.
-		$defaultLegacyFormID = $I->setupConvertKitPluginDefaultLegacyForm($I);
+    /**
+     * Test that the Default Legacy Form specified in the Plugin Settings works when
+     * creating and viewing a new WordPress Post.
+     * 
+     * @since 1.9.6.3
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewPostUsingDefaultLegacyForm(AcceptanceTester $I)
+    {
+        // Specify the Default Legacy Form in the Plugin Settings.
+        $defaultLegacyFormID = $I->setupConvertKitPluginDefaultLegacyForm($I);
 
-		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: Legacy: Default');
+        // Add a Post using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: Legacy: Default');
 
-		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'Default' ],
-		]);
+        // Configure metabox's Form setting = Default.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'form' => [ 'select2', 'Default' ],
+            ]
+        );
 
-		// Publish and view the Post on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Post on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Confirm that the ConvertKit Default Legacy Form displays.
-		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $defaultLegacyFormID . '/subscribe" data-remote="true">');
-	}
+        // Confirm that the ConvertKit Default Legacy Form displays.
+        $I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $defaultLegacyFormID . '/subscribe" data-remote="true">');
+    }
 
-	/**
-	 * Test that 'None' Form specified in the Post Settings works when
-	 * creating and viewing a new WordPress Post.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewPostUsingNoForm(AcceptanceTester $I)
-	{
-		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: None');
+    /**
+     * Test that 'None' Form specified in the Post Settings works when
+     * creating and viewing a new WordPress Post.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewPostUsingNoForm(AcceptanceTester $I)
+    {
+        // Add a Post using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: None');
 
-		// Configure metabox's Form setting = None.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'None' ],
-		]);
+        // Configure metabox's Form setting = None.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'form' => [ 'select2', 'None' ],
+            ]
+        );
 
-		// Publish and view the Post on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Post on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Confirm that no ConvertKit Form is displayed.
-		$I->dontSeeElementInDOM('form[data-sv-form]');
-	}
+        // Confirm that no ConvertKit Form is displayed.
+        $I->dontSeeElementInDOM('form[data-sv-form]');
+    }
 
-	/**
-	 * Test that the Form specified in the Post Settings works when
-	 * creating and viewing a new WordPress Post.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewPostUsingDefinedForm(AcceptanceTester $I)
-	{
-		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME']);
+    /**
+     * Test that the Form specified in the Post Settings works when
+     * creating and viewing a new WordPress Post.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewPostUsingDefinedForm(AcceptanceTester $I)
+    {
+        // Add a Post using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME']);
 
-		// Configure metabox's Form setting = None.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-		]);
+        // Configure metabox's Form setting = None.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+            ]
+        );
 
-		// Publish and view the Post on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Post on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Confirm that the ConvertKit Form displays.
-		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-	}
+        // Confirm that the ConvertKit Form displays.
+        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+    }
 
-	/**
-	 * Test that the Legacy Form specified in the Post Settings works when
-	 * creating and viewing a new WordPress Post.
-	 * 
-	 * @since 	1.9.6.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewPostUsingDefinedLegacyForm(AcceptanceTester $I)
-	{
-		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
+    /**
+     * Test that the Legacy Form specified in the Post Settings works when
+     * creating and viewing a new WordPress Post.
+     * 
+     * @since 1.9.6.3
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewPostUsingDefinedLegacyForm(AcceptanceTester $I)
+    {
+        // Add a Post using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
 
-		// Configure metabox's Form setting = None.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
-		]);
+        // Configure metabox's Form setting = None.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'form' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
+            ]
+        );
 
-		// Publish and view the Post on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Post on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Confirm that the ConvertKit Legacy Form displays.
-		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
-	}
+        // Confirm that the ConvertKit Legacy Form displays.
+        $I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
+    }
 
-	/**
-	 * Test that the Default Form for Posts displays when an invalid Form ID is specified
-	 * for a Post.
-	 * 
-	 * Whilst the on screen options won't permit selecting an invalid Form ID, a Post might
-	 * have an invalid Form ID because:
-	 * - the form belongs to another ConvertKit account (i.e. API credentials were changed in the Plugin, but this Post's specified Form was not changed)
-	 * - the form was deleted from the ConvertKit account.
-	 * 
-	 * @since 	1.9.7.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewPostUsingInvalidDefinedForm(AcceptanceTester $I)
-	{
-		// Setup the Default Form for Pages and Posts.
-		$I->setupConvertKitPluginDefaultForm($I);
+    /**
+     * Test that the Default Form for Posts displays when an invalid Form ID is specified
+     * for a Post.
+     * 
+     * Whilst the on screen options won't permit selecting an invalid Form ID, a Post might
+     * have an invalid Form ID because:
+     * - the form belongs to another ConvertKit account (i.e. API credentials were changed in the Plugin, but this Post's specified Form was not changed)
+     * - the form was deleted from the ConvertKit account.
+     * 
+     * @since 1.9.7.2
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewPostUsingInvalidDefinedForm(AcceptanceTester $I)
+    {
+        // Setup the Default Form for Pages and Posts.
+        $I->setupConvertKitPluginDefaultForm($I);
 
-		// Create Post, with an invalid Form ID, as if it were created prior to API credentials being changed and/or
-		// a Form being deleted in ConvertKit.
-		$postID = $I->havePostInDatabase([
-			'post_type' 	=> 'post',
-			'post_title' 	=> 'ConvertKit: Post: Form: Specific: Invalid',
-			'meta_input'	=> [
-				'_wp_convertkit_post_meta' => [
-					'form'         => '11111',
-					'landing_page' => '',
-					'tag'          => '',
-				]
-			],
-		]);
+        // Create Post, with an invalid Form ID, as if it were created prior to API credentials being changed and/or
+        // a Form being deleted in ConvertKit.
+        $postID = $I->havePostInDatabase(
+            [
+            'post_type'     => 'post',
+            'post_title'     => 'ConvertKit: Post: Form: Specific: Invalid',
+            'meta_input'    => [
+            '_wp_convertkit_post_meta' => [
+            'form'         => '11111',
+            'landing_page' => '',
+            'tag'          => '',
+            ]
+            ],
+            ]
+        );
 
-		// Load the Post on the frontend site.
-		$I->amOnPage('/?p='.$postID);
+        // Load the Post on the frontend site.
+        $I->amOnPage('/?p='.$postID);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the invalid ConvertKit Form does not display.
-		$I->dontSeeElementInDOM('form[data-sv-form="11111"]');
+        // Confirm that the invalid ConvertKit Form does not display.
+        $I->dontSeeElementInDOM('form[data-sv-form="11111"]');
 
-		// Confirm that the Default Form for Posts does display as a fallback.
-		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-	}
+        // Confirm that the Default Form for Posts does display as a fallback.
+        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+    }
 
-	/**
-	 * Test that the Form specified in the Category assigned to the WordPress Post is used when the WordPress Post
-	 * is set to use the Default Form.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewPostUsingDefaultFormWithCategoryFormSpecified(AcceptanceTester $I)
-	{
-		// Create Category.
-		$termID = $I->haveTermInDatabase( 'ConvertKit', 'category' );
-		$termID = $termID[0];
+    /**
+     * Test that the Form specified in the Category assigned to the WordPress Post is used when the WordPress Post
+     * is set to use the Default Form.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewPostUsingDefaultFormWithCategoryFormSpecified(AcceptanceTester $I)
+    {
+        // Create Category.
+        $termID = $I->haveTermInDatabase('ConvertKit', 'category');
+        $termID = $termID[0];
 		
-		// Create Post, assigned to ConvertKit Category.
-		$postID = $I->havePostInDatabase([
-			'post_type' 	=> 'post',
-			'post_title' 	=> 'ConvertKit Form inherited from ConvertKit Category',
-			'tax_input' => [
-				[ 'category' => $termID ],
-			],
-		]);
+        // Create Post, assigned to ConvertKit Category.
+        $postID = $I->havePostInDatabase(
+            [
+            'post_type'     => 'post',
+            'post_title'     => 'ConvertKit Form inherited from ConvertKit Category',
+            'tax_input' => [
+            [ 'category' => $termID ],
+            ],
+            ]
+        );
 
-		// Edit the Term, defining a Form.
-		$I->amOnAdminPage('term.php?taxonomy=category&tag_ID=' . $termID);
+        // Edit the Term, defining a Form.
+        $I->amOnAdminPage('term.php?taxonomy=category&tag_ID=' . $termID);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Check that the Form option is displayed.
-		$I->seeElementInDOM('#wp-convertkit-form');
+        // Check that the Form option is displayed.
+        $I->seeElementInDOM('#wp-convertkit-form');
 
-		// Change Form to value specified in the .env file.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+        // Change Form to value specified in the .env file.
+        $I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
-		// Click Update
-		$I->click('Update');
+        // Click Update
+        $I->click('Update');
 
-		// Check that the update succeeded.
-		$I->seeElementInDOM('div.notice-success');
+        // Check that the update succeeded.
+        $I->seeElementInDOM('div.notice-success');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Load the Post on the frontend site
-		$I->amOnPage('/?p=' . $postID);
+        // Load the Post on the frontend site
+        $I->amOnPage('/?p=' . $postID);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the ConvertKit Form displays.
-		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-	}
+        // Confirm that the ConvertKit Form displays.
+        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+    }
 
-  	/**
-	 * Test that the Default Form specified at Plugin level for Posts displays when:
-	 * - A Category was created with ConvertKit Form = 'None' when 1.9.5.2 or earlier of the Plugin was activated,
-	 * - The WordPress Post is set to use the Default Form,
-	 * - A Default Form is set in the Plugin settings.
-	 * 
-	 * 1.9.5.2 and earlier stored the 'None' option as 'default' for Categories, meaning that the Post (or Plugin) default form
-	 * should be used. 
-	 * 
-	 * 1.9.6.0 and later changed the value to 0 for Categories, bringing it in line with the Post Form's 'None'
-	 * setting.
-	 * 
-	 * @since 	1.9.7.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewPostUsingDefaultFormWithCategoryCreatedBefore1960(AcceptanceTester $I)
-	{
-		// Setup Default Forms.
-		$I->setupConvertKitPluginDefaultForm($I);
+    /**
+     * Test that the Default Form specified at Plugin level for Posts displays when:
+     * - A Category was created with ConvertKit Form = 'None' when 1.9.5.2 or earlier of the Plugin was activated,
+     * - The WordPress Post is set to use the Default Form,
+     * - A Default Form is set in the Plugin settings.
+     * 
+     * 1.9.5.2 and earlier stored the 'None' option as 'default' for Categories, meaning that the Post (or Plugin) default form
+     * should be used. 
+     * 
+     * 1.9.6.0 and later changed the value to 0 for Categories, bringing it in line with the Post Form's 'None'
+     * setting.
+     * 
+     * @since 1.9.7.3
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewPostUsingDefaultFormWithCategoryCreatedBefore1960(AcceptanceTester $I)
+    {
+        // Setup Default Forms.
+        $I->setupConvertKitPluginDefaultForm($I);
 
-		// Create Category as if it were created / edited when the ConvertKit Plugin < 1.9.6.0
-		// was active.
-		$termID = $I->haveTermInDatabase( 'ConvertKit 1.9.5.2 and earlier', 'category', [
-			'meta' => [
-				'ck_default_form' => 'default', // Emulate how 1.9.5.2 and earlier store this setting.
-			],
-		] );
-		$termID = $termID[0];
+        // Create Category as if it were created / edited when the ConvertKit Plugin < 1.9.6.0
+        // was active.
+        $termID = $I->haveTermInDatabase(
+            'ConvertKit 1.9.5.2 and earlier', 'category', [
+            'meta' => [
+            'ck_default_form' => 'default', // Emulate how 1.9.5.2 and earlier store this setting.
+            ],
+            ] 
+        );
+        $termID = $termID[0];
 		
-		// Create Post, assigned to Category.
-		$postID = $I->havePostInDatabase([
-			'post_type' 	=> 'post',
-			'post_title' 	=> 'ConvertKit: Default Form: Category Created before 1.9.6.0',
-			'tax_input' => [
-				[ 'category' => $termID ],
-			],
-		]);
+        // Create Post, assigned to Category.
+        $postID = $I->havePostInDatabase(
+            [
+            'post_type'     => 'post',
+            'post_title'     => 'ConvertKit: Default Form: Category Created before 1.9.6.0',
+            'tax_input' => [
+            [ 'category' => $termID ],
+            ],
+            ]
+        );
 
-		// Load the Post on the frontend site.
-		$I->amOnPage('/?p=' . $postID);
+        // Load the Post on the frontend site.
+        $I->amOnPage('/?p=' . $postID);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the ConvertKit Form displays as defined in the Plugin Settings.
-		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-	}
+        // Confirm that the ConvertKit Form displays as defined in the Plugin Settings.
+        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+    }
 
-	/**
-	 * Test that the Default Form for Pages displays when the Default option is chosen via
-	 * WordPress' Quick Edit functionality.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testQuickEditUsingDefaultForm(AcceptanceTester $I)
-	{
-		// Specify the Default Form in the Plugin Settings.
-		$I->setupConvertKitPluginDefaultForm($I);
+    /**
+     * Test that the Default Form for Pages displays when the Default option is chosen via
+     * WordPress' Quick Edit functionality.
+     * 
+     * @since 1.9.8.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testQuickEditUsingDefaultForm(AcceptanceTester $I)
+    {
+        // Specify the Default Form in the Plugin Settings.
+        $I->setupConvertKitPluginDefaultForm($I);
 
-		// Programmatically create a Post.
-		$postID = $I->havePostInDatabase([
-			'post_type' 	=> 'post',
-			'post_title' 	=> 'ConvertKit: Post: Form: Default: Quick Edit',
-		]);
+        // Programmatically create a Post.
+        $postID = $I->havePostInDatabase(
+            [
+            'post_type'     => 'post',
+            'post_title'     => 'ConvertKit: Post: Form: Default: Quick Edit',
+            ]
+        );
 
-		// Quick Edit the Post in the Posts WP_List_Table.
-		$I->quickEdit($I, 'post', $postID, [
-			'form' => [ 'select', 'Default' ],
-		]);
+        // Quick Edit the Post in the Posts WP_List_Table.
+        $I->quickEdit(
+            $I, 'post', $postID, [
+            'form' => [ 'select', 'Default' ],
+            ]
+        );
 
-		// Load the Post on the frontend site.
-		$I->amOnPage('/?p='.$postID);
+        // Load the Post on the frontend site.
+        $I->amOnPage('/?p='.$postID);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the ConvertKit Default Form displays.
-		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-	}
+        // Confirm that the ConvertKit Default Form displays.
+        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+    }
 
-	/**
-	 * Test that the defined form displays when chosen via
-	 * WordPress' Quick Edit functionality.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testQuickEditUsingDefinedForm(AcceptanceTester $I)
-	{
-		// Programmatically create a Post.
-		$postID = $I->havePostInDatabase([
-			'post_type' 	=> 'post',
-			'post_title' 	=> 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
-		]);
+    /**
+     * Test that the defined form displays when chosen via
+     * WordPress' Quick Edit functionality.
+     * 
+     * @since 1.9.8.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testQuickEditUsingDefinedForm(AcceptanceTester $I)
+    {
+        // Programmatically create a Post.
+        $postID = $I->havePostInDatabase(
+            [
+            'post_type'     => 'post',
+            'post_title'     => 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
+            ]
+        );
 
-		// Quick Edit the Post in the Posts WP_List_Table.
-		$I->quickEdit($I, 'post', $postID, [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-		]);
+        // Quick Edit the Post in the Posts WP_List_Table.
+        $I->quickEdit(
+            $I, 'post', $postID, [
+            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+            ]
+        );
 
-		// Load the Post on the frontend site.
-		$I->amOnPage('/?p='.$postID);
+        // Load the Post on the frontend site.
+        $I->amOnPage('/?p='.$postID);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the ConvertKit Default Form displays.
-		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-	}
+        // Confirm that the ConvertKit Default Form displays.
+        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+    }
 
-	/**
-	 * Test that the Default Form for Posts displays when the Default option is chosen via
-	 * WordPress' Bulk Edit functionality.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBulkEditUsingDefaultForm(AcceptanceTester $I)
-	{
-		// Specify the Default Form in the Plugin Settings.
-		$I->setupConvertKitPluginDefaultForm($I);
+    /**
+     * Test that the Default Form for Posts displays when the Default option is chosen via
+     * WordPress' Bulk Edit functionality.
+     * 
+     * @since 1.9.8.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBulkEditUsingDefaultForm(AcceptanceTester $I)
+    {
+        // Specify the Default Form in the Plugin Settings.
+        $I->setupConvertKitPluginDefaultForm($I);
 
-		// Programmatically create two Posts.
-		$postIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'post',
-				'post_title' 	=> 'ConvertKit: Post: Form: Default: Bulk Edit #1',
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'post',
-				'post_title' 	=> 'ConvertKit: Post: Form: Default: Bulk Edit #2',
-			])
-		);
+        // Programmatically create two Posts.
+        $postIDs = array(
+        $I->havePostInDatabase(
+            [
+            'post_type'     => 'post',
+            'post_title'     => 'ConvertKit: Post: Form: Default: Bulk Edit #1',
+            ]
+        ),
+        $I->havePostInDatabase(
+            [
+            'post_type'     => 'post',
+            'post_title'     => 'ConvertKit: Post: Form: Default: Bulk Edit #2',
+            ]
+        )
+        );
 
-		// Bulk Edit the Posts in the Posts WP_List_Table.
-		$I->bulkEdit($I, 'post', $postIDs, [
-			'form' => [ 'select', 'Default' ],
-		]);
+        // Bulk Edit the Posts in the Posts WP_List_Table.
+        $I->bulkEdit(
+            $I, 'post', $postIDs, [
+            'form' => [ 'select', 'Default' ],
+            ]
+        );
 
-		// Iterate through Posts to run frontend tests.
-		foreach($postIDs as $postID) {
-			// Load Post on the frontend site.
-			$I->amOnPage('/?p='.$postID);
+        // Iterate through Posts to run frontend tests.
+        foreach($postIDs as $postID) {
+            // Load Post on the frontend site.
+            $I->amOnPage('/?p='.$postID);
 
-			// Check that no PHP warnings or notices were output.
-			$I->checkNoWarningsAndNoticesOnScreen($I);
+            // Check that no PHP warnings or notices were output.
+            $I->checkNoWarningsAndNoticesOnScreen($I);
 
-			// Confirm that the ConvertKit Default Form displays.
-			$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-		}
-	}
+            // Confirm that the ConvertKit Default Form displays.
+            $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+        }
+    }
 
-	/**
-	 * Test that the defined form displays when chosen via
-	 * WordPress' Bulk Edit functionality.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBulkEditUsingDefinedForm(AcceptanceTester $I)
-	{
-		// Programmatically create two Posts.
-		$postIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'post',
-				'post_title' 	=> 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'post',
-				'post_title' 	=> 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
-			])
-		);
+    /**
+     * Test that the defined form displays when chosen via
+     * WordPress' Bulk Edit functionality.
+     * 
+     * @since 1.9.8.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBulkEditUsingDefinedForm(AcceptanceTester $I)
+    {
+        // Programmatically create two Posts.
+        $postIDs = array(
+        $I->havePostInDatabase(
+            [
+            'post_type'     => 'post',
+            'post_title'     => 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
+            ]
+        ),
+        $I->havePostInDatabase(
+            [
+            'post_type'     => 'post',
+            'post_title'     => 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
+            ]
+        )
+        );
 
-		// Bulk Edit the Posts in the Posts WP_List_Table.
-		$I->bulkEdit($I, 'post', $postIDs, [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-		]);
+        // Bulk Edit the Posts in the Posts WP_List_Table.
+        $I->bulkEdit(
+            $I, 'post', $postIDs, [
+            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+            ]
+        );
 
-		// Iterate through Posts to run frontend tests.
-		foreach($postIDs as $postID) {
-			// Load Post on the frontend site.
-			$I->amOnPage('/?p='.$postID);
+        // Iterate through Posts to run frontend tests.
+        foreach($postIDs as $postID) {
+            // Load Post on the frontend site.
+            $I->amOnPage('/?p='.$postID);
 
-			// Check that no PHP warnings or notices were output.
-			$I->checkNoWarningsAndNoticesOnScreen($I);
+            // Check that no PHP warnings or notices were output.
+            $I->checkNoWarningsAndNoticesOnScreen($I);
 
-			// Confirm that the ConvertKit Form displays.
-			$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-		}
-	}
+            // Confirm that the ConvertKit Form displays.
+            $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+        }
+    }
 
-	/**
-	 * Test that the existing settings are honored and not changed
-	 * when the Bulk Edit options are set to 'No Change'.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBulkEditWithNoChanges(AcceptanceTester $I)
-	{
-		// Programmatically create two Posts with a defined form.
-		$postIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'post',
-				'post_title' 	=> 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #1',
-				'meta_input'	=> [
-					'_wp_convertkit_post_meta' => [
-						'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
-						'landing_page' => '',
-						'tag'          => '',
-					]
-				],
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'post',
-				'post_title' 	=> 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
-				'meta_input'	=> [
-					'_wp_convertkit_post_meta' => [
-						'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
-						'landing_page' => '',
-						'tag'          => '',
-					]
-				],
-			])
-		);
+    /**
+     * Test that the existing settings are honored and not changed
+     * when the Bulk Edit options are set to 'No Change'.
+     * 
+     * @since 1.9.8.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBulkEditWithNoChanges(AcceptanceTester $I)
+    {
+        // Programmatically create two Posts with a defined form.
+        $postIDs = array(
+        $I->havePostInDatabase(
+            [
+            'post_type'     => 'post',
+            'post_title'     => 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #1',
+            'meta_input'    => [
+            '_wp_convertkit_post_meta' => [
+            'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
+            'landing_page' => '',
+            'tag'          => '',
+            ]
+            ],
+            ]
+        ),
+        $I->havePostInDatabase(
+            [
+            'post_type'     => 'post',
+            'post_title'     => 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
+            'meta_input'    => [
+            '_wp_convertkit_post_meta' => [
+            'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
+            'landing_page' => '',
+            'tag'          => '',
+            ]
+            ],
+            ]
+        )
+        );
 
-		// Bulk Edit the Posts in the Posts WP_List_Table.
-		$I->bulkEdit($I, 'post', $postIDs, [
-			'form' => [ 'select', '— No Change —' ],
-		]);
+        // Bulk Edit the Posts in the Posts WP_List_Table.
+        $I->bulkEdit(
+            $I, 'post', $postIDs, [
+            'form' => [ 'select', '— No Change —' ],
+            ]
+        );
 
-		// Iterate through Posts to run frontend tests.
-		foreach($postIDs as $postID) {
-			// Load Post on the frontend site.
-			$I->amOnPage('/?p='.$postID);
+        // Iterate through Posts to run frontend tests.
+        foreach($postIDs as $postID) {
+            // Load Post on the frontend site.
+            $I->amOnPage('/?p='.$postID);
 
-			// Check that no PHP warnings or notices were output.
-			$I->checkNoWarningsAndNoticesOnScreen($I);
+            // Check that no PHP warnings or notices were output.
+            $I->checkNoWarningsAndNoticesOnScreen($I);
 
-			// Confirm that the ConvertKit Form displays.
-			$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-		}
-	}
+            // Confirm that the ConvertKit Form displays.
+            $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+        }
+    }
 
-	/**
-	 * Test that the Bulk Edit fields do not display when a search on a WP_List_Table
-	 * returns no results.
-	 * 
-	 * @since 	1.9.8.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBulkEditFieldsHiddenWhenNoPostsFound(AcceptanceTester $I)
-	{
-		// Emulate the user searching for Posts with a query string that yields no results.
-		$I->amOnAdminPage('edit.php?post_type=post&s=nothing');
+    /**
+     * Test that the Bulk Edit fields do not display when a search on a WP_List_Table
+     * returns no results.
+     * 
+     * @since 1.9.8.1
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBulkEditFieldsHiddenWhenNoPostsFound(AcceptanceTester $I)
+    {
+        // Emulate the user searching for Posts with a query string that yields no results.
+        $I->amOnAdminPage('edit.php?post_type=post&s=nothing');
 
-		// Confirm that the Bulk Edit fields do not display.
-		$I->dontSeeElement('#convertkit-bulk-edit');
-	}
+        // Confirm that the Bulk Edit fields do not display.
+        $I->dontSeeElement('#convertkit-bulk-edit');
+    }
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/forms/PostFormCest.php
+++ b/tests/acceptance/forms/PostFormCest.php
@@ -1,21 +1,21 @@
 <?php
 /**
  * Tests for ConvertKit Forms on WordPress Posts.
- * 
- * @since 	1.9.6
+ *
+ * @since   1.9.6
  */
 class PostFormCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
-		// Activate and Setup ConvertKit plugin
+		// Activate and Setup ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
 		$I->enableDebugLog($I);
@@ -23,14 +23,14 @@ class PostFormCest
 
 	/**
 	 * Test that the Posts > Add New screen has expected a11y output, such as label[for].
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAccessibility(AcceptanceTester $I)
 	{
-		// Navigate to Post Type (e.g. Pages / Posts) > Add New
+		// Navigate to Post Type (e.g. Pages / Posts) > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=post');
 
 		// Confirm that settings have label[for] attributes.
@@ -42,10 +42,10 @@ class PostFormCest
 	 * Test that the 'Default' option for the Default Form setting in the Plugin Settings works when
 	 * creating and viewing a new WordPress Post, and there is no Default Form specified in the Plugin
 	 * settings.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewPostUsingDefaultFormWithNoDefaultFormSpecifiedInPlugin(AcceptanceTester $I)
 	{
@@ -53,9 +53,13 @@ class PostFormCest
 		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: Default: None');
 
 		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'Default' ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'Default' ],
+			]
+		);
 
 		// Publish and view the Post on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -67,10 +71,10 @@ class PostFormCest
 	/**
 	 * Test that the Default Form specified in the Plugin Settings works when
 	 * creating and viewing a new WordPress Post.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewPostUsingDefaultForm(AcceptanceTester $I)
 	{
@@ -81,9 +85,13 @@ class PostFormCest
 		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: Default');
 
 		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'Default' ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'Default' ],
+			]
+		);
 
 		// Publish and view the Post on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -95,10 +103,10 @@ class PostFormCest
 	/**
 	 * Test that the Default Legacy Form specified in the Plugin Settings works when
 	 * creating and viewing a new WordPress Post.
-	 * 
-	 * @since 	1.9.6.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewPostUsingDefaultLegacyForm(AcceptanceTester $I)
 	{
@@ -109,9 +117,13 @@ class PostFormCest
 		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: Legacy: Default');
 
 		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'Default' ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'Default' ],
+			]
+		);
 
 		// Publish and view the Post on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -123,10 +135,10 @@ class PostFormCest
 	/**
 	 * Test that 'None' Form specified in the Post Settings works when
 	 * creating and viewing a new WordPress Post.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewPostUsingNoForm(AcceptanceTester $I)
 	{
@@ -134,9 +146,13 @@ class PostFormCest
 		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: None');
 
 		// Configure metabox's Form setting = None.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'None' ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
 
 		// Publish and view the Post on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -148,10 +164,10 @@ class PostFormCest
 	/**
 	 * Test that the Form specified in the Post Settings works when
 	 * creating and viewing a new WordPress Post.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewPostUsingDefinedForm(AcceptanceTester $I)
 	{
@@ -159,9 +175,13 @@ class PostFormCest
 		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME']);
 
 		// Configure metabox's Form setting = None.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+			]
+		);
 
 		// Publish and view the Post on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -173,10 +193,10 @@ class PostFormCest
 	/**
 	 * Test that the Legacy Form specified in the Post Settings works when
 	 * creating and viewing a new WordPress Post.
-	 * 
-	 * @since 	1.9.6.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewPostUsingDefinedLegacyForm(AcceptanceTester $I)
 	{
@@ -184,9 +204,13 @@ class PostFormCest
 		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
 
 		// Configure metabox's Form setting = None.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
+			]
+		);
 
 		// Publish and view the Post on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -198,15 +222,15 @@ class PostFormCest
 	/**
 	 * Test that the Default Form for Posts displays when an invalid Form ID is specified
 	 * for a Post.
-	 * 
+	 *
 	 * Whilst the on screen options won't permit selecting an invalid Form ID, a Post might
 	 * have an invalid Form ID because:
 	 * - the form belongs to another ConvertKit account (i.e. API credentials were changed in the Plugin, but this Post's specified Form was not changed)
 	 * - the form was deleted from the ConvertKit account.
-	 * 
-	 * @since 	1.9.7.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewPostUsingInvalidDefinedForm(AcceptanceTester $I)
 	{
@@ -215,20 +239,22 @@ class PostFormCest
 
 		// Create Post, with an invalid Form ID, as if it were created prior to API credentials being changed and/or
 		// a Form being deleted in ConvertKit.
-		$postID = $I->havePostInDatabase([
-			'post_type' 	=> 'post',
-			'post_title' 	=> 'ConvertKit: Post: Form: Specific: Invalid',
-			'meta_input'	=> [
-				'_wp_convertkit_post_meta' => [
-					'form'         => '11111',
-					'landing_page' => '',
-					'tag'          => '',
-				]
-			],
-		]);
+		$postID = $I->havePostInDatabase(
+			[
+				'post_type'  => 'post',
+				'post_title' => 'ConvertKit: Post: Form: Specific: Invalid',
+				'meta_input' => [
+					'_wp_convertkit_post_meta' => [
+						'form'         => '11111',
+						'landing_page' => '',
+						'tag'          => '',
+					],
+				],
+			]
+		);
 
 		// Load the Post on the frontend site.
-		$I->amOnPage('/?p='.$postID);
+		$I->amOnPage('/?p=' . $postID);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -243,25 +269,27 @@ class PostFormCest
 	/**
 	 * Test that the Form specified in the Category assigned to the WordPress Post is used when the WordPress Post
 	 * is set to use the Default Form.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewPostUsingDefaultFormWithCategoryFormSpecified(AcceptanceTester $I)
 	{
 		// Create Category.
 		$termID = $I->haveTermInDatabase( 'ConvertKit', 'category' );
 		$termID = $termID[0];
-		
+
 		// Create Post, assigned to ConvertKit Category.
-		$postID = $I->havePostInDatabase([
-			'post_type' 	=> 'post',
-			'post_title' 	=> 'ConvertKit Form inherited from ConvertKit Category',
-			'tax_input' => [
-				[ 'category' => $termID ],
-			],
-		]);
+		$postID = $I->havePostInDatabase(
+			[
+				'post_type'  => 'post',
+				'post_title' => 'ConvertKit Form inherited from ConvertKit Category',
+				'tax_input'  => [
+					[ 'category' => $termID ],
+				],
+			]
+		);
 
 		// Edit the Term, defining a Form.
 		$I->amOnAdminPage('term.php?taxonomy=category&tag_ID=' . $termID);
@@ -275,7 +303,7 @@ class PostFormCest
 		// Change Form to value specified in the .env file.
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
-		// Click Update
+		// Click Update.
 		$I->click('Update');
 
 		// Check that the update succeeded.
@@ -284,7 +312,7 @@ class PostFormCest
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Load the Post on the frontend site
+		// Load the Post on the frontend site.
 		$I->amOnPage('/?p=' . $postID);
 
 		// Check that no PHP warnings or notices were output.
@@ -294,21 +322,21 @@ class PostFormCest
 		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 	}
 
-  	/**
+	/**
 	 * Test that the Default Form specified at Plugin level for Posts displays when:
 	 * - A Category was created with ConvertKit Form = 'None' when 1.9.5.2 or earlier of the Plugin was activated,
 	 * - The WordPress Post is set to use the Default Form,
 	 * - A Default Form is set in the Plugin settings.
-	 * 
+	 *
 	 * 1.9.5.2 and earlier stored the 'None' option as 'default' for Categories, meaning that the Post (or Plugin) default form
-	 * should be used. 
-	 * 
+	 * should be used.
+	 *
 	 * 1.9.6.0 and later changed the value to 0 for Categories, bringing it in line with the Post Form's 'None'
 	 * setting.
-	 * 
-	 * @since 	1.9.7.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewPostUsingDefaultFormWithCategoryCreatedBefore1960(AcceptanceTester $I)
 	{
@@ -317,21 +345,27 @@ class PostFormCest
 
 		// Create Category as if it were created / edited when the ConvertKit Plugin < 1.9.6.0
 		// was active.
-		$termID = $I->haveTermInDatabase( 'ConvertKit 1.9.5.2 and earlier', 'category', [
-			'meta' => [
-				'ck_default_form' => 'default', // Emulate how 1.9.5.2 and earlier store this setting.
-			],
-		] );
+		$termID = $I->haveTermInDatabase(
+			'ConvertKit 1.9.5.2 and earlier',
+			'category',
+			[
+				'meta' => [
+					'ck_default_form' => 'default', // Emulate how 1.9.5.2 and earlier store this setting.
+				],
+			]
+		);
 		$termID = $termID[0];
-		
+
 		// Create Post, assigned to Category.
-		$postID = $I->havePostInDatabase([
-			'post_type' 	=> 'post',
-			'post_title' 	=> 'ConvertKit: Default Form: Category Created before 1.9.6.0',
-			'tax_input' => [
-				[ 'category' => $termID ],
-			],
-		]);
+		$postID = $I->havePostInDatabase(
+			[
+				'post_type'  => 'post',
+				'post_title' => 'ConvertKit: Default Form: Category Created before 1.9.6.0',
+				'tax_input'  => [
+					[ 'category' => $termID ],
+				],
+			]
+		);
 
 		// Load the Post on the frontend site.
 		$I->amOnPage('/?p=' . $postID);
@@ -346,10 +380,10 @@ class PostFormCest
 	/**
 	 * Test that the Default Form for Pages displays when the Default option is chosen via
 	 * WordPress' Quick Edit functionality.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testQuickEditUsingDefaultForm(AcceptanceTester $I)
 	{
@@ -357,18 +391,25 @@ class PostFormCest
 		$I->setupConvertKitPluginDefaultForm($I);
 
 		// Programmatically create a Post.
-		$postID = $I->havePostInDatabase([
-			'post_type' 	=> 'post',
-			'post_title' 	=> 'ConvertKit: Post: Form: Default: Quick Edit',
-		]);
+		$postID = $I->havePostInDatabase(
+			[
+				'post_type'  => 'post',
+				'post_title' => 'ConvertKit: Post: Form: Default: Quick Edit',
+			]
+		);
 
 		// Quick Edit the Post in the Posts WP_List_Table.
-		$I->quickEdit($I, 'post', $postID, [
-			'form' => [ 'select', 'Default' ],
-		]);
+		$I->quickEdit(
+			$I,
+			'post',
+			$postID,
+			[
+				'form' => [ 'select', 'Default' ],
+			]
+		);
 
 		// Load the Post on the frontend site.
-		$I->amOnPage('/?p='.$postID);
+		$I->amOnPage('/?p=' . $postID);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -380,26 +421,33 @@ class PostFormCest
 	/**
 	 * Test that the defined form displays when chosen via
 	 * WordPress' Quick Edit functionality.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testQuickEditUsingDefinedForm(AcceptanceTester $I)
 	{
 		// Programmatically create a Post.
-		$postID = $I->havePostInDatabase([
-			'post_type' 	=> 'post',
-			'post_title' 	=> 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
-		]);
+		$postID = $I->havePostInDatabase(
+			[
+				'post_type'  => 'post',
+				'post_title' => 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
+			]
+		);
 
 		// Quick Edit the Post in the Posts WP_List_Table.
-		$I->quickEdit($I, 'post', $postID, [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-		]);
+		$I->quickEdit(
+			$I,
+			'post',
+			$postID,
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+			]
+		);
 
 		// Load the Post on the frontend site.
-		$I->amOnPage('/?p='.$postID);
+		$I->amOnPage('/?p=' . $postID);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -411,10 +459,10 @@ class PostFormCest
 	/**
 	 * Test that the Default Form for Posts displays when the Default option is chosen via
 	 * WordPress' Bulk Edit functionality.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBulkEditUsingDefaultForm(AcceptanceTester $I)
 	{
@@ -423,25 +471,34 @@ class PostFormCest
 
 		// Programmatically create two Posts.
 		$postIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'post',
-				'post_title' 	=> 'ConvertKit: Post: Form: Default: Bulk Edit #1',
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'post',
-				'post_title' 	=> 'ConvertKit: Post: Form: Default: Bulk Edit #2',
-			])
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'post',
+					'post_title' => 'ConvertKit: Post: Form: Default: Bulk Edit #1',
+				]
+			),
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'post',
+					'post_title' => 'ConvertKit: Post: Form: Default: Bulk Edit #2',
+				]
+			),
 		);
 
 		// Bulk Edit the Posts in the Posts WP_List_Table.
-		$I->bulkEdit($I, 'post', $postIDs, [
-			'form' => [ 'select', 'Default' ],
-		]);
+		$I->bulkEdit(
+			$I,
+			'post',
+			$postIDs,
+			[
+				'form' => [ 'select', 'Default' ],
+			]
+		);
 
 		// Iterate through Posts to run frontend tests.
-		foreach($postIDs as $postID) {
+		foreach ($postIDs as $postID) {
 			// Load Post on the frontend site.
-			$I->amOnPage('/?p='.$postID);
+			$I->amOnPage('/?p=' . $postID);
 
 			// Check that no PHP warnings or notices were output.
 			$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -454,34 +511,43 @@ class PostFormCest
 	/**
 	 * Test that the defined form displays when chosen via
 	 * WordPress' Bulk Edit functionality.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBulkEditUsingDefinedForm(AcceptanceTester $I)
 	{
 		// Programmatically create two Posts.
 		$postIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'post',
-				'post_title' 	=> 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'post',
-				'post_title' 	=> 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
-			])
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'post',
+					'post_title' => 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
+				]
+			),
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'post',
+					'post_title' => 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
+				]
+			),
 		);
 
 		// Bulk Edit the Posts in the Posts WP_List_Table.
-		$I->bulkEdit($I, 'post', $postIDs, [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-		]);
+		$I->bulkEdit(
+			$I,
+			'post',
+			$postIDs,
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+			]
+		);
 
 		// Iterate through Posts to run frontend tests.
-		foreach($postIDs as $postID) {
+		foreach ($postIDs as $postID) {
 			// Load Post on the frontend site.
-			$I->amOnPage('/?p='.$postID);
+			$I->amOnPage('/?p=' . $postID);
 
 			// Check that no PHP warnings or notices were output.
 			$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -494,48 +560,57 @@ class PostFormCest
 	/**
 	 * Test that the existing settings are honored and not changed
 	 * when the Bulk Edit options are set to 'No Change'.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBulkEditWithNoChanges(AcceptanceTester $I)
 	{
 		// Programmatically create two Posts with a defined form.
 		$postIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'post',
-				'post_title' 	=> 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #1',
-				'meta_input'	=> [
-					'_wp_convertkit_post_meta' => [
-						'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
-						'landing_page' => '',
-						'tag'          => '',
-					]
-				],
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'post',
-				'post_title' 	=> 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
-				'meta_input'	=> [
-					'_wp_convertkit_post_meta' => [
-						'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
-						'landing_page' => '',
-						'tag'          => '',
-					]
-				],
-			])
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'post',
+					'post_title' => 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #1',
+					'meta_input' => [
+						'_wp_convertkit_post_meta' => [
+							'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
+							'landing_page' => '',
+							'tag'          => '',
+						],
+					],
+				]
+			),
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'post',
+					'post_title' => 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
+					'meta_input' => [
+						'_wp_convertkit_post_meta' => [
+							'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
+							'landing_page' => '',
+							'tag'          => '',
+						],
+					],
+				]
+			),
 		);
 
 		// Bulk Edit the Posts in the Posts WP_List_Table.
-		$I->bulkEdit($I, 'post', $postIDs, [
-			'form' => [ 'select', '— No Change —' ],
-		]);
+		$I->bulkEdit(
+			$I,
+			'post',
+			$postIDs,
+			[
+				'form' => [ 'select', '— No Change —' ],
+			]
+		);
 
 		// Iterate through Posts to run frontend tests.
-		foreach($postIDs as $postID) {
+		foreach ($postIDs as $postID) {
 			// Load Post on the frontend site.
-			$I->amOnPage('/?p='.$postID);
+			$I->amOnPage('/?p=' . $postID);
 
 			// Check that no PHP warnings or notices were output.
 			$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -548,10 +623,10 @@ class PostFormCest
 	/**
 	 * Test that the Bulk Edit fields do not display when a search on a WP_List_Table
 	 * returns no results.
-	 * 
-	 * @since 	1.9.8.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBulkEditFieldsHiddenWhenNoPostsFound(AcceptanceTester $I)
 	{
@@ -566,10 +641,10 @@ class PostFormCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/forms/PostFormCest.php
+++ b/tests/acceptance/forms/PostFormCest.php
@@ -473,7 +473,7 @@ class PostFormCest
         );
 
         // Iterate through Posts to run frontend tests.
-        foreach($postIDs as $postID) {
+        foreach ($postIDs as $postID) {
             // Load Post on the frontend site.
             $I->amOnPage('/?p='.$postID);
 
@@ -519,7 +519,7 @@ class PostFormCest
         );
 
         // Iterate through Posts to run frontend tests.
-        foreach($postIDs as $postID) {
+        foreach ($postIDs as $postID) {
             // Load Post on the frontend site.
             $I->amOnPage('/?p='.$postID);
 
@@ -579,7 +579,7 @@ class PostFormCest
         );
 
         // Iterate through Posts to run frontend tests.
-        foreach($postIDs as $postID) {
+        foreach ($postIDs as $postID) {
             // Load Post on the frontend site.
             $I->amOnPage('/?p='.$postID);
 

--- a/tests/acceptance/forms/WidgetFormCest.php
+++ b/tests/acceptance/forms/WidgetFormCest.php
@@ -106,7 +106,7 @@ class WidgetFormCest
 		);
 
 		// Confirm that the widget displays.
-		$I->seeBlockWidget($I, 'convertkit-form', 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+		$I->seeBlockWidget($I, 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 	}
 
 	/**
@@ -166,7 +166,7 @@ class WidgetFormCest
 		$I->switchToIFrame();
 
 		// Confirm that the widget displays.
-		$I->seeBlockWidget($I, 'convertkit-form', 'form[data-sv-form]');
+		$I->seeBlockWidget($I, 'form[data-sv-form]');
 	}
 
 	/**
@@ -200,7 +200,7 @@ class WidgetFormCest
 		$I->switchToIFrame();
 
 		// Confirm that the widget displays.
-		$I->seeBlockWidget($I, 'convertkit-form', 'form[data-sv-form]');
+		$I->seeBlockWidget($I, 'form[data-sv-form]');
 	}
 
 	/**
@@ -234,7 +234,7 @@ class WidgetFormCest
 		$I->switchToIFrame();
 
 		// Confirm that the widget displays.
-		$I->seeBlockWidget($I, 'convertkit-form', 'form[data-sv-form]');
+		$I->seeBlockWidget($I, 'form[data-sv-form]');
 	}
 
 	/**

--- a/tests/acceptance/forms/WidgetFormCest.php
+++ b/tests/acceptance/forms/WidgetFormCest.php
@@ -1,23 +1,23 @@
 <?php
 /**
  * Tests for the ConvertKit Form widget.
- * 
+ *
  * A widget area is typically defined by a Theme in a shared area, such as a sidebar or footer.
- * 
+ *
  * We test both legacy widgets (registered in includes/widgets/class-ck-widget-form.php),
  * and the Gutenberg Form Block, which can be inserted into a widget area starting from
  * WordPress 5.8.
- * 
- * @since 	1.9.7.6
+ *
+ * @since   1.9.7.6
  */
 class WidgetFormCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -31,24 +31,29 @@ class WidgetFormCest
 
 	/**
 	 * Test that the legacy Form widget works when a valid Form is selected.
-	 * 
+	 *
 	 * We retain this legacy non-block widget, because it's been available since 1.4.3,
 	 * and there is no smooth conversion path to making legacy widgets into widget blocks
-	 * for WordPress 5.8+. 
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 * for WordPress 5.8+.
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testLegacyFormWidgetWithValidFormParameter(AcceptanceTester $I)
 	{
 		// Add legacy widget, setting the Form setting to the value specified in the .env file.
-		$I->addLegacyWidget($I, 'ConvertKit Form', 'convertkit-form', [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
-		]);
+		$I->addLegacyWidget(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+			]
+		);
 
 		// Confirm that the widget displays.
-		$I->seeLegacyWidget($I, 'convertkit-form', 'form[data-sv-form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]');
+		$I->seeLegacyWidget($I, 'convertkit-form', 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 	}
 
 	/**
@@ -58,16 +63,21 @@ class WidgetFormCest
 	 * and there is no smooth conversion path to making legacy widgets into widget blocks
 	 * for WordPress 5.8+.
 	 *
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 * @since   1.9.7.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testLegacyFormWidgetWithValidLegacyFormParameter(AcceptanceTester $I)
 	{
 		// Add legacy widget, setting the Form setting to the value specified in the .env file.
-		$I->addLegacyWidget($I, 'ConvertKit Form', 'convertkit-form', [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ]
-		]);
+		$I->addLegacyWidget(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
+			]
+		);
 
 		// View the home page.
 		$I->amOnPage('/');
@@ -78,35 +88,45 @@ class WidgetFormCest
 
 	/**
 	 * Test the Form widget works when a valid Form is selected.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBlockFormWidgetWithValidFormParameter(AcceptanceTester $I)
 	{
 		// Add block widget, setting the Form setting to the value specified in the .env file.
-		$I->addBlockWidget($I, 'ConvertKit Form', 'convertkit-form', [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
-		]);
+		$I->addBlockWidget(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+			]
+		);
 
 		// Confirm that the widget displays.
-		$I->seeBlockWidget($I, 'convertkit-form', 'form[data-sv-form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]');
+		$I->seeBlockWidget($I, 'convertkit-form', 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 	}
 
 	/**
 	 * Test the Form widget works when a valid Legacy Form is selected.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBlockFormBlockWithValidLegacyFormParameter(AcceptanceTester $I)
 	{
 		// Add block widget, setting the Form setting to the value specified in the .env file.
-		$I->addBlockWidget($I, 'ConvertKit Form', 'convertkit-form', [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ]
-		]);
+		$I->addBlockWidget(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
+			]
+		);
 
 		// View the home page.
 		$I->amOnPage('/');
@@ -118,17 +138,22 @@ class WidgetFormCest
 	/**
 	 * Test the Form widget displays a message explaining why the block cannot be previewed
 	 * when a valid Modal Form is selected.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testFormWidgetWithValidModalFormParameter(AcceptanceTester $I)
 	{
 		// Add block widget, setting the Form setting to the value specified in the .env file.
-		$I->addBlockWidget($I, 'ConvertKit Form', 'convertkit-form', [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ]
-		]);
+		$I->addBlockWidget(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
+			]
+		);
 
 		// Switch to iframe preview for the Form block.
 		$I->switchToIFrame('iframe[class="components-sandbox"]');
@@ -147,17 +172,22 @@ class WidgetFormCest
 	/**
 	 * Test the Form widget displays a message explaining why the block cannot be previewed
 	 *  when a valid Slide In Form is selected.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBlockFormWidgetWithValidSlideInFormParameter(AcceptanceTester $I)
 	{
 		// Add block widget, setting the Form setting to the value specified in the .env file.
-		$I->addBlockWidget($I, 'ConvertKit Form', 'convertkit-form', [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] ]
-		]);
+		$I->addBlockWidget(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] ],
+			]
+		);
 
 		// Switch to iframe preview for the Form block.
 		$I->switchToIFrame('iframe[class="components-sandbox"]');
@@ -176,17 +206,22 @@ class WidgetFormCest
 	/**
 	 * Test the Form widget displays a message explaining why the block cannot be previewed
 	 * when a valid Sticky Bar Form is selected.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBlockFormWidgetWithValidStickyBarFormParameter(AcceptanceTester $I)
 	{
 		// Add block widget, setting the Form setting to the value specified in the .env file.
-		$I->addBlockWidget($I, 'ConvertKit Form', 'convertkit-form', [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ]
-		]);
+		$I->addBlockWidget(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ],
+			]
+		);
 
 		// Switch to iframe preview for the Form block.
 		$I->switchToIFrame('iframe[class="components-sandbox"]');
@@ -206,10 +241,10 @@ class WidgetFormCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/forms/WidgetFormCest.php
+++ b/tests/acceptance/forms/WidgetFormCest.php
@@ -8,215 +8,229 @@
  * and the Gutenberg Form Block, which can be inserted into a widget area starting from
  * WordPress 5.8.
  * 
- * @since 	1.9.7.6
+ * @since 1.9.7.6
  */
 class WidgetFormCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.7.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        $I->activateConvertKitPlugin($I);
+        $I->setupConvertKitPlugin($I);
+        $I->enableDebugLog($I);
 
-		// Activate an older WordPress Theme that supports Widgets.
-		$I->useTheme('twentytwentyone');
-	}
+        // Activate an older WordPress Theme that supports Widgets.
+        $I->useTheme('twentytwentyone');
+    }
 
-	/**
-	 * Test that the legacy Form widget works when a valid Form is selected.
-	 * 
-	 * We retain this legacy non-block widget, because it's been available since 1.4.3,
-	 * and there is no smooth conversion path to making legacy widgets into widget blocks
-	 * for WordPress 5.8+. 
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testLegacyFormWidgetWithValidFormParameter(AcceptanceTester $I)
-	{
-		// Add legacy widget, setting the Form setting to the value specified in the .env file.
-		$I->addLegacyWidget($I, 'ConvertKit Form', 'convertkit-form', [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
-		]);
+    /**
+     * Test that the legacy Form widget works when a valid Form is selected.
+     * 
+     * We retain this legacy non-block widget, because it's been available since 1.4.3,
+     * and there is no smooth conversion path to making legacy widgets into widget blocks
+     * for WordPress 5.8+. 
+     * 
+     * @since 1.9.7.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testLegacyFormWidgetWithValidFormParameter(AcceptanceTester $I)
+    {
+        // Add legacy widget, setting the Form setting to the value specified in the .env file.
+        $I->addLegacyWidget(
+            $I, 'ConvertKit Form', 'convertkit-form', [
+            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+            ]
+        );
 
-		// Confirm that the widget displays.
-		$I->seeLegacyWidget($I, 'convertkit-form', 'form[data-sv-form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]');
-	}
+        // Confirm that the widget displays.
+        $I->seeLegacyWidget($I, 'convertkit-form', 'form[data-sv-form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]');
+    }
 
-	/**
-	 * Test that the legacy Form widget works when a valid Legacy Form is selected.
-	 *
-	 * We retain this legacy non-block widget, because it's been available since 1.4.3,
-	 * and there is no smooth conversion path to making legacy widgets into widget blocks
-	 * for WordPress 5.8+.
-	 *
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testLegacyFormWidgetWithValidLegacyFormParameter(AcceptanceTester $I)
-	{
-		// Add legacy widget, setting the Form setting to the value specified in the .env file.
-		$I->addLegacyWidget($I, 'ConvertKit Form', 'convertkit-form', [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ]
-		]);
+    /**
+     * Test that the legacy Form widget works when a valid Legacy Form is selected.
+     *
+     * We retain this legacy non-block widget, because it's been available since 1.4.3,
+     * and there is no smooth conversion path to making legacy widgets into widget blocks
+     * for WordPress 5.8+.
+     *
+     * @since 1.9.7.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testLegacyFormWidgetWithValidLegacyFormParameter(AcceptanceTester $I)
+    {
+        // Add legacy widget, setting the Form setting to the value specified in the .env file.
+        $I->addLegacyWidget(
+            $I, 'ConvertKit Form', 'convertkit-form', [
+            'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ]
+            ]
+        );
 
-		// View the home page.
-		$I->amOnPage('/');
+        // View the home page.
+        $I->amOnPage('/');
 
-		// Confirm that the widget displays.
-		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
-	}
+        // Confirm that the widget displays.
+        $I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
+    }
 
-	/**
-	 * Test the Form widget works when a valid Form is selected.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBlockFormWidgetWithValidFormParameter(AcceptanceTester $I)
-	{
-		// Add block widget, setting the Form setting to the value specified in the .env file.
-		$I->addBlockWidget($I, 'ConvertKit Form', 'convertkit-form', [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
-		]);
+    /**
+     * Test the Form widget works when a valid Form is selected.
+     * 
+     * @since 1.9.7.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBlockFormWidgetWithValidFormParameter(AcceptanceTester $I)
+    {
+        // Add block widget, setting the Form setting to the value specified in the .env file.
+        $I->addBlockWidget(
+            $I, 'ConvertKit Form', 'convertkit-form', [
+            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+            ]
+        );
 
-		// Confirm that the widget displays.
-		$I->seeBlockWidget($I, 'convertkit-form', 'form[data-sv-form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]');
-	}
+        // Confirm that the widget displays.
+        $I->seeBlockWidget($I, 'convertkit-form', 'form[data-sv-form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]');
+    }
 
-	/**
-	 * Test the Form widget works when a valid Legacy Form is selected.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBlockFormBlockWithValidLegacyFormParameter(AcceptanceTester $I)
-	{
-		// Add block widget, setting the Form setting to the value specified in the .env file.
-		$I->addBlockWidget($I, 'ConvertKit Form', 'convertkit-form', [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ]
-		]);
+    /**
+     * Test the Form widget works when a valid Legacy Form is selected.
+     * 
+     * @since 1.9.7.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBlockFormBlockWithValidLegacyFormParameter(AcceptanceTester $I)
+    {
+        // Add block widget, setting the Form setting to the value specified in the .env file.
+        $I->addBlockWidget(
+            $I, 'ConvertKit Form', 'convertkit-form', [
+            'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ]
+            ]
+        );
 
-		// View the home page.
-		$I->amOnPage('/');
+        // View the home page.
+        $I->amOnPage('/');
 
-		// Confirm that the widget displays.
-		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
-	}
+        // Confirm that the widget displays.
+        $I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
+    }
 
-	/**
-	 * Test the Form widget displays a message explaining why the block cannot be previewed
-	 * when a valid Modal Form is selected.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testFormWidgetWithValidModalFormParameter(AcceptanceTester $I)
-	{
-		// Add block widget, setting the Form setting to the value specified in the .env file.
-		$I->addBlockWidget($I, 'ConvertKit Form', 'convertkit-form', [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ]
-		]);
+    /**
+     * Test the Form widget displays a message explaining why the block cannot be previewed
+     * when a valid Modal Form is selected.
+     * 
+     * @since 1.9.7.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testFormWidgetWithValidModalFormParameter(AcceptanceTester $I)
+    {
+        // Add block widget, setting the Form setting to the value specified in the .env file.
+        $I->addBlockWidget(
+            $I, 'ConvertKit Form', 'convertkit-form', [
+            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ]
+            ]
+        );
 
-		// Switch to iframe preview for the Form block.
-		$I->switchToIFrame('iframe[class="components-sandbox"]');
+        // Switch to iframe preview for the Form block.
+        $I->switchToIFrame('iframe[class="components-sandbox"]');
 
-		// Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
-		// site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
-		$I->see('Modal form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . '" selected. View on the frontend site to see the modal form.');
+        // Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
+        // site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
+        $I->see('Modal form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . '" selected. View on the frontend site to see the modal form.');
 
-		// Switch back to main window.
-		$I->switchToIFrame();
+        // Switch back to main window.
+        $I->switchToIFrame();
 
-		// Confirm that the widget displays.
-		$I->seeBlockWidget($I, 'convertkit-form', 'form[data-sv-form]');
-	}
+        // Confirm that the widget displays.
+        $I->seeBlockWidget($I, 'convertkit-form', 'form[data-sv-form]');
+    }
 
-	/**
-	 * Test the Form widget displays a message explaining why the block cannot be previewed
-	 *  when a valid Slide In Form is selected.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBlockFormWidgetWithValidSlideInFormParameter(AcceptanceTester $I)
-	{
-		// Add block widget, setting the Form setting to the value specified in the .env file.
-		$I->addBlockWidget($I, 'ConvertKit Form', 'convertkit-form', [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] ]
-		]);
+    /**
+     * Test the Form widget displays a message explaining why the block cannot be previewed
+     *  when a valid Slide In Form is selected.
+     * 
+     * @since 1.9.7.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBlockFormWidgetWithValidSlideInFormParameter(AcceptanceTester $I)
+    {
+        // Add block widget, setting the Form setting to the value specified in the .env file.
+        $I->addBlockWidget(
+            $I, 'ConvertKit Form', 'convertkit-form', [
+            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] ]
+            ]
+        );
 
-		// Switch to iframe preview for the Form block.
-		$I->switchToIFrame('iframe[class="components-sandbox"]');
+        // Switch to iframe preview for the Form block.
+        $I->switchToIFrame('iframe[class="components-sandbox"]');
 
-		// Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
-		// site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
-		$I->see('Slide in form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] . '" selected. View on the frontend site to see the slide in form.');
+        // Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
+        // site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
+        $I->see('Slide in form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] . '" selected. View on the frontend site to see the slide in form.');
 
-		// Switch back to main window.
-		$I->switchToIFrame();
+        // Switch back to main window.
+        $I->switchToIFrame();
 
-		// Confirm that the widget displays.
-		$I->seeBlockWidget($I, 'convertkit-form', 'form[data-sv-form]');
-	}
+        // Confirm that the widget displays.
+        $I->seeBlockWidget($I, 'convertkit-form', 'form[data-sv-form]');
+    }
 
-	/**
-	 * Test the Form widget displays a message explaining why the block cannot be previewed
-	 * when a valid Sticky Bar Form is selected.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBlockFormWidgetWithValidStickyBarFormParameter(AcceptanceTester $I)
-	{
-		// Add block widget, setting the Form setting to the value specified in the .env file.
-		$I->addBlockWidget($I, 'ConvertKit Form', 'convertkit-form', [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ]
-		]);
+    /**
+     * Test the Form widget displays a message explaining why the block cannot be previewed
+     * when a valid Sticky Bar Form is selected.
+     * 
+     * @since 1.9.7.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBlockFormWidgetWithValidStickyBarFormParameter(AcceptanceTester $I)
+    {
+        // Add block widget, setting the Form setting to the value specified in the .env file.
+        $I->addBlockWidget(
+            $I, 'ConvertKit Form', 'convertkit-form', [
+            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ]
+            ]
+        );
 
-		// Switch to iframe preview for the Form block.
-		$I->switchToIFrame('iframe[class="components-sandbox"]');
+        // Switch to iframe preview for the Form block.
+        $I->switchToIFrame('iframe[class="components-sandbox"]');
 
-		// Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
-		// site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
-		$I->see('Sticky bar form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] . '" selected. View on the frontend site to see the sticky bar form.');
+        // Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
+        // site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
+        $I->see('Sticky bar form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] . '" selected. View on the frontend site to see the sticky bar form.');
 
-		// Switch back to main window.
-		$I->switchToIFrame();
+        // Switch back to main window.
+        $I->switchToIFrame();
 
-		// Confirm that the widget displays.
-		$I->seeBlockWidget($I, 'convertkit-form', 'form[data-sv-form]');
-	}
+        // Confirm that the widget displays.
+        $I->seeBlockWidget($I, 'convertkit-form', 'form[data-sv-form]');
+    }
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		// Activate the current theme.
-		$I->useTheme('twentytwentytwo');
-		$I->resetWidgets($I);
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.7.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        // Activate the current theme.
+        $I->useTheme('twentytwentytwo');
+        $I->resetWidgets($I);
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/forms/WidgetFormCest.php
+++ b/tests/acceptance/forms/WidgetFormCest.php
@@ -1,57 +1,54 @@
 <?php
 /**
  * Tests for the ConvertKit Form widget.
- *
+ * 
  * A widget area is typically defined by a Theme in a shared area, such as a sidebar or footer.
- *
+ * 
  * We test both legacy widgets (registered in includes/widgets/class-ck-widget-form.php),
  * and the Gutenberg Form Block, which can be inserted into a widget area starting from
  * WordPress 5.8.
- *
- * @since 1.9.7.6
+ * 
+ * @since 	1.9.7.6
  */
-class WidgetFormCest {
-
+class WidgetFormCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
-		$I->activateConvertKitPlugin( $I );
-		$I->setupConvertKitPlugin( $I );
-		$I->enableDebugLog( $I );
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
 
 		// Activate an older WordPress Theme that supports Widgets.
-		$I->useTheme( 'twentytwentyone' );
+		$I->useTheme('twentytwentyone');
 	}
 
 	/**
 	 * Test that the legacy Form widget works when a valid Form is selected.
-	 *
+	 * 
 	 * We retain this legacy non-block widget, because it's been available since 1.4.3,
 	 * and there is no smooth conversion path to making legacy widgets into widget blocks
-	 * for WordPress 5.8+.
-	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * for WordPress 5.8+. 
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testLegacyFormWidgetWithValidFormParameter( AcceptanceTester $I ) {
+	public function testLegacyFormWidgetWithValidFormParameter(AcceptanceTester $I)
+	{
 		// Add legacy widget, setting the Form setting to the value specified in the .env file.
-		$I->addLegacyWidget(
-			$I,
-			'ConvertKit Form',
-			'convertkit-form',
-			array(
-				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
-			)
-		);
+		$I->addLegacyWidget($I, 'ConvertKit Form', 'convertkit-form', [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+		]);
 
 		// Confirm that the widget displays.
-		$I->seeLegacyWidget( $I, 'convertkit-form', 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		$I->seeLegacyWidget($I, 'convertkit-form', 'form[data-sv-form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]');
 	}
 
 	/**
@@ -61,188 +58,165 @@ class WidgetFormCest {
 	 * and there is no smooth conversion path to making legacy widgets into widget blocks
 	 * for WordPress 5.8+.
 	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testLegacyFormWidgetWithValidLegacyFormParameter( AcceptanceTester $I ) {
+	public function testLegacyFormWidgetWithValidLegacyFormParameter(AcceptanceTester $I)
+	{
 		// Add legacy widget, setting the Form setting to the value specified in the .env file.
-		$I->addLegacyWidget(
-			$I,
-			'ConvertKit Form',
-			'convertkit-form',
-			array(
-				'form' => array( 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ),
-			)
-		);
+		$I->addLegacyWidget($I, 'ConvertKit Form', 'convertkit-form', [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ]
+		]);
 
 		// View the home page.
-		$I->amOnPage( '/' );
+		$I->amOnPage('/');
 
 		// Confirm that the widget displays.
-		$I->seeInSource( '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">' );
+		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
 	}
 
 	/**
 	 * Test the Form widget works when a valid Form is selected.
-	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBlockFormWidgetWithValidFormParameter( AcceptanceTester $I ) {
+	public function testBlockFormWidgetWithValidFormParameter(AcceptanceTester $I)
+	{
 		// Add block widget, setting the Form setting to the value specified in the .env file.
-		$I->addBlockWidget(
-			$I,
-			'ConvertKit Form',
-			'convertkit-form',
-			array(
-				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
-			)
-		);
+		$I->addBlockWidget($I, 'ConvertKit Form', 'convertkit-form', [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+		]);
 
 		// Confirm that the widget displays.
-		$I->seeBlockWidget( $I, 'convertkit-form', 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		$I->seeBlockWidget($I, 'convertkit-form', 'form[data-sv-form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]');
 	}
 
 	/**
 	 * Test the Form widget works when a valid Legacy Form is selected.
-	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBlockFormBlockWithValidLegacyFormParameter( AcceptanceTester $I ) {
+	public function testBlockFormBlockWithValidLegacyFormParameter(AcceptanceTester $I)
+	{
 		// Add block widget, setting the Form setting to the value specified in the .env file.
-		$I->addBlockWidget(
-			$I,
-			'ConvertKit Form',
-			'convertkit-form',
-			array(
-				'form' => array( 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ),
-			)
-		);
+		$I->addBlockWidget($I, 'ConvertKit Form', 'convertkit-form', [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ]
+		]);
 
 		// View the home page.
-		$I->amOnPage( '/' );
+		$I->amOnPage('/');
 
 		// Confirm that the widget displays.
-		$I->seeInSource( '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">' );
+		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
 	}
 
 	/**
 	 * Test the Form widget displays a message explaining why the block cannot be previewed
 	 * when a valid Modal Form is selected.
-	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testFormWidgetWithValidModalFormParameter( AcceptanceTester $I ) {
+	public function testFormWidgetWithValidModalFormParameter(AcceptanceTester $I)
+	{
 		// Add block widget, setting the Form setting to the value specified in the .env file.
-		$I->addBlockWidget(
-			$I,
-			'ConvertKit Form',
-			'convertkit-form',
-			array(
-				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ),
-			)
-		);
+		$I->addBlockWidget($I, 'ConvertKit Form', 'convertkit-form', [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ]
+		]);
 
 		// Switch to iframe preview for the Form block.
-		$I->switchToIFrame( 'iframe[class="components-sandbox"]' );
+		$I->switchToIFrame('iframe[class="components-sandbox"]');
 
 		// Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
 		// site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
-		$I->see( 'Modal form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . '" selected. View on the frontend site to see the modal form.' );
+		$I->see('Modal form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . '" selected. View on the frontend site to see the modal form.');
 
 		// Switch back to main window.
 		$I->switchToIFrame();
 
 		// Confirm that the widget displays.
-		$I->seeBlockWidget( $I, 'convertkit-form', 'form[data-sv-form]' );
+		$I->seeBlockWidget($I, 'convertkit-form', 'form[data-sv-form]');
 	}
 
 	/**
 	 * Test the Form widget displays a message explaining why the block cannot be previewed
 	 *  when a valid Slide In Form is selected.
-	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBlockFormWidgetWithValidSlideInFormParameter( AcceptanceTester $I ) {
+	public function testBlockFormWidgetWithValidSlideInFormParameter(AcceptanceTester $I)
+	{
 		// Add block widget, setting the Form setting to the value specified in the .env file.
-		$I->addBlockWidget(
-			$I,
-			'ConvertKit Form',
-			'convertkit-form',
-			array(
-				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] ),
-			)
-		);
+		$I->addBlockWidget($I, 'ConvertKit Form', 'convertkit-form', [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] ]
+		]);
 
 		// Switch to iframe preview for the Form block.
-		$I->switchToIFrame( 'iframe[class="components-sandbox"]' );
+		$I->switchToIFrame('iframe[class="components-sandbox"]');
 
 		// Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
 		// site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
-		$I->see( 'Slide in form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] . '" selected. View on the frontend site to see the slide in form.' );
+		$I->see('Slide in form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] . '" selected. View on the frontend site to see the slide in form.');
 
 		// Switch back to main window.
 		$I->switchToIFrame();
 
 		// Confirm that the widget displays.
-		$I->seeBlockWidget( $I, 'convertkit-form', 'form[data-sv-form]' );
+		$I->seeBlockWidget($I, 'convertkit-form', 'form[data-sv-form]');
 	}
 
 	/**
 	 * Test the Form widget displays a message explaining why the block cannot be previewed
 	 * when a valid Sticky Bar Form is selected.
-	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBlockFormWidgetWithValidStickyBarFormParameter( AcceptanceTester $I ) {
+	public function testBlockFormWidgetWithValidStickyBarFormParameter(AcceptanceTester $I)
+	{
 		// Add block widget, setting the Form setting to the value specified in the .env file.
-		$I->addBlockWidget(
-			$I,
-			'ConvertKit Form',
-			'convertkit-form',
-			array(
-				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ),
-			)
-		);
+		$I->addBlockWidget($I, 'ConvertKit Form', 'convertkit-form', [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ]
+		]);
 
 		// Switch to iframe preview for the Form block.
-		$I->switchToIFrame( 'iframe[class="components-sandbox"]' );
+		$I->switchToIFrame('iframe[class="components-sandbox"]');
 
 		// Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
 		// site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
-		$I->see( 'Sticky bar form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] . '" selected. View on the frontend site to see the sticky bar form.' );
+		$I->see('Sticky bar form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] . '" selected. View on the frontend site to see the sticky bar form.');
 
 		// Switch back to main window.
 		$I->switchToIFrame();
 
 		// Confirm that the widget displays.
-		$I->seeBlockWidget( $I, 'convertkit-form', 'form[data-sv-form]' );
+		$I->seeBlockWidget($I, 'convertkit-form', 'form[data-sv-form]');
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
+	public function _passed(AcceptanceTester $I)
+	{
 		// Activate the current theme.
-		$I->useTheme( 'twentytwentytwo' );
-		$I->resetWidgets( $I );
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+		$I->useTheme('twentytwentytwo');
+		$I->resetWidgets($I);
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/forms/WidgetFormCest.php
+++ b/tests/acceptance/forms/WidgetFormCest.php
@@ -1,236 +1,248 @@
 <?php
 /**
  * Tests for the ConvertKit Form widget.
- * 
+ *
  * A widget area is typically defined by a Theme in a shared area, such as a sidebar or footer.
- * 
+ *
  * We test both legacy widgets (registered in includes/widgets/class-ck-widget-form.php),
  * and the Gutenberg Form Block, which can be inserted into a widget area starting from
  * WordPress 5.8.
- * 
+ *
  * @since 1.9.7.6
  */
-class WidgetFormCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.7.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        $I->activateConvertKitPlugin($I);
-        $I->setupConvertKitPlugin($I);
-        $I->enableDebugLog($I);
+class WidgetFormCest {
 
-        // Activate an older WordPress Theme that supports Widgets.
-        $I->useTheme('twentytwentyone');
-    }
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		$I->activateConvertKitPlugin( $I );
+		$I->setupConvertKitPlugin( $I );
+		$I->enableDebugLog( $I );
 
-    /**
-     * Test that the legacy Form widget works when a valid Form is selected.
-     * 
-     * We retain this legacy non-block widget, because it's been available since 1.4.3,
-     * and there is no smooth conversion path to making legacy widgets into widget blocks
-     * for WordPress 5.8+. 
-     * 
-     * @since 1.9.7.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testLegacyFormWidgetWithValidFormParameter(AcceptanceTester $I)
-    {
-        // Add legacy widget, setting the Form setting to the value specified in the .env file.
-        $I->addLegacyWidget(
-            $I, 'ConvertKit Form', 'convertkit-form', [
-            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
-            ]
-        );
+		// Activate an older WordPress Theme that supports Widgets.
+		$I->useTheme( 'twentytwentyone' );
+	}
 
-        // Confirm that the widget displays.
-        $I->seeLegacyWidget($I, 'convertkit-form', 'form[data-sv-form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]');
-    }
+	/**
+	 * Test that the legacy Form widget works when a valid Form is selected.
+	 *
+	 * We retain this legacy non-block widget, because it's been available since 1.4.3,
+	 * and there is no smooth conversion path to making legacy widgets into widget blocks
+	 * for WordPress 5.8+.
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testLegacyFormWidgetWithValidFormParameter( AcceptanceTester $I ) {
+		// Add legacy widget, setting the Form setting to the value specified in the .env file.
+		$I->addLegacyWidget(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			array(
+				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
+			)
+		);
 
-    /**
-     * Test that the legacy Form widget works when a valid Legacy Form is selected.
-     *
-     * We retain this legacy non-block widget, because it's been available since 1.4.3,
-     * and there is no smooth conversion path to making legacy widgets into widget blocks
-     * for WordPress 5.8+.
-     *
-     * @since 1.9.7.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testLegacyFormWidgetWithValidLegacyFormParameter(AcceptanceTester $I)
-    {
-        // Add legacy widget, setting the Form setting to the value specified in the .env file.
-        $I->addLegacyWidget(
-            $I, 'ConvertKit Form', 'convertkit-form', [
-            'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ]
-            ]
-        );
+		// Confirm that the widget displays.
+		$I->seeLegacyWidget( $I, 'convertkit-form', 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+	}
 
-        // View the home page.
-        $I->amOnPage('/');
+	/**
+	 * Test that the legacy Form widget works when a valid Legacy Form is selected.
+	 *
+	 * We retain this legacy non-block widget, because it's been available since 1.4.3,
+	 * and there is no smooth conversion path to making legacy widgets into widget blocks
+	 * for WordPress 5.8+.
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testLegacyFormWidgetWithValidLegacyFormParameter( AcceptanceTester $I ) {
+		// Add legacy widget, setting the Form setting to the value specified in the .env file.
+		$I->addLegacyWidget(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			array(
+				'form' => array( 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ),
+			)
+		);
 
-        // Confirm that the widget displays.
-        $I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
-    }
+		// View the home page.
+		$I->amOnPage( '/' );
 
-    /**
-     * Test the Form widget works when a valid Form is selected.
-     * 
-     * @since 1.9.7.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBlockFormWidgetWithValidFormParameter(AcceptanceTester $I)
-    {
-        // Add block widget, setting the Form setting to the value specified in the .env file.
-        $I->addBlockWidget(
-            $I, 'ConvertKit Form', 'convertkit-form', [
-            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
-            ]
-        );
+		// Confirm that the widget displays.
+		$I->seeInSource( '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">' );
+	}
 
-        // Confirm that the widget displays.
-        $I->seeBlockWidget($I, 'convertkit-form', 'form[data-sv-form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]');
-    }
+	/**
+	 * Test the Form widget works when a valid Form is selected.
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBlockFormWidgetWithValidFormParameter( AcceptanceTester $I ) {
+		// Add block widget, setting the Form setting to the value specified in the .env file.
+		$I->addBlockWidget(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			array(
+				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
+			)
+		);
 
-    /**
-     * Test the Form widget works when a valid Legacy Form is selected.
-     * 
-     * @since 1.9.7.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBlockFormBlockWithValidLegacyFormParameter(AcceptanceTester $I)
-    {
-        // Add block widget, setting the Form setting to the value specified in the .env file.
-        $I->addBlockWidget(
-            $I, 'ConvertKit Form', 'convertkit-form', [
-            'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ]
-            ]
-        );
+		// Confirm that the widget displays.
+		$I->seeBlockWidget( $I, 'convertkit-form', 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+	}
 
-        // View the home page.
-        $I->amOnPage('/');
+	/**
+	 * Test the Form widget works when a valid Legacy Form is selected.
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBlockFormBlockWithValidLegacyFormParameter( AcceptanceTester $I ) {
+		// Add block widget, setting the Form setting to the value specified in the .env file.
+		$I->addBlockWidget(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			array(
+				'form' => array( 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ),
+			)
+		);
 
-        // Confirm that the widget displays.
-        $I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
-    }
+		// View the home page.
+		$I->amOnPage( '/' );
 
-    /**
-     * Test the Form widget displays a message explaining why the block cannot be previewed
-     * when a valid Modal Form is selected.
-     * 
-     * @since 1.9.7.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testFormWidgetWithValidModalFormParameter(AcceptanceTester $I)
-    {
-        // Add block widget, setting the Form setting to the value specified in the .env file.
-        $I->addBlockWidget(
-            $I, 'ConvertKit Form', 'convertkit-form', [
-            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ]
-            ]
-        );
+		// Confirm that the widget displays.
+		$I->seeInSource( '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">' );
+	}
 
-        // Switch to iframe preview for the Form block.
-        $I->switchToIFrame('iframe[class="components-sandbox"]');
+	/**
+	 * Test the Form widget displays a message explaining why the block cannot be previewed
+	 * when a valid Modal Form is selected.
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testFormWidgetWithValidModalFormParameter( AcceptanceTester $I ) {
+		// Add block widget, setting the Form setting to the value specified in the .env file.
+		$I->addBlockWidget(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			array(
+				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ),
+			)
+		);
 
-        // Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
-        // site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
-        $I->see('Modal form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . '" selected. View on the frontend site to see the modal form.');
+		// Switch to iframe preview for the Form block.
+		$I->switchToIFrame( 'iframe[class="components-sandbox"]' );
 
-        // Switch back to main window.
-        $I->switchToIFrame();
+		// Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
+		// site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
+		$I->see( 'Modal form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . '" selected. View on the frontend site to see the modal form.' );
 
-        // Confirm that the widget displays.
-        $I->seeBlockWidget($I, 'convertkit-form', 'form[data-sv-form]');
-    }
+		// Switch back to main window.
+		$I->switchToIFrame();
 
-    /**
-     * Test the Form widget displays a message explaining why the block cannot be previewed
-     *  when a valid Slide In Form is selected.
-     * 
-     * @since 1.9.7.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBlockFormWidgetWithValidSlideInFormParameter(AcceptanceTester $I)
-    {
-        // Add block widget, setting the Form setting to the value specified in the .env file.
-        $I->addBlockWidget(
-            $I, 'ConvertKit Form', 'convertkit-form', [
-            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] ]
-            ]
-        );
+		// Confirm that the widget displays.
+		$I->seeBlockWidget( $I, 'convertkit-form', 'form[data-sv-form]' );
+	}
 
-        // Switch to iframe preview for the Form block.
-        $I->switchToIFrame('iframe[class="components-sandbox"]');
+	/**
+	 * Test the Form widget displays a message explaining why the block cannot be previewed
+	 *  when a valid Slide In Form is selected.
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBlockFormWidgetWithValidSlideInFormParameter( AcceptanceTester $I ) {
+		// Add block widget, setting the Form setting to the value specified in the .env file.
+		$I->addBlockWidget(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			array(
+				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] ),
+			)
+		);
 
-        // Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
-        // site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
-        $I->see('Slide in form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] . '" selected. View on the frontend site to see the slide in form.');
+		// Switch to iframe preview for the Form block.
+		$I->switchToIFrame( 'iframe[class="components-sandbox"]' );
 
-        // Switch back to main window.
-        $I->switchToIFrame();
+		// Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
+		// site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
+		$I->see( 'Slide in form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_SLIDE_IN_NAME'] . '" selected. View on the frontend site to see the slide in form.' );
 
-        // Confirm that the widget displays.
-        $I->seeBlockWidget($I, 'convertkit-form', 'form[data-sv-form]');
-    }
+		// Switch back to main window.
+		$I->switchToIFrame();
 
-    /**
-     * Test the Form widget displays a message explaining why the block cannot be previewed
-     * when a valid Sticky Bar Form is selected.
-     * 
-     * @since 1.9.7.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBlockFormWidgetWithValidStickyBarFormParameter(AcceptanceTester $I)
-    {
-        // Add block widget, setting the Form setting to the value specified in the .env file.
-        $I->addBlockWidget(
-            $I, 'ConvertKit Form', 'convertkit-form', [
-            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ]
-            ]
-        );
+		// Confirm that the widget displays.
+		$I->seeBlockWidget( $I, 'convertkit-form', 'form[data-sv-form]' );
+	}
 
-        // Switch to iframe preview for the Form block.
-        $I->switchToIFrame('iframe[class="components-sandbox"]');
+	/**
+	 * Test the Form widget displays a message explaining why the block cannot be previewed
+	 * when a valid Sticky Bar Form is selected.
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBlockFormWidgetWithValidStickyBarFormParameter( AcceptanceTester $I ) {
+		// Add block widget, setting the Form setting to the value specified in the .env file.
+		$I->addBlockWidget(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			array(
+				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] ),
+			)
+		);
 
-        // Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
-        // site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
-        $I->see('Sticky bar form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] . '" selected. View on the frontend site to see the sticky bar form.');
+		// Switch to iframe preview for the Form block.
+		$I->switchToIFrame( 'iframe[class="components-sandbox"]' );
 
-        // Switch back to main window.
-        $I->switchToIFrame();
+		// Confirm that the Form block iframe sandbox preview displays that the Modal form was selected, and to view the frontend
+		// site to see it (we cannot preview Modal forms in the Gutenberg editor due to Gutenberg using an iframe).
+		$I->see( 'Sticky bar form "' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'] . '" selected. View on the frontend site to see the sticky bar form.' );
 
-        // Confirm that the widget displays.
-        $I->seeBlockWidget($I, 'convertkit-form', 'form[data-sv-form]');
-    }
+		// Switch back to main window.
+		$I->switchToIFrame();
 
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.7.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        // Activate the current theme.
-        $I->useTheme('twentytwentytwo');
-        $I->resetWidgets($I);
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+		// Confirm that the widget displays.
+		$I->seeBlockWidget( $I, 'convertkit-form', 'form[data-sv-form]' );
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		// Activate the current theme.
+		$I->useTheme( 'twentytwentytwo' );
+		$I->resetWidgets( $I );
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/general/ActivateDeactivatePluginCest.php
+++ b/tests/acceptance/general/ActivateDeactivatePluginCest.php
@@ -2,29 +2,29 @@
 
 class ActivateDeactivatePluginCest
 {
-	/**
-	 * Activate the Plugin and confirm a success notification
-	 * is displayed with no errors.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testPluginActivation(AcceptanceTester $I)
-	{
-		$I->activateConvertKitPlugin($I);
-	}
+    /**
+     * Activate the Plugin and confirm a success notification
+     * is displayed with no errors.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testPluginActivation(AcceptanceTester $I)
+    {
+        $I->activateConvertKitPlugin($I);
+    }
 
-	/**
-	 * Deactivate the Plugin and confirm a success notification
-	 * is displayed with no errors.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testPluginDeactivation(AcceptanceTester $I)
-	{
-		$I->deactivateConvertKitPlugin($I);
-	}
+    /**
+     * Deactivate the Plugin and confirm a success notification
+     * is displayed with no errors.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testPluginDeactivation(AcceptanceTester $I)
+    {
+        $I->deactivateConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/general/ActivateDeactivatePluginCest.php
+++ b/tests/acceptance/general/ActivateDeactivatePluginCest.php
@@ -1,28 +1,30 @@
 <?php
 
-class ActivateDeactivatePluginCest {
-
+class ActivateDeactivatePluginCest
+{
 	/**
 	 * Activate the Plugin and confirm a success notification
 	 * is displayed with no errors.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testPluginActivation( AcceptanceTester $I ) {
-		$I->activateConvertKitPlugin( $I );
+	public function testPluginActivation(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
 	}
 
 	/**
 	 * Deactivate the Plugin and confirm a success notification
 	 * is displayed with no errors.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testPluginDeactivation( AcceptanceTester $I ) {
-		$I->deactivateConvertKitPlugin( $I );
+	public function testPluginDeactivation(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/general/ActivateDeactivatePluginCest.php
+++ b/tests/acceptance/general/ActivateDeactivatePluginCest.php
@@ -1,30 +1,28 @@
 <?php
 
-class ActivateDeactivatePluginCest
-{
-    /**
-     * Activate the Plugin and confirm a success notification
-     * is displayed with no errors.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testPluginActivation(AcceptanceTester $I)
-    {
-        $I->activateConvertKitPlugin($I);
-    }
+class ActivateDeactivatePluginCest {
 
-    /**
-     * Deactivate the Plugin and confirm a success notification
-     * is displayed with no errors.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testPluginDeactivation(AcceptanceTester $I)
-    {
-        $I->deactivateConvertKitPlugin($I);
-    }
+	/**
+	 * Activate the Plugin and confirm a success notification
+	 * is displayed with no errors.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testPluginActivation( AcceptanceTester $I ) {
+		$I->activateConvertKitPlugin( $I );
+	}
+
+	/**
+	 * Deactivate the Plugin and confirm a success notification
+	 * is displayed with no errors.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testPluginDeactivation( AcceptanceTester $I ) {
+		$I->deactivateConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/general/ActivateDeactivatePluginCest.php
+++ b/tests/acceptance/general/ActivateDeactivatePluginCest.php
@@ -1,14 +1,18 @@
 <?php
-
+/**
+ * Tests Plugin activation and deactivation.
+ *
+ * @since   1.9.6
+ */
 class ActivateDeactivatePluginCest
 {
 	/**
 	 * Activate the Plugin and confirm a success notification
 	 * is displayed with no errors.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testPluginActivation(AcceptanceTester $I)
 	{
@@ -18,10 +22,10 @@ class ActivateDeactivatePluginCest
 	/**
 	 * Deactivate the Plugin and confirm a success notification
 	 * is displayed with no errors.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testPluginDeactivation(AcceptanceTester $I)
 	{

--- a/tests/acceptance/general/AnyErrorsOnBlankInstallCest.php
+++ b/tests/acceptance/general/AnyErrorsOnBlankInstallCest.php
@@ -1,13 +1,18 @@
 <?php
-
+/**
+ * Tests for any output errors on a clean installation and activation,
+ * with no Plugin configuration.
+ *
+ * @since   1.9.6
+ */
 class AnyErrorsOnBlankInstallCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -17,10 +22,10 @@ class AnyErrorsOnBlankInstallCest
 	/**
 	 * Check that no PHP errors or notices are displayed on the Plugin's Settings > General screen when the Plugin is activated
 	 * and not configured.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testSettingsGeneralScreen(AcceptanceTester $I)
 	{
@@ -31,10 +36,10 @@ class AnyErrorsOnBlankInstallCest
 	/**
 	 * Check that no PHP errors or notices are displayed on the Plugin's Setting > Tools screen when the Plugin is activated
 	 * and not configured.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testSettingsToolsScreen(AcceptanceTester $I)
 	{
@@ -45,14 +50,14 @@ class AnyErrorsOnBlankInstallCest
 	/**
 	 * Check that no errors are displayed on Pages > Add New, when the Plugin is activated
 	 * and not configured.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewPage(AcceptanceTester $I)
 	{
-		// Navigate to Pages > Add New
+		// Navigate to Pages > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=page');
 
 		// Check that no PHP warnings or notices were output.
@@ -62,14 +67,14 @@ class AnyErrorsOnBlankInstallCest
 	/**
 	 * Check that no errors are displayed on Posts > Add New, when the Plugin is activated
 	 * and not configured.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewPost(AcceptanceTester $I)
 	{
-		// Navigate to Pages > Add New
+		// Navigate to Pages > Add New.
 		$I->amOnAdminPage('post-new.php');
 
 		// Check that no PHP warnings or notices were output.
@@ -79,14 +84,14 @@ class AnyErrorsOnBlankInstallCest
 	/**
 	 * Check that no errors are displayed on Posts > Categories > Edit Uncategorized, when the Plugin is activated
 	 * and not configured.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testEditCategory(AcceptanceTester $I)
 	{
-		// Navigate to Posts > Categories > Edit Uncategorized
+		// Navigate to Posts > Categories > Edit Uncategorized.
 		$I->amOnAdminPage('term.php?taxonomy=category&tag_ID=1');
 
 		// Check that no PHP warnings or notices were output.
@@ -97,10 +102,10 @@ class AnyErrorsOnBlankInstallCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/general/AnyErrorsOnBlankInstallCest.php
+++ b/tests/acceptance/general/AnyErrorsOnBlankInstallCest.php
@@ -2,109 +2,109 @@
 
 class AnyErrorsOnBlankInstallCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		$I->activateConvertKitPlugin($I);
-	}
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        $I->activateConvertKitPlugin($I);
+    }
 
-	/**
-	 * Check that no PHP errors or notices are displayed on the Plugin's Settings > General screen when the Plugin is activated
-	 * and not configured.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testSettingsGeneralScreen(AcceptanceTester $I)
-	{
-		// Go to the Plugin's Settings > General Screen.
-		$I->loadConvertKitSettingsGeneralScreen($I);
-	}
+    /**
+     * Check that no PHP errors or notices are displayed on the Plugin's Settings > General screen when the Plugin is activated
+     * and not configured.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testSettingsGeneralScreen(AcceptanceTester $I)
+    {
+        // Go to the Plugin's Settings > General Screen.
+        $I->loadConvertKitSettingsGeneralScreen($I);
+    }
 
-	/**
-	 * Check that no PHP errors or notices are displayed on the Plugin's Setting > Tools screen when the Plugin is activated
-	 * and not configured.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testSettingsToolsScreen(AcceptanceTester $I)
-	{
-		// Go to the Plugin's Settings > Tools Screen.
-		$I->loadConvertKitSettingsToolsScreen($I);
-	}
+    /**
+     * Check that no PHP errors or notices are displayed on the Plugin's Setting > Tools screen when the Plugin is activated
+     * and not configured.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testSettingsToolsScreen(AcceptanceTester $I)
+    {
+        // Go to the Plugin's Settings > Tools Screen.
+        $I->loadConvertKitSettingsToolsScreen($I);
+    }
 
-	/**
-	 * Check that no errors are displayed on Pages > Add New, when the Plugin is activated
-	 * and not configured.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewPage(AcceptanceTester $I)
-	{
-		// Navigate to Pages > Add New
-		$I->amOnAdminPage('post-new.php?post_type=page');
+    /**
+     * Check that no errors are displayed on Pages > Add New, when the Plugin is activated
+     * and not configured.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewPage(AcceptanceTester $I)
+    {
+        // Navigate to Pages > Add New
+        $I->amOnAdminPage('post-new.php?post_type=page');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-	}
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
+    }
 
-	/**
-	 * Check that no errors are displayed on Posts > Add New, when the Plugin is activated
-	 * and not configured.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewPost(AcceptanceTester $I)
-	{
-		// Navigate to Pages > Add New
-		$I->amOnAdminPage('post-new.php');
+    /**
+     * Check that no errors are displayed on Posts > Add New, when the Plugin is activated
+     * and not configured.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewPost(AcceptanceTester $I)
+    {
+        // Navigate to Pages > Add New
+        $I->amOnAdminPage('post-new.php');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-	}
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
+    }
 
-	/**
-	 * Check that no errors are displayed on Posts > Categories > Edit Uncategorized, when the Plugin is activated
-	 * and not configured.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testEditCategory(AcceptanceTester $I)
-	{
-		// Navigate to Posts > Categories > Edit Uncategorized
-		$I->amOnAdminPage('term.php?taxonomy=category&tag_ID=1');
+    /**
+     * Check that no errors are displayed on Posts > Categories > Edit Uncategorized, when the Plugin is activated
+     * and not configured.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testEditCategory(AcceptanceTester $I)
+    {
+        // Navigate to Posts > Categories > Edit Uncategorized
+        $I->amOnAdminPage('term.php?taxonomy=category&tag_ID=1');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-	}
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
+    }
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/general/AnyErrorsOnBlankInstallCest.php
+++ b/tests/acceptance/general/AnyErrorsOnBlankInstallCest.php
@@ -1,110 +1,103 @@
 <?php
 
-class AnyErrorsOnBlankInstallCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        $I->activateConvertKitPlugin($I);
-    }
+class AnyErrorsOnBlankInstallCest {
 
-    /**
-     * Check that no PHP errors or notices are displayed on the Plugin's Settings > General screen when the Plugin is activated
-     * and not configured.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testSettingsGeneralScreen(AcceptanceTester $I)
-    {
-        // Go to the Plugin's Settings > General Screen.
-        $I->loadConvertKitSettingsGeneralScreen($I);
-    }
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		$I->activateConvertKitPlugin( $I );
+	}
 
-    /**
-     * Check that no PHP errors or notices are displayed on the Plugin's Setting > Tools screen when the Plugin is activated
-     * and not configured.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testSettingsToolsScreen(AcceptanceTester $I)
-    {
-        // Go to the Plugin's Settings > Tools Screen.
-        $I->loadConvertKitSettingsToolsScreen($I);
-    }
+	/**
+	 * Check that no PHP errors or notices are displayed on the Plugin's Settings > General screen when the Plugin is activated
+	 * and not configured.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testSettingsGeneralScreen( AcceptanceTester $I ) {
+		// Go to the Plugin's Settings > General Screen.
+		$I->loadConvertKitSettingsGeneralScreen( $I );
+	}
 
-    /**
-     * Check that no errors are displayed on Pages > Add New, when the Plugin is activated
-     * and not configured.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewPage(AcceptanceTester $I)
-    {
-        // Navigate to Pages > Add New
-        $I->amOnAdminPage('post-new.php?post_type=page');
+	/**
+	 * Check that no PHP errors or notices are displayed on the Plugin's Setting > Tools screen when the Plugin is activated
+	 * and not configured.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testSettingsToolsScreen( AcceptanceTester $I ) {
+		// Go to the Plugin's Settings > Tools Screen.
+		$I->loadConvertKitSettingsToolsScreen( $I );
+	}
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-    }
+	/**
+	 * Check that no errors are displayed on Pages > Add New, when the Plugin is activated
+	 * and not configured.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewPage( AcceptanceTester $I ) {
+		// Navigate to Pages > Add New
+		$I->amOnAdminPage( 'post-new.php?post_type=page' );
 
-    /**
-     * Check that no errors are displayed on Posts > Add New, when the Plugin is activated
-     * and not configured.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewPost(AcceptanceTester $I)
-    {
-        // Navigate to Pages > Add New
-        $I->amOnAdminPage('post-new.php');
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+	}
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-    }
+	/**
+	 * Check that no errors are displayed on Posts > Add New, when the Plugin is activated
+	 * and not configured.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewPost( AcceptanceTester $I ) {
+		// Navigate to Pages > Add New
+		$I->amOnAdminPage( 'post-new.php' );
 
-    /**
-     * Check that no errors are displayed on Posts > Categories > Edit Uncategorized, when the Plugin is activated
-     * and not configured.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testEditCategory(AcceptanceTester $I)
-    {
-        // Navigate to Posts > Categories > Edit Uncategorized
-        $I->amOnAdminPage('term.php?taxonomy=category&tag_ID=1');
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+	}
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-    }
+	/**
+	 * Check that no errors are displayed on Posts > Categories > Edit Uncategorized, when the Plugin is activated
+	 * and not configured.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testEditCategory( AcceptanceTester $I ) {
+		// Navigate to Posts > Categories > Edit Uncategorized
+		$I->amOnAdminPage( 'term.php?taxonomy=category&tag_ID=1' );
 
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/general/AnyErrorsOnBlankInstallCest.php
+++ b/tests/acceptance/general/AnyErrorsOnBlankInstallCest.php
@@ -1,103 +1,110 @@
 <?php
 
-class AnyErrorsOnBlankInstallCest {
-
+class AnyErrorsOnBlankInstallCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
-		$I->activateConvertKitPlugin( $I );
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
 	}
 
 	/**
 	 * Check that no PHP errors or notices are displayed on the Plugin's Settings > General screen when the Plugin is activated
 	 * and not configured.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testSettingsGeneralScreen( AcceptanceTester $I ) {
+	public function testSettingsGeneralScreen(AcceptanceTester $I)
+	{
 		// Go to the Plugin's Settings > General Screen.
-		$I->loadConvertKitSettingsGeneralScreen( $I );
+		$I->loadConvertKitSettingsGeneralScreen($I);
 	}
 
 	/**
 	 * Check that no PHP errors or notices are displayed on the Plugin's Setting > Tools screen when the Plugin is activated
 	 * and not configured.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testSettingsToolsScreen( AcceptanceTester $I ) {
+	public function testSettingsToolsScreen(AcceptanceTester $I)
+	{
 		// Go to the Plugin's Settings > Tools Screen.
-		$I->loadConvertKitSettingsToolsScreen( $I );
+		$I->loadConvertKitSettingsToolsScreen($I);
 	}
 
 	/**
 	 * Check that no errors are displayed on Pages > Add New, when the Plugin is activated
 	 * and not configured.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewPage( AcceptanceTester $I ) {
+	public function testAddNewPage(AcceptanceTester $I)
+	{
 		// Navigate to Pages > Add New
-		$I->amOnAdminPage( 'post-new.php?post_type=page' );
+		$I->amOnAdminPage('post-new.php?post_type=page');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 	}
 
 	/**
 	 * Check that no errors are displayed on Posts > Add New, when the Plugin is activated
 	 * and not configured.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewPost( AcceptanceTester $I ) {
+	public function testAddNewPost(AcceptanceTester $I)
+	{
 		// Navigate to Pages > Add New
-		$I->amOnAdminPage( 'post-new.php' );
+		$I->amOnAdminPage('post-new.php');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 	}
 
 	/**
 	 * Check that no errors are displayed on Posts > Categories > Edit Uncategorized, when the Plugin is activated
 	 * and not configured.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testEditCategory( AcceptanceTester $I ) {
+	public function testEditCategory(AcceptanceTester $I)
+	{
 		// Navigate to Posts > Categories > Edit Uncategorized
-		$I->amOnAdminPage( 'term.php?taxonomy=category&tag_ID=1' );
+		$I->amOnAdminPage('term.php?taxonomy=category&tag_ID=1');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/general/PageCest.php
+++ b/tests/acceptance/general/PageCest.php
@@ -1,67 +1,64 @@
 <?php
 /**
  * Tests for ConvertKit Settings on WordPress Pages when no API Credentials specified.
- * 
+ *
  * @since 1.9.6
  */
-class PageCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        $I->activateConvertKitPlugin($I);
-    }
+class PageCest {
 
-    /**
-     * Test that the ConvertKit Page Settings displays a message with a link to the Plugin Settings
-     * telling the user to configure their API Credentials, when no API Credentials exist.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewPageShowsLinkToPluginSettingsWhenNoAPICredentialsSpecified(AcceptanceTester $I)
-    {
-        // Navigate to Pages > Add New
-        $I->amOnAdminPage('post-new.php?post_type=page');
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		$I->activateConvertKitPlugin( $I );
+	}
 
-        // Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
-        $I->maybeCloseGutenbergWelcomeModal($I);
+	/**
+	 * Test that the ConvertKit Page Settings displays a message with a link to the Plugin Settings
+	 * telling the user to configure their API Credentials, when no API Credentials exist.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewPageShowsLinkToPluginSettingsWhenNoAPICredentialsSpecified( AcceptanceTester $I ) {
+		// Navigate to Pages > Add New
+		$I->amOnAdminPage( 'post-new.php?post_type=page' );
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
+		$I->maybeCloseGutenbergWelcomeModal( $I );
 
-        // Check that the metabox is displayed.
-        $I->seeElementInDOM('#wp-convertkit-meta-box');
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-        // Check that the Form option is not displayed.
-        $I->dontSeeElementInDOM('#wp-convertkit-form');
+		// Check that the metabox is displayed.
+		$I->seeElementInDOM( '#wp-convertkit-meta-box' );
 
-        // Check that an expected message is displayed.
-        $I->seeInSource('To configure the ConvertKit Form / Landing Page to display on this Page, enter your ConvertKit API credentials');
+		// Check that the Form option is not displayed.
+		$I->dontSeeElementInDOM( '#wp-convertkit-form' );
 
-        // Check that a link to the Plugin Settings exists.
-        $I->seeInSource('<a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/options-general.php?page=_wp_convertkit_settings">Plugin Settings</a>');
-    }
+		// Check that an expected message is displayed.
+		$I->seeInSource( 'To configure the ConvertKit Form / Landing Page to display on this Page, enter your ConvertKit API credentials' );
 
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+		// Check that a link to the Plugin Settings exists.
+		$I->seeInSource( '<a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/options-general.php?page=_wp_convertkit_settings">Plugin Settings</a>' );
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/general/PageCest.php
+++ b/tests/acceptance/general/PageCest.php
@@ -1,64 +1,67 @@
 <?php
 /**
  * Tests for ConvertKit Settings on WordPress Pages when no API Credentials specified.
- *
- * @since 1.9.6
+ * 
+ * @since 	1.9.6
  */
-class PageCest {
-
+class PageCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
-		$I->activateConvertKitPlugin( $I );
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
 	}
 
 	/**
 	 * Test that the ConvertKit Page Settings displays a message with a link to the Plugin Settings
 	 * telling the user to configure their API Credentials, when no API Credentials exist.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewPageShowsLinkToPluginSettingsWhenNoAPICredentialsSpecified( AcceptanceTester $I ) {
+	public function testAddNewPageShowsLinkToPluginSettingsWhenNoAPICredentialsSpecified(AcceptanceTester $I)
+	{
 		// Navigate to Pages > Add New
-		$I->amOnAdminPage( 'post-new.php?post_type=page' );
+		$I->amOnAdminPage('post-new.php?post_type=page');
 
 		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
-		$I->maybeCloseGutenbergWelcomeModal( $I );
+		$I->maybeCloseGutenbergWelcomeModal($I);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check that the metabox is displayed.
-		$I->seeElementInDOM( '#wp-convertkit-meta-box' );
+		$I->seeElementInDOM('#wp-convertkit-meta-box');
 
 		// Check that the Form option is not displayed.
-		$I->dontSeeElementInDOM( '#wp-convertkit-form' );
+		$I->dontSeeElementInDOM('#wp-convertkit-form');
 
 		// Check that an expected message is displayed.
-		$I->seeInSource( 'To configure the ConvertKit Form / Landing Page to display on this Page, enter your ConvertKit API credentials' );
+		$I->seeInSource('To configure the ConvertKit Form / Landing Page to display on this Page, enter your ConvertKit API credentials');
 
 		// Check that a link to the Plugin Settings exists.
-		$I->seeInSource( '<a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/options-general.php?page=_wp_convertkit_settings">Plugin Settings</a>' );
+		$I->seeInSource('<a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/options-general.php?page=_wp_convertkit_settings">Plugin Settings</a>');
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/general/PageCest.php
+++ b/tests/acceptance/general/PageCest.php
@@ -2,66 +2,66 @@
 /**
  * Tests for ConvertKit Settings on WordPress Pages when no API Credentials specified.
  * 
- * @since 	1.9.6
+ * @since 1.9.6
  */
 class PageCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		$I->activateConvertKitPlugin($I);
-	}
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        $I->activateConvertKitPlugin($I);
+    }
 
-	/**
-	 * Test that the ConvertKit Page Settings displays a message with a link to the Plugin Settings
-	 * telling the user to configure their API Credentials, when no API Credentials exist.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewPageShowsLinkToPluginSettingsWhenNoAPICredentialsSpecified(AcceptanceTester $I)
-	{
-		// Navigate to Pages > Add New
-		$I->amOnAdminPage('post-new.php?post_type=page');
+    /**
+     * Test that the ConvertKit Page Settings displays a message with a link to the Plugin Settings
+     * telling the user to configure their API Credentials, when no API Credentials exist.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewPageShowsLinkToPluginSettingsWhenNoAPICredentialsSpecified(AcceptanceTester $I)
+    {
+        // Navigate to Pages > Add New
+        $I->amOnAdminPage('post-new.php?post_type=page');
 
-		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
-		$I->maybeCloseGutenbergWelcomeModal($I);
+        // Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
+        $I->maybeCloseGutenbergWelcomeModal($I);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Check that the metabox is displayed.
-		$I->seeElementInDOM('#wp-convertkit-meta-box');
+        // Check that the metabox is displayed.
+        $I->seeElementInDOM('#wp-convertkit-meta-box');
 
-		// Check that the Form option is not displayed.
-		$I->dontSeeElementInDOM('#wp-convertkit-form');
+        // Check that the Form option is not displayed.
+        $I->dontSeeElementInDOM('#wp-convertkit-form');
 
-		// Check that an expected message is displayed.
-		$I->seeInSource('To configure the ConvertKit Form / Landing Page to display on this Page, enter your ConvertKit API credentials');
+        // Check that an expected message is displayed.
+        $I->seeInSource('To configure the ConvertKit Form / Landing Page to display on this Page, enter your ConvertKit API credentials');
 
-		// Check that a link to the Plugin Settings exists.
-		$I->seeInSource('<a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/options-general.php?page=_wp_convertkit_settings">Plugin Settings</a>');
-	}
+        // Check that a link to the Plugin Settings exists.
+        $I->seeInSource('<a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/options-general.php?page=_wp_convertkit_settings">Plugin Settings</a>');
+    }
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/general/PageCest.php
+++ b/tests/acceptance/general/PageCest.php
@@ -1,17 +1,17 @@
 <?php
 /**
  * Tests for ConvertKit Settings on WordPress Pages when no API Credentials specified.
- * 
- * @since 	1.9.6
+ *
+ * @since   1.9.6
  */
 class PageCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -21,17 +21,17 @@ class PageCest
 	/**
 	 * Test that the ConvertKit Page Settings displays a message with a link to the Plugin Settings
 	 * telling the user to configure their API Credentials, when no API Credentials exist.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewPageShowsLinkToPluginSettingsWhenNoAPICredentialsSpecified(AcceptanceTester $I)
 	{
-		// Navigate to Pages > Add New
+		// Navigate to Pages > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=page');
 
-		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
+		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed.
 		$I->maybeCloseGutenbergWelcomeModal($I);
 
 		// Check that no PHP warnings or notices were output.
@@ -54,10 +54,10 @@ class PageCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/general/PluginSettingsGeneralCest.php
+++ b/tests/acceptance/general/PluginSettingsGeneralCest.php
@@ -1,412 +1,397 @@
 <?php
 
-class PluginSettingsGeneralCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        $I->activateConvertKitPlugin($I);
-    }
-
-    /**
-     * Test that the Settings > ConvertKit > General screen has expected a11y output, such as label[for].
-     * 
-     * @since 1.9.7.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAccessibility(AcceptanceTester $I)
-    {
-        // Go to the Plugin's Settings Screen.
-        $I->loadConvertKitSettingsGeneralScreen($I);
-
-        // Confirm that settings have label[for] attributes.
-        $I->seeInSource('<label for="api_key">');
-        $I->seeInSource('<label for="api_secret">');
-        $I->seeInSource('<label for="_wp_convertkit_settings_page_form">');
-        $I->seeInSource('<label for="_wp_convertkit_settings_post_form">');
-        $I->seeInSource('<label for="debug">');
-        $I->seeInSource('<label for="no_scripts">');
-        $I->seeInSource('<label for="no_css">');
-    }
-
-    /**
-     * Test that UTM parameters are included in links displayed on the Plugins' Setting screen for the user to obtain
-     * their API Key and Secret, or sign in to their ConvertKit account.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testUTMParametersExist(AcceptanceTester $I)
-    {
-        // Go to the Plugin's Settings Screen.
-        $I->loadConvertKitSettingsGeneralScreen($I);
-
-        // Confirm that UTM parameters exist for the 'Get your ConvertKit API Key' link.
-        $I->seeInSource('<a href="https://app.convertkit.com/account_settings/advanced_settings/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">Get your ConvertKit API Key.</a>');
-		
-        // Confirm that UTM parameters exist for the 'Get your ConvertKit API Secret' link.
-        $I->seeInSource('<a href="https://app.convertkit.com/account_settings/advanced_settings/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">Get your ConvertKit API Secret.</a>');
-	
-        // Confirm that UTM parameters exist for the 'sign in to ConvertKit' link.
-        $I->seeInSource('<a href="https://app.convertkit.com/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">sign in to ConvertKit</a>');
-    }
-
-    /**
-     * Test that no PHP errors or notices are displayed on the Plugin's Setting screen when the Save Changes
-     * button is pressed and no settings are specified.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testSaveBlankSettings(AcceptanceTester $I)
-    {
-        // Go to the Plugin's Settings Screen.
-        $I->loadConvertKitSettingsGeneralScreen($I);
-
-        // Click the Save Changes button.
-        $I->click('Save Changes');
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Check that 'No Forms exist in ConvertKit' is displayed.
-        $I->seeInSource('No Forms exist in ConvertKit.');
-    }
-
-    /**
-     * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
-     * and a warning is displayed that the supplied API credentials are invalid, when
-     * saving invalid API credentials.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testSaveInvalidAPICredentials(AcceptanceTester $I)
-    {
-        // Go to the Plugin's Settings Screen.
-        $I->loadConvertKitSettingsGeneralScreen($I);
-
-        // Complete API Fields with incorrect data.
-        $I->fillField('_wp_convertkit_settings[api_key]', 'fakeApiKey');
-        $I->fillField('_wp_convertkit_settings[api_secret]', 'fakeApiSecret');
-
-        // Click the Save Changes button.
-        $I->click('Save Changes');
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-    }
-
-    /**
-     * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
-     * when valid API credentials are saved.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testSaveValidAPICredentials(AcceptanceTester $I)
-    {
-        $I->setupConvertKitPlugin($I);
-    }
-
-    /**
-     * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
-     * when valid API credentials are saved, but the ConvertKit account for the given API
-     * credentials have no forms.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testSaveValidAPICredentialsWithNoForms(AcceptanceTester $I)
-    {
-        // Go to the Plugin's Settings Screen.
-        $I->loadConvertKitSettingsGeneralScreen($I);
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Complete API Fields.
-        $I->fillField('_wp_convertkit_settings[api_key]', $_ENV['CONVERTKIT_API_KEY_NO_DATA']);
-        $I->fillField('_wp_convertkit_settings[api_secret]', $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
-
-        // Click the Save Changes button.
-        $I->click('Save Changes');
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Check that 'No Forms exist in ConvertKit' is displayed.
-        $I->seeInSource('No Forms exist in ConvertKit.');
-    }
-
-    /**
-     * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
-     * when the Default Form is changed.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testChangeDefaultFormSetting(AcceptanceTester $I)
-    {
-        // Setup Plugin.
-        $I->setupConvertKitPlugin($I);
-
-        // Go to the Plugin's Settings Screen.
-        $I->loadConvertKitSettingsGeneralScreen($I);
-
-        // Call helper function to define default Page and Post
-        $I->setupConvertKitPluginDefaultForm($I);
-    }
-
-    /**
-     * Test that the preview link for the Default Form settings works.
-     * 
-     * @since 1.9.8.5
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testPreviewFormLinks(AcceptanceTester $I)
-    {
-        // Create a Page and a Post, so that preview links display.
-        $I->havePostInDatabase(
-            [
-            'post_title'    => 'ConvertKit: Preview Form Links: Page',
-            'post_type'        => 'page',
-            'post_status'    => 'publish',
-            ]
-        );
-        $I->havePostInDatabase(
-            [
-            'post_title'    => 'ConvertKit: Preview Form Links: Post',
-            'post_type'        => 'post',
-            'post_status'    => 'publish',
-            ]
-        );
-
-        // Setup Plugin.
-        $I->setupConvertKitPlugin($I);
-
-        // Go to the Plugin's Settings Screen.
-        $I->loadConvertKitSettingsGeneralScreen($I);
-
-        // Select Default Form for Pages.
-        $I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
-
-        // Open preview.
-        $I->click('a#convertkit-preview-form-page');
-        $I->wait(2); // Required, otherwise switchToNextTab fails.
-
-        // Switch to newly opened tab.
-        $I->switchToNextTab();
-
-        // Confirm expected Form is displayed.
-        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-
-        // Close newly opened tab.
-        $I->closeTab();
-
-        // Select Default Form for Posts.
-        $I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_post_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
-
-        // Open preview.
-        $I->click('a#convertkit-preview-form-post');
-        $I->wait(2); // Required, otherwise switchToNextTab fails.
-
-        // Switch to newly opened tab.
-        $I->switchToNextTab();
-
-        // Confirm expected Form is displayed.
-        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-
-        // Close newly opened tab.
-        $I->closeTab();
-    }
-
-    /**
-     * Test that the settings screen does not display preview links
-     * when no Pages and Posts exist in WordPress.
-     *
-     * @since 1.9.8.5
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testPreviewFormLinksWhenNoPostsOrPagesExist(AcceptanceTester $I)
-    {
-        // Setup Plugin.
-        $I->setupConvertKitPlugin($I);
-
-        // Go to the Plugin's Settings Screen.
-        $I->loadConvertKitSettingsGeneralScreen($I);
-
-        // Confirm no Page or Post preview links exist, because there are no Pages or Posts in WordPress.
-        $I->dontSeeElementInDOM('a#convertkit-preview-form-post');
-        $I->dontSeeElementInDOM('a#convertkit-preview-form-page');
-    }
-
-    /**
-     * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
-     * when Debug settings are enabled and disabled.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testEnableAndDisableDebugSettings(AcceptanceTester $I)
-    {
-        // Setup API Keys in ConvertKit Plugin.
-        $I->setupConvertKitPlugin($I);
-
-        // Go to the Plugin's Settings Screen.
-        $I->loadConvertKitSettingsGeneralScreen($I);
-		
-        // Tick field.
-        $I->checkOption('#debug');
-
-        // Click the Save Changes button.
-        $I->click('Save Changes');
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Check the field remains ticked.
-        $I->seeCheckboxIsChecked('#debug');    
-
-        // Untick field.
-        $I->uncheckOption('#debug');
-
-        // Click the Save Changes button.
-        $I->click('Save Changes');
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Check the field remains unticked.
-        $I->dontSeeCheckboxIsChecked('#debug');    
-    }
-
-    /**
-     * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
-     * when the Disable JavaScript settings are enabled and disabled.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testEnableAndDisableJavaScriptSettings(AcceptanceTester $I)
-    {
-        // Go to the Plugin's Settings Screen.
-        $I->loadConvertKitSettingsGeneralScreen($I);
-		
-        // Tick fields.
-        $I->checkOption('#debug');
-        $I->checkOption('#no_scripts');
-
-        // Click the Save Changes button.
-        $I->click('Save Changes');
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Check the fields are ticked.
-        $I->seeCheckboxIsChecked('#debug');
-        $I->seeCheckboxIsChecked('#no_scripts');    
-    }
-
-    /**
-     * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
-     * when the Disable CSS settings is unchecked, and that CSS is output
-     * on the frontend web site.
-     * 
-     * @since 1.9.6.9
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testEnableCSSSetting(AcceptanceTester $I)
-    {
-        // Go to the Plugin's Settings Screen.
-        $I->loadConvertKitSettingsGeneralScreen($I);
-		
-        // Tick fields.
-        $I->checkOption('#debug');
-        $I->uncheckOption('#no_css');
-
-        // Click the Save Changes button.
-        $I->click('Save Changes');
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Check the fields are ticked.
-        $I->seeCheckboxIsChecked('#debug');
-        $I->dontSeeCheckboxIsChecked('#no_css');    
-
-        // Navigate to the home page.
-        $I->amOnPage('/');
-
-        // Confirm no CSS is output by the Plugin.
-        $I->seeInSource('broadcasts.css');
-    }
-
-    /**
-     * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
-     * when the Disable CSS settings is checked, and that no CSS is output
-     * on the frontend web site.
-     * 
-     * @since 1.9.6.9
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testDisableCSSSetting(AcceptanceTester $I)
-    {
-        // Go to the Plugin's Settings Screen.
-        $I->loadConvertKitSettingsGeneralScreen($I);
-		
-        // Tick fields.
-        $I->checkOption('#debug');
-        $I->checkOption('#no_css');
-
-        // Click the Save Changes button.
-        $I->click('Save Changes');
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Check the fields are ticked.
-        $I->seeCheckboxIsChecked('#debug');
-        $I->seeCheckboxIsChecked('#no_css');    
-
-        // Navigate to the home page.
-        $I->amOnPage('/');
-
-        // Confirm no CSS is output by the Plugin.
-        $I->dontSeeInSource('broadcasts.css');
-    }
-
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+class PluginSettingsGeneralCest {
+
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		$I->activateConvertKitPlugin( $I );
+	}
+
+	/**
+	 * Test that the Settings > ConvertKit > General screen has expected a11y output, such as label[for].
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAccessibility( AcceptanceTester $I ) {
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsGeneralScreen( $I );
+
+		// Confirm that settings have label[for] attributes.
+		$I->seeInSource( '<label for="api_key">' );
+		$I->seeInSource( '<label for="api_secret">' );
+		$I->seeInSource( '<label for="_wp_convertkit_settings_page_form">' );
+		$I->seeInSource( '<label for="_wp_convertkit_settings_post_form">' );
+		$I->seeInSource( '<label for="debug">' );
+		$I->seeInSource( '<label for="no_scripts">' );
+		$I->seeInSource( '<label for="no_css">' );
+	}
+
+	/**
+	 * Test that UTM parameters are included in links displayed on the Plugins' Setting screen for the user to obtain
+	 * their API Key and Secret, or sign in to their ConvertKit account.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testUTMParametersExist( AcceptanceTester $I ) {
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsGeneralScreen( $I );
+
+		// Confirm that UTM parameters exist for the 'Get your ConvertKit API Key' link.
+		$I->seeInSource( '<a href="https://app.convertkit.com/account_settings/advanced_settings/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">Get your ConvertKit API Key.</a>' );
+
+		// Confirm that UTM parameters exist for the 'Get your ConvertKit API Secret' link.
+		$I->seeInSource( '<a href="https://app.convertkit.com/account_settings/advanced_settings/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">Get your ConvertKit API Secret.</a>' );
+
+		// Confirm that UTM parameters exist for the 'sign in to ConvertKit' link.
+		$I->seeInSource( '<a href="https://app.convertkit.com/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">sign in to ConvertKit</a>' );
+	}
+
+	/**
+	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen when the Save Changes
+	 * button is pressed and no settings are specified.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testSaveBlankSettings( AcceptanceTester $I ) {
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsGeneralScreen( $I );
+
+		// Click the Save Changes button.
+		$I->click( 'Save Changes' );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Check that 'No Forms exist in ConvertKit' is displayed.
+		$I->seeInSource( 'No Forms exist in ConvertKit.' );
+	}
+
+	/**
+	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
+	 * and a warning is displayed that the supplied API credentials are invalid, when
+	 * saving invalid API credentials.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testSaveInvalidAPICredentials( AcceptanceTester $I ) {
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsGeneralScreen( $I );
+
+		// Complete API Fields with incorrect data.
+		$I->fillField( '_wp_convertkit_settings[api_key]', 'fakeApiKey' );
+		$I->fillField( '_wp_convertkit_settings[api_secret]', 'fakeApiSecret' );
+
+		// Click the Save Changes button.
+		$I->click( 'Save Changes' );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+	}
+
+	/**
+	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
+	 * when valid API credentials are saved.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testSaveValidAPICredentials( AcceptanceTester $I ) {
+		$I->setupConvertKitPlugin( $I );
+	}
+
+	/**
+	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
+	 * when valid API credentials are saved, but the ConvertKit account for the given API
+	 * credentials have no forms.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testSaveValidAPICredentialsWithNoForms( AcceptanceTester $I ) {
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsGeneralScreen( $I );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Complete API Fields.
+		$I->fillField( '_wp_convertkit_settings[api_key]', $_ENV['CONVERTKIT_API_KEY_NO_DATA'] );
+		$I->fillField( '_wp_convertkit_settings[api_secret]', $_ENV['CONVERTKIT_API_SECRET_NO_DATA'] );
+
+		// Click the Save Changes button.
+		$I->click( 'Save Changes' );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Check that 'No Forms exist in ConvertKit' is displayed.
+		$I->seeInSource( 'No Forms exist in ConvertKit.' );
+	}
+
+	/**
+	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
+	 * when the Default Form is changed.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testChangeDefaultFormSetting( AcceptanceTester $I ) {
+		// Setup Plugin.
+		$I->setupConvertKitPlugin( $I );
+
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsGeneralScreen( $I );
+
+		// Call helper function to define default Page and Post
+		$I->setupConvertKitPluginDefaultForm( $I );
+	}
+
+	/**
+	 * Test that the preview link for the Default Form settings works.
+	 *
+	 * @since 1.9.8.5
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testPreviewFormLinks( AcceptanceTester $I ) {
+		// Create a Page and a Post, so that preview links display.
+		$I->havePostInDatabase(
+			array(
+				'post_title'  => 'ConvertKit: Preview Form Links: Page',
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			)
+		);
+		$I->havePostInDatabase(
+			array(
+				'post_title'  => 'ConvertKit: Preview Form Links: Post',
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+			)
+		);
+
+		// Setup Plugin.
+		$I->setupConvertKitPlugin( $I );
+
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsGeneralScreen( $I );
+
+		// Select Default Form for Pages.
+		$I->fillSelect2Field( $I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+
+		// Open preview.
+		$I->click( 'a#convertkit-preview-form-page' );
+		$I->wait( 2 ); // Required, otherwise switchToNextTab fails.
+
+		// Switch to newly opened tab.
+		$I->switchToNextTab();
+
+		// Confirm expected Form is displayed.
+		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+
+		// Close newly opened tab.
+		$I->closeTab();
+
+		// Select Default Form for Posts.
+		$I->fillSelect2Field( $I, '#select2-_wp_convertkit_settings_post_form-container', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+
+		// Open preview.
+		$I->click( 'a#convertkit-preview-form-post' );
+		$I->wait( 2 ); // Required, otherwise switchToNextTab fails.
+
+		// Switch to newly opened tab.
+		$I->switchToNextTab();
+
+		// Confirm expected Form is displayed.
+		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+
+		// Close newly opened tab.
+		$I->closeTab();
+	}
+
+	/**
+	 * Test that the settings screen does not display preview links
+	 * when no Pages and Posts exist in WordPress.
+	 *
+	 * @since 1.9.8.5
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testPreviewFormLinksWhenNoPostsOrPagesExist( AcceptanceTester $I ) {
+		// Setup Plugin.
+		$I->setupConvertKitPlugin( $I );
+
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsGeneralScreen( $I );
+
+		// Confirm no Page or Post preview links exist, because there are no Pages or Posts in WordPress.
+		$I->dontSeeElementInDOM( 'a#convertkit-preview-form-post' );
+		$I->dontSeeElementInDOM( 'a#convertkit-preview-form-page' );
+	}
+
+	/**
+	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
+	 * when Debug settings are enabled and disabled.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testEnableAndDisableDebugSettings( AcceptanceTester $I ) {
+		// Setup API Keys in ConvertKit Plugin.
+		$I->setupConvertKitPlugin( $I );
+
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsGeneralScreen( $I );
+
+		// Tick field.
+		$I->checkOption( '#debug' );
+
+		// Click the Save Changes button.
+		$I->click( 'Save Changes' );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Check the field remains ticked.
+		$I->seeCheckboxIsChecked( '#debug' );
+
+		// Untick field.
+		$I->uncheckOption( '#debug' );
+
+		// Click the Save Changes button.
+		$I->click( 'Save Changes' );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Check the field remains unticked.
+		$I->dontSeeCheckboxIsChecked( '#debug' );
+	}
+
+	/**
+	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
+	 * when the Disable JavaScript settings are enabled and disabled.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testEnableAndDisableJavaScriptSettings( AcceptanceTester $I ) {
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsGeneralScreen( $I );
+
+		// Tick fields.
+		$I->checkOption( '#debug' );
+		$I->checkOption( '#no_scripts' );
+
+		// Click the Save Changes button.
+		$I->click( 'Save Changes' );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Check the fields are ticked.
+		$I->seeCheckboxIsChecked( '#debug' );
+		$I->seeCheckboxIsChecked( '#no_scripts' );
+	}
+
+	/**
+	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
+	 * when the Disable CSS settings is unchecked, and that CSS is output
+	 * on the frontend web site.
+	 *
+	 * @since 1.9.6.9
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testEnableCSSSetting( AcceptanceTester $I ) {
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsGeneralScreen( $I );
+
+		// Tick fields.
+		$I->checkOption( '#debug' );
+		$I->uncheckOption( '#no_css' );
+
+		// Click the Save Changes button.
+		$I->click( 'Save Changes' );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Check the fields are ticked.
+		$I->seeCheckboxIsChecked( '#debug' );
+		$I->dontSeeCheckboxIsChecked( '#no_css' );
+
+		// Navigate to the home page.
+		$I->amOnPage( '/' );
+
+		// Confirm no CSS is output by the Plugin.
+		$I->seeInSource( 'broadcasts.css' );
+	}
+
+	/**
+	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
+	 * when the Disable CSS settings is checked, and that no CSS is output
+	 * on the frontend web site.
+	 *
+	 * @since 1.9.6.9
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testDisableCSSSetting( AcceptanceTester $I ) {
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsGeneralScreen( $I );
+
+		// Tick fields.
+		$I->checkOption( '#debug' );
+		$I->checkOption( '#no_css' );
+
+		// Click the Save Changes button.
+		$I->click( 'Save Changes' );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Check the fields are ticked.
+		$I->seeCheckboxIsChecked( '#debug' );
+		$I->seeCheckboxIsChecked( '#no_css' );
+
+		// Navigate to the home page.
+		$I->amOnPage( '/' );
+
+		// Confirm no CSS is output by the Plugin.
+		$I->dontSeeInSource( 'broadcasts.css' );
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/general/PluginSettingsGeneralCest.php
+++ b/tests/acceptance/general/PluginSettingsGeneralCest.php
@@ -2,407 +2,411 @@
 
 class PluginSettingsGeneralCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		$I->activateConvertKitPlugin($I);
-	}
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        $I->activateConvertKitPlugin($I);
+    }
 
-	/**
-	 * Test that the Settings > ConvertKit > General screen has expected a11y output, such as label[for].
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAccessibility(AcceptanceTester $I)
-	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen($I);
+    /**
+     * Test that the Settings > ConvertKit > General screen has expected a11y output, such as label[for].
+     * 
+     * @since 1.9.7.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAccessibility(AcceptanceTester $I)
+    {
+        // Go to the Plugin's Settings Screen.
+        $I->loadConvertKitSettingsGeneralScreen($I);
 
-		// Confirm that settings have label[for] attributes.
-		$I->seeInSource('<label for="api_key">');
-		$I->seeInSource('<label for="api_secret">');
-		$I->seeInSource('<label for="_wp_convertkit_settings_page_form">');
-		$I->seeInSource('<label for="_wp_convertkit_settings_post_form">');
-		$I->seeInSource('<label for="debug">');
-		$I->seeInSource('<label for="no_scripts">');
-		$I->seeInSource('<label for="no_css">');
-	}
+        // Confirm that settings have label[for] attributes.
+        $I->seeInSource('<label for="api_key">');
+        $I->seeInSource('<label for="api_secret">');
+        $I->seeInSource('<label for="_wp_convertkit_settings_page_form">');
+        $I->seeInSource('<label for="_wp_convertkit_settings_post_form">');
+        $I->seeInSource('<label for="debug">');
+        $I->seeInSource('<label for="no_scripts">');
+        $I->seeInSource('<label for="no_css">');
+    }
 
-	/**
-	 * Test that UTM parameters are included in links displayed on the Plugins' Setting screen for the user to obtain
-	 * their API Key and Secret, or sign in to their ConvertKit account.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testUTMParametersExist(AcceptanceTester $I)
-	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen($I);
+    /**
+     * Test that UTM parameters are included in links displayed on the Plugins' Setting screen for the user to obtain
+     * their API Key and Secret, or sign in to their ConvertKit account.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testUTMParametersExist(AcceptanceTester $I)
+    {
+        // Go to the Plugin's Settings Screen.
+        $I->loadConvertKitSettingsGeneralScreen($I);
 
-		// Confirm that UTM parameters exist for the 'Get your ConvertKit API Key' link.
-		$I->seeInSource('<a href="https://app.convertkit.com/account_settings/advanced_settings/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">Get your ConvertKit API Key.</a>');
+        // Confirm that UTM parameters exist for the 'Get your ConvertKit API Key' link.
+        $I->seeInSource('<a href="https://app.convertkit.com/account_settings/advanced_settings/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">Get your ConvertKit API Key.</a>');
 		
-		// Confirm that UTM parameters exist for the 'Get your ConvertKit API Secret' link.
-		$I->seeInSource('<a href="https://app.convertkit.com/account_settings/advanced_settings/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">Get your ConvertKit API Secret.</a>');
+        // Confirm that UTM parameters exist for the 'Get your ConvertKit API Secret' link.
+        $I->seeInSource('<a href="https://app.convertkit.com/account_settings/advanced_settings/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">Get your ConvertKit API Secret.</a>');
 	
-		// Confirm that UTM parameters exist for the 'sign in to ConvertKit' link.
-		$I->seeInSource('<a href="https://app.convertkit.com/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">sign in to ConvertKit</a>');
-	}
+        // Confirm that UTM parameters exist for the 'sign in to ConvertKit' link.
+        $I->seeInSource('<a href="https://app.convertkit.com/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">sign in to ConvertKit</a>');
+    }
 
-	/**
-	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen when the Save Changes
-	 * button is pressed and no settings are specified.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testSaveBlankSettings(AcceptanceTester $I)
-	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen($I);
+    /**
+     * Test that no PHP errors or notices are displayed on the Plugin's Setting screen when the Save Changes
+     * button is pressed and no settings are specified.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testSaveBlankSettings(AcceptanceTester $I)
+    {
+        // Go to the Plugin's Settings Screen.
+        $I->loadConvertKitSettingsGeneralScreen($I);
 
-		// Click the Save Changes button.
-		$I->click('Save Changes');
+        // Click the Save Changes button.
+        $I->click('Save Changes');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Check that 'No Forms exist in ConvertKit' is displayed.
-		$I->seeInSource('No Forms exist in ConvertKit.');
-	}
+        // Check that 'No Forms exist in ConvertKit' is displayed.
+        $I->seeInSource('No Forms exist in ConvertKit.');
+    }
 
-	/**
-	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
-	 * and a warning is displayed that the supplied API credentials are invalid, when
-	 * saving invalid API credentials.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testSaveInvalidAPICredentials(AcceptanceTester $I)
-	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen($I);
+    /**
+     * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
+     * and a warning is displayed that the supplied API credentials are invalid, when
+     * saving invalid API credentials.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testSaveInvalidAPICredentials(AcceptanceTester $I)
+    {
+        // Go to the Plugin's Settings Screen.
+        $I->loadConvertKitSettingsGeneralScreen($I);
 
-		// Complete API Fields with incorrect data.
-		$I->fillField('_wp_convertkit_settings[api_key]', 'fakeApiKey');
-		$I->fillField('_wp_convertkit_settings[api_secret]', 'fakeApiSecret');
+        // Complete API Fields with incorrect data.
+        $I->fillField('_wp_convertkit_settings[api_key]', 'fakeApiKey');
+        $I->fillField('_wp_convertkit_settings[api_secret]', 'fakeApiSecret');
 
-		// Click the Save Changes button.
-		$I->click('Save Changes');
+        // Click the Save Changes button.
+        $I->click('Save Changes');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-	}
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
+    }
 
-	/**
-	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
-	 * when valid API credentials are saved.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testSaveValidAPICredentials(AcceptanceTester $I)
-	{
-		$I->setupConvertKitPlugin($I);
-	}
+    /**
+     * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
+     * when valid API credentials are saved.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testSaveValidAPICredentials(AcceptanceTester $I)
+    {
+        $I->setupConvertKitPlugin($I);
+    }
 
-	/**
-	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
-	 * when valid API credentials are saved, but the ConvertKit account for the given API
-	 * credentials have no forms.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testSaveValidAPICredentialsWithNoForms(AcceptanceTester $I)
-	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen($I);
+    /**
+     * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
+     * when valid API credentials are saved, but the ConvertKit account for the given API
+     * credentials have no forms.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testSaveValidAPICredentialsWithNoForms(AcceptanceTester $I)
+    {
+        // Go to the Plugin's Settings Screen.
+        $I->loadConvertKitSettingsGeneralScreen($I);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Complete API Fields.
-		$I->fillField('_wp_convertkit_settings[api_key]', $_ENV['CONVERTKIT_API_KEY_NO_DATA']);
-		$I->fillField('_wp_convertkit_settings[api_secret]', $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
+        // Complete API Fields.
+        $I->fillField('_wp_convertkit_settings[api_key]', $_ENV['CONVERTKIT_API_KEY_NO_DATA']);
+        $I->fillField('_wp_convertkit_settings[api_secret]', $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
 
-		// Click the Save Changes button.
-		$I->click('Save Changes');
+        // Click the Save Changes button.
+        $I->click('Save Changes');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Check that 'No Forms exist in ConvertKit' is displayed.
-		$I->seeInSource('No Forms exist in ConvertKit.');
-	}
+        // Check that 'No Forms exist in ConvertKit' is displayed.
+        $I->seeInSource('No Forms exist in ConvertKit.');
+    }
 
-	/**
-	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
-	 * when the Default Form is changed.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testChangeDefaultFormSetting(AcceptanceTester $I)
-	{
-		// Setup Plugin.
-		$I->setupConvertKitPlugin($I);
+    /**
+     * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
+     * when the Default Form is changed.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testChangeDefaultFormSetting(AcceptanceTester $I)
+    {
+        // Setup Plugin.
+        $I->setupConvertKitPlugin($I);
 
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen($I);
+        // Go to the Plugin's Settings Screen.
+        $I->loadConvertKitSettingsGeneralScreen($I);
 
-		// Call helper function to define default Page and Post
-		$I->setupConvertKitPluginDefaultForm($I);
-	}
+        // Call helper function to define default Page and Post
+        $I->setupConvertKitPluginDefaultForm($I);
+    }
 
-	/**
-	 * Test that the preview link for the Default Form settings works.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testPreviewFormLinks(AcceptanceTester $I)
-	{
-		// Create a Page and a Post, so that preview links display.
-		$I->havePostInDatabase([
-			'post_title'	=> 'ConvertKit: Preview Form Links: Page',
-			'post_type'		=> 'page',
-			'post_status'	=> 'publish',
-		]);
-		$I->havePostInDatabase([
-			'post_title'	=> 'ConvertKit: Preview Form Links: Post',
-			'post_type'		=> 'post',
-			'post_status'	=> 'publish',
-		]);
+    /**
+     * Test that the preview link for the Default Form settings works.
+     * 
+     * @since 1.9.8.5
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testPreviewFormLinks(AcceptanceTester $I)
+    {
+        // Create a Page and a Post, so that preview links display.
+        $I->havePostInDatabase(
+            [
+            'post_title'    => 'ConvertKit: Preview Form Links: Page',
+            'post_type'        => 'page',
+            'post_status'    => 'publish',
+            ]
+        );
+        $I->havePostInDatabase(
+            [
+            'post_title'    => 'ConvertKit: Preview Form Links: Post',
+            'post_type'        => 'post',
+            'post_status'    => 'publish',
+            ]
+        );
 
-		// Setup Plugin.
-		$I->setupConvertKitPlugin($I);
+        // Setup Plugin.
+        $I->setupConvertKitPlugin($I);
 
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen($I);
+        // Go to the Plugin's Settings Screen.
+        $I->loadConvertKitSettingsGeneralScreen($I);
 
-		// Select Default Form for Pages.
-		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+        // Select Default Form for Pages.
+        $I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
-		// Open preview.
-		$I->click('a#convertkit-preview-form-page');
-		$I->wait(2); // Required, otherwise switchToNextTab fails.
+        // Open preview.
+        $I->click('a#convertkit-preview-form-page');
+        $I->wait(2); // Required, otherwise switchToNextTab fails.
 
-		// Switch to newly opened tab.
-		$I->switchToNextTab();
+        // Switch to newly opened tab.
+        $I->switchToNextTab();
 
-		// Confirm expected Form is displayed.
-		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+        // Confirm expected Form is displayed.
+        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 
-		// Close newly opened tab.
-		$I->closeTab();
+        // Close newly opened tab.
+        $I->closeTab();
 
-		// Select Default Form for Posts.
-		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_post_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+        // Select Default Form for Posts.
+        $I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_post_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
-		// Open preview.
-		$I->click('a#convertkit-preview-form-post');
-		$I->wait(2); // Required, otherwise switchToNextTab fails.
+        // Open preview.
+        $I->click('a#convertkit-preview-form-post');
+        $I->wait(2); // Required, otherwise switchToNextTab fails.
 
-		// Switch to newly opened tab.
-		$I->switchToNextTab();
+        // Switch to newly opened tab.
+        $I->switchToNextTab();
 
-		// Confirm expected Form is displayed.
-		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+        // Confirm expected Form is displayed.
+        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 
-		// Close newly opened tab.
-		$I->closeTab();
-	}
+        // Close newly opened tab.
+        $I->closeTab();
+    }
 
-	/**
-	 * Test that the settings screen does not display preview links
-	 * when no Pages and Posts exist in WordPress.
-	 *
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testPreviewFormLinksWhenNoPostsOrPagesExist(AcceptanceTester $I)
-	{
-		// Setup Plugin.
-		$I->setupConvertKitPlugin($I);
+    /**
+     * Test that the settings screen does not display preview links
+     * when no Pages and Posts exist in WordPress.
+     *
+     * @since 1.9.8.5
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testPreviewFormLinksWhenNoPostsOrPagesExist(AcceptanceTester $I)
+    {
+        // Setup Plugin.
+        $I->setupConvertKitPlugin($I);
 
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen($I);
+        // Go to the Plugin's Settings Screen.
+        $I->loadConvertKitSettingsGeneralScreen($I);
 
-		// Confirm no Page or Post preview links exist, because there are no Pages or Posts in WordPress.
-		$I->dontSeeElementInDOM('a#convertkit-preview-form-post');
-		$I->dontSeeElementInDOM('a#convertkit-preview-form-page');
-	}
+        // Confirm no Page or Post preview links exist, because there are no Pages or Posts in WordPress.
+        $I->dontSeeElementInDOM('a#convertkit-preview-form-post');
+        $I->dontSeeElementInDOM('a#convertkit-preview-form-page');
+    }
 
-	/**
-	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
-	 * when Debug settings are enabled and disabled.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testEnableAndDisableDebugSettings(AcceptanceTester $I)
-	{
-		// Setup API Keys in ConvertKit Plugin.
-		$I->setupConvertKitPlugin($I);
+    /**
+     * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
+     * when Debug settings are enabled and disabled.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testEnableAndDisableDebugSettings(AcceptanceTester $I)
+    {
+        // Setup API Keys in ConvertKit Plugin.
+        $I->setupConvertKitPlugin($I);
 
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen($I);
+        // Go to the Plugin's Settings Screen.
+        $I->loadConvertKitSettingsGeneralScreen($I);
 		
-		// Tick field.
-		$I->checkOption('#debug');
+        // Tick field.
+        $I->checkOption('#debug');
 
-		// Click the Save Changes button.
-		$I->click('Save Changes');
+        // Click the Save Changes button.
+        $I->click('Save Changes');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Check the field remains ticked.
-		$I->seeCheckboxIsChecked('#debug');	
+        // Check the field remains ticked.
+        $I->seeCheckboxIsChecked('#debug');    
 
-		// Untick field.
-		$I->uncheckOption('#debug');
+        // Untick field.
+        $I->uncheckOption('#debug');
 
-		// Click the Save Changes button.
-		$I->click('Save Changes');
+        // Click the Save Changes button.
+        $I->click('Save Changes');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Check the field remains unticked.
-		$I->dontSeeCheckboxIsChecked('#debug');	
-	}
+        // Check the field remains unticked.
+        $I->dontSeeCheckboxIsChecked('#debug');    
+    }
 
-	/**
-	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
-	 * when the Disable JavaScript settings are enabled and disabled.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testEnableAndDisableJavaScriptSettings(AcceptanceTester $I)
-	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen($I);
+    /**
+     * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
+     * when the Disable JavaScript settings are enabled and disabled.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testEnableAndDisableJavaScriptSettings(AcceptanceTester $I)
+    {
+        // Go to the Plugin's Settings Screen.
+        $I->loadConvertKitSettingsGeneralScreen($I);
 		
-		// Tick fields.
-		$I->checkOption('#debug');
-		$I->checkOption('#no_scripts');
+        // Tick fields.
+        $I->checkOption('#debug');
+        $I->checkOption('#no_scripts');
 
-		// Click the Save Changes button.
-		$I->click('Save Changes');
+        // Click the Save Changes button.
+        $I->click('Save Changes');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Check the fields are ticked.
-		$I->seeCheckboxIsChecked('#debug');
-		$I->seeCheckboxIsChecked('#no_scripts');	
-	}
+        // Check the fields are ticked.
+        $I->seeCheckboxIsChecked('#debug');
+        $I->seeCheckboxIsChecked('#no_scripts');    
+    }
 
-	/**
-	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
-	 * when the Disable CSS settings is unchecked, and that CSS is output
-	 * on the frontend web site.
-	 * 
-	 * @since 	1.9.6.9
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testEnableCSSSetting(AcceptanceTester $I)
-	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen($I);
+    /**
+     * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
+     * when the Disable CSS settings is unchecked, and that CSS is output
+     * on the frontend web site.
+     * 
+     * @since 1.9.6.9
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testEnableCSSSetting(AcceptanceTester $I)
+    {
+        // Go to the Plugin's Settings Screen.
+        $I->loadConvertKitSettingsGeneralScreen($I);
 		
-		// Tick fields.
-		$I->checkOption('#debug');
-		$I->uncheckOption('#no_css');
+        // Tick fields.
+        $I->checkOption('#debug');
+        $I->uncheckOption('#no_css');
 
-		// Click the Save Changes button.
-		$I->click('Save Changes');
+        // Click the Save Changes button.
+        $I->click('Save Changes');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Check the fields are ticked.
-		$I->seeCheckboxIsChecked('#debug');
-		$I->dontSeeCheckboxIsChecked('#no_css');	
+        // Check the fields are ticked.
+        $I->seeCheckboxIsChecked('#debug');
+        $I->dontSeeCheckboxIsChecked('#no_css');    
 
-		// Navigate to the home page.
-		$I->amOnPage('/');
+        // Navigate to the home page.
+        $I->amOnPage('/');
 
-		// Confirm no CSS is output by the Plugin.
-		$I->seeInSource('broadcasts.css');
-	}
+        // Confirm no CSS is output by the Plugin.
+        $I->seeInSource('broadcasts.css');
+    }
 
-	/**
-	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
-	 * when the Disable CSS settings is checked, and that no CSS is output
-	 * on the frontend web site.
-	 * 
-	 * @since 	1.9.6.9
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testDisableCSSSetting(AcceptanceTester $I)
-	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen($I);
+    /**
+     * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
+     * when the Disable CSS settings is checked, and that no CSS is output
+     * on the frontend web site.
+     * 
+     * @since 1.9.6.9
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testDisableCSSSetting(AcceptanceTester $I)
+    {
+        // Go to the Plugin's Settings Screen.
+        $I->loadConvertKitSettingsGeneralScreen($I);
 		
-		// Tick fields.
-		$I->checkOption('#debug');
-		$I->checkOption('#no_css');
+        // Tick fields.
+        $I->checkOption('#debug');
+        $I->checkOption('#no_css');
 
-		// Click the Save Changes button.
-		$I->click('Save Changes');
+        // Click the Save Changes button.
+        $I->click('Save Changes');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Check the fields are ticked.
-		$I->seeCheckboxIsChecked('#debug');
-		$I->seeCheckboxIsChecked('#no_css');	
+        // Check the fields are ticked.
+        $I->seeCheckboxIsChecked('#debug');
+        $I->seeCheckboxIsChecked('#no_css');    
 
-		// Navigate to the home page.
-		$I->amOnPage('/');
+        // Navigate to the home page.
+        $I->amOnPage('/');
 
-		// Confirm no CSS is output by the Plugin.
-		$I->dontSeeInSource('broadcasts.css');
-	}
+        // Confirm no CSS is output by the Plugin.
+        $I->dontSeeInSource('broadcasts.css');
+    }
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/general/PluginSettingsGeneralCest.php
+++ b/tests/acceptance/general/PluginSettingsGeneralCest.php
@@ -1,226 +1,231 @@
 <?php
 
-class PluginSettingsGeneralCest {
-
+class PluginSettingsGeneralCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
-		$I->activateConvertKitPlugin( $I );
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
 	}
 
 	/**
 	 * Test that the Settings > ConvertKit > General screen has expected a11y output, such as label[for].
-	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAccessibility( AcceptanceTester $I ) {
+	public function testAccessibility(AcceptanceTester $I)
+	{
 		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen( $I );
+		$I->loadConvertKitSettingsGeneralScreen($I);
 
 		// Confirm that settings have label[for] attributes.
-		$I->seeInSource( '<label for="api_key">' );
-		$I->seeInSource( '<label for="api_secret">' );
-		$I->seeInSource( '<label for="_wp_convertkit_settings_page_form">' );
-		$I->seeInSource( '<label for="_wp_convertkit_settings_post_form">' );
-		$I->seeInSource( '<label for="debug">' );
-		$I->seeInSource( '<label for="no_scripts">' );
-		$I->seeInSource( '<label for="no_css">' );
+		$I->seeInSource('<label for="api_key">');
+		$I->seeInSource('<label for="api_secret">');
+		$I->seeInSource('<label for="_wp_convertkit_settings_page_form">');
+		$I->seeInSource('<label for="_wp_convertkit_settings_post_form">');
+		$I->seeInSource('<label for="debug">');
+		$I->seeInSource('<label for="no_scripts">');
+		$I->seeInSource('<label for="no_css">');
 	}
 
 	/**
 	 * Test that UTM parameters are included in links displayed on the Plugins' Setting screen for the user to obtain
 	 * their API Key and Secret, or sign in to their ConvertKit account.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testUTMParametersExist( AcceptanceTester $I ) {
+	public function testUTMParametersExist(AcceptanceTester $I)
+	{
 		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen( $I );
+		$I->loadConvertKitSettingsGeneralScreen($I);
 
 		// Confirm that UTM parameters exist for the 'Get your ConvertKit API Key' link.
-		$I->seeInSource( '<a href="https://app.convertkit.com/account_settings/advanced_settings/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">Get your ConvertKit API Key.</a>' );
-
+		$I->seeInSource('<a href="https://app.convertkit.com/account_settings/advanced_settings/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">Get your ConvertKit API Key.</a>');
+		
 		// Confirm that UTM parameters exist for the 'Get your ConvertKit API Secret' link.
-		$I->seeInSource( '<a href="https://app.convertkit.com/account_settings/advanced_settings/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">Get your ConvertKit API Secret.</a>' );
-
+		$I->seeInSource('<a href="https://app.convertkit.com/account_settings/advanced_settings/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">Get your ConvertKit API Secret.</a>');
+	
 		// Confirm that UTM parameters exist for the 'sign in to ConvertKit' link.
-		$I->seeInSource( '<a href="https://app.convertkit.com/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">sign in to ConvertKit</a>' );
+		$I->seeInSource('<a href="https://app.convertkit.com/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">sign in to ConvertKit</a>');
 	}
 
 	/**
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen when the Save Changes
 	 * button is pressed and no settings are specified.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testSaveBlankSettings( AcceptanceTester $I ) {
+	public function testSaveBlankSettings(AcceptanceTester $I)
+	{
 		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen( $I );
+		$I->loadConvertKitSettingsGeneralScreen($I);
 
 		// Click the Save Changes button.
-		$I->click( 'Save Changes' );
+		$I->click('Save Changes');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check that 'No Forms exist in ConvertKit' is displayed.
-		$I->seeInSource( 'No Forms exist in ConvertKit.' );
+		$I->seeInSource('No Forms exist in ConvertKit.');
 	}
 
 	/**
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
 	 * and a warning is displayed that the supplied API credentials are invalid, when
 	 * saving invalid API credentials.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testSaveInvalidAPICredentials( AcceptanceTester $I ) {
+	public function testSaveInvalidAPICredentials(AcceptanceTester $I)
+	{
 		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen( $I );
+		$I->loadConvertKitSettingsGeneralScreen($I);
 
 		// Complete API Fields with incorrect data.
-		$I->fillField( '_wp_convertkit_settings[api_key]', 'fakeApiKey' );
-		$I->fillField( '_wp_convertkit_settings[api_secret]', 'fakeApiSecret' );
+		$I->fillField('_wp_convertkit_settings[api_key]', 'fakeApiKey');
+		$I->fillField('_wp_convertkit_settings[api_secret]', 'fakeApiSecret');
 
 		// Click the Save Changes button.
-		$I->click( 'Save Changes' );
+		$I->click('Save Changes');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 	}
 
 	/**
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
 	 * when valid API credentials are saved.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testSaveValidAPICredentials( AcceptanceTester $I ) {
-		$I->setupConvertKitPlugin( $I );
+	public function testSaveValidAPICredentials(AcceptanceTester $I)
+	{
+		$I->setupConvertKitPlugin($I);
 	}
 
 	/**
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
 	 * when valid API credentials are saved, but the ConvertKit account for the given API
 	 * credentials have no forms.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testSaveValidAPICredentialsWithNoForms( AcceptanceTester $I ) {
+	public function testSaveValidAPICredentialsWithNoForms(AcceptanceTester $I)
+	{
 		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen( $I );
+		$I->loadConvertKitSettingsGeneralScreen($I);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Complete API Fields.
-		$I->fillField( '_wp_convertkit_settings[api_key]', $_ENV['CONVERTKIT_API_KEY_NO_DATA'] );
-		$I->fillField( '_wp_convertkit_settings[api_secret]', $_ENV['CONVERTKIT_API_SECRET_NO_DATA'] );
+		$I->fillField('_wp_convertkit_settings[api_key]', $_ENV['CONVERTKIT_API_KEY_NO_DATA']);
+		$I->fillField('_wp_convertkit_settings[api_secret]', $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
 
 		// Click the Save Changes button.
-		$I->click( 'Save Changes' );
+		$I->click('Save Changes');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check that 'No Forms exist in ConvertKit' is displayed.
-		$I->seeInSource( 'No Forms exist in ConvertKit.' );
+		$I->seeInSource('No Forms exist in ConvertKit.');
 	}
 
 	/**
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
 	 * when the Default Form is changed.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testChangeDefaultFormSetting( AcceptanceTester $I ) {
+	public function testChangeDefaultFormSetting(AcceptanceTester $I)
+	{
 		// Setup Plugin.
-		$I->setupConvertKitPlugin( $I );
+		$I->setupConvertKitPlugin($I);
 
 		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen( $I );
+		$I->loadConvertKitSettingsGeneralScreen($I);
 
 		// Call helper function to define default Page and Post
-		$I->setupConvertKitPluginDefaultForm( $I );
+		$I->setupConvertKitPluginDefaultForm($I);
 	}
 
 	/**
 	 * Test that the preview link for the Default Form settings works.
-	 *
-	 * @since 1.9.8.5
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testPreviewFormLinks( AcceptanceTester $I ) {
+	public function testPreviewFormLinks(AcceptanceTester $I)
+	{
 		// Create a Page and a Post, so that preview links display.
-		$I->havePostInDatabase(
-			array(
-				'post_title'  => 'ConvertKit: Preview Form Links: Page',
-				'post_type'   => 'page',
-				'post_status' => 'publish',
-			)
-		);
-		$I->havePostInDatabase(
-			array(
-				'post_title'  => 'ConvertKit: Preview Form Links: Post',
-				'post_type'   => 'post',
-				'post_status' => 'publish',
-			)
-		);
+		$I->havePostInDatabase([
+			'post_title'	=> 'ConvertKit: Preview Form Links: Page',
+			'post_type'		=> 'page',
+			'post_status'	=> 'publish',
+		]);
+		$I->havePostInDatabase([
+			'post_title'	=> 'ConvertKit: Preview Form Links: Post',
+			'post_type'		=> 'post',
+			'post_status'	=> 'publish',
+		]);
 
 		// Setup Plugin.
-		$I->setupConvertKitPlugin( $I );
+		$I->setupConvertKitPlugin($I);
 
 		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen( $I );
+		$I->loadConvertKitSettingsGeneralScreen($I);
 
 		// Select Default Form for Pages.
-		$I->fillSelect2Field( $I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
 		// Open preview.
-		$I->click( 'a#convertkit-preview-form-page' );
-		$I->wait( 2 ); // Required, otherwise switchToNextTab fails.
+		$I->click('a#convertkit-preview-form-page');
+		$I->wait(2); // Required, otherwise switchToNextTab fails.
 
 		// Switch to newly opened tab.
 		$I->switchToNextTab();
 
 		// Confirm expected Form is displayed.
-		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 
 		// Close newly opened tab.
 		$I->closeTab();
 
 		// Select Default Form for Posts.
-		$I->fillSelect2Field( $I, '#select2-_wp_convertkit_settings_post_form-container', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_post_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
 		// Open preview.
-		$I->click( 'a#convertkit-preview-form-post' );
-		$I->wait( 2 ); // Required, otherwise switchToNextTab fails.
+		$I->click('a#convertkit-preview-form-post');
+		$I->wait(2); // Required, otherwise switchToNextTab fails.
 
 		// Switch to newly opened tab.
 		$I->switchToNextTab();
 
 		// Confirm expected Form is displayed.
-		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 
 		// Close newly opened tab.
 		$I->closeTab();
@@ -230,168 +235,174 @@ class PluginSettingsGeneralCest {
 	 * Test that the settings screen does not display preview links
 	 * when no Pages and Posts exist in WordPress.
 	 *
-	 * @since 1.9.8.5
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testPreviewFormLinksWhenNoPostsOrPagesExist( AcceptanceTester $I ) {
+	public function testPreviewFormLinksWhenNoPostsOrPagesExist(AcceptanceTester $I)
+	{
 		// Setup Plugin.
-		$I->setupConvertKitPlugin( $I );
+		$I->setupConvertKitPlugin($I);
 
 		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen( $I );
+		$I->loadConvertKitSettingsGeneralScreen($I);
 
 		// Confirm no Page or Post preview links exist, because there are no Pages or Posts in WordPress.
-		$I->dontSeeElementInDOM( 'a#convertkit-preview-form-post' );
-		$I->dontSeeElementInDOM( 'a#convertkit-preview-form-page' );
+		$I->dontSeeElementInDOM('a#convertkit-preview-form-post');
+		$I->dontSeeElementInDOM('a#convertkit-preview-form-page');
 	}
 
 	/**
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
 	 * when Debug settings are enabled and disabled.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testEnableAndDisableDebugSettings( AcceptanceTester $I ) {
+	public function testEnableAndDisableDebugSettings(AcceptanceTester $I)
+	{
 		// Setup API Keys in ConvertKit Plugin.
-		$I->setupConvertKitPlugin( $I );
+		$I->setupConvertKitPlugin($I);
 
 		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen( $I );
-
+		$I->loadConvertKitSettingsGeneralScreen($I);
+		
 		// Tick field.
-		$I->checkOption( '#debug' );
+		$I->checkOption('#debug');
 
 		// Click the Save Changes button.
-		$I->click( 'Save Changes' );
+		$I->click('Save Changes');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check the field remains ticked.
-		$I->seeCheckboxIsChecked( '#debug' );
+		$I->seeCheckboxIsChecked('#debug');	
 
 		// Untick field.
-		$I->uncheckOption( '#debug' );
+		$I->uncheckOption('#debug');
 
 		// Click the Save Changes button.
-		$I->click( 'Save Changes' );
+		$I->click('Save Changes');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check the field remains unticked.
-		$I->dontSeeCheckboxIsChecked( '#debug' );
+		$I->dontSeeCheckboxIsChecked('#debug');	
 	}
 
 	/**
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
 	 * when the Disable JavaScript settings are enabled and disabled.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testEnableAndDisableJavaScriptSettings( AcceptanceTester $I ) {
+	public function testEnableAndDisableJavaScriptSettings(AcceptanceTester $I)
+	{
 		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen( $I );
-
+		$I->loadConvertKitSettingsGeneralScreen($I);
+		
 		// Tick fields.
-		$I->checkOption( '#debug' );
-		$I->checkOption( '#no_scripts' );
+		$I->checkOption('#debug');
+		$I->checkOption('#no_scripts');
 
 		// Click the Save Changes button.
-		$I->click( 'Save Changes' );
+		$I->click('Save Changes');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check the fields are ticked.
-		$I->seeCheckboxIsChecked( '#debug' );
-		$I->seeCheckboxIsChecked( '#no_scripts' );
+		$I->seeCheckboxIsChecked('#debug');
+		$I->seeCheckboxIsChecked('#no_scripts');	
 	}
 
 	/**
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
 	 * when the Disable CSS settings is unchecked, and that CSS is output
 	 * on the frontend web site.
-	 *
-	 * @since 1.9.6.9
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.9
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testEnableCSSSetting( AcceptanceTester $I ) {
+	public function testEnableCSSSetting(AcceptanceTester $I)
+	{
 		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen( $I );
-
+		$I->loadConvertKitSettingsGeneralScreen($I);
+		
 		// Tick fields.
-		$I->checkOption( '#debug' );
-		$I->uncheckOption( '#no_css' );
+		$I->checkOption('#debug');
+		$I->uncheckOption('#no_css');
 
 		// Click the Save Changes button.
-		$I->click( 'Save Changes' );
+		$I->click('Save Changes');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check the fields are ticked.
-		$I->seeCheckboxIsChecked( '#debug' );
-		$I->dontSeeCheckboxIsChecked( '#no_css' );
+		$I->seeCheckboxIsChecked('#debug');
+		$I->dontSeeCheckboxIsChecked('#no_css');	
 
 		// Navigate to the home page.
-		$I->amOnPage( '/' );
+		$I->amOnPage('/');
 
 		// Confirm no CSS is output by the Plugin.
-		$I->seeInSource( 'broadcasts.css' );
+		$I->seeInSource('broadcasts.css');
 	}
 
 	/**
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
 	 * when the Disable CSS settings is checked, and that no CSS is output
 	 * on the frontend web site.
-	 *
-	 * @since 1.9.6.9
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.9
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testDisableCSSSetting( AcceptanceTester $I ) {
+	public function testDisableCSSSetting(AcceptanceTester $I)
+	{
 		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen( $I );
-
+		$I->loadConvertKitSettingsGeneralScreen($I);
+		
 		// Tick fields.
-		$I->checkOption( '#debug' );
-		$I->checkOption( '#no_css' );
+		$I->checkOption('#debug');
+		$I->checkOption('#no_css');
 
 		// Click the Save Changes button.
-		$I->click( 'Save Changes' );
+		$I->click('Save Changes');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check the fields are ticked.
-		$I->seeCheckboxIsChecked( '#debug' );
-		$I->seeCheckboxIsChecked( '#no_css' );
+		$I->seeCheckboxIsChecked('#debug');
+		$I->seeCheckboxIsChecked('#no_css');	
 
 		// Navigate to the home page.
-		$I->amOnPage( '/' );
+		$I->amOnPage('/');
 
 		// Confirm no CSS is output by the Plugin.
-		$I->dontSeeInSource( 'broadcasts.css' );
+		$I->dontSeeInSource('broadcasts.css');
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/general/PluginSettingsGeneralCest.php
+++ b/tests/acceptance/general/PluginSettingsGeneralCest.php
@@ -1,13 +1,17 @@
 <?php
-
+/**
+ * Tests for the Settings > ConvertKit > General screens.
+ *
+ * @since   1.9.6
+ */
 class PluginSettingsGeneralCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -16,10 +20,10 @@ class PluginSettingsGeneralCest
 
 	/**
 	 * Test that the Settings > ConvertKit > General screen has expected a11y output, such as label[for].
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAccessibility(AcceptanceTester $I)
 	{
@@ -39,10 +43,10 @@ class PluginSettingsGeneralCest
 	/**
 	 * Test that UTM parameters are included in links displayed on the Plugins' Setting screen for the user to obtain
 	 * their API Key and Secret, or sign in to their ConvertKit account.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testUTMParametersExist(AcceptanceTester $I)
 	{
@@ -51,10 +55,10 @@ class PluginSettingsGeneralCest
 
 		// Confirm that UTM parameters exist for the 'Get your ConvertKit API Key' link.
 		$I->seeInSource('<a href="https://app.convertkit.com/account_settings/advanced_settings/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">Get your ConvertKit API Key.</a>');
-		
+
 		// Confirm that UTM parameters exist for the 'Get your ConvertKit API Secret' link.
 		$I->seeInSource('<a href="https://app.convertkit.com/account_settings/advanced_settings/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">Get your ConvertKit API Secret.</a>');
-	
+
 		// Confirm that UTM parameters exist for the 'sign in to ConvertKit' link.
 		$I->seeInSource('<a href="https://app.convertkit.com/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">sign in to ConvertKit</a>');
 	}
@@ -62,10 +66,10 @@ class PluginSettingsGeneralCest
 	/**
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen when the Save Changes
 	 * button is pressed and no settings are specified.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testSaveBlankSettings(AcceptanceTester $I)
 	{
@@ -86,10 +90,10 @@ class PluginSettingsGeneralCest
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
 	 * and a warning is displayed that the supplied API credentials are invalid, when
 	 * saving invalid API credentials.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testSaveInvalidAPICredentials(AcceptanceTester $I)
 	{
@@ -110,10 +114,10 @@ class PluginSettingsGeneralCest
 	/**
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
 	 * when valid API credentials are saved.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testSaveValidAPICredentials(AcceptanceTester $I)
 	{
@@ -124,10 +128,10 @@ class PluginSettingsGeneralCest
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
 	 * when valid API credentials are saved, but the ConvertKit account for the given API
 	 * credentials have no forms.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testSaveValidAPICredentialsWithNoForms(AcceptanceTester $I)
 	{
@@ -154,10 +158,10 @@ class PluginSettingsGeneralCest
 	/**
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
 	 * when the Default Form is changed.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testChangeDefaultFormSetting(AcceptanceTester $I)
 	{
@@ -167,30 +171,34 @@ class PluginSettingsGeneralCest
 		// Go to the Plugin's Settings Screen.
 		$I->loadConvertKitSettingsGeneralScreen($I);
 
-		// Call helper function to define default Page and Post
+		// Call helper function to define default Page and Post.
 		$I->setupConvertKitPluginDefaultForm($I);
 	}
 
 	/**
 	 * Test that the preview link for the Default Form settings works.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testPreviewFormLinks(AcceptanceTester $I)
 	{
 		// Create a Page and a Post, so that preview links display.
-		$I->havePostInDatabase([
-			'post_title'	=> 'ConvertKit: Preview Form Links: Page',
-			'post_type'		=> 'page',
-			'post_status'	=> 'publish',
-		]);
-		$I->havePostInDatabase([
-			'post_title'	=> 'ConvertKit: Preview Form Links: Post',
-			'post_type'		=> 'post',
-			'post_status'	=> 'publish',
-		]);
+		$I->havePostInDatabase(
+			[
+				'post_title'  => 'ConvertKit: Preview Form Links: Page',
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			]
+		);
+		$I->havePostInDatabase(
+			[
+				'post_title'  => 'ConvertKit: Preview Form Links: Post',
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+			]
+		);
 
 		// Setup Plugin.
 		$I->setupConvertKitPlugin($I);
@@ -235,9 +243,9 @@ class PluginSettingsGeneralCest
 	 * Test that the settings screen does not display preview links
 	 * when no Pages and Posts exist in WordPress.
 	 *
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 * @since   1.9.8.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testPreviewFormLinksWhenNoPostsOrPagesExist(AcceptanceTester $I)
 	{
@@ -255,10 +263,10 @@ class PluginSettingsGeneralCest
 	/**
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
 	 * when Debug settings are enabled and disabled.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testEnableAndDisableDebugSettings(AcceptanceTester $I)
 	{
@@ -267,7 +275,7 @@ class PluginSettingsGeneralCest
 
 		// Go to the Plugin's Settings Screen.
 		$I->loadConvertKitSettingsGeneralScreen($I);
-		
+
 		// Tick field.
 		$I->checkOption('#debug');
 
@@ -278,7 +286,7 @@ class PluginSettingsGeneralCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check the field remains ticked.
-		$I->seeCheckboxIsChecked('#debug');	
+		$I->seeCheckboxIsChecked('#debug');
 
 		// Untick field.
 		$I->uncheckOption('#debug');
@@ -290,22 +298,22 @@ class PluginSettingsGeneralCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check the field remains unticked.
-		$I->dontSeeCheckboxIsChecked('#debug');	
+		$I->dontSeeCheckboxIsChecked('#debug');
 	}
 
 	/**
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
 	 * when the Disable JavaScript settings are enabled and disabled.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testEnableAndDisableJavaScriptSettings(AcceptanceTester $I)
 	{
 		// Go to the Plugin's Settings Screen.
 		$I->loadConvertKitSettingsGeneralScreen($I);
-		
+
 		// Tick fields.
 		$I->checkOption('#debug');
 		$I->checkOption('#no_scripts');
@@ -318,23 +326,23 @@ class PluginSettingsGeneralCest
 
 		// Check the fields are ticked.
 		$I->seeCheckboxIsChecked('#debug');
-		$I->seeCheckboxIsChecked('#no_scripts');	
+		$I->seeCheckboxIsChecked('#no_scripts');
 	}
 
 	/**
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
 	 * when the Disable CSS settings is unchecked, and that CSS is output
 	 * on the frontend web site.
-	 * 
-	 * @since 	1.9.6.9
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.9
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testEnableCSSSetting(AcceptanceTester $I)
 	{
 		// Go to the Plugin's Settings Screen.
 		$I->loadConvertKitSettingsGeneralScreen($I);
-		
+
 		// Tick fields.
 		$I->checkOption('#debug');
 		$I->uncheckOption('#no_css');
@@ -347,7 +355,7 @@ class PluginSettingsGeneralCest
 
 		// Check the fields are ticked.
 		$I->seeCheckboxIsChecked('#debug');
-		$I->dontSeeCheckboxIsChecked('#no_css');	
+		$I->dontSeeCheckboxIsChecked('#no_css');
 
 		// Navigate to the home page.
 		$I->amOnPage('/');
@@ -360,16 +368,16 @@ class PluginSettingsGeneralCest
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
 	 * when the Disable CSS settings is checked, and that no CSS is output
 	 * on the frontend web site.
-	 * 
-	 * @since 	1.9.6.9
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.9
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testDisableCSSSetting(AcceptanceTester $I)
 	{
 		// Go to the Plugin's Settings Screen.
 		$I->loadConvertKitSettingsGeneralScreen($I);
-		
+
 		// Tick fields.
 		$I->checkOption('#debug');
 		$I->checkOption('#no_css');
@@ -382,7 +390,7 @@ class PluginSettingsGeneralCest
 
 		// Check the fields are ticked.
 		$I->seeCheckboxIsChecked('#debug');
-		$I->seeCheckboxIsChecked('#no_css');	
+		$I->seeCheckboxIsChecked('#no_css');
 
 		// Navigate to the home page.
 		$I->amOnPage('/');
@@ -395,10 +403,10 @@ class PluginSettingsGeneralCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/general/PluginSettingsToolsCest.php
+++ b/tests/acceptance/general/PluginSettingsToolsCest.php
@@ -1,275 +1,286 @@
 <?php
 
-class PluginSettingsToolsCest {
-
+class PluginSettingsToolsCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
+	public function _before(AcceptanceTester $I)
+	{
 		// Activate and Setup ConvertKit plugin
-		$I->activateConvertKitPlugin( $I );
+		$I->activateConvertKitPlugin($I);
 	}
 
 	/**
 	 * Test that the Debug Log section is populated when debugging is enabled and an action is
 	 * performed that will populate the log.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testDebugLogExists( AcceptanceTester $I ) {
-		$I->setupConvertKitPlugin( $I );
-		$I->enableDebugLog( $I );
-		$I->loadConvertKitSettingsToolsScreen( $I );
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+	public function testDebugLogExists(AcceptanceTester $I)
+	{
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
+		$I->loadConvertKitSettingsToolsScreen($I);
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check that the Debug Log textarea contains some expected output i.e.
 		// does not show the 'No logs have been generated.' message.
-		$I->dontSeeInField( '#debug-log-textarea', 'No logs have been generated.' );
+		$I->dontSeeInField('#debug-log-textarea', 'No logs have been generated.');
 	}
 
 	/**
 	 * Test that the Download Log option works.
-	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testDownloadLog( AcceptanceTester $I ) {
-		$I->setupConvertKitPlugin( $I );
-		$I->enableDebugLog( $I );
-		$I->loadConvertKitSettingsToolsScreen( $I );
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+	public function testDownloadLog(AcceptanceTester $I)
+	{
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
+		$I->loadConvertKitSettingsToolsScreen($I);
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Click the Export button.
 		// This will download the file to $_ENV['WP_ROOT_FOLDER'].
-		$I->click( 'input#convertkit-download-debug-log' );
+		$I->click('input#convertkit-download-debug-log');
 
 		// Wait 2 seconds for the download to complete.
-		sleep( 2 );
+		sleep(2);
 
 		// Check downloaded file exists and contains some expected information.
-		$I->openFile( $_ENV['WP_ROOT_FOLDER'] . '/convertkit-log.txt' );
-		$I->seeInThisFile( 'API: account()' );
-
+		$I->openFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-log.txt');
+		$I->seeInThisFile('API: account()');
+	
 		// Delete the file.
-		$I->deleteFile( $_ENV['WP_ROOT_FOLDER'] . '/convertkit-log.txt' );
+		$I->deleteFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-log.txt');
 	}
 
 	/**
 	 * Test that the System Info section is populated.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testSystemInfoExists( AcceptanceTester $I ) {
-		$I->setupConvertKitPlugin( $I );
-		$I->enableDebugLog( $I );
-		$I->loadConvertKitSettingsToolsScreen( $I );
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+	public function testSystemInfoExists(AcceptanceTester $I)
+	{
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
+		$I->loadConvertKitSettingsToolsScreen($I);
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check that the System Info textarea contains some expected output.
-		$I->assertNotFalse( strpos( $I->grabValueFrom( '#system-info-textarea' ), '### wp-core' ) );
-		$I->assertNotFalse( strpos( $I->grabValueFrom( '#system-info-textarea' ), '### wp-active-theme' ) );
-		$I->assertNotFalse( strpos( $I->grabValueFrom( '#system-info-textarea' ), '### wp-themes-inactive' ) );
-		$I->assertNotFalse( strpos( $I->grabValueFrom( '#system-info-textarea' ), '### wp-plugins-active' ) );
-		$I->assertNotFalse( strpos( $I->grabValueFrom( '#system-info-textarea' ), '### wp-plugins-inactive' ) );
-		$I->assertNotFalse( strpos( $I->grabValueFrom( '#system-info-textarea' ), '### wp-media' ) );
-		$I->assertNotFalse( strpos( $I->grabValueFrom( '#system-info-textarea' ), '### wp-server' ) );
-		$I->assertNotFalse( strpos( $I->grabValueFrom( '#system-info-textarea' ), '### wp-database' ) );
-		$I->assertNotFalse( strpos( $I->grabValueFrom( '#system-info-textarea' ), '### wp-constants' ) );
-		$I->assertNotFalse( strpos( $I->grabValueFrom( '#system-info-textarea' ), '### wp-filesystem' ) );
+		$I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-core'));
+		$I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-active-theme'));
+		$I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-themes-inactive'));
+		$I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-plugins-active'));
+		$I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-plugins-inactive'));
+		$I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-media'));
+		$I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-server'));
+		$I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-database'));
+		$I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-constants'));
+		$I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-filesystem'));
 	}
 
 	/**
 	 * Test that the Download System Info option works.
-	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testDownloadSystemInfo( AcceptanceTester $I ) {
-		$I->setupConvertKitPlugin( $I );
-		$I->enableDebugLog( $I );
-		$I->loadConvertKitSettingsToolsScreen( $I );
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+	public function testDownloadSystemInfo(AcceptanceTester $I)
+	{
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
+		$I->loadConvertKitSettingsToolsScreen($I);
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Click the Export button.
 		// This will download the file to $_ENV['WP_ROOT_FOLDER'].
-		$I->click( 'input#convertkit-download-system-info' );
+		$I->click('input#convertkit-download-system-info');
 
 		// Wait 2 seconds for the download to complete.
-		sleep( 2 );
+		sleep(2);
 
 		// Check downloaded file exists and contains some expected information.
-		$I->openFile( $_ENV['WP_ROOT_FOLDER'] . '/convertkit-system-info.txt' );
-		$I->seeInThisFile( '### wp-core' );
-		$I->seeInThisFile( '### wp-active-theme' );
-		$I->seeInThisFile( '### wp-themes-inactive' );
-		$I->seeInThisFile( '### wp-plugins-active' );
-		$I->seeInThisFile( '### wp-plugins-inactive' );
-		$I->seeInThisFile( '### wp-media' );
-		$I->seeInThisFile( '### wp-server' );
-		$I->seeInThisFile( '### wp-database' );
-		$I->seeInThisFile( '### wp-constants' );
-		$I->seeInThisFile( '### wp-filesystem' );
+		$I->openFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-system-info.txt');
+		$I->seeInThisFile('### wp-core');
+		$I->seeInThisFile('### wp-active-theme');
+		$I->seeInThisFile('### wp-themes-inactive');
+		$I->seeInThisFile('### wp-plugins-active');
+		$I->seeInThisFile('### wp-plugins-inactive');
+		$I->seeInThisFile('### wp-media');
+		$I->seeInThisFile('### wp-server');
+		$I->seeInThisFile('### wp-database');
+		$I->seeInThisFile('### wp-constants');
+		$I->seeInThisFile('### wp-filesystem');
 
 		// Delete the file.
-		$I->deleteFile( $_ENV['WP_ROOT_FOLDER'] . '/convertkit-system-info.txt' );
+		$I->deleteFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-system-info.txt');
 	}
 
 	/**
 	 * Test that the Export Configuration option works.
-	 *
-	 * @since 1.9.7.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testExportConfiguration( AcceptanceTester $I ) {
-		$I->setupConvertKitPlugin( $I );
-		$I->enableDebugLog( $I );
-		$I->loadConvertKitSettingsToolsScreen( $I );
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+	public function testExportConfiguration(AcceptanceTester $I)
+	{
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
+		$I->loadConvertKitSettingsToolsScreen($I);
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Click the Export button.
 		// This will download the file to $_ENV['WP_ROOT_FOLDER'].
-		$I->scrollTo( '#export' );
-		$I->click( 'input#convertkit-export' );
+		$I->scrollTo('#export');
+		$I->click('input#convertkit-export');
 
 		// Wait 2 seconds for the download to complete.
-		sleep( 2 );
+		sleep(2);
 
 		// Check downloaded file exists and contains some expected information.
-		$I->openFile( $_ENV['WP_ROOT_FOLDER'] . '/convertkit-export.json' );
-		$I->seeInThisFile( '{"settings":{"api_key":"' . $_ENV['CONVERTKIT_API_KEY'] . '","api_secret":"' . $_ENV['CONVERTKIT_API_SECRET'] . '"' );
-
+		$I->openFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-export.json');
+		$I->seeInThisFile('{"settings":{"api_key":"' . $_ENV['CONVERTKIT_API_KEY'] . '","api_secret":"' . $_ENV['CONVERTKIT_API_SECRET'] . '"');
+	
 		// Delete the file.
-		$I->deleteFile( $_ENV['WP_ROOT_FOLDER'] . '/convertkit-export.json' );
+		$I->deleteFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-export.json');
 	}
 
 	/**
 	 * Test that the Import Configuration option works.
-	 *
-	 * @since 1.9.7.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testImportConfiguration( AcceptanceTester $I ) {
+	public function testImportConfiguration(AcceptanceTester $I)
+	{
 		// Load Tools screen.
-		$I->loadConvertKitSettingsToolsScreen( $I );
+		$I->loadConvertKitSettingsToolsScreen($I);
 
 		// Scroll to Import section.
-		$I->scrollTo( '#import' );
+		$I->scrollTo('#import');
 
 		// Select the configuration file at tests/_data/convertkit-export.json to import.
-		$I->attachFile( 'input[name=import]', 'convertkit-export.json' );
+		$I->attachFile('input[name=import]', 'convertkit-export.json');
 
 		// Click the Import button.
-		$I->click( 'input#convertkit-import' );
+		$I->click('input#convertkit-import');
 
 		// Confirm success message displays.
-		$I->seeInSource( 'Configuration imported successfully.' );
+		$I->seeInSource('Configuration imported successfully.');
 
 		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen( $I );
+		$I->loadConvertKitSettingsGeneralScreen($I);
 
 		// Confirm that the fake API Key and Secret are populated.
-		$I->seeInField( '_wp_convertkit_settings[api_key]', 'fakeApiKey' );
-		$I->seeInField( '_wp_convertkit_settings[api_secret]', 'fakeApiSecret' );
+		$I->seeInField('_wp_convertkit_settings[api_key]', 'fakeApiKey');
+		$I->seeInField('_wp_convertkit_settings[api_secret]', 'fakeApiSecret');
 
 		// Check the fields are ticked.
-		$I->seeCheckboxIsChecked( '#debug' );
+		$I->seeCheckboxIsChecked('#debug');
 	}
 
 	/**
 	 * Test that the Import Configuration option returns the expected error when no file
 	 * is selected.
-	 *
-	 * @since 1.9.7.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testImportConfigurationWithNoFile( AcceptanceTester $I ) {
+	public function testImportConfigurationWithNoFile(AcceptanceTester $I)
+	{
 		// Load Tools screen.
-		$I->loadConvertKitSettingsToolsScreen( $I );
+		$I->loadConvertKitSettingsToolsScreen($I);
 
 		// Scroll to Import section.
-		$I->scrollTo( '#import' );
+		$I->scrollTo('#import');
 
 		// Click the Import button.
-		$I->click( 'input#convertkit-import' );
+		$I->click('input#convertkit-import');
 
 		// Confirm error message displays.
-		$I->seeInSource( 'An error occured uploading the configuration file.' );
+		$I->seeInSource('An error occured uploading the configuration file.');
 	}
 
 	/**
 	 * Test that the Import Configuration option returns the expected error when an invalid file
 	 * is selected.
-	 *
-	 * @since 1.9.7.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testImportConfigurationWithInvalidFile( AcceptanceTester $I ) {
+	public function testImportConfigurationWithInvalidFile(AcceptanceTester $I)
+	{
 		// Load Tools screen.
-		$I->loadConvertKitSettingsToolsScreen( $I );
+		$I->loadConvertKitSettingsToolsScreen($I);
 
 		// Scroll to Import section.
-		$I->scrollTo( '#import' );
+		$I->scrollTo('#import');
 
 		// Select the invalid configuration file at tests/_data/convertkit-export-invalid.json to import.
-		$I->attachFile( 'input[name=import]', 'convertkit-export-invalid.json' );
+		$I->attachFile('input[name=import]', 'convertkit-export-invalid.json');
 
 		// Click the Import button.
-		$I->click( 'input#convertkit-import' );
+		$I->click('input#convertkit-import');
 
 		// Confirm error message displays.
-		$I->seeInSource( 'The uploaded configuration file contains no settings.' );
+		$I->seeInSource('The uploaded configuration file contains no settings.');
 	}
 
 	/**
 	 * Test that the Import Configuration option returns the expected error when a file
 	 * that appears to be JSON is selected, but its content are not JSON.
-	 *
-	 * @since 1.9.7.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testImportConfigurationWithFakeJSONFile( AcceptanceTester $I ) {
+	public function testImportConfigurationWithFakeJSONFile(AcceptanceTester $I)
+	{
 		// Load Tools screen.
-		$I->loadConvertKitSettingsToolsScreen( $I );
+		$I->loadConvertKitSettingsToolsScreen($I);
 
 		// Scroll to Import section.
-		$I->scrollTo( '#import' );
+		$I->scrollTo('#import');
 
 		// Select the invalid configuration file at tests/_data/convertkit-export-invalid.json to import.
-		$I->attachFile( 'input[name=import]', 'convertkit-export-fake.json' );
+		$I->attachFile('input[name=import]', 'convertkit-export-fake.json');
 
 		// Click the Import button.
-		$I->click( 'input#convertkit-import' );
+		$I->click('input#convertkit-import');
 
 		// Confirm error message displays.
-		$I->seeInSource( 'The uploaded configuration file isn\'t valid.' );
+		$I->seeInSource('The uploaded configuration file isn\'t valid.');
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/general/PluginSettingsToolsCest.php
+++ b/tests/acceptance/general/PluginSettingsToolsCest.php
@@ -2,285 +2,285 @@
 
 class PluginSettingsToolsCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		// Activate and Setup ConvertKit plugin
-		$I->activateConvertKitPlugin($I);
-	}
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        // Activate and Setup ConvertKit plugin
+        $I->activateConvertKitPlugin($I);
+    }
 
-	/**
-	 * Test that the Debug Log section is populated when debugging is enabled and an action is
-	 * performed that will populate the log.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testDebugLogExists(AcceptanceTester $I)
-	{
-		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
-		$I->loadConvertKitSettingsToolsScreen($I);
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+    /**
+     * Test that the Debug Log section is populated when debugging is enabled and an action is
+     * performed that will populate the log.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testDebugLogExists(AcceptanceTester $I)
+    {
+        $I->setupConvertKitPlugin($I);
+        $I->enableDebugLog($I);
+        $I->loadConvertKitSettingsToolsScreen($I);
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Check that the Debug Log textarea contains some expected output i.e.
-		// does not show the 'No logs have been generated.' message.
-		$I->dontSeeInField('#debug-log-textarea', 'No logs have been generated.');
-	}
+        // Check that the Debug Log textarea contains some expected output i.e.
+        // does not show the 'No logs have been generated.' message.
+        $I->dontSeeInField('#debug-log-textarea', 'No logs have been generated.');
+    }
 
-	/**
-	 * Test that the Download Log option works.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testDownloadLog(AcceptanceTester $I)
-	{
-		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
-		$I->loadConvertKitSettingsToolsScreen($I);
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+    /**
+     * Test that the Download Log option works.
+     * 
+     * @since 1.9.7.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testDownloadLog(AcceptanceTester $I)
+    {
+        $I->setupConvertKitPlugin($I);
+        $I->enableDebugLog($I);
+        $I->loadConvertKitSettingsToolsScreen($I);
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Click the Export button.
-		// This will download the file to $_ENV['WP_ROOT_FOLDER'].
-		$I->click('input#convertkit-download-debug-log');
+        // Click the Export button.
+        // This will download the file to $_ENV['WP_ROOT_FOLDER'].
+        $I->click('input#convertkit-download-debug-log');
 
-		// Wait 2 seconds for the download to complete.
-		sleep(2);
+        // Wait 2 seconds for the download to complete.
+        sleep(2);
 
-		// Check downloaded file exists and contains some expected information.
-		$I->openFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-log.txt');
-		$I->seeInThisFile('API: account()');
+        // Check downloaded file exists and contains some expected information.
+        $I->openFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-log.txt');
+        $I->seeInThisFile('API: account()');
 	
-		// Delete the file.
-		$I->deleteFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-log.txt');
-	}
+        // Delete the file.
+        $I->deleteFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-log.txt');
+    }
 
-	/**
-	 * Test that the System Info section is populated.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testSystemInfoExists(AcceptanceTester $I)
-	{
-		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
-		$I->loadConvertKitSettingsToolsScreen($I);
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+    /**
+     * Test that the System Info section is populated.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testSystemInfoExists(AcceptanceTester $I)
+    {
+        $I->setupConvertKitPlugin($I);
+        $I->enableDebugLog($I);
+        $I->loadConvertKitSettingsToolsScreen($I);
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Check that the System Info textarea contains some expected output.
-		$I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-core'));
-		$I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-active-theme'));
-		$I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-themes-inactive'));
-		$I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-plugins-active'));
-		$I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-plugins-inactive'));
-		$I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-media'));
-		$I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-server'));
-		$I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-database'));
-		$I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-constants'));
-		$I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-filesystem'));
-	}
+        // Check that the System Info textarea contains some expected output.
+        $I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-core'));
+        $I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-active-theme'));
+        $I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-themes-inactive'));
+        $I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-plugins-active'));
+        $I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-plugins-inactive'));
+        $I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-media'));
+        $I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-server'));
+        $I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-database'));
+        $I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-constants'));
+        $I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-filesystem'));
+    }
 
-	/**
-	 * Test that the Download System Info option works.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testDownloadSystemInfo(AcceptanceTester $I)
-	{
-		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
-		$I->loadConvertKitSettingsToolsScreen($I);
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+    /**
+     * Test that the Download System Info option works.
+     * 
+     * @since 1.9.7.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testDownloadSystemInfo(AcceptanceTester $I)
+    {
+        $I->setupConvertKitPlugin($I);
+        $I->enableDebugLog($I);
+        $I->loadConvertKitSettingsToolsScreen($I);
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Click the Export button.
-		// This will download the file to $_ENV['WP_ROOT_FOLDER'].
-		$I->click('input#convertkit-download-system-info');
+        // Click the Export button.
+        // This will download the file to $_ENV['WP_ROOT_FOLDER'].
+        $I->click('input#convertkit-download-system-info');
 
-		// Wait 2 seconds for the download to complete.
-		sleep(2);
+        // Wait 2 seconds for the download to complete.
+        sleep(2);
 
-		// Check downloaded file exists and contains some expected information.
-		$I->openFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-system-info.txt');
-		$I->seeInThisFile('### wp-core');
-		$I->seeInThisFile('### wp-active-theme');
-		$I->seeInThisFile('### wp-themes-inactive');
-		$I->seeInThisFile('### wp-plugins-active');
-		$I->seeInThisFile('### wp-plugins-inactive');
-		$I->seeInThisFile('### wp-media');
-		$I->seeInThisFile('### wp-server');
-		$I->seeInThisFile('### wp-database');
-		$I->seeInThisFile('### wp-constants');
-		$I->seeInThisFile('### wp-filesystem');
+        // Check downloaded file exists and contains some expected information.
+        $I->openFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-system-info.txt');
+        $I->seeInThisFile('### wp-core');
+        $I->seeInThisFile('### wp-active-theme');
+        $I->seeInThisFile('### wp-themes-inactive');
+        $I->seeInThisFile('### wp-plugins-active');
+        $I->seeInThisFile('### wp-plugins-inactive');
+        $I->seeInThisFile('### wp-media');
+        $I->seeInThisFile('### wp-server');
+        $I->seeInThisFile('### wp-database');
+        $I->seeInThisFile('### wp-constants');
+        $I->seeInThisFile('### wp-filesystem');
 
-		// Delete the file.
-		$I->deleteFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-system-info.txt');
-	}
+        // Delete the file.
+        $I->deleteFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-system-info.txt');
+    }
 
-	/**
-	 * Test that the Export Configuration option works.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testExportConfiguration(AcceptanceTester $I)
-	{
-		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
-		$I->loadConvertKitSettingsToolsScreen($I);
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+    /**
+     * Test that the Export Configuration option works.
+     * 
+     * @since 1.9.7.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testExportConfiguration(AcceptanceTester $I)
+    {
+        $I->setupConvertKitPlugin($I);
+        $I->enableDebugLog($I);
+        $I->loadConvertKitSettingsToolsScreen($I);
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Click the Export button.
-		// This will download the file to $_ENV['WP_ROOT_FOLDER'].
-		$I->scrollTo('#export');
-		$I->click('input#convertkit-export');
+        // Click the Export button.
+        // This will download the file to $_ENV['WP_ROOT_FOLDER'].
+        $I->scrollTo('#export');
+        $I->click('input#convertkit-export');
 
-		// Wait 2 seconds for the download to complete.
-		sleep(2);
+        // Wait 2 seconds for the download to complete.
+        sleep(2);
 
-		// Check downloaded file exists and contains some expected information.
-		$I->openFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-export.json');
-		$I->seeInThisFile('{"settings":{"api_key":"' . $_ENV['CONVERTKIT_API_KEY'] . '","api_secret":"' . $_ENV['CONVERTKIT_API_SECRET'] . '"');
+        // Check downloaded file exists and contains some expected information.
+        $I->openFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-export.json');
+        $I->seeInThisFile('{"settings":{"api_key":"' . $_ENV['CONVERTKIT_API_KEY'] . '","api_secret":"' . $_ENV['CONVERTKIT_API_SECRET'] . '"');
 	
-		// Delete the file.
-		$I->deleteFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-export.json');
-	}
+        // Delete the file.
+        $I->deleteFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-export.json');
+    }
 
-	/**
-	 * Test that the Import Configuration option works.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testImportConfiguration(AcceptanceTester $I)
-	{
-		// Load Tools screen.
-		$I->loadConvertKitSettingsToolsScreen($I);
+    /**
+     * Test that the Import Configuration option works.
+     * 
+     * @since 1.9.7.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testImportConfiguration(AcceptanceTester $I)
+    {
+        // Load Tools screen.
+        $I->loadConvertKitSettingsToolsScreen($I);
 
-		// Scroll to Import section.
-		$I->scrollTo('#import');
+        // Scroll to Import section.
+        $I->scrollTo('#import');
 
-		// Select the configuration file at tests/_data/convertkit-export.json to import.
-		$I->attachFile('input[name=import]', 'convertkit-export.json');
+        // Select the configuration file at tests/_data/convertkit-export.json to import.
+        $I->attachFile('input[name=import]', 'convertkit-export.json');
 
-		// Click the Import button.
-		$I->click('input#convertkit-import');
+        // Click the Import button.
+        $I->click('input#convertkit-import');
 
-		// Confirm success message displays.
-		$I->seeInSource('Configuration imported successfully.');
+        // Confirm success message displays.
+        $I->seeInSource('Configuration imported successfully.');
 
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen($I);
+        // Go to the Plugin's Settings Screen.
+        $I->loadConvertKitSettingsGeneralScreen($I);
 
-		// Confirm that the fake API Key and Secret are populated.
-		$I->seeInField('_wp_convertkit_settings[api_key]', 'fakeApiKey');
-		$I->seeInField('_wp_convertkit_settings[api_secret]', 'fakeApiSecret');
+        // Confirm that the fake API Key and Secret are populated.
+        $I->seeInField('_wp_convertkit_settings[api_key]', 'fakeApiKey');
+        $I->seeInField('_wp_convertkit_settings[api_secret]', 'fakeApiSecret');
 
-		// Check the fields are ticked.
-		$I->seeCheckboxIsChecked('#debug');
-	}
+        // Check the fields are ticked.
+        $I->seeCheckboxIsChecked('#debug');
+    }
 
-	/**
-	 * Test that the Import Configuration option returns the expected error when no file
-	 * is selected.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testImportConfigurationWithNoFile(AcceptanceTester $I)
-	{
-		// Load Tools screen.
-		$I->loadConvertKitSettingsToolsScreen($I);
+    /**
+     * Test that the Import Configuration option returns the expected error when no file
+     * is selected.
+     * 
+     * @since 1.9.7.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testImportConfigurationWithNoFile(AcceptanceTester $I)
+    {
+        // Load Tools screen.
+        $I->loadConvertKitSettingsToolsScreen($I);
 
-		// Scroll to Import section.
-		$I->scrollTo('#import');
+        // Scroll to Import section.
+        $I->scrollTo('#import');
 
-		// Click the Import button.
-		$I->click('input#convertkit-import');
+        // Click the Import button.
+        $I->click('input#convertkit-import');
 
-		// Confirm error message displays.
-		$I->seeInSource('An error occured uploading the configuration file.');
-	}
+        // Confirm error message displays.
+        $I->seeInSource('An error occured uploading the configuration file.');
+    }
 
-	/**
-	 * Test that the Import Configuration option returns the expected error when an invalid file
-	 * is selected.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testImportConfigurationWithInvalidFile(AcceptanceTester $I)
-	{
-		// Load Tools screen.
-		$I->loadConvertKitSettingsToolsScreen($I);
+    /**
+     * Test that the Import Configuration option returns the expected error when an invalid file
+     * is selected.
+     * 
+     * @since 1.9.7.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testImportConfigurationWithInvalidFile(AcceptanceTester $I)
+    {
+        // Load Tools screen.
+        $I->loadConvertKitSettingsToolsScreen($I);
 
-		// Scroll to Import section.
-		$I->scrollTo('#import');
+        // Scroll to Import section.
+        $I->scrollTo('#import');
 
-		// Select the invalid configuration file at tests/_data/convertkit-export-invalid.json to import.
-		$I->attachFile('input[name=import]', 'convertkit-export-invalid.json');
+        // Select the invalid configuration file at tests/_data/convertkit-export-invalid.json to import.
+        $I->attachFile('input[name=import]', 'convertkit-export-invalid.json');
 
-		// Click the Import button.
-		$I->click('input#convertkit-import');
+        // Click the Import button.
+        $I->click('input#convertkit-import');
 
-		// Confirm error message displays.
-		$I->seeInSource('The uploaded configuration file contains no settings.');
-	}
+        // Confirm error message displays.
+        $I->seeInSource('The uploaded configuration file contains no settings.');
+    }
 
-	/**
-	 * Test that the Import Configuration option returns the expected error when a file
-	 * that appears to be JSON is selected, but its content are not JSON.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testImportConfigurationWithFakeJSONFile(AcceptanceTester $I)
-	{
-		// Load Tools screen.
-		$I->loadConvertKitSettingsToolsScreen($I);
+    /**
+     * Test that the Import Configuration option returns the expected error when a file
+     * that appears to be JSON is selected, but its content are not JSON.
+     * 
+     * @since 1.9.7.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testImportConfigurationWithFakeJSONFile(AcceptanceTester $I)
+    {
+        // Load Tools screen.
+        $I->loadConvertKitSettingsToolsScreen($I);
 
-		// Scroll to Import section.
-		$I->scrollTo('#import');
+        // Scroll to Import section.
+        $I->scrollTo('#import');
 
-		// Select the invalid configuration file at tests/_data/convertkit-export-invalid.json to import.
-		$I->attachFile('input[name=import]', 'convertkit-export-fake.json');
+        // Select the invalid configuration file at tests/_data/convertkit-export-invalid.json to import.
+        $I->attachFile('input[name=import]', 'convertkit-export-fake.json');
 
-		// Click the Import button.
-		$I->click('input#convertkit-import');
+        // Click the Import button.
+        $I->click('input#convertkit-import');
 
-		// Confirm error message displays.
-		$I->seeInSource('The uploaded configuration file isn\'t valid.');
-	}
+        // Confirm error message displays.
+        $I->seeInSource('The uploaded configuration file isn\'t valid.');
+    }
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/general/PluginSettingsToolsCest.php
+++ b/tests/acceptance/general/PluginSettingsToolsCest.php
@@ -1,286 +1,275 @@
 <?php
 
-class PluginSettingsToolsCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        // Activate and Setup ConvertKit plugin
-        $I->activateConvertKitPlugin($I);
-    }
+class PluginSettingsToolsCest {
 
-    /**
-     * Test that the Debug Log section is populated when debugging is enabled and an action is
-     * performed that will populate the log.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testDebugLogExists(AcceptanceTester $I)
-    {
-        $I->setupConvertKitPlugin($I);
-        $I->enableDebugLog($I);
-        $I->loadConvertKitSettingsToolsScreen($I);
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		// Activate and Setup ConvertKit plugin
+		$I->activateConvertKitPlugin( $I );
+	}
 
-        // Check that the Debug Log textarea contains some expected output i.e.
-        // does not show the 'No logs have been generated.' message.
-        $I->dontSeeInField('#debug-log-textarea', 'No logs have been generated.');
-    }
+	/**
+	 * Test that the Debug Log section is populated when debugging is enabled and an action is
+	 * performed that will populate the log.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testDebugLogExists( AcceptanceTester $I ) {
+		$I->setupConvertKitPlugin( $I );
+		$I->enableDebugLog( $I );
+		$I->loadConvertKitSettingsToolsScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-    /**
-     * Test that the Download Log option works.
-     * 
-     * @since 1.9.7.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testDownloadLog(AcceptanceTester $I)
-    {
-        $I->setupConvertKitPlugin($I);
-        $I->enableDebugLog($I);
-        $I->loadConvertKitSettingsToolsScreen($I);
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Check that the Debug Log textarea contains some expected output i.e.
+		// does not show the 'No logs have been generated.' message.
+		$I->dontSeeInField( '#debug-log-textarea', 'No logs have been generated.' );
+	}
 
-        // Click the Export button.
-        // This will download the file to $_ENV['WP_ROOT_FOLDER'].
-        $I->click('input#convertkit-download-debug-log');
+	/**
+	 * Test that the Download Log option works.
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testDownloadLog( AcceptanceTester $I ) {
+		$I->setupConvertKitPlugin( $I );
+		$I->enableDebugLog( $I );
+		$I->loadConvertKitSettingsToolsScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-        // Wait 2 seconds for the download to complete.
-        sleep(2);
+		// Click the Export button.
+		// This will download the file to $_ENV['WP_ROOT_FOLDER'].
+		$I->click( 'input#convertkit-download-debug-log' );
 
-        // Check downloaded file exists and contains some expected information.
-        $I->openFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-log.txt');
-        $I->seeInThisFile('API: account()');
-	
-        // Delete the file.
-        $I->deleteFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-log.txt');
-    }
+		// Wait 2 seconds for the download to complete.
+		sleep( 2 );
 
-    /**
-     * Test that the System Info section is populated.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testSystemInfoExists(AcceptanceTester $I)
-    {
-        $I->setupConvertKitPlugin($I);
-        $I->enableDebugLog($I);
-        $I->loadConvertKitSettingsToolsScreen($I);
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Check downloaded file exists and contains some expected information.
+		$I->openFile( $_ENV['WP_ROOT_FOLDER'] . '/convertkit-log.txt' );
+		$I->seeInThisFile( 'API: account()' );
 
-        // Check that the System Info textarea contains some expected output.
-        $I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-core'));
-        $I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-active-theme'));
-        $I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-themes-inactive'));
-        $I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-plugins-active'));
-        $I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-plugins-inactive'));
-        $I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-media'));
-        $I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-server'));
-        $I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-database'));
-        $I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-constants'));
-        $I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-filesystem'));
-    }
+		// Delete the file.
+		$I->deleteFile( $_ENV['WP_ROOT_FOLDER'] . '/convertkit-log.txt' );
+	}
 
-    /**
-     * Test that the Download System Info option works.
-     * 
-     * @since 1.9.7.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testDownloadSystemInfo(AcceptanceTester $I)
-    {
-        $I->setupConvertKitPlugin($I);
-        $I->enableDebugLog($I);
-        $I->loadConvertKitSettingsToolsScreen($I);
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+	/**
+	 * Test that the System Info section is populated.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testSystemInfoExists( AcceptanceTester $I ) {
+		$I->setupConvertKitPlugin( $I );
+		$I->enableDebugLog( $I );
+		$I->loadConvertKitSettingsToolsScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-        // Click the Export button.
-        // This will download the file to $_ENV['WP_ROOT_FOLDER'].
-        $I->click('input#convertkit-download-system-info');
+		// Check that the System Info textarea contains some expected output.
+		$I->assertNotFalse( strpos( $I->grabValueFrom( '#system-info-textarea' ), '### wp-core' ) );
+		$I->assertNotFalse( strpos( $I->grabValueFrom( '#system-info-textarea' ), '### wp-active-theme' ) );
+		$I->assertNotFalse( strpos( $I->grabValueFrom( '#system-info-textarea' ), '### wp-themes-inactive' ) );
+		$I->assertNotFalse( strpos( $I->grabValueFrom( '#system-info-textarea' ), '### wp-plugins-active' ) );
+		$I->assertNotFalse( strpos( $I->grabValueFrom( '#system-info-textarea' ), '### wp-plugins-inactive' ) );
+		$I->assertNotFalse( strpos( $I->grabValueFrom( '#system-info-textarea' ), '### wp-media' ) );
+		$I->assertNotFalse( strpos( $I->grabValueFrom( '#system-info-textarea' ), '### wp-server' ) );
+		$I->assertNotFalse( strpos( $I->grabValueFrom( '#system-info-textarea' ), '### wp-database' ) );
+		$I->assertNotFalse( strpos( $I->grabValueFrom( '#system-info-textarea' ), '### wp-constants' ) );
+		$I->assertNotFalse( strpos( $I->grabValueFrom( '#system-info-textarea' ), '### wp-filesystem' ) );
+	}
 
-        // Wait 2 seconds for the download to complete.
-        sleep(2);
+	/**
+	 * Test that the Download System Info option works.
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testDownloadSystemInfo( AcceptanceTester $I ) {
+		$I->setupConvertKitPlugin( $I );
+		$I->enableDebugLog( $I );
+		$I->loadConvertKitSettingsToolsScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-        // Check downloaded file exists and contains some expected information.
-        $I->openFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-system-info.txt');
-        $I->seeInThisFile('### wp-core');
-        $I->seeInThisFile('### wp-active-theme');
-        $I->seeInThisFile('### wp-themes-inactive');
-        $I->seeInThisFile('### wp-plugins-active');
-        $I->seeInThisFile('### wp-plugins-inactive');
-        $I->seeInThisFile('### wp-media');
-        $I->seeInThisFile('### wp-server');
-        $I->seeInThisFile('### wp-database');
-        $I->seeInThisFile('### wp-constants');
-        $I->seeInThisFile('### wp-filesystem');
+		// Click the Export button.
+		// This will download the file to $_ENV['WP_ROOT_FOLDER'].
+		$I->click( 'input#convertkit-download-system-info' );
 
-        // Delete the file.
-        $I->deleteFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-system-info.txt');
-    }
+		// Wait 2 seconds for the download to complete.
+		sleep( 2 );
 
-    /**
-     * Test that the Export Configuration option works.
-     * 
-     * @since 1.9.7.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testExportConfiguration(AcceptanceTester $I)
-    {
-        $I->setupConvertKitPlugin($I);
-        $I->enableDebugLog($I);
-        $I->loadConvertKitSettingsToolsScreen($I);
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Check downloaded file exists and contains some expected information.
+		$I->openFile( $_ENV['WP_ROOT_FOLDER'] . '/convertkit-system-info.txt' );
+		$I->seeInThisFile( '### wp-core' );
+		$I->seeInThisFile( '### wp-active-theme' );
+		$I->seeInThisFile( '### wp-themes-inactive' );
+		$I->seeInThisFile( '### wp-plugins-active' );
+		$I->seeInThisFile( '### wp-plugins-inactive' );
+		$I->seeInThisFile( '### wp-media' );
+		$I->seeInThisFile( '### wp-server' );
+		$I->seeInThisFile( '### wp-database' );
+		$I->seeInThisFile( '### wp-constants' );
+		$I->seeInThisFile( '### wp-filesystem' );
 
-        // Click the Export button.
-        // This will download the file to $_ENV['WP_ROOT_FOLDER'].
-        $I->scrollTo('#export');
-        $I->click('input#convertkit-export');
+		// Delete the file.
+		$I->deleteFile( $_ENV['WP_ROOT_FOLDER'] . '/convertkit-system-info.txt' );
+	}
 
-        // Wait 2 seconds for the download to complete.
-        sleep(2);
+	/**
+	 * Test that the Export Configuration option works.
+	 *
+	 * @since 1.9.7.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testExportConfiguration( AcceptanceTester $I ) {
+		$I->setupConvertKitPlugin( $I );
+		$I->enableDebugLog( $I );
+		$I->loadConvertKitSettingsToolsScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-        // Check downloaded file exists and contains some expected information.
-        $I->openFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-export.json');
-        $I->seeInThisFile('{"settings":{"api_key":"' . $_ENV['CONVERTKIT_API_KEY'] . '","api_secret":"' . $_ENV['CONVERTKIT_API_SECRET'] . '"');
-	
-        // Delete the file.
-        $I->deleteFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-export.json');
-    }
+		// Click the Export button.
+		// This will download the file to $_ENV['WP_ROOT_FOLDER'].
+		$I->scrollTo( '#export' );
+		$I->click( 'input#convertkit-export' );
 
-    /**
-     * Test that the Import Configuration option works.
-     * 
-     * @since 1.9.7.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testImportConfiguration(AcceptanceTester $I)
-    {
-        // Load Tools screen.
-        $I->loadConvertKitSettingsToolsScreen($I);
+		// Wait 2 seconds for the download to complete.
+		sleep( 2 );
 
-        // Scroll to Import section.
-        $I->scrollTo('#import');
+		// Check downloaded file exists and contains some expected information.
+		$I->openFile( $_ENV['WP_ROOT_FOLDER'] . '/convertkit-export.json' );
+		$I->seeInThisFile( '{"settings":{"api_key":"' . $_ENV['CONVERTKIT_API_KEY'] . '","api_secret":"' . $_ENV['CONVERTKIT_API_SECRET'] . '"' );
 
-        // Select the configuration file at tests/_data/convertkit-export.json to import.
-        $I->attachFile('input[name=import]', 'convertkit-export.json');
+		// Delete the file.
+		$I->deleteFile( $_ENV['WP_ROOT_FOLDER'] . '/convertkit-export.json' );
+	}
 
-        // Click the Import button.
-        $I->click('input#convertkit-import');
+	/**
+	 * Test that the Import Configuration option works.
+	 *
+	 * @since 1.9.7.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testImportConfiguration( AcceptanceTester $I ) {
+		// Load Tools screen.
+		$I->loadConvertKitSettingsToolsScreen( $I );
 
-        // Confirm success message displays.
-        $I->seeInSource('Configuration imported successfully.');
+		// Scroll to Import section.
+		$I->scrollTo( '#import' );
 
-        // Go to the Plugin's Settings Screen.
-        $I->loadConvertKitSettingsGeneralScreen($I);
+		// Select the configuration file at tests/_data/convertkit-export.json to import.
+		$I->attachFile( 'input[name=import]', 'convertkit-export.json' );
 
-        // Confirm that the fake API Key and Secret are populated.
-        $I->seeInField('_wp_convertkit_settings[api_key]', 'fakeApiKey');
-        $I->seeInField('_wp_convertkit_settings[api_secret]', 'fakeApiSecret');
+		// Click the Import button.
+		$I->click( 'input#convertkit-import' );
 
-        // Check the fields are ticked.
-        $I->seeCheckboxIsChecked('#debug');
-    }
+		// Confirm success message displays.
+		$I->seeInSource( 'Configuration imported successfully.' );
 
-    /**
-     * Test that the Import Configuration option returns the expected error when no file
-     * is selected.
-     * 
-     * @since 1.9.7.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testImportConfigurationWithNoFile(AcceptanceTester $I)
-    {
-        // Load Tools screen.
-        $I->loadConvertKitSettingsToolsScreen($I);
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsGeneralScreen( $I );
 
-        // Scroll to Import section.
-        $I->scrollTo('#import');
+		// Confirm that the fake API Key and Secret are populated.
+		$I->seeInField( '_wp_convertkit_settings[api_key]', 'fakeApiKey' );
+		$I->seeInField( '_wp_convertkit_settings[api_secret]', 'fakeApiSecret' );
 
-        // Click the Import button.
-        $I->click('input#convertkit-import');
+		// Check the fields are ticked.
+		$I->seeCheckboxIsChecked( '#debug' );
+	}
 
-        // Confirm error message displays.
-        $I->seeInSource('An error occured uploading the configuration file.');
-    }
+	/**
+	 * Test that the Import Configuration option returns the expected error when no file
+	 * is selected.
+	 *
+	 * @since 1.9.7.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testImportConfigurationWithNoFile( AcceptanceTester $I ) {
+		// Load Tools screen.
+		$I->loadConvertKitSettingsToolsScreen( $I );
 
-    /**
-     * Test that the Import Configuration option returns the expected error when an invalid file
-     * is selected.
-     * 
-     * @since 1.9.7.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testImportConfigurationWithInvalidFile(AcceptanceTester $I)
-    {
-        // Load Tools screen.
-        $I->loadConvertKitSettingsToolsScreen($I);
+		// Scroll to Import section.
+		$I->scrollTo( '#import' );
 
-        // Scroll to Import section.
-        $I->scrollTo('#import');
+		// Click the Import button.
+		$I->click( 'input#convertkit-import' );
 
-        // Select the invalid configuration file at tests/_data/convertkit-export-invalid.json to import.
-        $I->attachFile('input[name=import]', 'convertkit-export-invalid.json');
+		// Confirm error message displays.
+		$I->seeInSource( 'An error occured uploading the configuration file.' );
+	}
 
-        // Click the Import button.
-        $I->click('input#convertkit-import');
+	/**
+	 * Test that the Import Configuration option returns the expected error when an invalid file
+	 * is selected.
+	 *
+	 * @since 1.9.7.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testImportConfigurationWithInvalidFile( AcceptanceTester $I ) {
+		// Load Tools screen.
+		$I->loadConvertKitSettingsToolsScreen( $I );
 
-        // Confirm error message displays.
-        $I->seeInSource('The uploaded configuration file contains no settings.');
-    }
+		// Scroll to Import section.
+		$I->scrollTo( '#import' );
 
-    /**
-     * Test that the Import Configuration option returns the expected error when a file
-     * that appears to be JSON is selected, but its content are not JSON.
-     * 
-     * @since 1.9.7.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testImportConfigurationWithFakeJSONFile(AcceptanceTester $I)
-    {
-        // Load Tools screen.
-        $I->loadConvertKitSettingsToolsScreen($I);
+		// Select the invalid configuration file at tests/_data/convertkit-export-invalid.json to import.
+		$I->attachFile( 'input[name=import]', 'convertkit-export-invalid.json' );
 
-        // Scroll to Import section.
-        $I->scrollTo('#import');
+		// Click the Import button.
+		$I->click( 'input#convertkit-import' );
 
-        // Select the invalid configuration file at tests/_data/convertkit-export-invalid.json to import.
-        $I->attachFile('input[name=import]', 'convertkit-export-fake.json');
+		// Confirm error message displays.
+		$I->seeInSource( 'The uploaded configuration file contains no settings.' );
+	}
 
-        // Click the Import button.
-        $I->click('input#convertkit-import');
+	/**
+	 * Test that the Import Configuration option returns the expected error when a file
+	 * that appears to be JSON is selected, but its content are not JSON.
+	 *
+	 * @since 1.9.7.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testImportConfigurationWithFakeJSONFile( AcceptanceTester $I ) {
+		// Load Tools screen.
+		$I->loadConvertKitSettingsToolsScreen( $I );
 
-        // Confirm error message displays.
-        $I->seeInSource('The uploaded configuration file isn\'t valid.');
-    }
+		// Scroll to Import section.
+		$I->scrollTo( '#import' );
 
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+		// Select the invalid configuration file at tests/_data/convertkit-export-invalid.json to import.
+		$I->attachFile( 'input[name=import]', 'convertkit-export-fake.json' );
+
+		// Click the Import button.
+		$I->click( 'input#convertkit-import' );
+
+		// Confirm error message displays.
+		$I->seeInSource( 'The uploaded configuration file isn\'t valid.' );
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/general/PluginSettingsToolsCest.php
+++ b/tests/acceptance/general/PluginSettingsToolsCest.php
@@ -1,27 +1,31 @@
 <?php
-
+/**
+ * Tests for the Settings > ConvertKit > Tools screens.
+ *
+ * @since   1.9.6
+ */
 class PluginSettingsToolsCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
-		// Activate and Setup ConvertKit plugin
+		// Activate and Setup ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
 	}
 
 	/**
 	 * Test that the Debug Log section is populated when debugging is enabled and an action is
 	 * performed that will populate the log.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testDebugLogExists(AcceptanceTester $I)
 	{
@@ -37,10 +41,10 @@ class PluginSettingsToolsCest
 
 	/**
 	 * Test that the Download Log option works.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testDownloadLog(AcceptanceTester $I)
 	{
@@ -59,17 +63,17 @@ class PluginSettingsToolsCest
 		// Check downloaded file exists and contains some expected information.
 		$I->openFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-log.txt');
 		$I->seeInThisFile('API: account()');
-	
+
 		// Delete the file.
 		$I->deleteFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-log.txt');
 	}
 
 	/**
 	 * Test that the System Info section is populated.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testSystemInfoExists(AcceptanceTester $I)
 	{
@@ -93,10 +97,10 @@ class PluginSettingsToolsCest
 
 	/**
 	 * Test that the Download System Info option works.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testDownloadSystemInfo(AcceptanceTester $I)
 	{
@@ -131,10 +135,10 @@ class PluginSettingsToolsCest
 
 	/**
 	 * Test that the Export Configuration option works.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testExportConfiguration(AcceptanceTester $I)
 	{
@@ -154,17 +158,17 @@ class PluginSettingsToolsCest
 		// Check downloaded file exists and contains some expected information.
 		$I->openFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-export.json');
 		$I->seeInThisFile('{"settings":{"api_key":"' . $_ENV['CONVERTKIT_API_KEY'] . '","api_secret":"' . $_ENV['CONVERTKIT_API_SECRET'] . '"');
-	
+
 		// Delete the file.
 		$I->deleteFile($_ENV['WP_ROOT_FOLDER'] . '/convertkit-export.json');
 	}
 
 	/**
 	 * Test that the Import Configuration option works.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testImportConfiguration(AcceptanceTester $I)
 	{
@@ -197,10 +201,10 @@ class PluginSettingsToolsCest
 	/**
 	 * Test that the Import Configuration option returns the expected error when no file
 	 * is selected.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testImportConfigurationWithNoFile(AcceptanceTester $I)
 	{
@@ -220,10 +224,10 @@ class PluginSettingsToolsCest
 	/**
 	 * Test that the Import Configuration option returns the expected error when an invalid file
 	 * is selected.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testImportConfigurationWithInvalidFile(AcceptanceTester $I)
 	{
@@ -246,10 +250,10 @@ class PluginSettingsToolsCest
 	/**
 	 * Test that the Import Configuration option returns the expected error when a file
 	 * that appears to be JSON is selected, but its content are not JSON.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testImportConfigurationWithFakeJSONFile(AcceptanceTester $I)
 	{
@@ -273,10 +277,10 @@ class PluginSettingsToolsCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/general/PluginSetupWizardCest.php
+++ b/tests/acceptance/general/PluginSetupWizardCest.php
@@ -1,291 +1,289 @@
 <?php
 
-class PluginSetupWizardCest {
-
+class PluginSetupWizardCest
+{
 	/**
 	 * Test that the Setup Wizard displays when the Plugin is activated.
-	 *
-	 * @since 1.9.8.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testSetupWizardDisplays( AcceptanceTester $I ) {
+	public function testSetupWizardDisplays(AcceptanceTester $I)
+	{
 		// Activate Plugin.
-		$this->_activatePlugin( $I );
+		$this->_activatePlugin($I);
 
 		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen( $I, 1, 'Welcome to the ConvertKit Setup Wizard' );
+		$this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
 	}
 
 	/**
 	 * Test that the Setup Wizard displays when the Plugin is activated on a site
 	 * where the Plugin has previously been activated and configured with API Keys.
-	 *
-	 * @since 1.9.8.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testSetupWizardDoesNotDisplayWhenConfigured( AcceptanceTester $I ) {
+	public function testSetupWizardDoesNotDisplayWhenConfigured(AcceptanceTester $I)
+	{
 		// Define Plugin settings as if the Plugin were previously activated and configured.
-		$I->haveOptionInDatabase(
-			'_wp_convertkit_settings',
-			array(
-				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-				'debug'      => 'on',
-				'no_scripts' => '',
-				'no_css'     => '',
-			)
-		);
+		$I->haveOptionInDatabase('_wp_convertkit_settings', [
+			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+			'debug'      => 'on',
+			'no_scripts' => '',
+			'no_css'     => '',
+		]);
 
 		// Activate Plugin.
-		$this->_activatePlugin( $I );
+		$this->_activatePlugin($I);
 
 		// Confirm setup wizard does not display.
-		$I->dontSee( 'Welcome to the ConvertKit Setup Wizard' );
+		$I->dontSee('Welcome to the ConvertKit Setup Wizard');
 	}
 
 	/**
 	 * Test that the Setup Wizard exit link works.
-	 *
-	 * @since 1.9.8.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testSetupWizardExitLink( AcceptanceTester $I ) {
+	public function testSetupWizardExitLink(AcceptanceTester $I)
+	{
 		// Activate Plugin.
-		$this->_activatePlugin( $I );
+		$this->_activatePlugin($I);
 
 		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen( $I, 1, 'Welcome to the ConvertKit Setup Wizard' );
+		$this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
 
 		// Click Exit wizard link.
-		$I->click( 'Exit wizard' );
+		$I->click('Exit wizard');
 
 		// Confirm exit.
 		$I->acceptPopup();
 
 		// Confirm Plugin settings screen loaded.
-		$I->seeInCurrentUrl( 'options-general.php?page=_wp_convertkit_settings' );
+		$I->seeInCurrentUrl('options-general.php?page=_wp_convertkit_settings');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 	}
 
 	/**
 	 * Test that the Setup Wizard > Setup > Register button works.
 	 *
-	 * @since 1.9.8.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * @since 	1.9.8.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testSetupWizardSetupScreenRegisterButton( AcceptanceTester $I ) {
+	public function testSetupWizardSetupScreenRegisterButton(AcceptanceTester $I)
+	{
 		// Activate Plugin.
-		$this->_activatePlugin( $I );
+		$this->_activatePlugin($I);
 
 		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen( $I, 1, 'Welcome to the ConvertKit Setup Wizard' );
+		$this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
 
 		// Test Register button opens a new tab.
-		$I->click( 'Register' );
-		$I->wait( 2 ); // Required, otherwise switchToNextTab fails.
+		$I->click('Register');
+		$I->wait(2); // Required, otherwise switchToNextTab fails.
 		$I->switchToNextTab();
-		$I->seeInCurrentUrl( 'users/signup?utm_source=wordpress&utm_content=convertkit' );
+		$I->seeInCurrentUrl('users/signup?utm_source=wordpress&utm_content=convertkit');
 
 		// Close newly opened tab from above button.
 		$I->closeTab();
 
 		// Confirm that the original tab is now displaying the Connect Account screen.
-		$this->_seeExpectedSetupWizardScreen( $I, 2, 'Connect your ConvertKit account' );
+		$this->_seeExpectedSetupWizardScreen($I, 2, 'Connect your ConvertKit account');
 	}
 
 	/**
 	 * Test that the Setup Wizard > Setup > Connect button works.
 	 *
-	 * @since 1.9.8.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * @since 	1.9.8.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testSetupWizardSetupScreenConnectButton( AcceptanceTester $I ) {
+	public function testSetupWizardSetupScreenConnectButton(AcceptanceTester $I)
+	{
 		// Activate Plugin.
-		$this->_activatePlugin( $I );
+		$this->_activatePlugin($I);
 
 		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen( $I, 1, 'Welcome to the ConvertKit Setup Wizard' );
+		$this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
 
 		// Test Connect button
-		$I->click( 'Connect' );
+		$I->click('Connect');
 
 		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen( $I, 2, 'Connect your ConvertKit account' );
+		$this->_seeExpectedSetupWizardScreen($I, 2, 'Connect your ConvertKit account');
 	}
 
 	/**
 	 * Test that the Setup Wizard > Connect Account screen works as expected when valid API credentials
 	 * are specified.
 	 *
-	 * @since 1.9.8.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * @since 	1.9.8.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testSetupWizardConnectAccountScreen( AcceptanceTester $I ) {
+	public function testSetupWizardConnectAccountScreen(AcceptanceTester $I)
+	{
 		// Activate Plugin.
-		$this->_activatePlugin( $I );
+		$this->_activatePlugin($I);
 
 		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen( $I, 1, 'Welcome to the ConvertKit Setup Wizard' );
+		$this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
 
 		// Test Connect button
-		$I->click( 'Connect' );
+		$I->click('Connect');
 
 		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen( $I, 2, 'Connect your ConvertKit account' );
+		$this->_seeExpectedSetupWizardScreen($I, 2, 'Connect your ConvertKit account');
 
 		// Wait to prevent API rate limit hit due to parallel tests.
-		$I->wait( 2 );
+		$I->wait(2);
 
 		// Fill fields with invalid API Keys.
-		$I->fillField( 'api_key', $_ENV['CONVERTKIT_API_KEY'] );
-		$I->fillField( 'api_secret', $_ENV['CONVERTKIT_API_SECRET'] );
+		$I->fillField('api_key', $_ENV['CONVERTKIT_API_KEY']);
+		$I->fillField('api_secret', $_ENV['CONVERTKIT_API_SECRET']);
 
 		// Click Connect button.
-		$I->click( 'Connect' );
+		$I->click('Connect');
 
 		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen( $I, 3, 'Display an email capture form' );
+		$this->_seeExpectedSetupWizardScreen($I, 3, 'Display an email capture form');
 	}
 
 	/**
 	 * Test that the Setup Wizard > Connect Account screen works as expected when invalid API credentials
 	 * are specified.
 	 *
-	 * @since 1.9.8.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * @since 	1.9.8.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testSetupWizardConnectAccountScreenWithInvalidAPICredentials( AcceptanceTester $I ) {
+	public function testSetupWizardConnectAccountScreenWithInvalidAPICredentials(AcceptanceTester $I)
+	{
 		// Activate Plugin.
-		$this->_activatePlugin( $I );
+		$this->_activatePlugin($I);
 
 		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen( $I, 1, 'Welcome to the ConvertKit Setup Wizard' );
+		$this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
 
 		// Test Connect button
-		$I->click( 'Connect' );
+		$I->click('Connect');
 
 		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen( $I, 2, 'Connect your ConvertKit account' );
+		$this->_seeExpectedSetupWizardScreen($I, 2, 'Connect your ConvertKit account');
 
 		// Fill fields with invalid API Keys.
-		$I->fillField( 'api_key', 'fakeApiKey' );
-		$I->fillField( 'api_secret', 'fakeApiSecret' );
+		$I->fillField('api_key', 'fakeApiKey');
+		$I->fillField('api_secret', 'fakeApiSecret');
 
 		// Click Connect button.
-		$I->click( 'Connect' );
+		$I->click('Connect');
 
 		// Confirm expected setup wizard screen is still displayed.
-		$this->_seeExpectedSetupWizardScreen( $I, 2, 'Connect your ConvertKit account' );
+		$this->_seeExpectedSetupWizardScreen($I, 2, 'Connect your ConvertKit account');
 
 		// Confirm error notification is displayed.
-		$I->seeElement( 'div.notice.notice-error.is-dismissible' );
+		$I->seeElement('div.notice.notice-error.is-dismissible');
 
 		// Dismiss notification.
-		$I->click( 'div.notice-error button.notice-dismiss' );
+		$I->click('div.notice-error button.notice-dismiss');
 
 		// Confirm notification no longer displayed.
-		$I->wait( 1 );
-		$I->dontSeeElement( 'div.notice.notice-error.is-dismissible' );
+		$I->wait(1);
+		$I->dontSeeElement('div.notice.notice-error.is-dismissible');
 	}
 
 	/**
 	 * Test that the Setup Wizard > Form Configuration screen works as expected.
 	 *
-	 * @since 1.9.8.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * @since 	1.9.8.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testSetupWizardFormConfigurationScreen( AcceptanceTester $I ) {
+	public function testSetupWizardFormConfigurationScreen(AcceptanceTester $I)
+	{
 		// Activate Plugin.
-		$this->_activatePlugin( $I );
+		$this->_activatePlugin($I);
 
 		// Define Plugin settings.
-		$I->haveOptionInDatabase(
-			'_wp_convertkit_settings',
-			array(
-				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-			)
-		);
+		$I->haveOptionInDatabase('_wp_convertkit_settings', [
+			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+		]);
 
 		// Create a Page and a Post, so that preview links display.
-		$I->havePostInDatabase(
-			array(
-				'post_title'  => 'ConvertKit: Setup Wizard: Page',
-				'post_type'   => 'page',
-				'post_status' => 'publish',
-			)
-		);
-		$I->havePostInDatabase(
-			array(
-				'post_title'  => 'ConvertKit: Setup Wizard: Post',
-				'post_type'   => 'post',
-				'post_status' => 'publish',
-			)
-		);
+		$I->havePostInDatabase([
+			'post_title'	=> 'ConvertKit: Setup Wizard: Page',
+			'post_type'		=> 'page',
+			'post_status'	=> 'publish',
+		]);
+		$I->havePostInDatabase([
+			'post_title'	=> 'ConvertKit: Setup Wizard: Post',
+			'post_type'		=> 'post',
+			'post_status'	=> 'publish',
+		]);
 
 		// Load Step 3/4.
-		$I->amOnAdminPage( 'index.php?page=convertkit-setup&step=3' );
+		$I->amOnAdminPage('index.php?page=convertkit-setup&step=3');
 
 		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen( $I, 3, 'Display an email capture form' );
+		$this->_seeExpectedSetupWizardScreen($I, 3, 'Display an email capture form');
 
 		// Select a Post Form.
-		$I->fillSelect2Field( $I, '#select2-wp-convertkit-form-posts-container', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-posts-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
 		// Open preview.
-		$I->click( 'a#convertkit-preview-form-post' );
-		$I->wait( 2 ); // Required, otherwise switchToNextTab fails.
+		$I->click('a#convertkit-preview-form-post');
+		$I->wait(2); // Required, otherwise switchToNextTab fails.
 
 		// Switch to newly opened tab.
 		$I->switchToNextTab();
 
 		// Confirm expected Form is displayed.
-		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 
 		// Close newly opened tab.
 		$I->closeTab();
 
 		// Select a Page Form.
-		$I->fillSelect2Field( $I, '#select2-wp-convertkit-form-pages-container', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-pages-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
 		// Open preview.
-		$I->click( 'a#convertkit-preview-form-page' );
-		$I->wait( 2 ); // Required, otherwise switchToNextTab fails.
+		$I->click('a#convertkit-preview-form-page');
+		$I->wait(2); // Required, otherwise switchToNextTab fails.
 
 		// Switch to newly opened tab.
 		$I->switchToNextTab();
 
 		// Confirm expected Form is displayed.
-		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 
 		// Close newly opened tab.
 		$I->closeTab();
 
 		// Click Finish Setup button.
-		$I->click( 'Finish Setup' );
+		$I->click('Finish Setup');
 
 		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen( $I, 4, 'Setup complete' );
+		$this->_seeExpectedSetupWizardScreen($I, 4, 'Setup complete');
 
 		// Click Plugin Settings.
-		$I->click( 'Plugin Settings' );
+		$I->click('Plugin Settings');
 
 		// Confirm that Plugin Settings screen contains expected values for API Key, Secret and Default Forms.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
-		$I->seeInField( '_wp_convertkit_settings[api_key]', $_ENV['CONVERTKIT_API_KEY'] );
-		$I->seeInField( '_wp_convertkit_settings[api_secret]', $_ENV['CONVERTKIT_API_SECRET'] );
-		$I->seeInField( '_wp_convertkit_settings[page_form]', $_ENV['CONVERTKIT_API_FORM_NAME'] );
-		$I->seeInField( '_wp_convertkit_settings[post_form]', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+		$I->seeInField('_wp_convertkit_settings[api_key]', $_ENV['CONVERTKIT_API_KEY']);
+		$I->seeInField('_wp_convertkit_settings[api_secret]', $_ENV['CONVERTKIT_API_SECRET']);
+		$I->seeInField('_wp_convertkit_settings[page_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->seeInField('_wp_convertkit_settings[post_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
 	}
 
 	/**
@@ -293,143 +291,138 @@ class PluginSetupWizardCest {
 	 * when API credentials are supplied for a ConvertKit account that contains
 	 * no forms.
 	 *
-	 * @since 1.9.8.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * @since 	1.9.8.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testSetupWizardFormConfigurationScreenWhenNoFormsExist( AcceptanceTester $I ) {
+	public function testSetupWizardFormConfigurationScreenWhenNoFormsExist(AcceptanceTester $I)
+	{
 		// Activate Plugin.
-		$this->_activatePlugin( $I );
+		$this->_activatePlugin($I);
 
 		// Define Plugin settings with a ConvertKit account containing no forms.
-		$I->haveOptionInDatabase(
-			'_wp_convertkit_settings',
-			array(
-				'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
-				'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
-			)
-		);
+		$I->haveOptionInDatabase('_wp_convertkit_settings', [
+			'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+			'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+		]);
 
 		// Load Step 3/4.
-		$I->amOnAdminPage( 'index.php?page=convertkit-setup&step=3' );
+		$I->amOnAdminPage('index.php?page=convertkit-setup&step=3');
 
 		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen( $I, 3, 'Create your first ConvertKit Form', true );
+		$this->_seeExpectedSetupWizardScreen($I, 3, 'Create your first ConvertKit Form', true);
 
 		// Confirm button link to create a form on ConvertKit is correct.
-		$I->seeInSource( '<a href="https://app.convertkit.com/forms/new?format=inline"' );
+		$I->seeInSource('<a href="https://app.convertkit.com/forms/new?format=inline"');
 
 		// Define Plugin settings with a ConvertKit account containing forms,
 		// as if we created a form in ConvertKit.
-		$I->haveOptionInDatabase(
-			'_wp_convertkit_settings',
-			array(
-				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-			)
-		);
+		$I->haveOptionInDatabase('_wp_convertkit_settings', [
+			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+		]);
 
 		// Click "I've created a form in ConvertKit" button.
-		$I->click( 'I\'ve created a form in ConvertKit' );
+		$I->click('I\'ve created a form in ConvertKit');
 
 		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen( $I, 3, 'Display an email capture form' );
+		$this->_seeExpectedSetupWizardScreen($I, 3, 'Display an email capture form');
 
 		// Confirm we can select a Post Form.
-		$I->fillSelect2Field( $I, '#select2-wp-convertkit-form-posts-container', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-posts-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
 	}
 
 	/**
 	 * Test that the Setup Wizard > Form Configuration screen does not display preview links
 	 * when no Pages and Posts exist in WordPress.
 	 *
-	 * @since 1.9.8.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * @since 	1.9.8.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testSetupWizardFormConfigurationScreenWhenNoPostsOrPagesExist( AcceptanceTester $I ) {
+	public function testSetupWizardFormConfigurationScreenWhenNoPostsOrPagesExist(AcceptanceTester $I)
+	{
 		// Activate Plugin.
-		$this->_activatePlugin( $I );
+		$this->_activatePlugin($I);
 
 		// Define Plugin settings.
-		$I->haveOptionInDatabase(
-			'_wp_convertkit_settings',
-			array(
-				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-			)
-		);
+		$I->haveOptionInDatabase('_wp_convertkit_settings', [
+			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+		]);
 
 		// Load Step 3/4.
-		$I->amOnAdminPage( 'index.php?page=convertkit-setup&step=3' );
+		$I->amOnAdminPage('index.php?page=convertkit-setup&step=3');
 
 		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen( $I, 3, 'Display an email capture form' );
+		$this->_seeExpectedSetupWizardScreen($I, 3, 'Display an email capture form');
 
 		// Confirm no Page or Post preview links exist, because there are no Pages or Posts in WordPress.
-		$I->dontSeeElementInDOM( 'a#convertkit-preview-form-post' );
-		$I->dontSeeElementInDOM( 'a#convertkit-preview-form-page' );
+		$I->dontSeeElementInDOM('a#convertkit-preview-form-post');
+		$I->dontSeeElementInDOM('a#convertkit-preview-form-page');
 	}
 
 	/**
 	 * Activate the Plugin, without checking it is activated, so that its Setup Wizard
 	 * screen loads.
-	 *
+	 * 
 	 * This differs from the activateConvertKitPlugin() method, which will ignore a Setup Wizard
 	 * screen by reloading the Plugins screen to confirm a Plugin's activation.
-	 *
-	 * @since 1.9.8.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	private function _activatePlugin( AcceptanceTester $I ) {
+	private function _activatePlugin(AcceptanceTester $I)
+	{
 		$I->loginAsAdmin();
 		$I->amOnPluginsPage();
-		$I->activatePlugin( 'convertkit' );
+		$I->activatePlugin('convertkit');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 	}
 
 	/**
 	 * Runs tests on a Setup Wizard screen, to confirm that the expected step, title and buttons
 	 * are displayed.
-	 *
-	 * @since 1.9.8.4
-	 *
-	 * @param AcceptanceTester $I                Tester
-	 * @param int              $step             Current step
-	 * @param string           $title            Expected title
-	 * @param bool             $nextButtonIsLink Check that next button is a link (false = must be a <button> element).
+	 * 
+	 * @since 	1.9.8.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 		Tester
+	 * @param 	int 				$step 	Current step
+	 * @param 	string 				$title 	Expected title
+	 * @param 	bool 				$nextButtonIsLink 	Check that next button is a link (false = must be a <button> element).
 	 */
-	private function _seeExpectedSetupWizardScreen( AcceptanceTester $I, $step, $title, $nextButtonIsLink = false ) {
+	private function _seeExpectedSetupWizardScreen(AcceptanceTester $I, $step, $title, $nextButtonIsLink = false)
+	{
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm expected setup wizard screen loaded.
-		$I->seeInCurrentUrl( 'index.php?page=convertkit-setup' );
-
+		$I->seeInCurrentUrl('index.php?page=convertkit-setup');
+		
 		// Confirm expected title is displayed.
-		$I->see( $title );
+		$I->see($title);
 
 		// Confirm current and previous steps are highlighted as 'done'.
-		for ( $stepCount = 1; $stepCount <= $step; $stepCount++ ) {
-			$I->seeElement( 'li.step-' . $stepCount . '.done' );
+		for ($stepCount = 1; $stepCount <= $step; $stepCount++) {
+			$I->seeElement('li.step-'.$stepCount.'.done');
 		}
 
 		// Confirm Step text is correct.
-		$I->see( 'Step ' . $step . ' of 4' );
+		$I->see('Step '.$step.' of 4');
 
 		// Depending on the step, confirm previous/next buttons exist / do not exist.
-		switch ( $step ) {
+		switch ($step) {
 			/**
 			 * First and last step should not display any footer buttons.
 			 */
 			case 1:
 			case 4:
-				$I->dontSeeElementInDOM( '#convertkit-setup-wizard-footer div.left a.button' );
-				$I->dontSeeElementInDOM( '#convertkit-setup-wizard-footer div.right button' );
-				$I->dontSeeElementInDOM( '#convertkit-setup-wizard-footer div.right a.button' );
+				$I->dontSeeElementInDOM('#convertkit-setup-wizard-footer div.left a.button');
+				$I->dontSeeElementInDOM('#convertkit-setup-wizard-footer div.right button');
+				$I->dontSeeElementInDOM('#convertkit-setup-wizard-footer div.right a.button');
 				break;
 
 			/**
@@ -437,14 +430,14 @@ class PluginSetupWizardCest {
 			 */
 			case 2:
 			case 3:
-				$I->seeElementInDOM( '#convertkit-setup-wizard-footer div.left a.button' );
+				$I->seeElementInDOM('#convertkit-setup-wizard-footer div.left a.button');
 
-				if ( $nextButtonIsLink ) {
+				if ($nextButtonIsLink) {
 					// Next button must be a link.
-					$I->seeElementInDOM( '#convertkit-setup-wizard-footer div.right a.button' );
+					$I->seeElementInDOM('#convertkit-setup-wizard-footer div.right a.button');
 				} else {
 					// Next button must be a <button> element to submit form.
-					$I->seeElementInDOM( '#convertkit-setup-wizard-footer div.right button' );
+					$I->seeElementInDOM('#convertkit-setup-wizard-footer div.right button');	
 				}
 				break;
 
@@ -455,13 +448,14 @@ class PluginSetupWizardCest {
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.8.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/general/PluginSetupWizardCest.php
+++ b/tests/acceptance/general/PluginSetupWizardCest.php
@@ -1,13 +1,17 @@
 <?php
-
+/**
+ * Tests for the ConvertKit Plugin Setup Wizard, displayed on new Plugin activations.
+ *
+ * @since   1.9.8.4
+ */
 class PluginSetupWizardCest
 {
 	/**
 	 * Test that the Setup Wizard displays when the Plugin is activated.
-	 * 
-	 * @since 	1.9.8.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testSetupWizardDisplays(AcceptanceTester $I)
 	{
@@ -21,21 +25,24 @@ class PluginSetupWizardCest
 	/**
 	 * Test that the Setup Wizard displays when the Plugin is activated on a site
 	 * where the Plugin has previously been activated and configured with API Keys.
-	 * 
-	 * @since 	1.9.8.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testSetupWizardDoesNotDisplayWhenConfigured(AcceptanceTester $I)
 	{
 		// Define Plugin settings as if the Plugin were previously activated and configured.
-		$I->haveOptionInDatabase('_wp_convertkit_settings', [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-			'debug'      => 'on',
-			'no_scripts' => '',
-			'no_css'     => '',
-		]);
+		$I->haveOptionInDatabase(
+			'_wp_convertkit_settings',
+			[
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+				'debug'      => 'on',
+				'no_scripts' => '',
+				'no_css'     => '',
+			]
+		);
 
 		// Activate Plugin.
 		$this->_activatePlugin($I);
@@ -46,10 +53,10 @@ class PluginSetupWizardCest
 
 	/**
 	 * Test that the Setup Wizard exit link works.
-	 * 
-	 * @since 	1.9.8.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testSetupWizardExitLink(AcceptanceTester $I)
 	{
@@ -75,9 +82,9 @@ class PluginSetupWizardCest
 	/**
 	 * Test that the Setup Wizard > Setup > Register button works.
 	 *
-	 * @since 	1.9.8.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 * @since   1.9.8.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testSetupWizardSetupScreenRegisterButton(AcceptanceTester $I)
 	{
@@ -103,9 +110,9 @@ class PluginSetupWizardCest
 	/**
 	 * Test that the Setup Wizard > Setup > Connect button works.
 	 *
-	 * @since 	1.9.8.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 * @since   1.9.8.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testSetupWizardSetupScreenConnectButton(AcceptanceTester $I)
 	{
@@ -115,7 +122,7 @@ class PluginSetupWizardCest
 		// Confirm expected setup wizard screen is displayed.
 		$this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
 
-		// Test Connect button
+		// Test Connect button.
 		$I->click('Connect');
 
 		// Confirm expected setup wizard screen is displayed.
@@ -126,9 +133,9 @@ class PluginSetupWizardCest
 	 * Test that the Setup Wizard > Connect Account screen works as expected when valid API credentials
 	 * are specified.
 	 *
-	 * @since 	1.9.8.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 * @since   1.9.8.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testSetupWizardConnectAccountScreen(AcceptanceTester $I)
 	{
@@ -138,7 +145,7 @@ class PluginSetupWizardCest
 		// Confirm expected setup wizard screen is displayed.
 		$this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
 
-		// Test Connect button
+		// Test Connect button.
 		$I->click('Connect');
 
 		// Confirm expected setup wizard screen is displayed.
@@ -162,9 +169,9 @@ class PluginSetupWizardCest
 	 * Test that the Setup Wizard > Connect Account screen works as expected when invalid API credentials
 	 * are specified.
 	 *
-	 * @since 	1.9.8.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 * @since   1.9.8.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testSetupWizardConnectAccountScreenWithInvalidAPICredentials(AcceptanceTester $I)
 	{
@@ -174,7 +181,7 @@ class PluginSetupWizardCest
 		// Confirm expected setup wizard screen is displayed.
 		$this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
 
-		// Test Connect button
+		// Test Connect button.
 		$I->click('Connect');
 
 		// Confirm expected setup wizard screen is displayed.
@@ -204,9 +211,9 @@ class PluginSetupWizardCest
 	/**
 	 * Test that the Setup Wizard > Form Configuration screen works as expected.
 	 *
-	 * @since 	1.9.8.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 * @since   1.9.8.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testSetupWizardFormConfigurationScreen(AcceptanceTester $I)
 	{
@@ -214,22 +221,29 @@ class PluginSetupWizardCest
 		$this->_activatePlugin($I);
 
 		// Define Plugin settings.
-		$I->haveOptionInDatabase('_wp_convertkit_settings', [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-		]);
+		$I->haveOptionInDatabase(
+			'_wp_convertkit_settings',
+			[
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+			]
+		);
 
 		// Create a Page and a Post, so that preview links display.
-		$I->havePostInDatabase([
-			'post_title'	=> 'ConvertKit: Setup Wizard: Page',
-			'post_type'		=> 'page',
-			'post_status'	=> 'publish',
-		]);
-		$I->havePostInDatabase([
-			'post_title'	=> 'ConvertKit: Setup Wizard: Post',
-			'post_type'		=> 'post',
-			'post_status'	=> 'publish',
-		]);
+		$I->havePostInDatabase(
+			[
+				'post_title'  => 'ConvertKit: Setup Wizard: Page',
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			]
+		);
+		$I->havePostInDatabase(
+			[
+				'post_title'  => 'ConvertKit: Setup Wizard: Post',
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+			]
+		);
 
 		// Load Step 3/4.
 		$I->amOnAdminPage('index.php?page=convertkit-setup&step=3');
@@ -291,9 +305,9 @@ class PluginSetupWizardCest
 	 * when API credentials are supplied for a ConvertKit account that contains
 	 * no forms.
 	 *
-	 * @since 	1.9.8.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 * @since   1.9.8.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testSetupWizardFormConfigurationScreenWhenNoFormsExist(AcceptanceTester $I)
 	{
@@ -301,10 +315,13 @@ class PluginSetupWizardCest
 		$this->_activatePlugin($I);
 
 		// Define Plugin settings with a ConvertKit account containing no forms.
-		$I->haveOptionInDatabase('_wp_convertkit_settings', [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
-		]);
+		$I->haveOptionInDatabase(
+			'_wp_convertkit_settings',
+			[
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+			]
+		);
 
 		// Load Step 3/4.
 		$I->amOnAdminPage('index.php?page=convertkit-setup&step=3');
@@ -317,10 +334,13 @@ class PluginSetupWizardCest
 
 		// Define Plugin settings with a ConvertKit account containing forms,
 		// as if we created a form in ConvertKit.
-		$I->haveOptionInDatabase('_wp_convertkit_settings', [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-		]);
+		$I->haveOptionInDatabase(
+			'_wp_convertkit_settings',
+			[
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+			]
+		);
 
 		// Click "I've created a form in ConvertKit" button.
 		$I->click('I\'ve created a form in ConvertKit');
@@ -336,9 +356,9 @@ class PluginSetupWizardCest
 	 * Test that the Setup Wizard > Form Configuration screen does not display preview links
 	 * when no Pages and Posts exist in WordPress.
 	 *
-	 * @since 	1.9.8.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 * @since   1.9.8.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testSetupWizardFormConfigurationScreenWhenNoPostsOrPagesExist(AcceptanceTester $I)
 	{
@@ -346,10 +366,13 @@ class PluginSetupWizardCest
 		$this->_activatePlugin($I);
 
 		// Define Plugin settings.
-		$I->haveOptionInDatabase('_wp_convertkit_settings', [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-		]);
+		$I->haveOptionInDatabase(
+			'_wp_convertkit_settings',
+			[
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+			]
+		);
 
 		// Load Step 3/4.
 		$I->amOnAdminPage('index.php?page=convertkit-setup&step=3');
@@ -365,13 +388,13 @@ class PluginSetupWizardCest
 	/**
 	 * Activate the Plugin, without checking it is activated, so that its Setup Wizard
 	 * screen loads.
-	 * 
+	 *
 	 * This differs from the activateConvertKitPlugin() method, which will ignore a Setup Wizard
 	 * screen by reloading the Plugins screen to confirm a Plugin's activation.
-	 * 
-	 * @since 	1.9.8.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	private function _activatePlugin(AcceptanceTester $I)
 	{
@@ -386,13 +409,13 @@ class PluginSetupWizardCest
 	/**
 	 * Runs tests on a Setup Wizard screen, to confirm that the expected step, title and buttons
 	 * are displayed.
-	 * 
-	 * @since 	1.9.8.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 		Tester
-	 * @param 	int 				$step 	Current step
-	 * @param 	string 				$title 	Expected title
-	 * @param 	bool 				$nextButtonIsLink 	Check that next button is a link (false = must be a <button> element).
+	 *
+	 * @since   1.9.8.4
+	 *
+	 * @param   AcceptanceTester $I      Tester.
+	 * @param   int              $step   Current step.
+	 * @param   string           $title  Expected title.
+	 * @param   bool             $nextButtonIsLink   Check that next button is a link (false = must be a <button> element).
 	 */
 	private function _seeExpectedSetupWizardScreen(AcceptanceTester $I, $step, $title, $nextButtonIsLink = false)
 	{
@@ -401,17 +424,17 @@ class PluginSetupWizardCest
 
 		// Confirm expected setup wizard screen loaded.
 		$I->seeInCurrentUrl('index.php?page=convertkit-setup');
-		
+
 		// Confirm expected title is displayed.
 		$I->see($title);
 
 		// Confirm current and previous steps are highlighted as 'done'.
 		for ($stepCount = 1; $stepCount <= $step; $stepCount++) {
-			$I->seeElement('li.step-'.$stepCount.'.done');
+			$I->seeElement('li.step-' . $stepCount . '.done');
 		}
 
 		// Confirm Step text is correct.
-		$I->see('Step '.$step.' of 4');
+		$I->see('Step ' . $step . ' of 4');
 
 		// Depending on the step, confirm previous/next buttons exist / do not exist.
 		switch ($step) {
@@ -437,7 +460,7 @@ class PluginSetupWizardCest
 					$I->seeElementInDOM('#convertkit-setup-wizard-footer div.right a.button');
 				} else {
 					// Next button must be a <button> element to submit form.
-					$I->seeElementInDOM('#convertkit-setup-wizard-footer div.right button');	
+					$I->seeElementInDOM('#convertkit-setup-wizard-footer div.right button');
 				}
 				break;
 
@@ -448,10 +471,10 @@ class PluginSetupWizardCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.8.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/general/PluginSetupWizardCest.php
+++ b/tests/acceptance/general/PluginSetupWizardCest.php
@@ -1,475 +1,467 @@
 <?php
 
-class PluginSetupWizardCest
-{
-    /**
-     * Test that the Setup Wizard displays when the Plugin is activated.
-     * 
-     * @since 1.9.8.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testSetupWizardDisplays(AcceptanceTester $I)
-    {
-        // Activate Plugin.
-        $this->_activatePlugin($I);
-
-        // Confirm expected setup wizard screen is displayed.
-        $this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
-    }
-
-    /**
-     * Test that the Setup Wizard displays when the Plugin is activated on a site
-     * where the Plugin has previously been activated and configured with API Keys.
-     * 
-     * @since 1.9.8.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testSetupWizardDoesNotDisplayWhenConfigured(AcceptanceTester $I)
-    {
-        // Define Plugin settings as if the Plugin were previously activated and configured.
-        $I->haveOptionInDatabase(
-            '_wp_convertkit_settings', [
-            'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-            'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-            'debug'      => 'on',
-            'no_scripts' => '',
-            'no_css'     => '',
-            ]
-        );
-
-        // Activate Plugin.
-        $this->_activatePlugin($I);
-
-        // Confirm setup wizard does not display.
-        $I->dontSee('Welcome to the ConvertKit Setup Wizard');
-    }
-
-    /**
-     * Test that the Setup Wizard exit link works.
-     * 
-     * @since 1.9.8.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testSetupWizardExitLink(AcceptanceTester $I)
-    {
-        // Activate Plugin.
-        $this->_activatePlugin($I);
-
-        // Confirm expected setup wizard screen is displayed.
-        $this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
-
-        // Click Exit wizard link.
-        $I->click('Exit wizard');
-
-        // Confirm exit.
-        $I->acceptPopup();
-
-        // Confirm Plugin settings screen loaded.
-        $I->seeInCurrentUrl('options-general.php?page=_wp_convertkit_settings');
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-    }
-
-    /**
-     * Test that the Setup Wizard > Setup > Register button works.
-     *
-     * @since 1.9.8.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testSetupWizardSetupScreenRegisterButton(AcceptanceTester $I)
-    {
-        // Activate Plugin.
-        $this->_activatePlugin($I);
-
-        // Confirm expected setup wizard screen is displayed.
-        $this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
-
-        // Test Register button opens a new tab.
-        $I->click('Register');
-        $I->wait(2); // Required, otherwise switchToNextTab fails.
-        $I->switchToNextTab();
-        $I->seeInCurrentUrl('users/signup?utm_source=wordpress&utm_content=convertkit');
-
-        // Close newly opened tab from above button.
-        $I->closeTab();
-
-        // Confirm that the original tab is now displaying the Connect Account screen.
-        $this->_seeExpectedSetupWizardScreen($I, 2, 'Connect your ConvertKit account');
-    }
-
-    /**
-     * Test that the Setup Wizard > Setup > Connect button works.
-     *
-     * @since 1.9.8.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testSetupWizardSetupScreenConnectButton(AcceptanceTester $I)
-    {
-        // Activate Plugin.
-        $this->_activatePlugin($I);
-
-        // Confirm expected setup wizard screen is displayed.
-        $this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
-
-        // Test Connect button
-        $I->click('Connect');
-
-        // Confirm expected setup wizard screen is displayed.
-        $this->_seeExpectedSetupWizardScreen($I, 2, 'Connect your ConvertKit account');
-    }
-
-    /**
-     * Test that the Setup Wizard > Connect Account screen works as expected when valid API credentials
-     * are specified.
-     *
-     * @since 1.9.8.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testSetupWizardConnectAccountScreen(AcceptanceTester $I)
-    {
-        // Activate Plugin.
-        $this->_activatePlugin($I);
-
-        // Confirm expected setup wizard screen is displayed.
-        $this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
-
-        // Test Connect button
-        $I->click('Connect');
-
-        // Confirm expected setup wizard screen is displayed.
-        $this->_seeExpectedSetupWizardScreen($I, 2, 'Connect your ConvertKit account');
-
-        // Wait to prevent API rate limit hit due to parallel tests.
-        $I->wait(2);
-
-        // Fill fields with invalid API Keys.
-        $I->fillField('api_key', $_ENV['CONVERTKIT_API_KEY']);
-        $I->fillField('api_secret', $_ENV['CONVERTKIT_API_SECRET']);
-
-        // Click Connect button.
-        $I->click('Connect');
-
-        // Confirm expected setup wizard screen is displayed.
-        $this->_seeExpectedSetupWizardScreen($I, 3, 'Display an email capture form');
-    }
-
-    /**
-     * Test that the Setup Wizard > Connect Account screen works as expected when invalid API credentials
-     * are specified.
-     *
-     * @since 1.9.8.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testSetupWizardConnectAccountScreenWithInvalidAPICredentials(AcceptanceTester $I)
-    {
-        // Activate Plugin.
-        $this->_activatePlugin($I);
-
-        // Confirm expected setup wizard screen is displayed.
-        $this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
-
-        // Test Connect button
-        $I->click('Connect');
-
-        // Confirm expected setup wizard screen is displayed.
-        $this->_seeExpectedSetupWizardScreen($I, 2, 'Connect your ConvertKit account');
-
-        // Fill fields with invalid API Keys.
-        $I->fillField('api_key', 'fakeApiKey');
-        $I->fillField('api_secret', 'fakeApiSecret');
-
-        // Click Connect button.
-        $I->click('Connect');
-
-        // Confirm expected setup wizard screen is still displayed.
-        $this->_seeExpectedSetupWizardScreen($I, 2, 'Connect your ConvertKit account');
-
-        // Confirm error notification is displayed.
-        $I->seeElement('div.notice.notice-error.is-dismissible');
-
-        // Dismiss notification.
-        $I->click('div.notice-error button.notice-dismiss');
-
-        // Confirm notification no longer displayed.
-        $I->wait(1);
-        $I->dontSeeElement('div.notice.notice-error.is-dismissible');
-    }
-
-    /**
-     * Test that the Setup Wizard > Form Configuration screen works as expected.
-     *
-     * @since 1.9.8.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testSetupWizardFormConfigurationScreen(AcceptanceTester $I)
-    {
-        // Activate Plugin.
-        $this->_activatePlugin($I);
-
-        // Define Plugin settings.
-        $I->haveOptionInDatabase(
-            '_wp_convertkit_settings', [
-            'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-            'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-            ]
-        );
-
-        // Create a Page and a Post, so that preview links display.
-        $I->havePostInDatabase(
-            [
-            'post_title'    => 'ConvertKit: Setup Wizard: Page',
-            'post_type'        => 'page',
-            'post_status'    => 'publish',
-            ]
-        );
-        $I->havePostInDatabase(
-            [
-            'post_title'    => 'ConvertKit: Setup Wizard: Post',
-            'post_type'        => 'post',
-            'post_status'    => 'publish',
-            ]
-        );
-
-        // Load Step 3/4.
-        $I->amOnAdminPage('index.php?page=convertkit-setup&step=3');
-
-        // Confirm expected setup wizard screen is displayed.
-        $this->_seeExpectedSetupWizardScreen($I, 3, 'Display an email capture form');
-
-        // Select a Post Form.
-        $I->fillSelect2Field($I, '#select2-wp-convertkit-form-posts-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
-
-        // Open preview.
-        $I->click('a#convertkit-preview-form-post');
-        $I->wait(2); // Required, otherwise switchToNextTab fails.
-
-        // Switch to newly opened tab.
-        $I->switchToNextTab();
-
-        // Confirm expected Form is displayed.
-        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-
-        // Close newly opened tab.
-        $I->closeTab();
-
-        // Select a Page Form.
-        $I->fillSelect2Field($I, '#select2-wp-convertkit-form-pages-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
-
-        // Open preview.
-        $I->click('a#convertkit-preview-form-page');
-        $I->wait(2); // Required, otherwise switchToNextTab fails.
-
-        // Switch to newly opened tab.
-        $I->switchToNextTab();
-
-        // Confirm expected Form is displayed.
-        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-
-        // Close newly opened tab.
-        $I->closeTab();
-
-        // Click Finish Setup button.
-        $I->click('Finish Setup');
-
-        // Confirm expected setup wizard screen is displayed.
-        $this->_seeExpectedSetupWizardScreen($I, 4, 'Setup complete');
-
-        // Click Plugin Settings.
-        $I->click('Plugin Settings');
-
-        // Confirm that Plugin Settings screen contains expected values for API Key, Secret and Default Forms.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-        $I->seeInField('_wp_convertkit_settings[api_key]', $_ENV['CONVERTKIT_API_KEY']);
-        $I->seeInField('_wp_convertkit_settings[api_secret]', $_ENV['CONVERTKIT_API_SECRET']);
-        $I->seeInField('_wp_convertkit_settings[page_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
-        $I->seeInField('_wp_convertkit_settings[post_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
-    }
-
-    /**
-     * Test that the Setup Wizard > Form Configuration screen works as expected
-     * when API credentials are supplied for a ConvertKit account that contains
-     * no forms.
-     *
-     * @since 1.9.8.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testSetupWizardFormConfigurationScreenWhenNoFormsExist(AcceptanceTester $I)
-    {
-        // Activate Plugin.
-        $this->_activatePlugin($I);
-
-        // Define Plugin settings with a ConvertKit account containing no forms.
-        $I->haveOptionInDatabase(
-            '_wp_convertkit_settings', [
-            'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
-            'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
-            ]
-        );
-
-        // Load Step 3/4.
-        $I->amOnAdminPage('index.php?page=convertkit-setup&step=3');
-
-        // Confirm expected setup wizard screen is displayed.
-        $this->_seeExpectedSetupWizardScreen($I, 3, 'Create your first ConvertKit Form', true);
-
-        // Confirm button link to create a form on ConvertKit is correct.
-        $I->seeInSource('<a href="https://app.convertkit.com/forms/new?format=inline"');
-
-        // Define Plugin settings with a ConvertKit account containing forms,
-        // as if we created a form in ConvertKit.
-        $I->haveOptionInDatabase(
-            '_wp_convertkit_settings', [
-            'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-            'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-            ]
-        );
-
-        // Click "I've created a form in ConvertKit" button.
-        $I->click('I\'ve created a form in ConvertKit');
-
-        // Confirm expected setup wizard screen is displayed.
-        $this->_seeExpectedSetupWizardScreen($I, 3, 'Display an email capture form');
-
-        // Confirm we can select a Post Form.
-        $I->fillSelect2Field($I, '#select2-wp-convertkit-form-posts-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
-    }
-
-    /**
-     * Test that the Setup Wizard > Form Configuration screen does not display preview links
-     * when no Pages and Posts exist in WordPress.
-     *
-     * @since 1.9.8.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testSetupWizardFormConfigurationScreenWhenNoPostsOrPagesExist(AcceptanceTester $I)
-    {
-        // Activate Plugin.
-        $this->_activatePlugin($I);
-
-        // Define Plugin settings.
-        $I->haveOptionInDatabase(
-            '_wp_convertkit_settings', [
-            'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-            'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-            ]
-        );
-
-        // Load Step 3/4.
-        $I->amOnAdminPage('index.php?page=convertkit-setup&step=3');
-
-        // Confirm expected setup wizard screen is displayed.
-        $this->_seeExpectedSetupWizardScreen($I, 3, 'Display an email capture form');
-
-        // Confirm no Page or Post preview links exist, because there are no Pages or Posts in WordPress.
-        $I->dontSeeElementInDOM('a#convertkit-preview-form-post');
-        $I->dontSeeElementInDOM('a#convertkit-preview-form-page');
-    }
-
-    /**
-     * Activate the Plugin, without checking it is activated, so that its Setup Wizard
-     * screen loads.
-     * 
-     * This differs from the activateConvertKitPlugin() method, which will ignore a Setup Wizard
-     * screen by reloading the Plugins screen to confirm a Plugin's activation.
-     * 
-     * @since 1.9.8.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    private function _activatePlugin(AcceptanceTester $I)
-    {
-        $I->loginAsAdmin();
-        $I->amOnPluginsPage();
-        $I->activatePlugin('convertkit');
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-    }
-
-    /**
-     * Runs tests on a Setup Wizard screen, to confirm that the expected step, title and buttons
-     * are displayed.
-     * 
-     * @since 1.9.8.4
-     * 
-     * @param AcceptanceTester $I                Tester
-     * @param int              $step             Current step
-     * @param string           $title            Expected title
-     * @param bool             $nextButtonIsLink Check that next button is a link (false = must be a <button> element).
-     */
-    private function _seeExpectedSetupWizardScreen(AcceptanceTester $I, $step, $title, $nextButtonIsLink = false)
-    {
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Confirm expected setup wizard screen loaded.
-        $I->seeInCurrentUrl('index.php?page=convertkit-setup');
-		
-        // Confirm expected title is displayed.
-        $I->see($title);
-
-        // Confirm current and previous steps are highlighted as 'done'.
-        for ($stepCount = 1; $stepCount <= $step; $stepCount++) {
-            $I->seeElement('li.step-'.$stepCount.'.done');
-        }
-
-        // Confirm Step text is correct.
-        $I->see('Step '.$step.' of 4');
-
-        // Depending on the step, confirm previous/next buttons exist / do not exist.
-        switch ($step) {
-         /**
-          * First and last step should not display any footer buttons.
-          */
-        case 1:
-        case 4:
-            $I->dontSeeElementInDOM('#convertkit-setup-wizard-footer div.left a.button');
-            $I->dontSeeElementInDOM('#convertkit-setup-wizard-footer div.right button');
-            $I->dontSeeElementInDOM('#convertkit-setup-wizard-footer div.right a.button');
-            break;
-
-        /**
-         * Middle steps should always display footer buttons.
-         */
-        case 2:
-        case 3:
-            $I->seeElementInDOM('#convertkit-setup-wizard-footer div.left a.button');
-
-            if ($nextButtonIsLink) {
-                // Next button must be a link.
-                $I->seeElementInDOM('#convertkit-setup-wizard-footer div.right a.button');
-            } else {
-                // Next button must be a <button> element to submit form.
-                $I->seeElementInDOM('#convertkit-setup-wizard-footer div.right button');    
-            }
-            break;
-
-        }
-    }
-
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.8.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+class PluginSetupWizardCest {
+
+	/**
+	 * Test that the Setup Wizard displays when the Plugin is activated.
+	 *
+	 * @since 1.9.8.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testSetupWizardDisplays( AcceptanceTester $I ) {
+		// Activate Plugin.
+		$this->_activatePlugin( $I );
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen( $I, 1, 'Welcome to the ConvertKit Setup Wizard' );
+	}
+
+	/**
+	 * Test that the Setup Wizard displays when the Plugin is activated on a site
+	 * where the Plugin has previously been activated and configured with API Keys.
+	 *
+	 * @since 1.9.8.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testSetupWizardDoesNotDisplayWhenConfigured( AcceptanceTester $I ) {
+		// Define Plugin settings as if the Plugin were previously activated and configured.
+		$I->haveOptionInDatabase(
+			'_wp_convertkit_settings',
+			array(
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+				'debug'      => 'on',
+				'no_scripts' => '',
+				'no_css'     => '',
+			)
+		);
+
+		// Activate Plugin.
+		$this->_activatePlugin( $I );
+
+		// Confirm setup wizard does not display.
+		$I->dontSee( 'Welcome to the ConvertKit Setup Wizard' );
+	}
+
+	/**
+	 * Test that the Setup Wizard exit link works.
+	 *
+	 * @since 1.9.8.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testSetupWizardExitLink( AcceptanceTester $I ) {
+		// Activate Plugin.
+		$this->_activatePlugin( $I );
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen( $I, 1, 'Welcome to the ConvertKit Setup Wizard' );
+
+		// Click Exit wizard link.
+		$I->click( 'Exit wizard' );
+
+		// Confirm exit.
+		$I->acceptPopup();
+
+		// Confirm Plugin settings screen loaded.
+		$I->seeInCurrentUrl( 'options-general.php?page=_wp_convertkit_settings' );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+	}
+
+	/**
+	 * Test that the Setup Wizard > Setup > Register button works.
+	 *
+	 * @since 1.9.8.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testSetupWizardSetupScreenRegisterButton( AcceptanceTester $I ) {
+		// Activate Plugin.
+		$this->_activatePlugin( $I );
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen( $I, 1, 'Welcome to the ConvertKit Setup Wizard' );
+
+		// Test Register button opens a new tab.
+		$I->click( 'Register' );
+		$I->wait( 2 ); // Required, otherwise switchToNextTab fails.
+		$I->switchToNextTab();
+		$I->seeInCurrentUrl( 'users/signup?utm_source=wordpress&utm_content=convertkit' );
+
+		// Close newly opened tab from above button.
+		$I->closeTab();
+
+		// Confirm that the original tab is now displaying the Connect Account screen.
+		$this->_seeExpectedSetupWizardScreen( $I, 2, 'Connect your ConvertKit account' );
+	}
+
+	/**
+	 * Test that the Setup Wizard > Setup > Connect button works.
+	 *
+	 * @since 1.9.8.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testSetupWizardSetupScreenConnectButton( AcceptanceTester $I ) {
+		// Activate Plugin.
+		$this->_activatePlugin( $I );
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen( $I, 1, 'Welcome to the ConvertKit Setup Wizard' );
+
+		// Test Connect button
+		$I->click( 'Connect' );
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen( $I, 2, 'Connect your ConvertKit account' );
+	}
+
+	/**
+	 * Test that the Setup Wizard > Connect Account screen works as expected when valid API credentials
+	 * are specified.
+	 *
+	 * @since 1.9.8.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testSetupWizardConnectAccountScreen( AcceptanceTester $I ) {
+		// Activate Plugin.
+		$this->_activatePlugin( $I );
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen( $I, 1, 'Welcome to the ConvertKit Setup Wizard' );
+
+		// Test Connect button
+		$I->click( 'Connect' );
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen( $I, 2, 'Connect your ConvertKit account' );
+
+		// Wait to prevent API rate limit hit due to parallel tests.
+		$I->wait( 2 );
+
+		// Fill fields with invalid API Keys.
+		$I->fillField( 'api_key', $_ENV['CONVERTKIT_API_KEY'] );
+		$I->fillField( 'api_secret', $_ENV['CONVERTKIT_API_SECRET'] );
+
+		// Click Connect button.
+		$I->click( 'Connect' );
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen( $I, 3, 'Display an email capture form' );
+	}
+
+	/**
+	 * Test that the Setup Wizard > Connect Account screen works as expected when invalid API credentials
+	 * are specified.
+	 *
+	 * @since 1.9.8.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testSetupWizardConnectAccountScreenWithInvalidAPICredentials( AcceptanceTester $I ) {
+		// Activate Plugin.
+		$this->_activatePlugin( $I );
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen( $I, 1, 'Welcome to the ConvertKit Setup Wizard' );
+
+		// Test Connect button
+		$I->click( 'Connect' );
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen( $I, 2, 'Connect your ConvertKit account' );
+
+		// Fill fields with invalid API Keys.
+		$I->fillField( 'api_key', 'fakeApiKey' );
+		$I->fillField( 'api_secret', 'fakeApiSecret' );
+
+		// Click Connect button.
+		$I->click( 'Connect' );
+
+		// Confirm expected setup wizard screen is still displayed.
+		$this->_seeExpectedSetupWizardScreen( $I, 2, 'Connect your ConvertKit account' );
+
+		// Confirm error notification is displayed.
+		$I->seeElement( 'div.notice.notice-error.is-dismissible' );
+
+		// Dismiss notification.
+		$I->click( 'div.notice-error button.notice-dismiss' );
+
+		// Confirm notification no longer displayed.
+		$I->wait( 1 );
+		$I->dontSeeElement( 'div.notice.notice-error.is-dismissible' );
+	}
+
+	/**
+	 * Test that the Setup Wizard > Form Configuration screen works as expected.
+	 *
+	 * @since 1.9.8.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testSetupWizardFormConfigurationScreen( AcceptanceTester $I ) {
+		// Activate Plugin.
+		$this->_activatePlugin( $I );
+
+		// Define Plugin settings.
+		$I->haveOptionInDatabase(
+			'_wp_convertkit_settings',
+			array(
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+			)
+		);
+
+		// Create a Page and a Post, so that preview links display.
+		$I->havePostInDatabase(
+			array(
+				'post_title'  => 'ConvertKit: Setup Wizard: Page',
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			)
+		);
+		$I->havePostInDatabase(
+			array(
+				'post_title'  => 'ConvertKit: Setup Wizard: Post',
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+			)
+		);
+
+		// Load Step 3/4.
+		$I->amOnAdminPage( 'index.php?page=convertkit-setup&step=3' );
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen( $I, 3, 'Display an email capture form' );
+
+		// Select a Post Form.
+		$I->fillSelect2Field( $I, '#select2-wp-convertkit-form-posts-container', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+
+		// Open preview.
+		$I->click( 'a#convertkit-preview-form-post' );
+		$I->wait( 2 ); // Required, otherwise switchToNextTab fails.
+
+		// Switch to newly opened tab.
+		$I->switchToNextTab();
+
+		// Confirm expected Form is displayed.
+		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+
+		// Close newly opened tab.
+		$I->closeTab();
+
+		// Select a Page Form.
+		$I->fillSelect2Field( $I, '#select2-wp-convertkit-form-pages-container', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+
+		// Open preview.
+		$I->click( 'a#convertkit-preview-form-page' );
+		$I->wait( 2 ); // Required, otherwise switchToNextTab fails.
+
+		// Switch to newly opened tab.
+		$I->switchToNextTab();
+
+		// Confirm expected Form is displayed.
+		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+
+		// Close newly opened tab.
+		$I->closeTab();
+
+		// Click Finish Setup button.
+		$I->click( 'Finish Setup' );
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen( $I, 4, 'Setup complete' );
+
+		// Click Plugin Settings.
+		$I->click( 'Plugin Settings' );
+
+		// Confirm that Plugin Settings screen contains expected values for API Key, Secret and Default Forms.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->seeInField( '_wp_convertkit_settings[api_key]', $_ENV['CONVERTKIT_API_KEY'] );
+		$I->seeInField( '_wp_convertkit_settings[api_secret]', $_ENV['CONVERTKIT_API_SECRET'] );
+		$I->seeInField( '_wp_convertkit_settings[page_form]', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+		$I->seeInField( '_wp_convertkit_settings[post_form]', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+	}
+
+	/**
+	 * Test that the Setup Wizard > Form Configuration screen works as expected
+	 * when API credentials are supplied for a ConvertKit account that contains
+	 * no forms.
+	 *
+	 * @since 1.9.8.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testSetupWizardFormConfigurationScreenWhenNoFormsExist( AcceptanceTester $I ) {
+		// Activate Plugin.
+		$this->_activatePlugin( $I );
+
+		// Define Plugin settings with a ConvertKit account containing no forms.
+		$I->haveOptionInDatabase(
+			'_wp_convertkit_settings',
+			array(
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+			)
+		);
+
+		// Load Step 3/4.
+		$I->amOnAdminPage( 'index.php?page=convertkit-setup&step=3' );
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen( $I, 3, 'Create your first ConvertKit Form', true );
+
+		// Confirm button link to create a form on ConvertKit is correct.
+		$I->seeInSource( '<a href="https://app.convertkit.com/forms/new?format=inline"' );
+
+		// Define Plugin settings with a ConvertKit account containing forms,
+		// as if we created a form in ConvertKit.
+		$I->haveOptionInDatabase(
+			'_wp_convertkit_settings',
+			array(
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+			)
+		);
+
+		// Click "I've created a form in ConvertKit" button.
+		$I->click( 'I\'ve created a form in ConvertKit' );
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen( $I, 3, 'Display an email capture form' );
+
+		// Confirm we can select a Post Form.
+		$I->fillSelect2Field( $I, '#select2-wp-convertkit-form-posts-container', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+	}
+
+	/**
+	 * Test that the Setup Wizard > Form Configuration screen does not display preview links
+	 * when no Pages and Posts exist in WordPress.
+	 *
+	 * @since 1.9.8.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testSetupWizardFormConfigurationScreenWhenNoPostsOrPagesExist( AcceptanceTester $I ) {
+		// Activate Plugin.
+		$this->_activatePlugin( $I );
+
+		// Define Plugin settings.
+		$I->haveOptionInDatabase(
+			'_wp_convertkit_settings',
+			array(
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+			)
+		);
+
+		// Load Step 3/4.
+		$I->amOnAdminPage( 'index.php?page=convertkit-setup&step=3' );
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen( $I, 3, 'Display an email capture form' );
+
+		// Confirm no Page or Post preview links exist, because there are no Pages or Posts in WordPress.
+		$I->dontSeeElementInDOM( 'a#convertkit-preview-form-post' );
+		$I->dontSeeElementInDOM( 'a#convertkit-preview-form-page' );
+	}
+
+	/**
+	 * Activate the Plugin, without checking it is activated, so that its Setup Wizard
+	 * screen loads.
+	 *
+	 * This differs from the activateConvertKitPlugin() method, which will ignore a Setup Wizard
+	 * screen by reloading the Plugins screen to confirm a Plugin's activation.
+	 *
+	 * @since 1.9.8.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	private function _activatePlugin( AcceptanceTester $I ) {
+		$I->loginAsAdmin();
+		$I->amOnPluginsPage();
+		$I->activatePlugin( 'convertkit' );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+	}
+
+	/**
+	 * Runs tests on a Setup Wizard screen, to confirm that the expected step, title and buttons
+	 * are displayed.
+	 *
+	 * @since 1.9.8.4
+	 *
+	 * @param AcceptanceTester $I                Tester
+	 * @param int              $step             Current step
+	 * @param string           $title            Expected title
+	 * @param bool             $nextButtonIsLink Check that next button is a link (false = must be a <button> element).
+	 */
+	private function _seeExpectedSetupWizardScreen( AcceptanceTester $I, $step, $title, $nextButtonIsLink = false ) {
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Confirm expected setup wizard screen loaded.
+		$I->seeInCurrentUrl( 'index.php?page=convertkit-setup' );
+
+		// Confirm expected title is displayed.
+		$I->see( $title );
+
+		// Confirm current and previous steps are highlighted as 'done'.
+		for ( $stepCount = 1; $stepCount <= $step; $stepCount++ ) {
+			$I->seeElement( 'li.step-' . $stepCount . '.done' );
+		}
+
+		// Confirm Step text is correct.
+		$I->see( 'Step ' . $step . ' of 4' );
+
+		// Depending on the step, confirm previous/next buttons exist / do not exist.
+		switch ( $step ) {
+			/**
+			 * First and last step should not display any footer buttons.
+			 */
+			case 1:
+			case 4:
+				$I->dontSeeElementInDOM( '#convertkit-setup-wizard-footer div.left a.button' );
+				$I->dontSeeElementInDOM( '#convertkit-setup-wizard-footer div.right button' );
+				$I->dontSeeElementInDOM( '#convertkit-setup-wizard-footer div.right a.button' );
+				break;
+
+			/**
+			 * Middle steps should always display footer buttons.
+			 */
+			case 2:
+			case 3:
+				$I->seeElementInDOM( '#convertkit-setup-wizard-footer div.left a.button' );
+
+				if ( $nextButtonIsLink ) {
+					// Next button must be a link.
+					$I->seeElementInDOM( '#convertkit-setup-wizard-footer div.right a.button' );
+				} else {
+					// Next button must be a <button> element to submit form.
+					$I->seeElementInDOM( '#convertkit-setup-wizard-footer div.right button' );
+				}
+				break;
+
+		}
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.8.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/general/PluginSetupWizardCest.php
+++ b/tests/acceptance/general/PluginSetupWizardCest.php
@@ -2,457 +2,471 @@
 
 class PluginSetupWizardCest
 {
-	/**
-	 * Test that the Setup Wizard displays when the Plugin is activated.
-	 * 
-	 * @since 	1.9.8.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testSetupWizardDisplays(AcceptanceTester $I)
-	{
-		// Activate Plugin.
-		$this->_activatePlugin($I);
-
-		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
-	}
-
-	/**
-	 * Test that the Setup Wizard displays when the Plugin is activated on a site
-	 * where the Plugin has previously been activated and configured with API Keys.
-	 * 
-	 * @since 	1.9.8.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testSetupWizardDoesNotDisplayWhenConfigured(AcceptanceTester $I)
-	{
-		// Define Plugin settings as if the Plugin were previously activated and configured.
-		$I->haveOptionInDatabase('_wp_convertkit_settings', [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-			'debug'      => 'on',
-			'no_scripts' => '',
-			'no_css'     => '',
-		]);
-
-		// Activate Plugin.
-		$this->_activatePlugin($I);
-
-		// Confirm setup wizard does not display.
-		$I->dontSee('Welcome to the ConvertKit Setup Wizard');
-	}
-
-	/**
-	 * Test that the Setup Wizard exit link works.
-	 * 
-	 * @since 	1.9.8.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testSetupWizardExitLink(AcceptanceTester $I)
-	{
-		// Activate Plugin.
-		$this->_activatePlugin($I);
-
-		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
-
-		// Click Exit wizard link.
-		$I->click('Exit wizard');
-
-		// Confirm exit.
-		$I->acceptPopup();
-
-		// Confirm Plugin settings screen loaded.
-		$I->seeInCurrentUrl('options-general.php?page=_wp_convertkit_settings');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-	}
-
-	/**
-	 * Test that the Setup Wizard > Setup > Register button works.
-	 *
-	 * @since 	1.9.8.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testSetupWizardSetupScreenRegisterButton(AcceptanceTester $I)
-	{
-		// Activate Plugin.
-		$this->_activatePlugin($I);
-
-		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
-
-		// Test Register button opens a new tab.
-		$I->click('Register');
-		$I->wait(2); // Required, otherwise switchToNextTab fails.
-		$I->switchToNextTab();
-		$I->seeInCurrentUrl('users/signup?utm_source=wordpress&utm_content=convertkit');
-
-		// Close newly opened tab from above button.
-		$I->closeTab();
-
-		// Confirm that the original tab is now displaying the Connect Account screen.
-		$this->_seeExpectedSetupWizardScreen($I, 2, 'Connect your ConvertKit account');
-	}
-
-	/**
-	 * Test that the Setup Wizard > Setup > Connect button works.
-	 *
-	 * @since 	1.9.8.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testSetupWizardSetupScreenConnectButton(AcceptanceTester $I)
-	{
-		// Activate Plugin.
-		$this->_activatePlugin($I);
-
-		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
-
-		// Test Connect button
-		$I->click('Connect');
-
-		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen($I, 2, 'Connect your ConvertKit account');
-	}
-
-	/**
-	 * Test that the Setup Wizard > Connect Account screen works as expected when valid API credentials
-	 * are specified.
-	 *
-	 * @since 	1.9.8.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testSetupWizardConnectAccountScreen(AcceptanceTester $I)
-	{
-		// Activate Plugin.
-		$this->_activatePlugin($I);
-
-		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
-
-		// Test Connect button
-		$I->click('Connect');
-
-		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen($I, 2, 'Connect your ConvertKit account');
-
-		// Fill fields with invalid API Keys.
-		$I->fillField('api_key', $_ENV['CONVERTKIT_API_KEY']);
-		$I->fillField('api_secret', $_ENV['CONVERTKIT_API_SECRET']);
-
-		// Click Connect button.
-		$I->click('Connect');
-
-		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen($I, 3, 'Display an email capture form');
-	}
-
-	/**
-	 * Test that the Setup Wizard > Connect Account screen works as expected when invalid API credentials
-	 * are specified.
-	 *
-	 * @since 	1.9.8.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testSetupWizardConnectAccountScreenWithInvalidAPICredentials(AcceptanceTester $I)
-	{
-		// Activate Plugin.
-		$this->_activatePlugin($I);
-
-		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
-
-		// Test Connect button
-		$I->click('Connect');
-
-		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen($I, 2, 'Connect your ConvertKit account');
-
-		// Fill fields with invalid API Keys.
-		$I->fillField('api_key', 'fakeApiKey');
-		$I->fillField('api_secret', 'fakeApiSecret');
-
-		// Click Connect button.
-		$I->click('Connect');
-
-		// Confirm expected setup wizard screen is still displayed.
-		$this->_seeExpectedSetupWizardScreen($I, 2, 'Connect your ConvertKit account');
-
-		// Confirm error notification is displayed.
-		$I->seeElement('div.notice.notice-error.is-dismissible');
-
-		// Dismiss notification.
-		$I->click('div.notice-error button.notice-dismiss');
-
-		// Confirm notification no longer displayed.
-		$I->wait(1);
-		$I->dontSeeElement('div.notice.notice-error.is-dismissible');
-	}
-
-	/**
-	 * Test that the Setup Wizard > Form Configuration screen works as expected.
-	 *
-	 * @since 	1.9.8.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testSetupWizardFormConfigurationScreen(AcceptanceTester $I)
-	{
-		// Activate Plugin.
-		$this->_activatePlugin($I);
-
-		// Define Plugin settings.
-		$I->haveOptionInDatabase('_wp_convertkit_settings', [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-		]);
-
-		// Create a Page and a Post, so that preview links display.
-		$I->havePostInDatabase([
-			'post_title'	=> 'ConvertKit: Setup Wizard: Page',
-			'post_type'		=> 'page',
-			'post_status'	=> 'publish',
-		]);
-		$I->havePostInDatabase([
-			'post_title'	=> 'ConvertKit: Setup Wizard: Post',
-			'post_type'		=> 'post',
-			'post_status'	=> 'publish',
-		]);
-
-		// Load Step 3/4.
-		$I->amOnAdminPage('index.php?page=convertkit-setup&step=3');
-
-		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen($I, 3, 'Display an email capture form');
-
-		// Select a Post Form.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-posts-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
-
-		// Open preview.
-		$I->click('a#convertkit-preview-form-post');
-		$I->wait(2); // Required, otherwise switchToNextTab fails.
-
-		// Switch to newly opened tab.
-		$I->switchToNextTab();
-
-		// Confirm expected Form is displayed.
-		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-
-		// Close newly opened tab.
-		$I->closeTab();
-
-		// Select a Page Form.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-pages-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
-
-		// Open preview.
-		$I->click('a#convertkit-preview-form-page');
-		$I->wait(2); // Required, otherwise switchToNextTab fails.
-
-		// Switch to newly opened tab.
-		$I->switchToNextTab();
-
-		// Confirm expected Form is displayed.
-		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-
-		// Close newly opened tab.
-		$I->closeTab();
-
-		// Click Finish Setup button.
-		$I->click('Finish Setup');
-
-		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen($I, 4, 'Setup complete');
-
-		// Click Plugin Settings.
-		$I->click('Plugin Settings');
-
-		// Confirm that Plugin Settings screen contains expected values for API Key, Secret and Default Forms.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-		$I->seeInField('_wp_convertkit_settings[api_key]', $_ENV['CONVERTKIT_API_KEY']);
-		$I->seeInField('_wp_convertkit_settings[api_secret]', $_ENV['CONVERTKIT_API_SECRET']);
-		$I->seeInField('_wp_convertkit_settings[page_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
-		$I->seeInField('_wp_convertkit_settings[post_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
-	}
-
-	/**
-	 * Test that the Setup Wizard > Form Configuration screen works as expected
-	 * when API credentials are supplied for a ConvertKit account that contains
-	 * no forms.
-	 *
-	 * @since 	1.9.8.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testSetupWizardFormConfigurationScreenWhenNoFormsExist(AcceptanceTester $I)
-	{
-		// Activate Plugin.
-		$this->_activatePlugin($I);
-
-		// Define Plugin settings with a ConvertKit account containing no forms.
-		$I->haveOptionInDatabase('_wp_convertkit_settings', [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
-		]);
-
-		// Load Step 3/4.
-		$I->amOnAdminPage('index.php?page=convertkit-setup&step=3');
-
-		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen($I, 3, 'Create your first ConvertKit Form', true);
-
-		// Confirm button link to create a form on ConvertKit is correct.
-		$I->seeInSource('<a href="https://app.convertkit.com/forms/new?format=inline"');
-
-		// Define Plugin settings with a ConvertKit account containing forms,
-		// as if we created a form in ConvertKit.
-		$I->haveOptionInDatabase('_wp_convertkit_settings', [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-		]);
-
-		// Click "I've created a form in ConvertKit" button.
-		$I->click('I\'ve created a form in ConvertKit');
-
-		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen($I, 3, 'Display an email capture form');
-
-		// Confirm we can select a Post Form.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-posts-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
-	}
-
-	/**
-	 * Test that the Setup Wizard > Form Configuration screen does not display preview links
-	 * when no Pages and Posts exist in WordPress.
-	 *
-	 * @since 	1.9.8.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testSetupWizardFormConfigurationScreenWhenNoPostsOrPagesExist(AcceptanceTester $I)
-	{
-		// Activate Plugin.
-		$this->_activatePlugin($I);
-
-		// Define Plugin settings.
-		$I->haveOptionInDatabase('_wp_convertkit_settings', [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-		]);
-
-		// Load Step 3/4.
-		$I->amOnAdminPage('index.php?page=convertkit-setup&step=3');
-
-		// Confirm expected setup wizard screen is displayed.
-		$this->_seeExpectedSetupWizardScreen($I, 3, 'Display an email capture form');
-
-		// Confirm no Page or Post preview links exist, because there are no Pages or Posts in WordPress.
-		$I->dontSeeElementInDOM('a#convertkit-preview-form-post');
-		$I->dontSeeElementInDOM('a#convertkit-preview-form-page');
-	}
-
-	/**
-	 * Activate the Plugin, without checking it is activated, so that its Setup Wizard
-	 * screen loads.
-	 * 
-	 * This differs from the activateConvertKitPlugin() method, which will ignore a Setup Wizard
-	 * screen by reloading the Plugins screen to confirm a Plugin's activation.
-	 * 
-	 * @since 	1.9.8.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	private function _activatePlugin(AcceptanceTester $I)
-	{
-		$I->loginAsAdmin();
-		$I->amOnPluginsPage();
-		$I->activatePlugin('convertkit');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-	}
-
-	/**
-	 * Runs tests on a Setup Wizard screen, to confirm that the expected step, title and buttons
-	 * are displayed.
-	 * 
-	 * @since 	1.9.8.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 		Tester
-	 * @param 	int 				$step 	Current step
-	 * @param 	string 				$title 	Expected title
-	 * @param 	bool 				$nextButtonIsLink 	Check that next button is a link (false = must be a <button> element).
-	 */
-	private function _seeExpectedSetupWizardScreen(AcceptanceTester $I, $step, $title, $nextButtonIsLink = false)
-	{
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm expected setup wizard screen loaded.
-		$I->seeInCurrentUrl('index.php?page=convertkit-setup');
+    /**
+     * Test that the Setup Wizard displays when the Plugin is activated.
+     * 
+     * @since 1.9.8.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testSetupWizardDisplays(AcceptanceTester $I)
+    {
+        // Activate Plugin.
+        $this->_activatePlugin($I);
+
+        // Confirm expected setup wizard screen is displayed.
+        $this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
+    }
+
+    /**
+     * Test that the Setup Wizard displays when the Plugin is activated on a site
+     * where the Plugin has previously been activated and configured with API Keys.
+     * 
+     * @since 1.9.8.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testSetupWizardDoesNotDisplayWhenConfigured(AcceptanceTester $I)
+    {
+        // Define Plugin settings as if the Plugin were previously activated and configured.
+        $I->haveOptionInDatabase(
+            '_wp_convertkit_settings', [
+            'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+            'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+            'debug'      => 'on',
+            'no_scripts' => '',
+            'no_css'     => '',
+            ]
+        );
+
+        // Activate Plugin.
+        $this->_activatePlugin($I);
+
+        // Confirm setup wizard does not display.
+        $I->dontSee('Welcome to the ConvertKit Setup Wizard');
+    }
+
+    /**
+     * Test that the Setup Wizard exit link works.
+     * 
+     * @since 1.9.8.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testSetupWizardExitLink(AcceptanceTester $I)
+    {
+        // Activate Plugin.
+        $this->_activatePlugin($I);
+
+        // Confirm expected setup wizard screen is displayed.
+        $this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
+
+        // Click Exit wizard link.
+        $I->click('Exit wizard');
+
+        // Confirm exit.
+        $I->acceptPopup();
+
+        // Confirm Plugin settings screen loaded.
+        $I->seeInCurrentUrl('options-general.php?page=_wp_convertkit_settings');
+
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
+    }
+
+    /**
+     * Test that the Setup Wizard > Setup > Register button works.
+     *
+     * @since 1.9.8.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testSetupWizardSetupScreenRegisterButton(AcceptanceTester $I)
+    {
+        // Activate Plugin.
+        $this->_activatePlugin($I);
+
+        // Confirm expected setup wizard screen is displayed.
+        $this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
+
+        // Test Register button opens a new tab.
+        $I->click('Register');
+        $I->wait(2); // Required, otherwise switchToNextTab fails.
+        $I->switchToNextTab();
+        $I->seeInCurrentUrl('users/signup?utm_source=wordpress&utm_content=convertkit');
+
+        // Close newly opened tab from above button.
+        $I->closeTab();
+
+        // Confirm that the original tab is now displaying the Connect Account screen.
+        $this->_seeExpectedSetupWizardScreen($I, 2, 'Connect your ConvertKit account');
+    }
+
+    /**
+     * Test that the Setup Wizard > Setup > Connect button works.
+     *
+     * @since 1.9.8.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testSetupWizardSetupScreenConnectButton(AcceptanceTester $I)
+    {
+        // Activate Plugin.
+        $this->_activatePlugin($I);
+
+        // Confirm expected setup wizard screen is displayed.
+        $this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
+
+        // Test Connect button
+        $I->click('Connect');
+
+        // Confirm expected setup wizard screen is displayed.
+        $this->_seeExpectedSetupWizardScreen($I, 2, 'Connect your ConvertKit account');
+    }
+
+    /**
+     * Test that the Setup Wizard > Connect Account screen works as expected when valid API credentials
+     * are specified.
+     *
+     * @since 1.9.8.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testSetupWizardConnectAccountScreen(AcceptanceTester $I)
+    {
+        // Activate Plugin.
+        $this->_activatePlugin($I);
+
+        // Confirm expected setup wizard screen is displayed.
+        $this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
+
+        // Test Connect button
+        $I->click('Connect');
+
+        // Confirm expected setup wizard screen is displayed.
+        $this->_seeExpectedSetupWizardScreen($I, 2, 'Connect your ConvertKit account');
+
+        // Fill fields with invalid API Keys.
+        $I->fillField('api_key', $_ENV['CONVERTKIT_API_KEY']);
+        $I->fillField('api_secret', $_ENV['CONVERTKIT_API_SECRET']);
+
+        // Click Connect button.
+        $I->click('Connect');
+
+        // Confirm expected setup wizard screen is displayed.
+        $this->_seeExpectedSetupWizardScreen($I, 3, 'Display an email capture form');
+    }
+
+    /**
+     * Test that the Setup Wizard > Connect Account screen works as expected when invalid API credentials
+     * are specified.
+     *
+     * @since 1.9.8.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testSetupWizardConnectAccountScreenWithInvalidAPICredentials(AcceptanceTester $I)
+    {
+        // Activate Plugin.
+        $this->_activatePlugin($I);
+
+        // Confirm expected setup wizard screen is displayed.
+        $this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
+
+        // Test Connect button
+        $I->click('Connect');
+
+        // Confirm expected setup wizard screen is displayed.
+        $this->_seeExpectedSetupWizardScreen($I, 2, 'Connect your ConvertKit account');
+
+        // Fill fields with invalid API Keys.
+        $I->fillField('api_key', 'fakeApiKey');
+        $I->fillField('api_secret', 'fakeApiSecret');
+
+        // Click Connect button.
+        $I->click('Connect');
+
+        // Confirm expected setup wizard screen is still displayed.
+        $this->_seeExpectedSetupWizardScreen($I, 2, 'Connect your ConvertKit account');
+
+        // Confirm error notification is displayed.
+        $I->seeElement('div.notice.notice-error.is-dismissible');
+
+        // Dismiss notification.
+        $I->click('div.notice-error button.notice-dismiss');
+
+        // Confirm notification no longer displayed.
+        $I->wait(1);
+        $I->dontSeeElement('div.notice.notice-error.is-dismissible');
+    }
+
+    /**
+     * Test that the Setup Wizard > Form Configuration screen works as expected.
+     *
+     * @since 1.9.8.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testSetupWizardFormConfigurationScreen(AcceptanceTester $I)
+    {
+        // Activate Plugin.
+        $this->_activatePlugin($I);
+
+        // Define Plugin settings.
+        $I->haveOptionInDatabase(
+            '_wp_convertkit_settings', [
+            'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+            'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+            ]
+        );
+
+        // Create a Page and a Post, so that preview links display.
+        $I->havePostInDatabase(
+            [
+            'post_title'    => 'ConvertKit: Setup Wizard: Page',
+            'post_type'        => 'page',
+            'post_status'    => 'publish',
+            ]
+        );
+        $I->havePostInDatabase(
+            [
+            'post_title'    => 'ConvertKit: Setup Wizard: Post',
+            'post_type'        => 'post',
+            'post_status'    => 'publish',
+            ]
+        );
+
+        // Load Step 3/4.
+        $I->amOnAdminPage('index.php?page=convertkit-setup&step=3');
+
+        // Confirm expected setup wizard screen is displayed.
+        $this->_seeExpectedSetupWizardScreen($I, 3, 'Display an email capture form');
+
+        // Select a Post Form.
+        $I->fillSelect2Field($I, '#select2-wp-convertkit-form-posts-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+
+        // Open preview.
+        $I->click('a#convertkit-preview-form-post');
+        $I->wait(2); // Required, otherwise switchToNextTab fails.
+
+        // Switch to newly opened tab.
+        $I->switchToNextTab();
+
+        // Confirm expected Form is displayed.
+        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+
+        // Close newly opened tab.
+        $I->closeTab();
+
+        // Select a Page Form.
+        $I->fillSelect2Field($I, '#select2-wp-convertkit-form-pages-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+
+        // Open preview.
+        $I->click('a#convertkit-preview-form-page');
+        $I->wait(2); // Required, otherwise switchToNextTab fails.
+
+        // Switch to newly opened tab.
+        $I->switchToNextTab();
+
+        // Confirm expected Form is displayed.
+        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+
+        // Close newly opened tab.
+        $I->closeTab();
+
+        // Click Finish Setup button.
+        $I->click('Finish Setup');
+
+        // Confirm expected setup wizard screen is displayed.
+        $this->_seeExpectedSetupWizardScreen($I, 4, 'Setup complete');
+
+        // Click Plugin Settings.
+        $I->click('Plugin Settings');
+
+        // Confirm that Plugin Settings screen contains expected values for API Key, Secret and Default Forms.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
+        $I->seeInField('_wp_convertkit_settings[api_key]', $_ENV['CONVERTKIT_API_KEY']);
+        $I->seeInField('_wp_convertkit_settings[api_secret]', $_ENV['CONVERTKIT_API_SECRET']);
+        $I->seeInField('_wp_convertkit_settings[page_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
+        $I->seeInField('_wp_convertkit_settings[post_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
+    }
+
+    /**
+     * Test that the Setup Wizard > Form Configuration screen works as expected
+     * when API credentials are supplied for a ConvertKit account that contains
+     * no forms.
+     *
+     * @since 1.9.8.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testSetupWizardFormConfigurationScreenWhenNoFormsExist(AcceptanceTester $I)
+    {
+        // Activate Plugin.
+        $this->_activatePlugin($I);
+
+        // Define Plugin settings with a ConvertKit account containing no forms.
+        $I->haveOptionInDatabase(
+            '_wp_convertkit_settings', [
+            'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+            'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+            ]
+        );
+
+        // Load Step 3/4.
+        $I->amOnAdminPage('index.php?page=convertkit-setup&step=3');
+
+        // Confirm expected setup wizard screen is displayed.
+        $this->_seeExpectedSetupWizardScreen($I, 3, 'Create your first ConvertKit Form', true);
+
+        // Confirm button link to create a form on ConvertKit is correct.
+        $I->seeInSource('<a href="https://app.convertkit.com/forms/new?format=inline"');
+
+        // Define Plugin settings with a ConvertKit account containing forms,
+        // as if we created a form in ConvertKit.
+        $I->haveOptionInDatabase(
+            '_wp_convertkit_settings', [
+            'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+            'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+            ]
+        );
+
+        // Click "I've created a form in ConvertKit" button.
+        $I->click('I\'ve created a form in ConvertKit');
+
+        // Confirm expected setup wizard screen is displayed.
+        $this->_seeExpectedSetupWizardScreen($I, 3, 'Display an email capture form');
+
+        // Confirm we can select a Post Form.
+        $I->fillSelect2Field($I, '#select2-wp-convertkit-form-posts-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+    }
+
+    /**
+     * Test that the Setup Wizard > Form Configuration screen does not display preview links
+     * when no Pages and Posts exist in WordPress.
+     *
+     * @since 1.9.8.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testSetupWizardFormConfigurationScreenWhenNoPostsOrPagesExist(AcceptanceTester $I)
+    {
+        // Activate Plugin.
+        $this->_activatePlugin($I);
+
+        // Define Plugin settings.
+        $I->haveOptionInDatabase(
+            '_wp_convertkit_settings', [
+            'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+            'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+            ]
+        );
+
+        // Load Step 3/4.
+        $I->amOnAdminPage('index.php?page=convertkit-setup&step=3');
+
+        // Confirm expected setup wizard screen is displayed.
+        $this->_seeExpectedSetupWizardScreen($I, 3, 'Display an email capture form');
+
+        // Confirm no Page or Post preview links exist, because there are no Pages or Posts in WordPress.
+        $I->dontSeeElementInDOM('a#convertkit-preview-form-post');
+        $I->dontSeeElementInDOM('a#convertkit-preview-form-page');
+    }
+
+    /**
+     * Activate the Plugin, without checking it is activated, so that its Setup Wizard
+     * screen loads.
+     * 
+     * This differs from the activateConvertKitPlugin() method, which will ignore a Setup Wizard
+     * screen by reloading the Plugins screen to confirm a Plugin's activation.
+     * 
+     * @since 1.9.8.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    private function _activatePlugin(AcceptanceTester $I)
+    {
+        $I->loginAsAdmin();
+        $I->amOnPluginsPage();
+        $I->activatePlugin('convertkit');
+
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
+    }
+
+    /**
+     * Runs tests on a Setup Wizard screen, to confirm that the expected step, title and buttons
+     * are displayed.
+     * 
+     * @since 1.9.8.4
+     * 
+     * @param AcceptanceTester $I                Tester
+     * @param int              $step             Current step
+     * @param string           $title            Expected title
+     * @param bool             $nextButtonIsLink Check that next button is a link (false = must be a <button> element).
+     */
+    private function _seeExpectedSetupWizardScreen(AcceptanceTester $I, $step, $title, $nextButtonIsLink = false)
+    {
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
+
+        // Confirm expected setup wizard screen loaded.
+        $I->seeInCurrentUrl('index.php?page=convertkit-setup');
 		
-		// Confirm expected title is displayed.
-		$I->see($title);
+        // Confirm expected title is displayed.
+        $I->see($title);
 
-		// Confirm current and previous steps are highlighted as 'done'.
-		for ($stepCount = 1; $stepCount <= $step; $stepCount++) {
-			$I->seeElement('li.step-'.$stepCount.'.done');
-		}
+        // Confirm current and previous steps are highlighted as 'done'.
+        for ($stepCount = 1; $stepCount <= $step; $stepCount++) {
+            $I->seeElement('li.step-'.$stepCount.'.done');
+        }
 
-		// Confirm Step text is correct.
-		$I->see('Step '.$step.' of 4');
+        // Confirm Step text is correct.
+        $I->see('Step '.$step.' of 4');
 
-		// Depending on the step, confirm previous/next buttons exist / do not exist.
-		switch ($step) {
-			/**
-			 * First and last step should not display any footer buttons.
-			 */
-			case 1:
-			case 4:
-				$I->dontSeeElementInDOM('#convertkit-setup-wizard-footer div.left a.button');
-				$I->dontSeeElementInDOM('#convertkit-setup-wizard-footer div.right button');
-				$I->dontSeeElementInDOM('#convertkit-setup-wizard-footer div.right a.button');
-				break;
+        // Depending on the step, confirm previous/next buttons exist / do not exist.
+        switch ($step) {
+         /**
+          * First and last step should not display any footer buttons.
+          */
+        case 1:
+        case 4:
+            $I->dontSeeElementInDOM('#convertkit-setup-wizard-footer div.left a.button');
+            $I->dontSeeElementInDOM('#convertkit-setup-wizard-footer div.right button');
+            $I->dontSeeElementInDOM('#convertkit-setup-wizard-footer div.right a.button');
+            break;
 
-			/**
-			 * Middle steps should always display footer buttons.
-			 */
-			case 2:
-			case 3:
-				$I->seeElementInDOM('#convertkit-setup-wizard-footer div.left a.button');
+        /**
+         * Middle steps should always display footer buttons.
+         */
+        case 2:
+        case 3:
+            $I->seeElementInDOM('#convertkit-setup-wizard-footer div.left a.button');
 
-				if ($nextButtonIsLink) {
-					// Next button must be a link.
-					$I->seeElementInDOM('#convertkit-setup-wizard-footer div.right a.button');
-				} else {
-					// Next button must be a <button> element to submit form.
-					$I->seeElementInDOM('#convertkit-setup-wizard-footer div.right button');	
-				}
-				break;
+            if ($nextButtonIsLink) {
+                // Next button must be a link.
+                $I->seeElementInDOM('#convertkit-setup-wizard-footer div.right a.button');
+            } else {
+                // Next button must be a <button> element to submit form.
+                $I->seeElementInDOM('#convertkit-setup-wizard-footer div.right button');    
+            }
+            break;
 
-		}
-	}
+        }
+    }
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.8.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.8.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/general/PostCest.php
+++ b/tests/acceptance/general/PostCest.php
@@ -1,64 +1,67 @@
 <?php
 /**
  * Tests for ConvertKit Settings on WordPress Posts when no API Credentials specified.
- *
- * @since 1.9.6
+ * 
+ * @since 	1.9.6
  */
-class PostCest {
-
+class PostCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
-		$I->activateConvertKitPlugin( $I );
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
 	}
 
 	/**
 	 * Test that the ConvertKit Post Settings displays a message with a link to the Plugin Settings
 	 * telling the user to configure their API Credentials, when no API Credentials exist.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewPostShowsLinkToPluginSettingsWhenNoAPICredentialsSpecified( AcceptanceTester $I ) {
+	public function testAddNewPostShowsLinkToPluginSettingsWhenNoAPICredentialsSpecified(AcceptanceTester $I)
+	{
 		// Navigate to Posts > Add New
-		$I->amOnAdminPage( 'post-new.php' );
+		$I->amOnAdminPage('post-new.php');
 
 		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
-		$I->maybeCloseGutenbergWelcomeModal( $I );
+		$I->maybeCloseGutenbergWelcomeModal($I);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check that the metabox is displayed.
-		$I->seeElementInDOM( '#wp-convertkit-meta-box' );
+		$I->seeElementInDOM('#wp-convertkit-meta-box');
 
 		// Check that the Form option is not displayed.
-		$I->dontSeeElementInDOM( '#wp-convertkit-form' );
+		$I->dontSeeElementInDOM('#wp-convertkit-form');
 
 		// Check that an expected message is displayed.
-		$I->seeInSource( 'To configure the ConvertKit Form / Landing Page to display on this Post, enter your ConvertKit API credentials' );
+		$I->seeInSource('To configure the ConvertKit Form / Landing Page to display on this Post, enter your ConvertKit API credentials');
 
 		// Check that a link to the Plugin Settings exists.
-		$I->seeInSource( '<a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/options-general.php?page=_wp_convertkit_settings">Plugin Settings</a>' );
+		$I->seeInSource('<a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/options-general.php?page=_wp_convertkit_settings">Plugin Settings</a>');
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/general/PostCest.php
+++ b/tests/acceptance/general/PostCest.php
@@ -1,67 +1,64 @@
 <?php
 /**
  * Tests for ConvertKit Settings on WordPress Posts when no API Credentials specified.
- * 
+ *
  * @since 1.9.6
  */
-class PostCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        $I->activateConvertKitPlugin($I);
-    }
+class PostCest {
 
-    /**
-     * Test that the ConvertKit Post Settings displays a message with a link to the Plugin Settings
-     * telling the user to configure their API Credentials, when no API Credentials exist.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewPostShowsLinkToPluginSettingsWhenNoAPICredentialsSpecified(AcceptanceTester $I)
-    {
-        // Navigate to Posts > Add New
-        $I->amOnAdminPage('post-new.php');
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		$I->activateConvertKitPlugin( $I );
+	}
 
-        // Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
-        $I->maybeCloseGutenbergWelcomeModal($I);
+	/**
+	 * Test that the ConvertKit Post Settings displays a message with a link to the Plugin Settings
+	 * telling the user to configure their API Credentials, when no API Credentials exist.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewPostShowsLinkToPluginSettingsWhenNoAPICredentialsSpecified( AcceptanceTester $I ) {
+		// Navigate to Posts > Add New
+		$I->amOnAdminPage( 'post-new.php' );
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
+		$I->maybeCloseGutenbergWelcomeModal( $I );
 
-        // Check that the metabox is displayed.
-        $I->seeElementInDOM('#wp-convertkit-meta-box');
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-        // Check that the Form option is not displayed.
-        $I->dontSeeElementInDOM('#wp-convertkit-form');
+		// Check that the metabox is displayed.
+		$I->seeElementInDOM( '#wp-convertkit-meta-box' );
 
-        // Check that an expected message is displayed.
-        $I->seeInSource('To configure the ConvertKit Form / Landing Page to display on this Post, enter your ConvertKit API credentials');
+		// Check that the Form option is not displayed.
+		$I->dontSeeElementInDOM( '#wp-convertkit-form' );
 
-        // Check that a link to the Plugin Settings exists.
-        $I->seeInSource('<a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/options-general.php?page=_wp_convertkit_settings">Plugin Settings</a>');
-    }
+		// Check that an expected message is displayed.
+		$I->seeInSource( 'To configure the ConvertKit Form / Landing Page to display on this Post, enter your ConvertKit API credentials' );
 
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+		// Check that a link to the Plugin Settings exists.
+		$I->seeInSource( '<a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/options-general.php?page=_wp_convertkit_settings">Plugin Settings</a>' );
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/general/PostCest.php
+++ b/tests/acceptance/general/PostCest.php
@@ -1,17 +1,17 @@
 <?php
 /**
  * Tests for ConvertKit Settings on WordPress Posts when no API Credentials specified.
- * 
- * @since 	1.9.6
+ *
+ * @since   1.9.6
  */
 class PostCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -21,17 +21,17 @@ class PostCest
 	/**
 	 * Test that the ConvertKit Post Settings displays a message with a link to the Plugin Settings
 	 * telling the user to configure their API Credentials, when no API Credentials exist.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewPostShowsLinkToPluginSettingsWhenNoAPICredentialsSpecified(AcceptanceTester $I)
 	{
-		// Navigate to Posts > Add New
+		// Navigate to Posts > Add New.
 		$I->amOnAdminPage('post-new.php');
 
-		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
+		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed.
 		$I->maybeCloseGutenbergWelcomeModal($I);
 
 		// Check that no PHP warnings or notices were output.
@@ -54,10 +54,10 @@ class PostCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/general/PostCest.php
+++ b/tests/acceptance/general/PostCest.php
@@ -2,66 +2,66 @@
 /**
  * Tests for ConvertKit Settings on WordPress Posts when no API Credentials specified.
  * 
- * @since 	1.9.6
+ * @since 1.9.6
  */
 class PostCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		$I->activateConvertKitPlugin($I);
-	}
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        $I->activateConvertKitPlugin($I);
+    }
 
-	/**
-	 * Test that the ConvertKit Post Settings displays a message with a link to the Plugin Settings
-	 * telling the user to configure their API Credentials, when no API Credentials exist.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewPostShowsLinkToPluginSettingsWhenNoAPICredentialsSpecified(AcceptanceTester $I)
-	{
-		// Navigate to Posts > Add New
-		$I->amOnAdminPage('post-new.php');
+    /**
+     * Test that the ConvertKit Post Settings displays a message with a link to the Plugin Settings
+     * telling the user to configure their API Credentials, when no API Credentials exist.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewPostShowsLinkToPluginSettingsWhenNoAPICredentialsSpecified(AcceptanceTester $I)
+    {
+        // Navigate to Posts > Add New
+        $I->amOnAdminPage('post-new.php');
 
-		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
-		$I->maybeCloseGutenbergWelcomeModal($I);
+        // Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
+        $I->maybeCloseGutenbergWelcomeModal($I);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Check that the metabox is displayed.
-		$I->seeElementInDOM('#wp-convertkit-meta-box');
+        // Check that the metabox is displayed.
+        $I->seeElementInDOM('#wp-convertkit-meta-box');
 
-		// Check that the Form option is not displayed.
-		$I->dontSeeElementInDOM('#wp-convertkit-form');
+        // Check that the Form option is not displayed.
+        $I->dontSeeElementInDOM('#wp-convertkit-form');
 
-		// Check that an expected message is displayed.
-		$I->seeInSource('To configure the ConvertKit Form / Landing Page to display on this Post, enter your ConvertKit API credentials');
+        // Check that an expected message is displayed.
+        $I->seeInSource('To configure the ConvertKit Form / Landing Page to display on this Post, enter your ConvertKit API credentials');
 
-		// Check that a link to the Plugin Settings exists.
-		$I->seeInSource('<a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/options-general.php?page=_wp_convertkit_settings">Plugin Settings</a>');
-	}
+        // Check that a link to the Plugin Settings exists.
+        $I->seeInSource('<a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/options-general.php?page=_wp_convertkit_settings">Plugin Settings</a>');
+    }
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/general/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/general/RefreshResourcesButtonCest.php
@@ -2,17 +2,17 @@
 /**
  * Tests Refresh Resource buttons, which are displayed next to settings fields
  * across Page/Post editing, Bulk/Quick edit and Category editing.
- * 
- * @since 	1.9.8.0
+ *
+ * @since   1.9.8.0
  */
 class RefreshResourcesButtonCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -23,28 +23,31 @@ class RefreshResourcesButtonCest
 		// Change API keys in database to ones that have ConvertKit Resources.
 		// We do this directly vs. via the settings screen, so that the Plugin's cached resources remain blank
 		// until a refresh button is clicked.
-		$I->haveOptionInDatabase('_wp_convertkit_settings', [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-			'debug'      => 'on',
-			'no_scripts' => '',
-			'no_css'     => '',
-		]);
+		$I->haveOptionInDatabase(
+			'_wp_convertkit_settings',
+			[
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+				'debug'      => 'on',
+				'no_scripts' => '',
+				'no_css'     => '',
+			]
+		);
 	}
 
 	/**
 	 * Test that the refresh buttons for Forms, Landing Pages and Tags works when adding a new Page.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testRefreshResourcesOnPage(AcceptanceTester $I)
 	{
-		// Navigate to Pages > Add New
+		// Navigate to Pages > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=page');
 
-		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
+		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed.
 		$I->maybeCloseGutenbergWelcomeModal($I);
 
 		// Click the Forms refresh button.
@@ -80,18 +83,20 @@ class RefreshResourcesButtonCest
 
 	/**
 	 * Test that the refresh buttons for Forms and Tags works when Quick Editing a Page.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testRefreshResourcesOnQuickEdit(AcceptanceTester $I)
 	{
 		// Programmatically create a Page.
-		$pageID = $I->havePostInDatabase([
-			'post_type' 	=> 'page',
-			'post_title' 	=> 'ConvertKit: Page: Refresh Resources: Quick Edit',
-		]);
+		$pageID = $I->havePostInDatabase(
+			[
+				'post_type'  => 'page',
+				'post_title' => 'ConvertKit: Page: Refresh Resources: Quick Edit',
+			]
+		);
 
 		// Open Quick Edit form forthe Page in the Pages WP_List_Table.
 		$I->openQuickEdit($I, 'page', $pageID);
@@ -119,23 +124,27 @@ class RefreshResourcesButtonCest
 
 	/**
 	 * Test that the refresh buttons for Forms and Tags works when Bulk Editing Pages.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testRefreshResourcesOnBulkEdit(AcceptanceTester $I)
 	{
 		// Programmatically create two Pages.
 		$pageIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'page',
-				'post_title' 	=> 'ConvertKit: Page: Refresh Resources: Bulk Edit #1',
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'page',
-				'post_title' 	=> 'ConvertKit: Page: Refresh Resources: Bulk Edit #2',
-			])
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'page',
+					'post_title' => 'ConvertKit: Page: Refresh Resources: Bulk Edit #1',
+				]
+			),
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'page',
+					'post_title' => 'ConvertKit: Page: Refresh Resources: Bulk Edit #2',
+				]
+			),
 		);
 
 		// Open Bulk Edit form for the Pages in the Pages WP_List_Table.
@@ -164,10 +173,10 @@ class RefreshResourcesButtonCest
 
 	/**
 	 * Test that the refresh button for Forms works when editing a Category.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testRefreshResourcesOnCategory(AcceptanceTester $I)
 	{
@@ -192,27 +201,30 @@ class RefreshResourcesButtonCest
 	/**
 	 * Test that the refresh button triggers an error message when the AJAX request fails,
 	 * or the ConvertKit API returns an error, when adding a Page using the Gutenberg editor.
-	 * 
-	 * @since 	1.9.8.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testRefreshResourcesErrorNoticeOnPage(AcceptanceTester $I)
 	{
-		// Navigate to Pages > Add New
+		// Navigate to Pages > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=page');
 
-		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
+		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed.
 		$I->maybeCloseGutenbergWelcomeModal($I);
 
 		// Specify invalid API credentials, so that the AJAX request returns an error.
-		$I->haveOptionInDatabase('_wp_convertkit_settings', [
-			'api_key'    => 'fakeApiKey',
-			'api_secret' => 'fakeApiSecret',
-			'debug'      => 'on',
-			'no_scripts' => '',
-			'no_css'     => '',
-		]);
+		$I->haveOptionInDatabase(
+			'_wp_convertkit_settings',
+			[
+				'api_key'    => 'fakeApiKey',
+				'api_secret' => 'fakeApiSecret',
+				'debug'      => 'on',
+				'no_scripts' => '',
+				'no_css'     => '',
+			]
+		);
 
 		// Click the Forms refresh button.
 		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
@@ -234,10 +246,10 @@ class RefreshResourcesButtonCest
 	/**
 	 * Test that the refresh button triggers an error message when the AJAX request fails,
 	 * or the ConvertKit API returns an error, when adding a Page using the Classic Editor.
-	 * 
-	 * @since 	1.9.8.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testRefreshResourcesErrorNoticeOnPageClassicEditor(AcceptanceTester $I)
 	{
@@ -245,13 +257,16 @@ class RefreshResourcesButtonCest
 		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Refresh Resources: Classic Editor' );
 
 		// Specify invalid API credentials, so that the AJAX request returns an error.
-		$I->haveOptionInDatabase('_wp_convertkit_settings', [
-			'api_key'    => 'fakeApiKey',
-			'api_secret' => 'fakeApiSecret',
-			'debug'      => 'on',
-			'no_scripts' => '',
-			'no_css'     => '',
-		]);
+		$I->haveOptionInDatabase(
+			'_wp_convertkit_settings',
+			[
+				'api_key'    => 'fakeApiKey',
+				'api_secret' => 'fakeApiSecret',
+				'debug'      => 'on',
+				'no_scripts' => '',
+				'no_css'     => '',
+			]
+		);
 
 		// Click the Forms refresh button.
 		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
@@ -272,27 +287,32 @@ class RefreshResourcesButtonCest
 	/**
 	 * Test that the refresh button triggers an error message when the AJAX request fails,
 	 * or the ConvertKit API returns an error, when using the Quick Edit functionality.
-	 * 
-	 * @since 	1.9.8.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testRefreshResourcesErrorNoticeOnQuickEdit(AcceptanceTester $I)
 	{
 		// Specify invalid API credentials, so that the AJAX request returns an error.
-		$I->haveOptionInDatabase('_wp_convertkit_settings', [
-			'api_key'    => 'fakeApiKey',
-			'api_secret' => 'fakeApiSecret',
-			'debug'      => 'on',
-			'no_scripts' => '',
-			'no_css'     => '',
-		]);
+		$I->haveOptionInDatabase(
+			'_wp_convertkit_settings',
+			[
+				'api_key'    => 'fakeApiKey',
+				'api_secret' => 'fakeApiSecret',
+				'debug'      => 'on',
+				'no_scripts' => '',
+				'no_css'     => '',
+			]
+		);
 
 		// Programmatically create a Page.
-		$pageID = $I->havePostInDatabase([
-			'post_type' 	=> 'page',
-			'post_title' 	=> 'ConvertKit: Page: Refresh Resources: Quick Edit',
-		]);
+		$pageID = $I->havePostInDatabase(
+			[
+				'post_type'  => 'page',
+				'post_title' => 'ConvertKit: Page: Refresh Resources: Quick Edit',
+			]
+		);
 
 		// Open Quick Edit form forthe Page in the Pages WP_List_Table.
 		$I->openQuickEdit($I, 'page', $pageID);
@@ -316,32 +336,39 @@ class RefreshResourcesButtonCest
 	/**
 	 * Test that the refresh button triggers an error message when the AJAX request fails,
 	 * or the ConvertKit API returns an error, when using the Bulk Edit functionality.
-	 * 
-	 * @since 	1.9.8.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testRefreshResourcesErrorNoticeOnBulkEdit(AcceptanceTester $I)
 	{
 		// Specify invalid API credentials, so that the AJAX request returns an error.
-		$I->haveOptionInDatabase('_wp_convertkit_settings', [
-			'api_key'    => 'fakeApiKey',
-			'api_secret' => 'fakeApiSecret',
-			'debug'      => 'on',
-			'no_scripts' => '',
-			'no_css'     => '',
-		]);
+		$I->haveOptionInDatabase(
+			'_wp_convertkit_settings',
+			[
+				'api_key'    => 'fakeApiKey',
+				'api_secret' => 'fakeApiSecret',
+				'debug'      => 'on',
+				'no_scripts' => '',
+				'no_css'     => '',
+			]
+		);
 
 		// Programmatically create two Pages.
 		$pageIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'page',
-				'post_title' 	=> 'ConvertKit: Page: Refresh Resources: Bulk Edit #1',
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'page',
-				'post_title' 	=> 'ConvertKit: Page: Refresh Resources: Bulk Edit #2',
-			])
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'page',
+					'post_title' => 'ConvertKit: Page: Refresh Resources: Bulk Edit #1',
+				]
+			),
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'page',
+					'post_title' => 'ConvertKit: Page: Refresh Resources: Bulk Edit #2',
+				]
+			),
 		);
 
 		// Open Bulk Edit form for the Pages in the Pages WP_List_Table.
@@ -366,21 +393,24 @@ class RefreshResourcesButtonCest
 	/**
 	 * Test that the refresh button triggers an error message when the AJAX request fails,
 	 * or the ConvertKit API returns an error, when editing a Category.
-	 * 
-	 * @since 	1.9.8.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testRefreshResourcesErrorNoticeOnCategory(AcceptanceTester $I)
 	{
 		// Specify invalid API credentials, so that the AJAX request returns an error.
-		$I->haveOptionInDatabase('_wp_convertkit_settings', [
-			'api_key'    => 'fakeApiKey',
-			'api_secret' => 'fakeApiSecret',
-			'debug'      => 'on',
-			'no_scripts' => '',
-			'no_css'     => '',
-		]);
+		$I->haveOptionInDatabase(
+			'_wp_convertkit_settings',
+			[
+				'api_key'    => 'fakeApiKey',
+				'api_secret' => 'fakeApiSecret',
+				'debug'      => 'on',
+				'no_scripts' => '',
+				'no_css'     => '',
+			]
+		);
 
 		// Create Category.
 		$termID = $I->haveTermInDatabase( 'ConvertKit Refresh Resources', 'category' );
@@ -409,10 +439,10 @@ class RefreshResourcesButtonCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/general/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/general/RefreshResourcesButtonCest.php
@@ -3,421 +3,445 @@
  * Tests Refresh Resource buttons, which are displayed next to settings fields
  * across Page/Post editing, Bulk/Quick edit and Category editing.
  * 
- * @since 	1.9.8.0
+ * @since 1.9.8.0
  */
 class RefreshResourcesButtonCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		// Activate and Setup ConvertKit plugin using API keys that have no resources (forms, landing pages, tags).
-		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
-
-		// Change API keys in database to ones that have ConvertKit Resources.
-		// We do this directly vs. via the settings screen, so that the Plugin's cached resources remain blank
-		// until a refresh button is clicked.
-		$I->haveOptionInDatabase('_wp_convertkit_settings', [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-			'debug'      => 'on',
-			'no_scripts' => '',
-			'no_css'     => '',
-		]);
-	}
-
-	/**
-	 * Test that the refresh buttons for Forms, Landing Pages and Tags works when adding a new Page.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testRefreshResourcesOnPage(AcceptanceTester $I)
-	{
-		// Navigate to Pages > Add New
-		$I->amOnAdminPage('post-new.php?post_type=page');
-
-		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
-		$I->maybeCloseGutenbergWelcomeModal($I);
-
-		// Click the Forms refresh button.
-		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
-
-		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
-
-		// Change resource to value specified in the .env file, which should now be available.
-		// If the expected dropdown value does not exist in the Select2 field, this will fail the test.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
-
-		// Click the Landing Pages refresh button.
-		$I->click('button.wp-convertkit-refresh-resources[data-resource="landing_pages"]');
-
-		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="landing_pages"]:not(:disabled)');
-
-		// Change resource to value specified in the .env file, which should now be available.
-		// If the expected dropdown value does not exist in the Select2 field, this will fail the test.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-landing_page-container', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME']);
-
-		// Click the Tags refresh button.
-		$I->click('button.wp-convertkit-refresh-resources[data-resource="tags"]');
-
-		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="tags"]:not(:disabled)');
-
-		// Change resource to value specified in the .env file, which should now be available.
-		// If the expected dropdown value does not exist in the Select2 field, this will fail the test.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-tag-container', $_ENV['CONVERTKIT_API_TAG_NAME']);
-	}
-
-	/**
-	 * Test that the refresh buttons for Forms and Tags works when Quick Editing a Page.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testRefreshResourcesOnQuickEdit(AcceptanceTester $I)
-	{
-		// Programmatically create a Page.
-		$pageID = $I->havePostInDatabase([
-			'post_type' 	=> 'page',
-			'post_title' 	=> 'ConvertKit: Page: Refresh Resources: Quick Edit',
-		]);
-
-		// Open Quick Edit form forthe Page in the Pages WP_List_Table.
-		$I->openQuickEdit($I, 'page', $pageID);
-
-		// Click the Forms refresh button.
-		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
-
-		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
-
-		// Change resource to value specified in the .env file, which should now be available.
-		// If the expected dropdown value does not exist, this will fail the test.
-		$I->selectOption('#wp-convertkit-quick-edit-form', $_ENV['CONVERTKIT_API_FORM_NAME']);
-
-		// Click the Tags refresh button.
-		$I->click('button.wp-convertkit-refresh-resources[data-resource="tags"]');
-
-		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="tags"]:not(:disabled)');
-
-		// Change resource to value specified in the .env file, which should now be available.
-		// If the expected dropdown value does not exist, this will fail the test.
-		$I->selectOption('#wp-convertkit-quick-edit-tag', $_ENV['CONVERTKIT_API_TAG_NAME']);
-	}
-
-	/**
-	 * Test that the refresh buttons for Forms and Tags works when Bulk Editing Pages.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testRefreshResourcesOnBulkEdit(AcceptanceTester $I)
-	{
-		// Programmatically create two Pages.
-		$pageIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'page',
-				'post_title' 	=> 'ConvertKit: Page: Refresh Resources: Bulk Edit #1',
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'page',
-				'post_title' 	=> 'ConvertKit: Page: Refresh Resources: Bulk Edit #2',
-			])
-		);
-
-		// Open Bulk Edit form for the Pages in the Pages WP_List_Table.
-		$I->openBulkEdit($I, 'page', $pageIDs);
-
-		// Click the Forms refresh button.
-		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
-
-		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
-
-		// Change resource to value specified in the .env file, which should now be available.
-		// If the expected dropdown value does not exist, this will fail the test.
-		$I->selectOption('#wp-convertkit-bulk-edit-form', $_ENV['CONVERTKIT_API_FORM_NAME']);
-
-		// Click the Tags refresh button.
-		$I->click('button.wp-convertkit-refresh-resources[data-resource="tags"]');
-
-		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="tags"]:not(:disabled)');
-
-		// Change resource to value specified in the .env file, which should now be available.
-		// If the expected dropdown value does not exist, this will fail the test.
-		$I->selectOption('#wp-convertkit-bulk-edit-tag', $_ENV['CONVERTKIT_API_TAG_NAME']);
-	}
-
-	/**
-	 * Test that the refresh button for Forms works when editing a Category.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testRefreshResourcesOnCategory(AcceptanceTester $I)
-	{
-		// Create Category.
-		$termID = $I->haveTermInDatabase( 'ConvertKit Refresh Resources', 'category' );
-		$termID = $termID[0];
-
-		// Edit the Term.
-		$I->amOnAdminPage('term.php?taxonomy=category&tag_ID=' . $termID);
-
-		// Click the Forms refresh button.
-		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
-
-		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
-
-		// Change resource to value specified in the .env file, which should now be available.
-		// If the expected dropdown value does not exist in the Select2 field, this will fail the test.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
-	}
-
-	/**
-	 * Test that the refresh button triggers an error message when the AJAX request fails,
-	 * or the ConvertKit API returns an error, when adding a Page using the Gutenberg editor.
-	 * 
-	 * @since 	1.9.8.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testRefreshResourcesErrorNoticeOnPage(AcceptanceTester $I)
-	{
-		// Navigate to Pages > Add New
-		$I->amOnAdminPage('post-new.php?post_type=page');
-
-		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
-		$I->maybeCloseGutenbergWelcomeModal($I);
-
-		// Specify invalid API credentials, so that the AJAX request returns an error.
-		$I->haveOptionInDatabase('_wp_convertkit_settings', [
-			'api_key'    => 'fakeApiKey',
-			'api_secret' => 'fakeApiSecret',
-			'debug'      => 'on',
-			'no_scripts' => '',
-			'no_css'     => '',
-		]);
-
-		// Click the Forms refresh button.
-		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
-
-		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
-
-		// Confirm that an error notification is displayed on screen, with the expected error message.
-
-		$I->seeElementInDOM('div.components-notice-list div.is-error');
-		$I->see('Authorization Failed: API Key not valid');
-
-		// Confirm that the notice is dismissible.
-		$I->click('div.components-notice-list div.is-error button.components-notice__dismiss');
-		$I->wait(1);
-		$I->dontSeeElementInDOM('div.components-notice-list div.is-error');
-	}
-
-	/**
-	 * Test that the refresh button triggers an error message when the AJAX request fails,
-	 * or the ConvertKit API returns an error, when adding a Page using the Classic Editor.
-	 * 
-	 * @since 	1.9.8.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testRefreshResourcesErrorNoticeOnPageClassicEditor(AcceptanceTester $I)
-	{
-		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Refresh Resources: Classic Editor' );
-
-		// Specify invalid API credentials, so that the AJAX request returns an error.
-		$I->haveOptionInDatabase('_wp_convertkit_settings', [
-			'api_key'    => 'fakeApiKey',
-			'api_secret' => 'fakeApiSecret',
-			'debug'      => 'on',
-			'no_scripts' => '',
-			'no_css'     => '',
-		]);
-
-		// Click the Forms refresh button.
-		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
-
-		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
-
-		// Confirm that an error notification is displayed on screen, with the expected error message.
-		$I->seeElementInDOM('div.convertkit-error');
-		$I->see('Authorization Failed: API Key not valid');
-
-		// Confirm that the notice is dismissible.
-		$I->click('div.convertkit-error button.notice-dismiss');
-		$I->wait(1);
-		$I->dontSeeElementInDOM('div.convertkit-error');
-	}
-
-	/**
-	 * Test that the refresh button triggers an error message when the AJAX request fails,
-	 * or the ConvertKit API returns an error, when using the Quick Edit functionality.
-	 * 
-	 * @since 	1.9.8.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testRefreshResourcesErrorNoticeOnQuickEdit(AcceptanceTester $I)
-	{
-		// Specify invalid API credentials, so that the AJAX request returns an error.
-		$I->haveOptionInDatabase('_wp_convertkit_settings', [
-			'api_key'    => 'fakeApiKey',
-			'api_secret' => 'fakeApiSecret',
-			'debug'      => 'on',
-			'no_scripts' => '',
-			'no_css'     => '',
-		]);
-
-		// Programmatically create a Page.
-		$pageID = $I->havePostInDatabase([
-			'post_type' 	=> 'page',
-			'post_title' 	=> 'ConvertKit: Page: Refresh Resources: Quick Edit',
-		]);
-
-		// Open Quick Edit form forthe Page in the Pages WP_List_Table.
-		$I->openQuickEdit($I, 'page', $pageID);
-
-		// Click the Forms refresh button.
-		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
-
-		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
-
-		// Confirm that an error notification is displayed on screen, with the expected error message.
-		$I->seeElementInDOM('div.convertkit-error');
-		$I->see('Authorization Failed: API Key not valid');
-
-		// Confirm that the notice is dismissible.
-		$I->click('div.convertkit-error button.notice-dismiss');
-		$I->wait(1);
-		$I->dontSeeElementInDOM('div.convertkit-error');
-	}
-
-	/**
-	 * Test that the refresh button triggers an error message when the AJAX request fails,
-	 * or the ConvertKit API returns an error, when using the Bulk Edit functionality.
-	 * 
-	 * @since 	1.9.8.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testRefreshResourcesErrorNoticeOnBulkEdit(AcceptanceTester $I)
-	{
-		// Specify invalid API credentials, so that the AJAX request returns an error.
-		$I->haveOptionInDatabase('_wp_convertkit_settings', [
-			'api_key'    => 'fakeApiKey',
-			'api_secret' => 'fakeApiSecret',
-			'debug'      => 'on',
-			'no_scripts' => '',
-			'no_css'     => '',
-		]);
-
-		// Programmatically create two Pages.
-		$pageIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'page',
-				'post_title' 	=> 'ConvertKit: Page: Refresh Resources: Bulk Edit #1',
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'page',
-				'post_title' 	=> 'ConvertKit: Page: Refresh Resources: Bulk Edit #2',
-			])
-		);
-
-		// Open Bulk Edit form for the Pages in the Pages WP_List_Table.
-		$I->openBulkEdit($I, 'page', $pageIDs);
-
-		// Click the Forms refresh button.
-		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
-
-		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
-
-		// Confirm that an error notification is displayed on screen, with the expected error message.
-		$I->seeElementInDOM('div.convertkit-error');
-		$I->see('Authorization Failed: API Key not valid');
-
-		// Confirm that the notice is dismissible.
-		$I->click('div.convertkit-error button.notice-dismiss');
-		$I->wait(1);
-		$I->dontSeeElementInDOM('div.convertkit-error');
-	}
-
-	/**
-	 * Test that the refresh button triggers an error message when the AJAX request fails,
-	 * or the ConvertKit API returns an error, when editing a Category.
-	 * 
-	 * @since 	1.9.8.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testRefreshResourcesErrorNoticeOnCategory(AcceptanceTester $I)
-	{
-		// Specify invalid API credentials, so that the AJAX request returns an error.
-		$I->haveOptionInDatabase('_wp_convertkit_settings', [
-			'api_key'    => 'fakeApiKey',
-			'api_secret' => 'fakeApiSecret',
-			'debug'      => 'on',
-			'no_scripts' => '',
-			'no_css'     => '',
-		]);
-
-		// Create Category.
-		$termID = $I->haveTermInDatabase( 'ConvertKit Refresh Resources', 'category' );
-		$termID = $termID[0];
-
-		// Edit the Term.
-		$I->amOnAdminPage('term.php?taxonomy=category&tag_ID=' . $termID);
-
-		// Click the Forms refresh button.
-		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
-
-		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
-
-		// Confirm that an error notification is displayed on screen, with the expected error message.
-		$I->seeElementInDOM('div.convertkit-error');
-		$I->see('Authorization Failed: API Key not valid');
-
-		// Confirm that the notice is dismissible.
-		$I->click('div.convertkit-error button.notice-dismiss');
-		$I->wait(1);
-		$I->dontSeeElementInDOM('div.convertkit-error');
-	}
-
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateThirdPartyPlugin($I, 'classic-editor');
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.8.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        // Activate and Setup ConvertKit plugin using API keys that have no resources (forms, landing pages, tags).
+        $I->activateConvertKitPlugin($I);
+        $I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
+
+        // Change API keys in database to ones that have ConvertKit Resources.
+        // We do this directly vs. via the settings screen, so that the Plugin's cached resources remain blank
+        // until a refresh button is clicked.
+        $I->haveOptionInDatabase(
+            '_wp_convertkit_settings', [
+            'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+            'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+            'debug'      => 'on',
+            'no_scripts' => '',
+            'no_css'     => '',
+            ]
+        );
+    }
+
+    /**
+     * Test that the refresh buttons for Forms, Landing Pages and Tags works when adding a new Page.
+     * 
+     * @since 1.9.8.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testRefreshResourcesOnPage(AcceptanceTester $I)
+    {
+        // Navigate to Pages > Add New
+        $I->amOnAdminPage('post-new.php?post_type=page');
+
+        // Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
+        $I->maybeCloseGutenbergWelcomeModal($I);
+
+        // Click the Forms refresh button.
+        $I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
+
+        // Wait for button to change its state from disabled.
+        $I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
+
+        // Change resource to value specified in the .env file, which should now be available.
+        // If the expected dropdown value does not exist in the Select2 field, this will fail the test.
+        $I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+
+        // Click the Landing Pages refresh button.
+        $I->click('button.wp-convertkit-refresh-resources[data-resource="landing_pages"]');
+
+        // Wait for button to change its state from disabled.
+        $I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="landing_pages"]:not(:disabled)');
+
+        // Change resource to value specified in the .env file, which should now be available.
+        // If the expected dropdown value does not exist in the Select2 field, this will fail the test.
+        $I->fillSelect2Field($I, '#select2-wp-convertkit-landing_page-container', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME']);
+
+        // Click the Tags refresh button.
+        $I->click('button.wp-convertkit-refresh-resources[data-resource="tags"]');
+
+        // Wait for button to change its state from disabled.
+        $I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="tags"]:not(:disabled)');
+
+        // Change resource to value specified in the .env file, which should now be available.
+        // If the expected dropdown value does not exist in the Select2 field, this will fail the test.
+        $I->fillSelect2Field($I, '#select2-wp-convertkit-tag-container', $_ENV['CONVERTKIT_API_TAG_NAME']);
+    }
+
+    /**
+     * Test that the refresh buttons for Forms and Tags works when Quick Editing a Page.
+     * 
+     * @since 1.9.8.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testRefreshResourcesOnQuickEdit(AcceptanceTester $I)
+    {
+        // Programmatically create a Page.
+        $pageID = $I->havePostInDatabase(
+            [
+            'post_type'     => 'page',
+            'post_title'     => 'ConvertKit: Page: Refresh Resources: Quick Edit',
+            ]
+        );
+
+        // Open Quick Edit form forthe Page in the Pages WP_List_Table.
+        $I->openQuickEdit($I, 'page', $pageID);
+
+        // Click the Forms refresh button.
+        $I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
+
+        // Wait for button to change its state from disabled.
+        $I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
+
+        // Change resource to value specified in the .env file, which should now be available.
+        // If the expected dropdown value does not exist, this will fail the test.
+        $I->selectOption('#wp-convertkit-quick-edit-form', $_ENV['CONVERTKIT_API_FORM_NAME']);
+
+        // Click the Tags refresh button.
+        $I->click('button.wp-convertkit-refresh-resources[data-resource="tags"]');
+
+        // Wait for button to change its state from disabled.
+        $I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="tags"]:not(:disabled)');
+
+        // Change resource to value specified in the .env file, which should now be available.
+        // If the expected dropdown value does not exist, this will fail the test.
+        $I->selectOption('#wp-convertkit-quick-edit-tag', $_ENV['CONVERTKIT_API_TAG_NAME']);
+    }
+
+    /**
+     * Test that the refresh buttons for Forms and Tags works when Bulk Editing Pages.
+     * 
+     * @since 1.9.8.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testRefreshResourcesOnBulkEdit(AcceptanceTester $I)
+    {
+        // Programmatically create two Pages.
+        $pageIDs = array(
+        $I->havePostInDatabase(
+            [
+            'post_type'     => 'page',
+            'post_title'     => 'ConvertKit: Page: Refresh Resources: Bulk Edit #1',
+            ]
+        ),
+        $I->havePostInDatabase(
+            [
+            'post_type'     => 'page',
+            'post_title'     => 'ConvertKit: Page: Refresh Resources: Bulk Edit #2',
+            ]
+        )
+        );
+
+        // Open Bulk Edit form for the Pages in the Pages WP_List_Table.
+        $I->openBulkEdit($I, 'page', $pageIDs);
+
+        // Click the Forms refresh button.
+        $I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
+
+        // Wait for button to change its state from disabled.
+        $I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
+
+        // Change resource to value specified in the .env file, which should now be available.
+        // If the expected dropdown value does not exist, this will fail the test.
+        $I->selectOption('#wp-convertkit-bulk-edit-form', $_ENV['CONVERTKIT_API_FORM_NAME']);
+
+        // Click the Tags refresh button.
+        $I->click('button.wp-convertkit-refresh-resources[data-resource="tags"]');
+
+        // Wait for button to change its state from disabled.
+        $I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="tags"]:not(:disabled)');
+
+        // Change resource to value specified in the .env file, which should now be available.
+        // If the expected dropdown value does not exist, this will fail the test.
+        $I->selectOption('#wp-convertkit-bulk-edit-tag', $_ENV['CONVERTKIT_API_TAG_NAME']);
+    }
+
+    /**
+     * Test that the refresh button for Forms works when editing a Category.
+     * 
+     * @since 1.9.8.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testRefreshResourcesOnCategory(AcceptanceTester $I)
+    {
+        // Create Category.
+        $termID = $I->haveTermInDatabase('ConvertKit Refresh Resources', 'category');
+        $termID = $termID[0];
+
+        // Edit the Term.
+        $I->amOnAdminPage('term.php?taxonomy=category&tag_ID=' . $termID);
+
+        // Click the Forms refresh button.
+        $I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
+
+        // Wait for button to change its state from disabled.
+        $I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
+
+        // Change resource to value specified in the .env file, which should now be available.
+        // If the expected dropdown value does not exist in the Select2 field, this will fail the test.
+        $I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+    }
+
+    /**
+     * Test that the refresh button triggers an error message when the AJAX request fails,
+     * or the ConvertKit API returns an error, when adding a Page using the Gutenberg editor.
+     * 
+     * @since 1.9.8.3
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testRefreshResourcesErrorNoticeOnPage(AcceptanceTester $I)
+    {
+        // Navigate to Pages > Add New
+        $I->amOnAdminPage('post-new.php?post_type=page');
+
+        // Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
+        $I->maybeCloseGutenbergWelcomeModal($I);
+
+        // Specify invalid API credentials, so that the AJAX request returns an error.
+        $I->haveOptionInDatabase(
+            '_wp_convertkit_settings', [
+            'api_key'    => 'fakeApiKey',
+            'api_secret' => 'fakeApiSecret',
+            'debug'      => 'on',
+            'no_scripts' => '',
+            'no_css'     => '',
+            ]
+        );
+
+        // Click the Forms refresh button.
+        $I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
+
+        // Wait for button to change its state from disabled.
+        $I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
+
+        // Confirm that an error notification is displayed on screen, with the expected error message.
+
+        $I->seeElementInDOM('div.components-notice-list div.is-error');
+        $I->see('Authorization Failed: API Key not valid');
+
+        // Confirm that the notice is dismissible.
+        $I->click('div.components-notice-list div.is-error button.components-notice__dismiss');
+        $I->wait(1);
+        $I->dontSeeElementInDOM('div.components-notice-list div.is-error');
+    }
+
+    /**
+     * Test that the refresh button triggers an error message when the AJAX request fails,
+     * or the ConvertKit API returns an error, when adding a Page using the Classic Editor.
+     * 
+     * @since 1.9.8.3
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testRefreshResourcesErrorNoticeOnPageClassicEditor(AcceptanceTester $I)
+    {
+        // Add a Page using the Classic Editor.
+        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Refresh Resources: Classic Editor');
+
+        // Specify invalid API credentials, so that the AJAX request returns an error.
+        $I->haveOptionInDatabase(
+            '_wp_convertkit_settings', [
+            'api_key'    => 'fakeApiKey',
+            'api_secret' => 'fakeApiSecret',
+            'debug'      => 'on',
+            'no_scripts' => '',
+            'no_css'     => '',
+            ]
+        );
+
+        // Click the Forms refresh button.
+        $I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
+
+        // Wait for button to change its state from disabled.
+        $I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
+
+        // Confirm that an error notification is displayed on screen, with the expected error message.
+        $I->seeElementInDOM('div.convertkit-error');
+        $I->see('Authorization Failed: API Key not valid');
+
+        // Confirm that the notice is dismissible.
+        $I->click('div.convertkit-error button.notice-dismiss');
+        $I->wait(1);
+        $I->dontSeeElementInDOM('div.convertkit-error');
+    }
+
+    /**
+     * Test that the refresh button triggers an error message when the AJAX request fails,
+     * or the ConvertKit API returns an error, when using the Quick Edit functionality.
+     * 
+     * @since 1.9.8.3
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testRefreshResourcesErrorNoticeOnQuickEdit(AcceptanceTester $I)
+    {
+        // Specify invalid API credentials, so that the AJAX request returns an error.
+        $I->haveOptionInDatabase(
+            '_wp_convertkit_settings', [
+            'api_key'    => 'fakeApiKey',
+            'api_secret' => 'fakeApiSecret',
+            'debug'      => 'on',
+            'no_scripts' => '',
+            'no_css'     => '',
+            ]
+        );
+
+        // Programmatically create a Page.
+        $pageID = $I->havePostInDatabase(
+            [
+            'post_type'     => 'page',
+            'post_title'     => 'ConvertKit: Page: Refresh Resources: Quick Edit',
+            ]
+        );
+
+        // Open Quick Edit form forthe Page in the Pages WP_List_Table.
+        $I->openQuickEdit($I, 'page', $pageID);
+
+        // Click the Forms refresh button.
+        $I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
+
+        // Wait for button to change its state from disabled.
+        $I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
+
+        // Confirm that an error notification is displayed on screen, with the expected error message.
+        $I->seeElementInDOM('div.convertkit-error');
+        $I->see('Authorization Failed: API Key not valid');
+
+        // Confirm that the notice is dismissible.
+        $I->click('div.convertkit-error button.notice-dismiss');
+        $I->wait(1);
+        $I->dontSeeElementInDOM('div.convertkit-error');
+    }
+
+    /**
+     * Test that the refresh button triggers an error message when the AJAX request fails,
+     * or the ConvertKit API returns an error, when using the Bulk Edit functionality.
+     * 
+     * @since 1.9.8.3
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testRefreshResourcesErrorNoticeOnBulkEdit(AcceptanceTester $I)
+    {
+        // Specify invalid API credentials, so that the AJAX request returns an error.
+        $I->haveOptionInDatabase(
+            '_wp_convertkit_settings', [
+            'api_key'    => 'fakeApiKey',
+            'api_secret' => 'fakeApiSecret',
+            'debug'      => 'on',
+            'no_scripts' => '',
+            'no_css'     => '',
+            ]
+        );
+
+        // Programmatically create two Pages.
+        $pageIDs = array(
+        $I->havePostInDatabase(
+            [
+            'post_type'     => 'page',
+            'post_title'     => 'ConvertKit: Page: Refresh Resources: Bulk Edit #1',
+            ]
+        ),
+        $I->havePostInDatabase(
+            [
+            'post_type'     => 'page',
+            'post_title'     => 'ConvertKit: Page: Refresh Resources: Bulk Edit #2',
+            ]
+        )
+        );
+
+        // Open Bulk Edit form for the Pages in the Pages WP_List_Table.
+        $I->openBulkEdit($I, 'page', $pageIDs);
+
+        // Click the Forms refresh button.
+        $I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
+
+        // Wait for button to change its state from disabled.
+        $I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
+
+        // Confirm that an error notification is displayed on screen, with the expected error message.
+        $I->seeElementInDOM('div.convertkit-error');
+        $I->see('Authorization Failed: API Key not valid');
+
+        // Confirm that the notice is dismissible.
+        $I->click('div.convertkit-error button.notice-dismiss');
+        $I->wait(1);
+        $I->dontSeeElementInDOM('div.convertkit-error');
+    }
+
+    /**
+     * Test that the refresh button triggers an error message when the AJAX request fails,
+     * or the ConvertKit API returns an error, when editing a Category.
+     * 
+     * @since 1.9.8.3
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testRefreshResourcesErrorNoticeOnCategory(AcceptanceTester $I)
+    {
+        // Specify invalid API credentials, so that the AJAX request returns an error.
+        $I->haveOptionInDatabase(
+            '_wp_convertkit_settings', [
+            'api_key'    => 'fakeApiKey',
+            'api_secret' => 'fakeApiSecret',
+            'debug'      => 'on',
+            'no_scripts' => '',
+            'no_css'     => '',
+            ]
+        );
+
+        // Create Category.
+        $termID = $I->haveTermInDatabase('ConvertKit Refresh Resources', 'category');
+        $termID = $termID[0];
+
+        // Edit the Term.
+        $I->amOnAdminPage('term.php?taxonomy=category&tag_ID=' . $termID);
+
+        // Click the Forms refresh button.
+        $I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
+
+        // Wait for button to change its state from disabled.
+        $I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
+
+        // Confirm that an error notification is displayed on screen, with the expected error message.
+        $I->seeElementInDOM('div.convertkit-error');
+        $I->see('Authorization Failed: API Key not valid');
+
+        // Confirm that the notice is dismissible.
+        $I->click('div.convertkit-error button.notice-dismiss');
+        $I->wait(1);
+        $I->dontSeeElementInDOM('div.convertkit-error');
+    }
+
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.8.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateThirdPartyPlugin($I, 'classic-editor');
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/general/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/general/RefreshResourcesButtonCest.php
@@ -2,446 +2,441 @@
 /**
  * Tests Refresh Resource buttons, which are displayed next to settings fields
  * across Page/Post editing, Bulk/Quick edit and Category editing.
- * 
+ *
  * @since 1.9.8.0
  */
-class RefreshResourcesButtonCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.8.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        // Activate and Setup ConvertKit plugin using API keys that have no resources (forms, landing pages, tags).
-        $I->activateConvertKitPlugin($I);
-        $I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
-
-        // Change API keys in database to ones that have ConvertKit Resources.
-        // We do this directly vs. via the settings screen, so that the Plugin's cached resources remain blank
-        // until a refresh button is clicked.
-        $I->haveOptionInDatabase(
-            '_wp_convertkit_settings', [
-            'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-            'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-            'debug'      => 'on',
-            'no_scripts' => '',
-            'no_css'     => '',
-            ]
-        );
-    }
-
-    /**
-     * Test that the refresh buttons for Forms, Landing Pages and Tags works when adding a new Page.
-     * 
-     * @since 1.9.8.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testRefreshResourcesOnPage(AcceptanceTester $I)
-    {
-        // Navigate to Pages > Add New
-        $I->amOnAdminPage('post-new.php?post_type=page');
-
-        // Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
-        $I->maybeCloseGutenbergWelcomeModal($I);
-
-        // Click the Forms refresh button.
-        $I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
-
-        // Wait for button to change its state from disabled.
-        $I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
-
-        // Change resource to value specified in the .env file, which should now be available.
-        // If the expected dropdown value does not exist in the Select2 field, this will fail the test.
-        $I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
-
-        // Click the Landing Pages refresh button.
-        $I->click('button.wp-convertkit-refresh-resources[data-resource="landing_pages"]');
-
-        // Wait for button to change its state from disabled.
-        $I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="landing_pages"]:not(:disabled)');
-
-        // Change resource to value specified in the .env file, which should now be available.
-        // If the expected dropdown value does not exist in the Select2 field, this will fail the test.
-        $I->fillSelect2Field($I, '#select2-wp-convertkit-landing_page-container', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME']);
-
-        // Click the Tags refresh button.
-        $I->click('button.wp-convertkit-refresh-resources[data-resource="tags"]');
-
-        // Wait for button to change its state from disabled.
-        $I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="tags"]:not(:disabled)');
-
-        // Change resource to value specified in the .env file, which should now be available.
-        // If the expected dropdown value does not exist in the Select2 field, this will fail the test.
-        $I->fillSelect2Field($I, '#select2-wp-convertkit-tag-container', $_ENV['CONVERTKIT_API_TAG_NAME']);
-    }
-
-    /**
-     * Test that the refresh buttons for Forms and Tags works when Quick Editing a Page.
-     * 
-     * @since 1.9.8.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testRefreshResourcesOnQuickEdit(AcceptanceTester $I)
-    {
-        // Programmatically create a Page.
-        $pageID = $I->havePostInDatabase(
-            [
-            'post_type'     => 'page',
-            'post_title'     => 'ConvertKit: Page: Refresh Resources: Quick Edit',
-            ]
-        );
-
-        // Open Quick Edit form forthe Page in the Pages WP_List_Table.
-        $I->openQuickEdit($I, 'page', $pageID);
-
-        // Click the Forms refresh button.
-        $I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
-
-        // Wait for button to change its state from disabled.
-        $I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
-
-        // Change resource to value specified in the .env file, which should now be available.
-        // If the expected dropdown value does not exist, this will fail the test.
-        $I->selectOption('#wp-convertkit-quick-edit-form', $_ENV['CONVERTKIT_API_FORM_NAME']);
-
-        // Click the Tags refresh button.
-        $I->click('button.wp-convertkit-refresh-resources[data-resource="tags"]');
-
-        // Wait for button to change its state from disabled.
-        $I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="tags"]:not(:disabled)');
-
-        // Change resource to value specified in the .env file, which should now be available.
-        // If the expected dropdown value does not exist, this will fail the test.
-        $I->selectOption('#wp-convertkit-quick-edit-tag', $_ENV['CONVERTKIT_API_TAG_NAME']);
-    }
-
-    /**
-     * Test that the refresh buttons for Forms and Tags works when Bulk Editing Pages.
-     * 
-     * @since 1.9.8.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testRefreshResourcesOnBulkEdit(AcceptanceTester $I)
-    {
-        // Programmatically create two Pages.
-        $pageIDs = array(
-        $I->havePostInDatabase(
-            [
-            'post_type'     => 'page',
-            'post_title'     => 'ConvertKit: Page: Refresh Resources: Bulk Edit #1',
-            ]
-        ),
-        $I->havePostInDatabase(
-            [
-            'post_type'     => 'page',
-            'post_title'     => 'ConvertKit: Page: Refresh Resources: Bulk Edit #2',
-            ]
-        )
-        );
-
-        // Open Bulk Edit form for the Pages in the Pages WP_List_Table.
-        $I->openBulkEdit($I, 'page', $pageIDs);
-
-        // Click the Forms refresh button.
-        $I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
-
-        // Wait for button to change its state from disabled.
-        $I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
-
-        // Change resource to value specified in the .env file, which should now be available.
-        // If the expected dropdown value does not exist, this will fail the test.
-        $I->selectOption('#wp-convertkit-bulk-edit-form', $_ENV['CONVERTKIT_API_FORM_NAME']);
-
-        // Click the Tags refresh button.
-        $I->click('button.wp-convertkit-refresh-resources[data-resource="tags"]');
-
-        // Wait for button to change its state from disabled.
-        $I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="tags"]:not(:disabled)');
-
-        // Change resource to value specified in the .env file, which should now be available.
-        // If the expected dropdown value does not exist, this will fail the test.
-        $I->selectOption('#wp-convertkit-bulk-edit-tag', $_ENV['CONVERTKIT_API_TAG_NAME']);
-    }
-
-    /**
-     * Test that the refresh button for Forms works when editing a Category.
-     * 
-     * @since 1.9.8.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testRefreshResourcesOnCategory(AcceptanceTester $I)
-    {
-        // Create Category.
-        $termID = $I->haveTermInDatabase('ConvertKit Refresh Resources', 'category');
-        $termID = $termID[0];
-
-        // Edit the Term.
-        $I->amOnAdminPage('term.php?taxonomy=category&tag_ID=' . $termID);
-
-        // Click the Forms refresh button.
-        $I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
-
-        // Wait for button to change its state from disabled.
-        $I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
-
-        // Change resource to value specified in the .env file, which should now be available.
-        // If the expected dropdown value does not exist in the Select2 field, this will fail the test.
-        $I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
-    }
-
-    /**
-     * Test that the refresh button triggers an error message when the AJAX request fails,
-     * or the ConvertKit API returns an error, when adding a Page using the Gutenberg editor.
-     * 
-     * @since 1.9.8.3
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testRefreshResourcesErrorNoticeOnPage(AcceptanceTester $I)
-    {
-        // Navigate to Pages > Add New
-        $I->amOnAdminPage('post-new.php?post_type=page');
-
-        // Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
-        $I->maybeCloseGutenbergWelcomeModal($I);
-
-        // Specify invalid API credentials, so that the AJAX request returns an error.
-        $I->haveOptionInDatabase(
-            '_wp_convertkit_settings', [
-            'api_key'    => 'fakeApiKey',
-            'api_secret' => 'fakeApiSecret',
-            'debug'      => 'on',
-            'no_scripts' => '',
-            'no_css'     => '',
-            ]
-        );
-
-        // Click the Forms refresh button.
-        $I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
-
-        // Wait for button to change its state from disabled.
-        $I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
-
-        // Confirm that an error notification is displayed on screen, with the expected error message.
-
-        $I->seeElementInDOM('div.components-notice-list div.is-error');
-        $I->see('Authorization Failed: API Key not valid');
-
-        // Confirm that the notice is dismissible.
-        $I->click('div.components-notice-list div.is-error button.components-notice__dismiss');
-        $I->wait(1);
-        $I->dontSeeElementInDOM('div.components-notice-list div.is-error');
-    }
-
-    /**
-     * Test that the refresh button triggers an error message when the AJAX request fails,
-     * or the ConvertKit API returns an error, when adding a Page using the Classic Editor.
-     * 
-     * @since 1.9.8.3
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testRefreshResourcesErrorNoticeOnPageClassicEditor(AcceptanceTester $I)
-    {
-        // Add a Page using the Classic Editor.
-        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Refresh Resources: Classic Editor');
-
-        // Specify invalid API credentials, so that the AJAX request returns an error.
-        $I->haveOptionInDatabase(
-            '_wp_convertkit_settings', [
-            'api_key'    => 'fakeApiKey',
-            'api_secret' => 'fakeApiSecret',
-            'debug'      => 'on',
-            'no_scripts' => '',
-            'no_css'     => '',
-            ]
-        );
-
-        // Click the Forms refresh button.
-        $I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
-
-        // Wait for button to change its state from disabled.
-        $I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
-
-        // Confirm that an error notification is displayed on screen, with the expected error message.
-        $I->seeElementInDOM('div.convertkit-error');
-        $I->see('Authorization Failed: API Key not valid');
-
-        // Confirm that the notice is dismissible.
-        $I->click('div.convertkit-error button.notice-dismiss');
-        $I->wait(1);
-        $I->dontSeeElementInDOM('div.convertkit-error');
-    }
-
-    /**
-     * Test that the refresh button triggers an error message when the AJAX request fails,
-     * or the ConvertKit API returns an error, when using the Quick Edit functionality.
-     * 
-     * @since 1.9.8.3
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testRefreshResourcesErrorNoticeOnQuickEdit(AcceptanceTester $I)
-    {
-        // Specify invalid API credentials, so that the AJAX request returns an error.
-        $I->haveOptionInDatabase(
-            '_wp_convertkit_settings', [
-            'api_key'    => 'fakeApiKey',
-            'api_secret' => 'fakeApiSecret',
-            'debug'      => 'on',
-            'no_scripts' => '',
-            'no_css'     => '',
-            ]
-        );
-
-        // Programmatically create a Page.
-        $pageID = $I->havePostInDatabase(
-            [
-            'post_type'     => 'page',
-            'post_title'     => 'ConvertKit: Page: Refresh Resources: Quick Edit',
-            ]
-        );
-
-        // Open Quick Edit form forthe Page in the Pages WP_List_Table.
-        $I->openQuickEdit($I, 'page', $pageID);
-
-        // Click the Forms refresh button.
-        $I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
-
-        // Wait for button to change its state from disabled.
-        $I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
-
-        // Confirm that an error notification is displayed on screen, with the expected error message.
-        $I->seeElementInDOM('div.convertkit-error');
-        $I->see('Authorization Failed: API Key not valid');
-
-        // Confirm that the notice is dismissible.
-        $I->click('div.convertkit-error button.notice-dismiss');
-        $I->wait(1);
-        $I->dontSeeElementInDOM('div.convertkit-error');
-    }
-
-    /**
-     * Test that the refresh button triggers an error message when the AJAX request fails,
-     * or the ConvertKit API returns an error, when using the Bulk Edit functionality.
-     * 
-     * @since 1.9.8.3
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testRefreshResourcesErrorNoticeOnBulkEdit(AcceptanceTester $I)
-    {
-        // Specify invalid API credentials, so that the AJAX request returns an error.
-        $I->haveOptionInDatabase(
-            '_wp_convertkit_settings', [
-            'api_key'    => 'fakeApiKey',
-            'api_secret' => 'fakeApiSecret',
-            'debug'      => 'on',
-            'no_scripts' => '',
-            'no_css'     => '',
-            ]
-        );
-
-        // Programmatically create two Pages.
-        $pageIDs = array(
-        $I->havePostInDatabase(
-            [
-            'post_type'     => 'page',
-            'post_title'     => 'ConvertKit: Page: Refresh Resources: Bulk Edit #1',
-            ]
-        ),
-        $I->havePostInDatabase(
-            [
-            'post_type'     => 'page',
-            'post_title'     => 'ConvertKit: Page: Refresh Resources: Bulk Edit #2',
-            ]
-        )
-        );
-
-        // Open Bulk Edit form for the Pages in the Pages WP_List_Table.
-        $I->openBulkEdit($I, 'page', $pageIDs);
-
-        // Click the Forms refresh button.
-        $I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
-
-        // Wait for button to change its state from disabled.
-        $I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
-
-        // Confirm that an error notification is displayed on screen, with the expected error message.
-        $I->seeElementInDOM('div.convertkit-error');
-        $I->see('Authorization Failed: API Key not valid');
-
-        // Confirm that the notice is dismissible.
-        $I->click('div.convertkit-error button.notice-dismiss');
-        $I->wait(1);
-        $I->dontSeeElementInDOM('div.convertkit-error');
-    }
-
-    /**
-     * Test that the refresh button triggers an error message when the AJAX request fails,
-     * or the ConvertKit API returns an error, when editing a Category.
-     * 
-     * @since 1.9.8.3
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testRefreshResourcesErrorNoticeOnCategory(AcceptanceTester $I)
-    {
-        // Specify invalid API credentials, so that the AJAX request returns an error.
-        $I->haveOptionInDatabase(
-            '_wp_convertkit_settings', [
-            'api_key'    => 'fakeApiKey',
-            'api_secret' => 'fakeApiSecret',
-            'debug'      => 'on',
-            'no_scripts' => '',
-            'no_css'     => '',
-            ]
-        );
-
-        // Create Category.
-        $termID = $I->haveTermInDatabase('ConvertKit Refresh Resources', 'category');
-        $termID = $termID[0];
-
-        // Edit the Term.
-        $I->amOnAdminPage('term.php?taxonomy=category&tag_ID=' . $termID);
-
-        // Click the Forms refresh button.
-        $I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
-
-        // Wait for button to change its state from disabled.
-        $I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
-
-        // Confirm that an error notification is displayed on screen, with the expected error message.
-        $I->seeElementInDOM('div.convertkit-error');
-        $I->see('Authorization Failed: API Key not valid');
-
-        // Confirm that the notice is dismissible.
-        $I->click('div.convertkit-error button.notice-dismiss');
-        $I->wait(1);
-        $I->dontSeeElementInDOM('div.convertkit-error');
-    }
-
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.8.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateThirdPartyPlugin($I, 'classic-editor');
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+class RefreshResourcesButtonCest {
+
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.8.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		// Activate and Setup ConvertKit plugin using API keys that have no resources (forms, landing pages, tags).
+		$I->activateConvertKitPlugin( $I );
+		$I->setupConvertKitPlugin( $I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA'] );
+
+		// Change API keys in database to ones that have ConvertKit Resources.
+		// We do this directly vs. via the settings screen, so that the Plugin's cached resources remain blank
+		// until a refresh button is clicked.
+		$I->haveOptionInDatabase(
+			'_wp_convertkit_settings',
+			array(
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+				'debug'      => 'on',
+				'no_scripts' => '',
+				'no_css'     => '',
+			)
+		);
+	}
+
+	/**
+	 * Test that the refresh buttons for Forms, Landing Pages and Tags works when adding a new Page.
+	 *
+	 * @since 1.9.8.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testRefreshResourcesOnPage( AcceptanceTester $I ) {
+		// Navigate to Pages > Add New
+		$I->amOnAdminPage( 'post-new.php?post_type=page' );
+
+		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
+		$I->maybeCloseGutenbergWelcomeModal( $I );
+
+		// Click the Forms refresh button.
+		$I->click( 'button.wp-convertkit-refresh-resources[data-resource="forms"]' );
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible( 'button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)' );
+
+		// Change resource to value specified in the .env file, which should now be available.
+		// If the expected dropdown value does not exist in the Select2 field, this will fail the test.
+		$I->fillSelect2Field( $I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+
+		// Click the Landing Pages refresh button.
+		$I->click( 'button.wp-convertkit-refresh-resources[data-resource="landing_pages"]' );
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible( 'button.wp-convertkit-refresh-resources[data-resource="landing_pages"]:not(:disabled)' );
+
+		// Change resource to value specified in the .env file, which should now be available.
+		// If the expected dropdown value does not exist in the Select2 field, this will fail the test.
+		$I->fillSelect2Field( $I, '#select2-wp-convertkit-landing_page-container', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME'] );
+
+		// Click the Tags refresh button.
+		$I->click( 'button.wp-convertkit-refresh-resources[data-resource="tags"]' );
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible( 'button.wp-convertkit-refresh-resources[data-resource="tags"]:not(:disabled)' );
+
+		// Change resource to value specified in the .env file, which should now be available.
+		// If the expected dropdown value does not exist in the Select2 field, this will fail the test.
+		$I->fillSelect2Field( $I, '#select2-wp-convertkit-tag-container', $_ENV['CONVERTKIT_API_TAG_NAME'] );
+	}
+
+	/**
+	 * Test that the refresh buttons for Forms and Tags works when Quick Editing a Page.
+	 *
+	 * @since 1.9.8.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testRefreshResourcesOnQuickEdit( AcceptanceTester $I ) {
+		// Programmatically create a Page.
+		$pageID = $I->havePostInDatabase(
+			array(
+				'post_type'  => 'page',
+				'post_title' => 'ConvertKit: Page: Refresh Resources: Quick Edit',
+			)
+		);
+
+		// Open Quick Edit form forthe Page in the Pages WP_List_Table.
+		$I->openQuickEdit( $I, 'page', $pageID );
+
+		// Click the Forms refresh button.
+		$I->click( 'button.wp-convertkit-refresh-resources[data-resource="forms"]' );
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible( 'button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)' );
+
+		// Change resource to value specified in the .env file, which should now be available.
+		// If the expected dropdown value does not exist, this will fail the test.
+		$I->selectOption( '#wp-convertkit-quick-edit-form', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+
+		// Click the Tags refresh button.
+		$I->click( 'button.wp-convertkit-refresh-resources[data-resource="tags"]' );
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible( 'button.wp-convertkit-refresh-resources[data-resource="tags"]:not(:disabled)' );
+
+		// Change resource to value specified in the .env file, which should now be available.
+		// If the expected dropdown value does not exist, this will fail the test.
+		$I->selectOption( '#wp-convertkit-quick-edit-tag', $_ENV['CONVERTKIT_API_TAG_NAME'] );
+	}
+
+	/**
+	 * Test that the refresh buttons for Forms and Tags works when Bulk Editing Pages.
+	 *
+	 * @since 1.9.8.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testRefreshResourcesOnBulkEdit( AcceptanceTester $I ) {
+		// Programmatically create two Pages.
+		$pageIDs = array(
+			$I->havePostInDatabase(
+				array(
+					'post_type'  => 'page',
+					'post_title' => 'ConvertKit: Page: Refresh Resources: Bulk Edit #1',
+				)
+			),
+			$I->havePostInDatabase(
+				array(
+					'post_type'  => 'page',
+					'post_title' => 'ConvertKit: Page: Refresh Resources: Bulk Edit #2',
+				)
+			),
+		);
+
+		// Open Bulk Edit form for the Pages in the Pages WP_List_Table.
+		$I->openBulkEdit( $I, 'page', $pageIDs );
+
+		// Click the Forms refresh button.
+		$I->click( 'button.wp-convertkit-refresh-resources[data-resource="forms"]' );
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible( 'button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)' );
+
+		// Change resource to value specified in the .env file, which should now be available.
+		// If the expected dropdown value does not exist, this will fail the test.
+		$I->selectOption( '#wp-convertkit-bulk-edit-form', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+
+		// Click the Tags refresh button.
+		$I->click( 'button.wp-convertkit-refresh-resources[data-resource="tags"]' );
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible( 'button.wp-convertkit-refresh-resources[data-resource="tags"]:not(:disabled)' );
+
+		// Change resource to value specified in the .env file, which should now be available.
+		// If the expected dropdown value does not exist, this will fail the test.
+		$I->selectOption( '#wp-convertkit-bulk-edit-tag', $_ENV['CONVERTKIT_API_TAG_NAME'] );
+	}
+
+	/**
+	 * Test that the refresh button for Forms works when editing a Category.
+	 *
+	 * @since 1.9.8.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testRefreshResourcesOnCategory( AcceptanceTester $I ) {
+		// Create Category.
+		$termID = $I->haveTermInDatabase( 'ConvertKit Refresh Resources', 'category' );
+		$termID = $termID[0];
+
+		// Edit the Term.
+		$I->amOnAdminPage( 'term.php?taxonomy=category&tag_ID=' . $termID );
+
+		// Click the Forms refresh button.
+		$I->click( 'button.wp-convertkit-refresh-resources[data-resource="forms"]' );
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible( 'button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)' );
+
+		// Change resource to value specified in the .env file, which should now be available.
+		// If the expected dropdown value does not exist in the Select2 field, this will fail the test.
+		$I->fillSelect2Field( $I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+	}
+
+	/**
+	 * Test that the refresh button triggers an error message when the AJAX request fails,
+	 * or the ConvertKit API returns an error, when adding a Page using the Gutenberg editor.
+	 *
+	 * @since 1.9.8.3
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testRefreshResourcesErrorNoticeOnPage( AcceptanceTester $I ) {
+		// Navigate to Pages > Add New
+		$I->amOnAdminPage( 'post-new.php?post_type=page' );
+
+		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
+		$I->maybeCloseGutenbergWelcomeModal( $I );
+
+		// Specify invalid API credentials, so that the AJAX request returns an error.
+		$I->haveOptionInDatabase(
+			'_wp_convertkit_settings',
+			array(
+				'api_key'    => 'fakeApiKey',
+				'api_secret' => 'fakeApiSecret',
+				'debug'      => 'on',
+				'no_scripts' => '',
+				'no_css'     => '',
+			)
+		);
+
+		// Click the Forms refresh button.
+		$I->click( 'button.wp-convertkit-refresh-resources[data-resource="forms"]' );
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible( 'button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)' );
+
+		// Confirm that an error notification is displayed on screen, with the expected error message.
+
+		$I->seeElementInDOM( 'div.components-notice-list div.is-error' );
+		$I->see( 'Authorization Failed: API Key not valid' );
+
+		// Confirm that the notice is dismissible.
+		$I->click( 'div.components-notice-list div.is-error button.components-notice__dismiss' );
+		$I->wait( 1 );
+		$I->dontSeeElementInDOM( 'div.components-notice-list div.is-error' );
+	}
+
+	/**
+	 * Test that the refresh button triggers an error message when the AJAX request fails,
+	 * or the ConvertKit API returns an error, when adding a Page using the Classic Editor.
+	 *
+	 * @since 1.9.8.3
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testRefreshResourcesErrorNoticeOnPageClassicEditor( AcceptanceTester $I ) {
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Refresh Resources: Classic Editor' );
+
+		// Specify invalid API credentials, so that the AJAX request returns an error.
+		$I->haveOptionInDatabase(
+			'_wp_convertkit_settings',
+			array(
+				'api_key'    => 'fakeApiKey',
+				'api_secret' => 'fakeApiSecret',
+				'debug'      => 'on',
+				'no_scripts' => '',
+				'no_css'     => '',
+			)
+		);
+
+		// Click the Forms refresh button.
+		$I->click( 'button.wp-convertkit-refresh-resources[data-resource="forms"]' );
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible( 'button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)' );
+
+		// Confirm that an error notification is displayed on screen, with the expected error message.
+		$I->seeElementInDOM( 'div.convertkit-error' );
+		$I->see( 'Authorization Failed: API Key not valid' );
+
+		// Confirm that the notice is dismissible.
+		$I->click( 'div.convertkit-error button.notice-dismiss' );
+		$I->wait( 1 );
+		$I->dontSeeElementInDOM( 'div.convertkit-error' );
+	}
+
+	/**
+	 * Test that the refresh button triggers an error message when the AJAX request fails,
+	 * or the ConvertKit API returns an error, when using the Quick Edit functionality.
+	 *
+	 * @since 1.9.8.3
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testRefreshResourcesErrorNoticeOnQuickEdit( AcceptanceTester $I ) {
+		// Specify invalid API credentials, so that the AJAX request returns an error.
+		$I->haveOptionInDatabase(
+			'_wp_convertkit_settings',
+			array(
+				'api_key'    => 'fakeApiKey',
+				'api_secret' => 'fakeApiSecret',
+				'debug'      => 'on',
+				'no_scripts' => '',
+				'no_css'     => '',
+			)
+		);
+
+		// Programmatically create a Page.
+		$pageID = $I->havePostInDatabase(
+			array(
+				'post_type'  => 'page',
+				'post_title' => 'ConvertKit: Page: Refresh Resources: Quick Edit',
+			)
+		);
+
+		// Open Quick Edit form forthe Page in the Pages WP_List_Table.
+		$I->openQuickEdit( $I, 'page', $pageID );
+
+		// Click the Forms refresh button.
+		$I->click( 'button.wp-convertkit-refresh-resources[data-resource="forms"]' );
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible( 'button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)' );
+
+		// Confirm that an error notification is displayed on screen, with the expected error message.
+		$I->seeElementInDOM( 'div.convertkit-error' );
+		$I->see( 'Authorization Failed: API Key not valid' );
+
+		// Confirm that the notice is dismissible.
+		$I->click( 'div.convertkit-error button.notice-dismiss' );
+		$I->wait( 1 );
+		$I->dontSeeElementInDOM( 'div.convertkit-error' );
+	}
+
+	/**
+	 * Test that the refresh button triggers an error message when the AJAX request fails,
+	 * or the ConvertKit API returns an error, when using the Bulk Edit functionality.
+	 *
+	 * @since 1.9.8.3
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testRefreshResourcesErrorNoticeOnBulkEdit( AcceptanceTester $I ) {
+		// Specify invalid API credentials, so that the AJAX request returns an error.
+		$I->haveOptionInDatabase(
+			'_wp_convertkit_settings',
+			array(
+				'api_key'    => 'fakeApiKey',
+				'api_secret' => 'fakeApiSecret',
+				'debug'      => 'on',
+				'no_scripts' => '',
+				'no_css'     => '',
+			)
+		);
+
+		// Programmatically create two Pages.
+		$pageIDs = array(
+			$I->havePostInDatabase(
+				array(
+					'post_type'  => 'page',
+					'post_title' => 'ConvertKit: Page: Refresh Resources: Bulk Edit #1',
+				)
+			),
+			$I->havePostInDatabase(
+				array(
+					'post_type'  => 'page',
+					'post_title' => 'ConvertKit: Page: Refresh Resources: Bulk Edit #2',
+				)
+			),
+		);
+
+		// Open Bulk Edit form for the Pages in the Pages WP_List_Table.
+		$I->openBulkEdit( $I, 'page', $pageIDs );
+
+		// Click the Forms refresh button.
+		$I->click( 'button.wp-convertkit-refresh-resources[data-resource="forms"]' );
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible( 'button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)' );
+
+		// Confirm that an error notification is displayed on screen, with the expected error message.
+		$I->seeElementInDOM( 'div.convertkit-error' );
+		$I->see( 'Authorization Failed: API Key not valid' );
+
+		// Confirm that the notice is dismissible.
+		$I->click( 'div.convertkit-error button.notice-dismiss' );
+		$I->wait( 1 );
+		$I->dontSeeElementInDOM( 'div.convertkit-error' );
+	}
+
+	/**
+	 * Test that the refresh button triggers an error message when the AJAX request fails,
+	 * or the ConvertKit API returns an error, when editing a Category.
+	 *
+	 * @since 1.9.8.3
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testRefreshResourcesErrorNoticeOnCategory( AcceptanceTester $I ) {
+		// Specify invalid API credentials, so that the AJAX request returns an error.
+		$I->haveOptionInDatabase(
+			'_wp_convertkit_settings',
+			array(
+				'api_key'    => 'fakeApiKey',
+				'api_secret' => 'fakeApiSecret',
+				'debug'      => 'on',
+				'no_scripts' => '',
+				'no_css'     => '',
+			)
+		);
+
+		// Create Category.
+		$termID = $I->haveTermInDatabase( 'ConvertKit Refresh Resources', 'category' );
+		$termID = $termID[0];
+
+		// Edit the Term.
+		$I->amOnAdminPage( 'term.php?taxonomy=category&tag_ID=' . $termID );
+
+		// Click the Forms refresh button.
+		$I->click( 'button.wp-convertkit-refresh-resources[data-resource="forms"]' );
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible( 'button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)' );
+
+		// Confirm that an error notification is displayed on screen, with the expected error message.
+		$I->seeElementInDOM( 'div.convertkit-error' );
+		$I->see( 'Authorization Failed: API Key not valid' );
+
+		// Confirm that the notice is dismissible.
+		$I->click( 'div.convertkit-error button.notice-dismiss' );
+		$I->wait( 1 );
+		$I->dontSeeElementInDOM( 'div.convertkit-error' );
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.8.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateThirdPartyPlugin( $I, 'classic-editor' );
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/general/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/general/RefreshResourcesButtonCest.php
@@ -2,441 +2,422 @@
 /**
  * Tests Refresh Resource buttons, which are displayed next to settings fields
  * across Page/Post editing, Bulk/Quick edit and Category editing.
- *
- * @since 1.9.8.0
+ * 
+ * @since 	1.9.8.0
  */
-class RefreshResourcesButtonCest {
-
+class RefreshResourcesButtonCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.8.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
+	public function _before(AcceptanceTester $I)
+	{
 		// Activate and Setup ConvertKit plugin using API keys that have no resources (forms, landing pages, tags).
-		$I->activateConvertKitPlugin( $I );
-		$I->setupConvertKitPlugin( $I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA'] );
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
 
 		// Change API keys in database to ones that have ConvertKit Resources.
 		// We do this directly vs. via the settings screen, so that the Plugin's cached resources remain blank
 		// until a refresh button is clicked.
-		$I->haveOptionInDatabase(
-			'_wp_convertkit_settings',
-			array(
-				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-				'debug'      => 'on',
-				'no_scripts' => '',
-				'no_css'     => '',
-			)
-		);
+		$I->haveOptionInDatabase('_wp_convertkit_settings', [
+			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+			'debug'      => 'on',
+			'no_scripts' => '',
+			'no_css'     => '',
+		]);
 	}
 
 	/**
 	 * Test that the refresh buttons for Forms, Landing Pages and Tags works when adding a new Page.
-	 *
-	 * @since 1.9.8.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testRefreshResourcesOnPage( AcceptanceTester $I ) {
+	public function testRefreshResourcesOnPage(AcceptanceTester $I)
+	{
 		// Navigate to Pages > Add New
-		$I->amOnAdminPage( 'post-new.php?post_type=page' );
+		$I->amOnAdminPage('post-new.php?post_type=page');
 
 		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
-		$I->maybeCloseGutenbergWelcomeModal( $I );
+		$I->maybeCloseGutenbergWelcomeModal($I);
 
 		// Click the Forms refresh button.
-		$I->click( 'button.wp-convertkit-refresh-resources[data-resource="forms"]' );
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
 
 		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible( 'button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)' );
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
 
 		// Change resource to value specified in the .env file, which should now be available.
 		// If the expected dropdown value does not exist in the Select2 field, this will fail the test.
-		$I->fillSelect2Field( $I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
 		// Click the Landing Pages refresh button.
-		$I->click( 'button.wp-convertkit-refresh-resources[data-resource="landing_pages"]' );
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="landing_pages"]');
 
 		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible( 'button.wp-convertkit-refresh-resources[data-resource="landing_pages"]:not(:disabled)' );
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="landing_pages"]:not(:disabled)');
 
 		// Change resource to value specified in the .env file, which should now be available.
 		// If the expected dropdown value does not exist in the Select2 field, this will fail the test.
-		$I->fillSelect2Field( $I, '#select2-wp-convertkit-landing_page-container', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME'] );
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-landing_page-container', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME']);
 
 		// Click the Tags refresh button.
-		$I->click( 'button.wp-convertkit-refresh-resources[data-resource="tags"]' );
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="tags"]');
 
 		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible( 'button.wp-convertkit-refresh-resources[data-resource="tags"]:not(:disabled)' );
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="tags"]:not(:disabled)');
 
 		// Change resource to value specified in the .env file, which should now be available.
 		// If the expected dropdown value does not exist in the Select2 field, this will fail the test.
-		$I->fillSelect2Field( $I, '#select2-wp-convertkit-tag-container', $_ENV['CONVERTKIT_API_TAG_NAME'] );
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-tag-container', $_ENV['CONVERTKIT_API_TAG_NAME']);
 	}
 
 	/**
 	 * Test that the refresh buttons for Forms and Tags works when Quick Editing a Page.
-	 *
-	 * @since 1.9.8.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testRefreshResourcesOnQuickEdit( AcceptanceTester $I ) {
+	public function testRefreshResourcesOnQuickEdit(AcceptanceTester $I)
+	{
 		// Programmatically create a Page.
-		$pageID = $I->havePostInDatabase(
-			array(
-				'post_type'  => 'page',
-				'post_title' => 'ConvertKit: Page: Refresh Resources: Quick Edit',
-			)
-		);
+		$pageID = $I->havePostInDatabase([
+			'post_type' 	=> 'page',
+			'post_title' 	=> 'ConvertKit: Page: Refresh Resources: Quick Edit',
+		]);
 
 		// Open Quick Edit form forthe Page in the Pages WP_List_Table.
-		$I->openQuickEdit( $I, 'page', $pageID );
+		$I->openQuickEdit($I, 'page', $pageID);
 
 		// Click the Forms refresh button.
-		$I->click( 'button.wp-convertkit-refresh-resources[data-resource="forms"]' );
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
 
 		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible( 'button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)' );
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
 
 		// Change resource to value specified in the .env file, which should now be available.
 		// If the expected dropdown value does not exist, this will fail the test.
-		$I->selectOption( '#wp-convertkit-quick-edit-form', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+		$I->selectOption('#wp-convertkit-quick-edit-form', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
 		// Click the Tags refresh button.
-		$I->click( 'button.wp-convertkit-refresh-resources[data-resource="tags"]' );
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="tags"]');
 
 		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible( 'button.wp-convertkit-refresh-resources[data-resource="tags"]:not(:disabled)' );
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="tags"]:not(:disabled)');
 
 		// Change resource to value specified in the .env file, which should now be available.
 		// If the expected dropdown value does not exist, this will fail the test.
-		$I->selectOption( '#wp-convertkit-quick-edit-tag', $_ENV['CONVERTKIT_API_TAG_NAME'] );
+		$I->selectOption('#wp-convertkit-quick-edit-tag', $_ENV['CONVERTKIT_API_TAG_NAME']);
 	}
 
 	/**
 	 * Test that the refresh buttons for Forms and Tags works when Bulk Editing Pages.
-	 *
-	 * @since 1.9.8.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testRefreshResourcesOnBulkEdit( AcceptanceTester $I ) {
+	public function testRefreshResourcesOnBulkEdit(AcceptanceTester $I)
+	{
 		// Programmatically create two Pages.
 		$pageIDs = array(
-			$I->havePostInDatabase(
-				array(
-					'post_type'  => 'page',
-					'post_title' => 'ConvertKit: Page: Refresh Resources: Bulk Edit #1',
-				)
-			),
-			$I->havePostInDatabase(
-				array(
-					'post_type'  => 'page',
-					'post_title' => 'ConvertKit: Page: Refresh Resources: Bulk Edit #2',
-				)
-			),
+			$I->havePostInDatabase([
+				'post_type' 	=> 'page',
+				'post_title' 	=> 'ConvertKit: Page: Refresh Resources: Bulk Edit #1',
+			]),
+			$I->havePostInDatabase([
+				'post_type' 	=> 'page',
+				'post_title' 	=> 'ConvertKit: Page: Refresh Resources: Bulk Edit #2',
+			])
 		);
 
 		// Open Bulk Edit form for the Pages in the Pages WP_List_Table.
-		$I->openBulkEdit( $I, 'page', $pageIDs );
+		$I->openBulkEdit($I, 'page', $pageIDs);
 
 		// Click the Forms refresh button.
-		$I->click( 'button.wp-convertkit-refresh-resources[data-resource="forms"]' );
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
 
 		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible( 'button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)' );
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
 
 		// Change resource to value specified in the .env file, which should now be available.
 		// If the expected dropdown value does not exist, this will fail the test.
-		$I->selectOption( '#wp-convertkit-bulk-edit-form', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+		$I->selectOption('#wp-convertkit-bulk-edit-form', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
 		// Click the Tags refresh button.
-		$I->click( 'button.wp-convertkit-refresh-resources[data-resource="tags"]' );
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="tags"]');
 
 		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible( 'button.wp-convertkit-refresh-resources[data-resource="tags"]:not(:disabled)' );
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="tags"]:not(:disabled)');
 
 		// Change resource to value specified in the .env file, which should now be available.
 		// If the expected dropdown value does not exist, this will fail the test.
-		$I->selectOption( '#wp-convertkit-bulk-edit-tag', $_ENV['CONVERTKIT_API_TAG_NAME'] );
+		$I->selectOption('#wp-convertkit-bulk-edit-tag', $_ENV['CONVERTKIT_API_TAG_NAME']);
 	}
 
 	/**
 	 * Test that the refresh button for Forms works when editing a Category.
-	 *
-	 * @since 1.9.8.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testRefreshResourcesOnCategory( AcceptanceTester $I ) {
+	public function testRefreshResourcesOnCategory(AcceptanceTester $I)
+	{
 		// Create Category.
 		$termID = $I->haveTermInDatabase( 'ConvertKit Refresh Resources', 'category' );
 		$termID = $termID[0];
 
 		// Edit the Term.
-		$I->amOnAdminPage( 'term.php?taxonomy=category&tag_ID=' . $termID );
+		$I->amOnAdminPage('term.php?taxonomy=category&tag_ID=' . $termID);
 
 		// Click the Forms refresh button.
-		$I->click( 'button.wp-convertkit-refresh-resources[data-resource="forms"]' );
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
 
 		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible( 'button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)' );
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
 
 		// Change resource to value specified in the .env file, which should now be available.
 		// If the expected dropdown value does not exist in the Select2 field, this will fail the test.
-		$I->fillSelect2Field( $I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME'] );
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
 	}
 
 	/**
 	 * Test that the refresh button triggers an error message when the AJAX request fails,
 	 * or the ConvertKit API returns an error, when adding a Page using the Gutenberg editor.
-	 *
-	 * @since 1.9.8.3
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testRefreshResourcesErrorNoticeOnPage( AcceptanceTester $I ) {
+	public function testRefreshResourcesErrorNoticeOnPage(AcceptanceTester $I)
+	{
 		// Navigate to Pages > Add New
-		$I->amOnAdminPage( 'post-new.php?post_type=page' );
+		$I->amOnAdminPage('post-new.php?post_type=page');
 
 		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
-		$I->maybeCloseGutenbergWelcomeModal( $I );
+		$I->maybeCloseGutenbergWelcomeModal($I);
 
 		// Specify invalid API credentials, so that the AJAX request returns an error.
-		$I->haveOptionInDatabase(
-			'_wp_convertkit_settings',
-			array(
-				'api_key'    => 'fakeApiKey',
-				'api_secret' => 'fakeApiSecret',
-				'debug'      => 'on',
-				'no_scripts' => '',
-				'no_css'     => '',
-			)
-		);
+		$I->haveOptionInDatabase('_wp_convertkit_settings', [
+			'api_key'    => 'fakeApiKey',
+			'api_secret' => 'fakeApiSecret',
+			'debug'      => 'on',
+			'no_scripts' => '',
+			'no_css'     => '',
+		]);
 
 		// Click the Forms refresh button.
-		$I->click( 'button.wp-convertkit-refresh-resources[data-resource="forms"]' );
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
 
 		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible( 'button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)' );
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
 
 		// Confirm that an error notification is displayed on screen, with the expected error message.
 
-		$I->seeElementInDOM( 'div.components-notice-list div.is-error' );
-		$I->see( 'Authorization Failed: API Key not valid' );
+		$I->seeElementInDOM('div.components-notice-list div.is-error');
+		$I->see('Authorization Failed: API Key not valid');
 
 		// Confirm that the notice is dismissible.
-		$I->click( 'div.components-notice-list div.is-error button.components-notice__dismiss' );
-		$I->wait( 1 );
-		$I->dontSeeElementInDOM( 'div.components-notice-list div.is-error' );
+		$I->click('div.components-notice-list div.is-error button.components-notice__dismiss');
+		$I->wait(1);
+		$I->dontSeeElementInDOM('div.components-notice-list div.is-error');
 	}
 
 	/**
 	 * Test that the refresh button triggers an error message when the AJAX request fails,
 	 * or the ConvertKit API returns an error, when adding a Page using the Classic Editor.
-	 *
-	 * @since 1.9.8.3
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testRefreshResourcesErrorNoticeOnPageClassicEditor( AcceptanceTester $I ) {
+	public function testRefreshResourcesErrorNoticeOnPageClassicEditor(AcceptanceTester $I)
+	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Refresh Resources: Classic Editor' );
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Refresh Resources: Classic Editor' );
 
 		// Specify invalid API credentials, so that the AJAX request returns an error.
-		$I->haveOptionInDatabase(
-			'_wp_convertkit_settings',
-			array(
-				'api_key'    => 'fakeApiKey',
-				'api_secret' => 'fakeApiSecret',
-				'debug'      => 'on',
-				'no_scripts' => '',
-				'no_css'     => '',
-			)
-		);
+		$I->haveOptionInDatabase('_wp_convertkit_settings', [
+			'api_key'    => 'fakeApiKey',
+			'api_secret' => 'fakeApiSecret',
+			'debug'      => 'on',
+			'no_scripts' => '',
+			'no_css'     => '',
+		]);
 
 		// Click the Forms refresh button.
-		$I->click( 'button.wp-convertkit-refresh-resources[data-resource="forms"]' );
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
 
 		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible( 'button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)' );
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
 
 		// Confirm that an error notification is displayed on screen, with the expected error message.
-		$I->seeElementInDOM( 'div.convertkit-error' );
-		$I->see( 'Authorization Failed: API Key not valid' );
+		$I->seeElementInDOM('div.convertkit-error');
+		$I->see('Authorization Failed: API Key not valid');
 
 		// Confirm that the notice is dismissible.
-		$I->click( 'div.convertkit-error button.notice-dismiss' );
-		$I->wait( 1 );
-		$I->dontSeeElementInDOM( 'div.convertkit-error' );
+		$I->click('div.convertkit-error button.notice-dismiss');
+		$I->wait(1);
+		$I->dontSeeElementInDOM('div.convertkit-error');
 	}
 
 	/**
 	 * Test that the refresh button triggers an error message when the AJAX request fails,
 	 * or the ConvertKit API returns an error, when using the Quick Edit functionality.
-	 *
-	 * @since 1.9.8.3
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testRefreshResourcesErrorNoticeOnQuickEdit( AcceptanceTester $I ) {
+	public function testRefreshResourcesErrorNoticeOnQuickEdit(AcceptanceTester $I)
+	{
 		// Specify invalid API credentials, so that the AJAX request returns an error.
-		$I->haveOptionInDatabase(
-			'_wp_convertkit_settings',
-			array(
-				'api_key'    => 'fakeApiKey',
-				'api_secret' => 'fakeApiSecret',
-				'debug'      => 'on',
-				'no_scripts' => '',
-				'no_css'     => '',
-			)
-		);
+		$I->haveOptionInDatabase('_wp_convertkit_settings', [
+			'api_key'    => 'fakeApiKey',
+			'api_secret' => 'fakeApiSecret',
+			'debug'      => 'on',
+			'no_scripts' => '',
+			'no_css'     => '',
+		]);
 
 		// Programmatically create a Page.
-		$pageID = $I->havePostInDatabase(
-			array(
-				'post_type'  => 'page',
-				'post_title' => 'ConvertKit: Page: Refresh Resources: Quick Edit',
-			)
-		);
+		$pageID = $I->havePostInDatabase([
+			'post_type' 	=> 'page',
+			'post_title' 	=> 'ConvertKit: Page: Refresh Resources: Quick Edit',
+		]);
 
 		// Open Quick Edit form forthe Page in the Pages WP_List_Table.
-		$I->openQuickEdit( $I, 'page', $pageID );
+		$I->openQuickEdit($I, 'page', $pageID);
 
 		// Click the Forms refresh button.
-		$I->click( 'button.wp-convertkit-refresh-resources[data-resource="forms"]' );
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
 
 		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible( 'button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)' );
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
 
 		// Confirm that an error notification is displayed on screen, with the expected error message.
-		$I->seeElementInDOM( 'div.convertkit-error' );
-		$I->see( 'Authorization Failed: API Key not valid' );
+		$I->seeElementInDOM('div.convertkit-error');
+		$I->see('Authorization Failed: API Key not valid');
 
 		// Confirm that the notice is dismissible.
-		$I->click( 'div.convertkit-error button.notice-dismiss' );
-		$I->wait( 1 );
-		$I->dontSeeElementInDOM( 'div.convertkit-error' );
+		$I->click('div.convertkit-error button.notice-dismiss');
+		$I->wait(1);
+		$I->dontSeeElementInDOM('div.convertkit-error');
 	}
 
 	/**
 	 * Test that the refresh button triggers an error message when the AJAX request fails,
 	 * or the ConvertKit API returns an error, when using the Bulk Edit functionality.
-	 *
-	 * @since 1.9.8.3
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testRefreshResourcesErrorNoticeOnBulkEdit( AcceptanceTester $I ) {
+	public function testRefreshResourcesErrorNoticeOnBulkEdit(AcceptanceTester $I)
+	{
 		// Specify invalid API credentials, so that the AJAX request returns an error.
-		$I->haveOptionInDatabase(
-			'_wp_convertkit_settings',
-			array(
-				'api_key'    => 'fakeApiKey',
-				'api_secret' => 'fakeApiSecret',
-				'debug'      => 'on',
-				'no_scripts' => '',
-				'no_css'     => '',
-			)
-		);
+		$I->haveOptionInDatabase('_wp_convertkit_settings', [
+			'api_key'    => 'fakeApiKey',
+			'api_secret' => 'fakeApiSecret',
+			'debug'      => 'on',
+			'no_scripts' => '',
+			'no_css'     => '',
+		]);
 
 		// Programmatically create two Pages.
 		$pageIDs = array(
-			$I->havePostInDatabase(
-				array(
-					'post_type'  => 'page',
-					'post_title' => 'ConvertKit: Page: Refresh Resources: Bulk Edit #1',
-				)
-			),
-			$I->havePostInDatabase(
-				array(
-					'post_type'  => 'page',
-					'post_title' => 'ConvertKit: Page: Refresh Resources: Bulk Edit #2',
-				)
-			),
+			$I->havePostInDatabase([
+				'post_type' 	=> 'page',
+				'post_title' 	=> 'ConvertKit: Page: Refresh Resources: Bulk Edit #1',
+			]),
+			$I->havePostInDatabase([
+				'post_type' 	=> 'page',
+				'post_title' 	=> 'ConvertKit: Page: Refresh Resources: Bulk Edit #2',
+			])
 		);
 
 		// Open Bulk Edit form for the Pages in the Pages WP_List_Table.
-		$I->openBulkEdit( $I, 'page', $pageIDs );
+		$I->openBulkEdit($I, 'page', $pageIDs);
 
 		// Click the Forms refresh button.
-		$I->click( 'button.wp-convertkit-refresh-resources[data-resource="forms"]' );
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
 
 		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible( 'button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)' );
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
 
 		// Confirm that an error notification is displayed on screen, with the expected error message.
-		$I->seeElementInDOM( 'div.convertkit-error' );
-		$I->see( 'Authorization Failed: API Key not valid' );
+		$I->seeElementInDOM('div.convertkit-error');
+		$I->see('Authorization Failed: API Key not valid');
 
 		// Confirm that the notice is dismissible.
-		$I->click( 'div.convertkit-error button.notice-dismiss' );
-		$I->wait( 1 );
-		$I->dontSeeElementInDOM( 'div.convertkit-error' );
+		$I->click('div.convertkit-error button.notice-dismiss');
+		$I->wait(1);
+		$I->dontSeeElementInDOM('div.convertkit-error');
 	}
 
 	/**
 	 * Test that the refresh button triggers an error message when the AJAX request fails,
 	 * or the ConvertKit API returns an error, when editing a Category.
-	 *
-	 * @since 1.9.8.3
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testRefreshResourcesErrorNoticeOnCategory( AcceptanceTester $I ) {
+	public function testRefreshResourcesErrorNoticeOnCategory(AcceptanceTester $I)
+	{
 		// Specify invalid API credentials, so that the AJAX request returns an error.
-		$I->haveOptionInDatabase(
-			'_wp_convertkit_settings',
-			array(
-				'api_key'    => 'fakeApiKey',
-				'api_secret' => 'fakeApiSecret',
-				'debug'      => 'on',
-				'no_scripts' => '',
-				'no_css'     => '',
-			)
-		);
+		$I->haveOptionInDatabase('_wp_convertkit_settings', [
+			'api_key'    => 'fakeApiKey',
+			'api_secret' => 'fakeApiSecret',
+			'debug'      => 'on',
+			'no_scripts' => '',
+			'no_css'     => '',
+		]);
 
 		// Create Category.
 		$termID = $I->haveTermInDatabase( 'ConvertKit Refresh Resources', 'category' );
 		$termID = $termID[0];
 
 		// Edit the Term.
-		$I->amOnAdminPage( 'term.php?taxonomy=category&tag_ID=' . $termID );
+		$I->amOnAdminPage('term.php?taxonomy=category&tag_ID=' . $termID);
 
 		// Click the Forms refresh button.
-		$I->click( 'button.wp-convertkit-refresh-resources[data-resource="forms"]' );
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
 
 		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible( 'button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)' );
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
 
 		// Confirm that an error notification is displayed on screen, with the expected error message.
-		$I->seeElementInDOM( 'div.convertkit-error' );
-		$I->see( 'Authorization Failed: API Key not valid' );
+		$I->seeElementInDOM('div.convertkit-error');
+		$I->see('Authorization Failed: API Key not valid');
 
 		// Confirm that the notice is dismissible.
-		$I->click( 'div.convertkit-error button.notice-dismiss' );
-		$I->wait( 1 );
-		$I->dontSeeElementInDOM( 'div.convertkit-error' );
+		$I->click('div.convertkit-error button.notice-dismiss');
+		$I->wait(1);
+		$I->dontSeeElementInDOM('div.convertkit-error');
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.8.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateThirdPartyPlugin( $I, 'classic-editor' );
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateThirdPartyPlugin($I, 'classic-editor');
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/general/ReviewRequestCest.php
+++ b/tests/acceptance/general/ReviewRequestCest.php
@@ -1,211 +1,207 @@
 <?php
 /**
  * Tests the ConvertKit Review Notification.
- * 
+ *
  * @since 1.9.6
  */
-class ReviewRequestCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        $I->activateConvertKitPlugin($I);
-    }
+class ReviewRequestCest {
 
-    /**
-     * Test that the review request is set in the options table when the Plugin's
-     * Settings are saved with a Default Page Form specified in the Settings.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testReviewRequestOnSaveSettings(AcceptanceTester $I)
-    {
-        // Setup ConvertKit Plugin.
-        $I->setupConvertKitPlugin($I);
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		$I->activateConvertKitPlugin( $I );
+	}
 
-        // Define Default Form.
-        $I->setupConvertKitPluginDefaultForm($I);
+	/**
+	 * Test that the review request is set in the options table when the Plugin's
+	 * Settings are saved with a Default Page Form specified in the Settings.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testReviewRequestOnSaveSettings( AcceptanceTester $I ) {
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin( $I );
 
-        // Check that the options table does have a review request set.
-        $I->seeOptionInDatabase('convertkit-review-request');
+		// Define Default Form.
+		$I->setupConvertKitPluginDefaultForm( $I );
 
-        // Check that the option table does not yet have a review dismissed set.
-        $I->dontSeeOptionInDatabase('convertkit-review-dismissed');
-    }
+		// Check that the options table does have a review request set.
+		$I->seeOptionInDatabase( 'convertkit-review-request' );
 
-    /**
-     * Test that no review request is set in the options table when the Plugin's
-     * Settings are saved with no Forms specified in the Settings.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testReviewRequestOnSaveBlankSettings(AcceptanceTester $I)
-    {
-        // Go to the Plugin's Settings Screen.
-        $I->loadConvertKitSettingsGeneralScreen($I);
+		// Check that the option table does not yet have a review dismissed set.
+		$I->dontSeeOptionInDatabase( 'convertkit-review-dismissed' );
+	}
 
-        // Click the Save Changes button.
-        $I->click('Save Changes');
+	/**
+	 * Test that no review request is set in the options table when the Plugin's
+	 * Settings are saved with no Forms specified in the Settings.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testReviewRequestOnSaveBlankSettings( AcceptanceTester $I ) {
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsGeneralScreen( $I );
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Click the Save Changes button.
+		$I->click( 'Save Changes' );
 
-        // Check that the options table doesn't have a review request set.
-        $I->dontSeeOptionInDatabase('convertkit-review-request');
-        $I->dontSeeOptionInDatabase('convertkit-review-dismissed');
-    }
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-    /**
-     * Test that the review request is set in the options table when a
-     * WordPress Page is created and saved with a Form specified in
-     * the ConvertKit Meta Box.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testReviewRequestOnSavePageWithFormSpecified(AcceptanceTester $I)
-    {
-        // Setup ConvertKit Plugin.
-        $I->setupConvertKitPlugin($I);
+		// Check that the options table doesn't have a review request set.
+		$I->dontSeeOptionInDatabase( 'convertkit-review-request' );
+		$I->dontSeeOptionInDatabase( 'convertkit-review-dismissed' );
+	}
 
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Test Review Request on Save with Form Specified');
+	/**
+	 * Test that the review request is set in the options table when a
+	 * WordPress Page is created and saved with a Form specified in
+	 * the ConvertKit Meta Box.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testReviewRequestOnSavePageWithFormSpecified( AcceptanceTester $I ) {
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin( $I );
 
-        // Configure metabox's Form setting = Default.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-            ]
-        );
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Test Review Request on Save with Form Specified' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
+		// Configure metabox's Form setting = Default.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'form' => array( 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
+			)
+		);
 
-        // Navigate to a screen in the WordPress Administration.
-        $I->amOnAdminPage('index.php');
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
 
-        // Check that the options table does have a review request set.
-        $I->seeOptionInDatabase('convertkit-review-request');
+		// Navigate to a screen in the WordPress Administration.
+		$I->amOnAdminPage( 'index.php' );
 
-        // Check that the option table does not yet have a review dismissed set.
-        $I->dontSeeOptionInDatabase('convertkit-review-dismissed');
-    }
+		// Check that the options table does have a review request set.
+		$I->seeOptionInDatabase( 'convertkit-review-request' );
 
-    /**
-     * Test that the review request is set in the options table when a
-     * WordPress Page is created and saved with a Landing Page specified in
-     * the ConvertKit Meta Box.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testReviewRequestOnSavePageWithLandingPageSpecified(AcceptanceTester $I)
-    {
-        // Setup ConvertKit Plugin.
-        $I->setupConvertKitPlugin($I);
+		// Check that the option table does not yet have a review dismissed set.
+		$I->dontSeeOptionInDatabase( 'convertkit-review-dismissed' );
+	}
 
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Test Review Request on Save with Form Specified');
+	/**
+	 * Test that the review request is set in the options table when a
+	 * WordPress Page is created and saved with a Landing Page specified in
+	 * the ConvertKit Meta Box.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testReviewRequestOnSavePageWithLandingPageSpecified( AcceptanceTester $I ) {
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin( $I );
 
-        // Configure metabox's Form setting = Default.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME'] ],
-            ]
-        );
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Test Review Request on Save with Form Specified' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
+		// Configure metabox's Form setting = Default.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'landing_page' => array( 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME'] ),
+			)
+		);
 
-        // Navigate to a screen in the WordPress Administration.
-        $I->amOnAdminPage('index.php');
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
 
-        // Check that the options table does have a review request set.
-        $I->seeOptionInDatabase('convertkit-review-request');
+		// Navigate to a screen in the WordPress Administration.
+		$I->amOnAdminPage( 'index.php' );
 
-        // Check that the option table does not yet have a review dismissed set.
-        $I->dontSeeOptionInDatabase('convertkit-review-dismissed');
-    }
+		// Check that the options table does have a review request set.
+		$I->seeOptionInDatabase( 'convertkit-review-request' );
 
-    /**
-     * Test that the review request is displayed when the options table entries
-     * have the required values to display the review request notification.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testReviewRequestNotificationDisplayed(AcceptanceTester $I)
-    {
-        // Set review request option with a timestamp in the past, to emulate
-        // the Plugin having set this a few days ago.
-        $I->haveOptionInDatabase('convertkit-review-request', time() - 3600);
+		// Check that the option table does not yet have a review dismissed set.
+		$I->dontSeeOptionInDatabase( 'convertkit-review-dismissed' );
+	}
 
-        // Navigate to a screen in the WordPress Administration.
-        $I->amOnAdminPage('index.php');
+	/**
+	 * Test that the review request is displayed when the options table entries
+	 * have the required values to display the review request notification.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testReviewRequestNotificationDisplayed( AcceptanceTester $I ) {
+		// Set review request option with a timestamp in the past, to emulate
+		// the Plugin having set this a few days ago.
+		$I->haveOptionInDatabase( 'convertkit-review-request', time() - 3600 );
 
-        // Confirm the review displays.
-        $I->seeElementInDOM('div.review-convertkit');
+		// Navigate to a screen in the WordPress Administration.
+		$I->amOnAdminPage( 'index.php' );
 
-        // Confirm links are correct.
-        $I->seeInSource('<a href="https://wordpress.org/support/plugin/convertkit/reviews/?filter=5#new-post" class="button button-primary" rel="noopener" target="_blank">');
-        $I->seeInSource('<a href="https://convertkit.com/support" class="button" rel="noopener" target="_blank">');
-    }
+		// Confirm the review displays.
+		$I->seeElementInDOM( 'div.review-convertkit' );
 
-    /**
-     * Test that the review request is dismissed and does not reappear
-     * on a subsequent page load.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testReviewRequestNotificationDismissed(AcceptanceTester $I)
-    {
-        // Set review request option with a timestamp in the past, to emulate
-        // the Plugin having set this a few days ago.
-        $I->haveOptionInDatabase('convertkit-review-request', time() - 3600);
+		// Confirm links are correct.
+		$I->seeInSource( '<a href="https://wordpress.org/support/plugin/convertkit/reviews/?filter=5#new-post" class="button button-primary" rel="noopener" target="_blank">' );
+		$I->seeInSource( '<a href="https://convertkit.com/support" class="button" rel="noopener" target="_blank">' );
+	}
 
-        // Navigate to a screen in the WordPress Administration.
-        $I->amOnAdminPage('index.php');
+	/**
+	 * Test that the review request is dismissed and does not reappear
+	 * on a subsequent page load.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testReviewRequestNotificationDismissed( AcceptanceTester $I ) {
+		// Set review request option with a timestamp in the past, to emulate
+		// the Plugin having set this a few days ago.
+		$I->haveOptionInDatabase( 'convertkit-review-request', time() - 3600 );
 
-        // Confirm the review displays.
-        $I->seeElementInDOM('div.review-convertkit');
+		// Navigate to a screen in the WordPress Administration.
+		$I->amOnAdminPage( 'index.php' );
 
-        // Dismiss the review request.
-        $I->click('div.review-convertkit button.notice-dismiss');
+		// Confirm the review displays.
+		$I->seeElementInDOM( 'div.review-convertkit' );
 
-        // Navigate to a screen in the WordPress Administration.
-        $I->amOnAdminPage('index.php');
+		// Dismiss the review request.
+		$I->click( 'div.review-convertkit button.notice-dismiss' );
 
-        // Confirm the review notification no longer displays.
-        $I->dontSeeElementInDOM('div.review-convertkit');
-    }
+		// Navigate to a screen in the WordPress Administration.
+		$I->amOnAdminPage( 'index.php' );
 
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+		// Confirm the review notification no longer displays.
+		$I->dontSeeElementInDOM( 'div.review-convertkit' );
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/general/ReviewRequestCest.php
+++ b/tests/acceptance/general/ReviewRequestCest.php
@@ -1,17 +1,17 @@
 <?php
 /**
  * Tests the ConvertKit Review Notification.
- * 
- * @since 	1.9.6
+ *
+ * @since   1.9.6
  */
 class ReviewRequestCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -21,10 +21,10 @@ class ReviewRequestCest
 	/**
 	 * Test that the review request is set in the options table when the Plugin's
 	 * Settings are saved with a Default Page Form specified in the Settings.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testReviewRequestOnSaveSettings(AcceptanceTester $I)
 	{
@@ -44,10 +44,10 @@ class ReviewRequestCest
 	/**
 	 * Test that no review request is set in the options table when the Plugin's
 	 * Settings are saved with no Forms specified in the Settings.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testReviewRequestOnSaveBlankSettings(AcceptanceTester $I)
 	{
@@ -69,10 +69,10 @@ class ReviewRequestCest
 	 * Test that the review request is set in the options table when a
 	 * WordPress Page is created and saved with a Form specified in
 	 * the ConvertKit Meta Box.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testReviewRequestOnSavePageWithFormSpecified(AcceptanceTester $I)
 	{
@@ -83,9 +83,13 @@ class ReviewRequestCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Test Review Request on Save with Form Specified');
 
 		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+			]
+		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -104,10 +108,10 @@ class ReviewRequestCest
 	 * Test that the review request is set in the options table when a
 	 * WordPress Page is created and saved with a Landing Page specified in
 	 * the ConvertKit Meta Box.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testReviewRequestOnSavePageWithLandingPageSpecified(AcceptanceTester $I)
 	{
@@ -118,9 +122,13 @@ class ReviewRequestCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Test Review Request on Save with Form Specified');
 
 		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME'] ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME'] ],
+			]
+		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -138,10 +146,10 @@ class ReviewRequestCest
 	/**
 	 * Test that the review request is displayed when the options table entries
 	 * have the required values to display the review request notification.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testReviewRequestNotificationDisplayed(AcceptanceTester $I)
 	{
@@ -163,10 +171,10 @@ class ReviewRequestCest
 	/**
 	 * Test that the review request is dismissed and does not reappear
 	 * on a subsequent page load.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testReviewRequestNotificationDismissed(AcceptanceTester $I)
 	{
@@ -194,10 +202,10 @@ class ReviewRequestCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/general/ReviewRequestCest.php
+++ b/tests/acceptance/general/ReviewRequestCest.php
@@ -1,207 +1,207 @@
 <?php
 /**
  * Tests the ConvertKit Review Notification.
- *
- * @since 1.9.6
+ * 
+ * @since 	1.9.6
  */
-class ReviewRequestCest {
-
+class ReviewRequestCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
-		$I->activateConvertKitPlugin( $I );
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
 	}
 
 	/**
 	 * Test that the review request is set in the options table when the Plugin's
 	 * Settings are saved with a Default Page Form specified in the Settings.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testReviewRequestOnSaveSettings( AcceptanceTester $I ) {
+	public function testReviewRequestOnSaveSettings(AcceptanceTester $I)
+	{
 		// Setup ConvertKit Plugin.
-		$I->setupConvertKitPlugin( $I );
+		$I->setupConvertKitPlugin($I);
 
 		// Define Default Form.
-		$I->setupConvertKitPluginDefaultForm( $I );
+		$I->setupConvertKitPluginDefaultForm($I);
 
 		// Check that the options table does have a review request set.
-		$I->seeOptionInDatabase( 'convertkit-review-request' );
+		$I->seeOptionInDatabase('convertkit-review-request');
 
 		// Check that the option table does not yet have a review dismissed set.
-		$I->dontSeeOptionInDatabase( 'convertkit-review-dismissed' );
+		$I->dontSeeOptionInDatabase('convertkit-review-dismissed');
 	}
 
 	/**
 	 * Test that no review request is set in the options table when the Plugin's
 	 * Settings are saved with no Forms specified in the Settings.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testReviewRequestOnSaveBlankSettings( AcceptanceTester $I ) {
+	public function testReviewRequestOnSaveBlankSettings(AcceptanceTester $I)
+	{
 		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen( $I );
+		$I->loadConvertKitSettingsGeneralScreen($I);
 
 		// Click the Save Changes button.
-		$I->click( 'Save Changes' );
+		$I->click('Save Changes');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check that the options table doesn't have a review request set.
-		$I->dontSeeOptionInDatabase( 'convertkit-review-request' );
-		$I->dontSeeOptionInDatabase( 'convertkit-review-dismissed' );
+		$I->dontSeeOptionInDatabase('convertkit-review-request');
+		$I->dontSeeOptionInDatabase('convertkit-review-dismissed');
 	}
 
 	/**
 	 * Test that the review request is set in the options table when a
 	 * WordPress Page is created and saved with a Form specified in
 	 * the ConvertKit Meta Box.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testReviewRequestOnSavePageWithFormSpecified( AcceptanceTester $I ) {
+	public function testReviewRequestOnSavePageWithFormSpecified(AcceptanceTester $I)
+	{
 		// Setup ConvertKit Plugin.
-		$I->setupConvertKitPlugin( $I );
+		$I->setupConvertKitPlugin($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Test Review Request on Save with Form Specified' );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Test Review Request on Save with Form Specified');
 
 		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'form' => array( 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+		]);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Navigate to a screen in the WordPress Administration.
-		$I->amOnAdminPage( 'index.php' );
+		$I->amOnAdminPage('index.php');
 
 		// Check that the options table does have a review request set.
-		$I->seeOptionInDatabase( 'convertkit-review-request' );
+		$I->seeOptionInDatabase('convertkit-review-request');
 
 		// Check that the option table does not yet have a review dismissed set.
-		$I->dontSeeOptionInDatabase( 'convertkit-review-dismissed' );
+		$I->dontSeeOptionInDatabase('convertkit-review-dismissed');
 	}
 
 	/**
 	 * Test that the review request is set in the options table when a
 	 * WordPress Page is created and saved with a Landing Page specified in
 	 * the ConvertKit Meta Box.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testReviewRequestOnSavePageWithLandingPageSpecified( AcceptanceTester $I ) {
+	public function testReviewRequestOnSavePageWithLandingPageSpecified(AcceptanceTester $I)
+	{
 		// Setup ConvertKit Plugin.
-		$I->setupConvertKitPlugin( $I );
+		$I->setupConvertKitPlugin($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Test Review Request on Save with Form Specified' );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Test Review Request on Save with Form Specified');
 
 		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'landing_page' => array( 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME'] ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME'] ],
+		]);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Navigate to a screen in the WordPress Administration.
-		$I->amOnAdminPage( 'index.php' );
+		$I->amOnAdminPage('index.php');
 
 		// Check that the options table does have a review request set.
-		$I->seeOptionInDatabase( 'convertkit-review-request' );
+		$I->seeOptionInDatabase('convertkit-review-request');
 
 		// Check that the option table does not yet have a review dismissed set.
-		$I->dontSeeOptionInDatabase( 'convertkit-review-dismissed' );
+		$I->dontSeeOptionInDatabase('convertkit-review-dismissed');
 	}
 
 	/**
 	 * Test that the review request is displayed when the options table entries
 	 * have the required values to display the review request notification.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testReviewRequestNotificationDisplayed( AcceptanceTester $I ) {
+	public function testReviewRequestNotificationDisplayed(AcceptanceTester $I)
+	{
 		// Set review request option with a timestamp in the past, to emulate
 		// the Plugin having set this a few days ago.
-		$I->haveOptionInDatabase( 'convertkit-review-request', time() - 3600 );
+		$I->haveOptionInDatabase('convertkit-review-request', time() - 3600 );
 
 		// Navigate to a screen in the WordPress Administration.
-		$I->amOnAdminPage( 'index.php' );
+		$I->amOnAdminPage('index.php');
 
 		// Confirm the review displays.
-		$I->seeElementInDOM( 'div.review-convertkit' );
+		$I->seeElementInDOM('div.review-convertkit');
 
 		// Confirm links are correct.
-		$I->seeInSource( '<a href="https://wordpress.org/support/plugin/convertkit/reviews/?filter=5#new-post" class="button button-primary" rel="noopener" target="_blank">' );
-		$I->seeInSource( '<a href="https://convertkit.com/support" class="button" rel="noopener" target="_blank">' );
+		$I->seeInSource('<a href="https://wordpress.org/support/plugin/convertkit/reviews/?filter=5#new-post" class="button button-primary" rel="noopener" target="_blank">');
+		$I->seeInSource('<a href="https://convertkit.com/support" class="button" rel="noopener" target="_blank">');
 	}
 
 	/**
 	 * Test that the review request is dismissed and does not reappear
 	 * on a subsequent page load.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testReviewRequestNotificationDismissed( AcceptanceTester $I ) {
+	public function testReviewRequestNotificationDismissed(AcceptanceTester $I)
+	{
 		// Set review request option with a timestamp in the past, to emulate
 		// the Plugin having set this a few days ago.
-		$I->haveOptionInDatabase( 'convertkit-review-request', time() - 3600 );
+		$I->haveOptionInDatabase('convertkit-review-request', time() - 3600 );
 
 		// Navigate to a screen in the WordPress Administration.
-		$I->amOnAdminPage( 'index.php' );
+		$I->amOnAdminPage('index.php');
 
 		// Confirm the review displays.
-		$I->seeElementInDOM( 'div.review-convertkit' );
+		$I->seeElementInDOM('div.review-convertkit');
 
 		// Dismiss the review request.
-		$I->click( 'div.review-convertkit button.notice-dismiss' );
+		$I->click('div.review-convertkit button.notice-dismiss');
 
 		// Navigate to a screen in the WordPress Administration.
-		$I->amOnAdminPage( 'index.php' );
+		$I->amOnAdminPage('index.php');
 
 		// Confirm the review notification no longer displays.
-		$I->dontSeeElementInDOM( 'div.review-convertkit' );
+		$I->dontSeeElementInDOM('div.review-convertkit');
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/general/ReviewRequestCest.php
+++ b/tests/acceptance/general/ReviewRequestCest.php
@@ -2,206 +2,210 @@
 /**
  * Tests the ConvertKit Review Notification.
  * 
- * @since 	1.9.6
+ * @since 1.9.6
  */
 class ReviewRequestCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		$I->activateConvertKitPlugin($I);
-	}
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        $I->activateConvertKitPlugin($I);
+    }
 
-	/**
-	 * Test that the review request is set in the options table when the Plugin's
-	 * Settings are saved with a Default Page Form specified in the Settings.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testReviewRequestOnSaveSettings(AcceptanceTester $I)
-	{
-		// Setup ConvertKit Plugin.
-		$I->setupConvertKitPlugin($I);
+    /**
+     * Test that the review request is set in the options table when the Plugin's
+     * Settings are saved with a Default Page Form specified in the Settings.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testReviewRequestOnSaveSettings(AcceptanceTester $I)
+    {
+        // Setup ConvertKit Plugin.
+        $I->setupConvertKitPlugin($I);
 
-		// Define Default Form.
-		$I->setupConvertKitPluginDefaultForm($I);
+        // Define Default Form.
+        $I->setupConvertKitPluginDefaultForm($I);
 
-		// Check that the options table does have a review request set.
-		$I->seeOptionInDatabase('convertkit-review-request');
+        // Check that the options table does have a review request set.
+        $I->seeOptionInDatabase('convertkit-review-request');
 
-		// Check that the option table does not yet have a review dismissed set.
-		$I->dontSeeOptionInDatabase('convertkit-review-dismissed');
-	}
+        // Check that the option table does not yet have a review dismissed set.
+        $I->dontSeeOptionInDatabase('convertkit-review-dismissed');
+    }
 
-	/**
-	 * Test that no review request is set in the options table when the Plugin's
-	 * Settings are saved with no Forms specified in the Settings.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testReviewRequestOnSaveBlankSettings(AcceptanceTester $I)
-	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen($I);
+    /**
+     * Test that no review request is set in the options table when the Plugin's
+     * Settings are saved with no Forms specified in the Settings.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testReviewRequestOnSaveBlankSettings(AcceptanceTester $I)
+    {
+        // Go to the Plugin's Settings Screen.
+        $I->loadConvertKitSettingsGeneralScreen($I);
 
-		// Click the Save Changes button.
-		$I->click('Save Changes');
+        // Click the Save Changes button.
+        $I->click('Save Changes');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Check that the options table doesn't have a review request set.
-		$I->dontSeeOptionInDatabase('convertkit-review-request');
-		$I->dontSeeOptionInDatabase('convertkit-review-dismissed');
-	}
+        // Check that the options table doesn't have a review request set.
+        $I->dontSeeOptionInDatabase('convertkit-review-request');
+        $I->dontSeeOptionInDatabase('convertkit-review-dismissed');
+    }
 
-	/**
-	 * Test that the review request is set in the options table when a
-	 * WordPress Page is created and saved with a Form specified in
-	 * the ConvertKit Meta Box.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testReviewRequestOnSavePageWithFormSpecified(AcceptanceTester $I)
-	{
-		// Setup ConvertKit Plugin.
-		$I->setupConvertKitPlugin($I);
+    /**
+     * Test that the review request is set in the options table when a
+     * WordPress Page is created and saved with a Form specified in
+     * the ConvertKit Meta Box.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testReviewRequestOnSavePageWithFormSpecified(AcceptanceTester $I)
+    {
+        // Setup ConvertKit Plugin.
+        $I->setupConvertKitPlugin($I);
 
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Test Review Request on Save with Form Specified');
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Test Review Request on Save with Form Specified');
 
-		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-		]);
+        // Configure metabox's Form setting = Default.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+            ]
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Navigate to a screen in the WordPress Administration.
-		$I->amOnAdminPage('index.php');
+        // Navigate to a screen in the WordPress Administration.
+        $I->amOnAdminPage('index.php');
 
-		// Check that the options table does have a review request set.
-		$I->seeOptionInDatabase('convertkit-review-request');
+        // Check that the options table does have a review request set.
+        $I->seeOptionInDatabase('convertkit-review-request');
 
-		// Check that the option table does not yet have a review dismissed set.
-		$I->dontSeeOptionInDatabase('convertkit-review-dismissed');
-	}
+        // Check that the option table does not yet have a review dismissed set.
+        $I->dontSeeOptionInDatabase('convertkit-review-dismissed');
+    }
 
-	/**
-	 * Test that the review request is set in the options table when a
-	 * WordPress Page is created and saved with a Landing Page specified in
-	 * the ConvertKit Meta Box.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testReviewRequestOnSavePageWithLandingPageSpecified(AcceptanceTester $I)
-	{
-		// Setup ConvertKit Plugin.
-		$I->setupConvertKitPlugin($I);
+    /**
+     * Test that the review request is set in the options table when a
+     * WordPress Page is created and saved with a Landing Page specified in
+     * the ConvertKit Meta Box.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testReviewRequestOnSavePageWithLandingPageSpecified(AcceptanceTester $I)
+    {
+        // Setup ConvertKit Plugin.
+        $I->setupConvertKitPlugin($I);
 
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Test Review Request on Save with Form Specified');
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Test Review Request on Save with Form Specified');
 
-		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME'] ],
-		]);
+        // Configure metabox's Form setting = Default.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME'] ],
+            ]
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Navigate to a screen in the WordPress Administration.
-		$I->amOnAdminPage('index.php');
+        // Navigate to a screen in the WordPress Administration.
+        $I->amOnAdminPage('index.php');
 
-		// Check that the options table does have a review request set.
-		$I->seeOptionInDatabase('convertkit-review-request');
+        // Check that the options table does have a review request set.
+        $I->seeOptionInDatabase('convertkit-review-request');
 
-		// Check that the option table does not yet have a review dismissed set.
-		$I->dontSeeOptionInDatabase('convertkit-review-dismissed');
-	}
+        // Check that the option table does not yet have a review dismissed set.
+        $I->dontSeeOptionInDatabase('convertkit-review-dismissed');
+    }
 
-	/**
-	 * Test that the review request is displayed when the options table entries
-	 * have the required values to display the review request notification.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testReviewRequestNotificationDisplayed(AcceptanceTester $I)
-	{
-		// Set review request option with a timestamp in the past, to emulate
-		// the Plugin having set this a few days ago.
-		$I->haveOptionInDatabase('convertkit-review-request', time() - 3600 );
+    /**
+     * Test that the review request is displayed when the options table entries
+     * have the required values to display the review request notification.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testReviewRequestNotificationDisplayed(AcceptanceTester $I)
+    {
+        // Set review request option with a timestamp in the past, to emulate
+        // the Plugin having set this a few days ago.
+        $I->haveOptionInDatabase('convertkit-review-request', time() - 3600);
 
-		// Navigate to a screen in the WordPress Administration.
-		$I->amOnAdminPage('index.php');
+        // Navigate to a screen in the WordPress Administration.
+        $I->amOnAdminPage('index.php');
 
-		// Confirm the review displays.
-		$I->seeElementInDOM('div.review-convertkit');
+        // Confirm the review displays.
+        $I->seeElementInDOM('div.review-convertkit');
 
-		// Confirm links are correct.
-		$I->seeInSource('<a href="https://wordpress.org/support/plugin/convertkit/reviews/?filter=5#new-post" class="button button-primary" rel="noopener" target="_blank">');
-		$I->seeInSource('<a href="https://convertkit.com/support" class="button" rel="noopener" target="_blank">');
-	}
+        // Confirm links are correct.
+        $I->seeInSource('<a href="https://wordpress.org/support/plugin/convertkit/reviews/?filter=5#new-post" class="button button-primary" rel="noopener" target="_blank">');
+        $I->seeInSource('<a href="https://convertkit.com/support" class="button" rel="noopener" target="_blank">');
+    }
 
-	/**
-	 * Test that the review request is dismissed and does not reappear
-	 * on a subsequent page load.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testReviewRequestNotificationDismissed(AcceptanceTester $I)
-	{
-		// Set review request option with a timestamp in the past, to emulate
-		// the Plugin having set this a few days ago.
-		$I->haveOptionInDatabase('convertkit-review-request', time() - 3600 );
+    /**
+     * Test that the review request is dismissed and does not reappear
+     * on a subsequent page load.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testReviewRequestNotificationDismissed(AcceptanceTester $I)
+    {
+        // Set review request option with a timestamp in the past, to emulate
+        // the Plugin having set this a few days ago.
+        $I->haveOptionInDatabase('convertkit-review-request', time() - 3600);
 
-		// Navigate to a screen in the WordPress Administration.
-		$I->amOnAdminPage('index.php');
+        // Navigate to a screen in the WordPress Administration.
+        $I->amOnAdminPage('index.php');
 
-		// Confirm the review displays.
-		$I->seeElementInDOM('div.review-convertkit');
+        // Confirm the review displays.
+        $I->seeElementInDOM('div.review-convertkit');
 
-		// Dismiss the review request.
-		$I->click('div.review-convertkit button.notice-dismiss');
+        // Dismiss the review request.
+        $I->click('div.review-convertkit button.notice-dismiss');
 
-		// Navigate to a screen in the WordPress Administration.
-		$I->amOnAdminPage('index.php');
+        // Navigate to a screen in the WordPress Administration.
+        $I->amOnAdminPage('index.php');
 
-		// Confirm the review notification no longer displays.
-		$I->dontSeeElementInDOM('div.review-convertkit');
-	}
+        // Confirm the review notification no longer displays.
+        $I->dontSeeElementInDOM('div.review-convertkit');
+    }
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/general/SubscriberEmailToIDOnFormSubmitCest.php
+++ b/tests/acceptance/general/SubscriberEmailToIDOnFormSubmitCest.php
@@ -2,17 +2,17 @@
 /**
  * Tests that an API request is, or is not, made to the subscribers endpoint
  * when a ConvertKit Form is submitted.
- * 
- * @since 	1.9.6.7
+ *
+ * @since   1.9.6.7
  */
 class SubscriberEmailToIDOnFormSubmitCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -28,18 +28,20 @@ class SubscriberEmailToIDOnFormSubmitCest
 	/**
 	 * Test that no API call to the subscribers endpoint is made to fetch a subscriber ID
 	 * by email address when a ConvertKit Form is submitted with no email address.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testWhenFormSubmittedWithNoEmailAddress(AcceptanceTester $I)
 	{
 		// Create Page with Shortcode.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-subscriber-email-to-id-no-email',
-			'post_content'	=> 'No Email',
-		]);
+		$I->havePageInDatabase(
+			[
+				'post_name'    => 'convertkit-subscriber-email-to-id-no-email',
+				'post_content' => 'No Email',
+			]
+		);
 
 		// Load the Page on the frontend site.
 		$I->amOnPage('/convertkit-subscriber-email-to-id-no-email');
@@ -61,18 +63,20 @@ class SubscriberEmailToIDOnFormSubmitCest
 	/**
 	 * Test that no API call to the subscribers endpoint is made to fetch a subscriber ID
 	 * by email address when a ConvertKit Form is submitted with an invalid email address format.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testWhenFormSubmittedWithInvalidEmailAddress(AcceptanceTester $I)
 	{
 		// Create Page with Shortcode.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-subscriber-email-to-id-invalid-email',
-			'post_content'	=> 'Invalid Email',
-		]);
+		$I->havePageInDatabase(
+			[
+				'post_name'    => 'convertkit-subscriber-email-to-id-invalid-email',
+				'post_content' => 'Invalid Email',
+			]
+		);
 
 		// Load the Page on the frontend site.
 		$I->amOnPage('/convertkit-subscriber-email-to-id-invalid-email');
@@ -92,24 +96,26 @@ class SubscriberEmailToIDOnFormSubmitCest
 
 		// Check log does not contain get_subscriber_by_email() call with no email value.
 		$I->loadConvertKitSettingsToolsScreen($I);
-		$I->dontSeeInSource('API: get_subscriber_by_email(): [ email: '.$emailAddress.']');
+		$I->dontSeeInSource('API: get_subscriber_by_email(): [ email: ' . $emailAddress . ']');
 	}
 
 	/**
 	 * Test that an API call to the subscribers endpoint is made to fetch a subscriber ID
 	 * by email address when a ConvertKit Form is submitted with a valid email address format.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testWhenFormSubmittedWithValidEmailAddress(AcceptanceTester $I)
 	{
 		// Create Page with Shortcode.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-subscriber-email-to-id-valid-email',
-			'post_content'	=> 'Valid Email',
-		]);
+		$I->havePageInDatabase(
+			[
+				'post_name'    => 'convertkit-subscriber-email-to-id-valid-email',
+				'post_content' => 'Valid Email',
+			]
+		);
 
 		// Load the Page on the frontend site.
 		$I->amOnPage('/convertkit-subscriber-email-to-id-valid-email');
@@ -129,17 +135,17 @@ class SubscriberEmailToIDOnFormSubmitCest
 
 		// Check log does not contain get_subscriber_by_email() call with no email value.
 		$I->loadConvertKitSettingsToolsScreen($I);
-		$I->seeInSource('API: get_subscriber_by_email(): [ email: '.$emailAddress.']');
+		$I->seeInSource('API: get_subscriber_by_email(): [ email: ' . $emailAddress . ']');
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/general/SubscriberEmailToIDOnFormSubmitCest.php
+++ b/tests/acceptance/general/SubscriberEmailToIDOnFormSubmitCest.php
@@ -2,149 +2,148 @@
 /**
  * Tests that an API request is, or is not, made to the subscribers endpoint
  * when a ConvertKit Form is submitted.
- *
- * @since 1.9.6.7
+ * 
+ * @since 	1.9.6.7
  */
-class SubscriberEmailToIDOnFormSubmitCest {
-
+class SubscriberEmailToIDOnFormSubmitCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
-		$I->activateConvertKitPlugin( $I );
-		$I->setupConvertKitPlugin( $I );
-		$I->setupConvertKitPluginDefaultForm( $I );
-		$I->enableDebugLog( $I );
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginDefaultForm($I);
+		$I->enableDebugLog($I);
 
 		// Clear Log, so that entries from previous tests aren't included in this test.
-		$I->clearDebugLog( $I );
+		$I->clearDebugLog($I);
 	}
 
 	/**
 	 * Test that no API call to the subscribers endpoint is made to fetch a subscriber ID
 	 * by email address when a ConvertKit Form is submitted with no email address.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testWhenFormSubmittedWithNoEmailAddress( AcceptanceTester $I ) {
+	public function testWhenFormSubmittedWithNoEmailAddress(AcceptanceTester $I)
+	{
 		// Create Page with Shortcode.
-		$I->havePageInDatabase(
-			array(
-				'post_name'    => 'convertkit-subscriber-email-to-id-no-email',
-				'post_content' => 'No Email',
-			)
-		);
+		$I->havePageInDatabase([
+			'post_name' 	=> 'convertkit-subscriber-email-to-id-no-email',
+			'post_content'	=> 'No Email',
+		]);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage( '/convertkit-subscriber-email-to-id-no-email' );
+		$I->amOnPage('/convertkit-subscriber-email-to-id-no-email');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Submit Form.
-		$I->click( '.formkit-submit' );
+		$I->click('.formkit-submit');
 
 		// Wait for JS to complete.
-		$I->wait( 2 );
+		$I->wait(2);
 
 		// Check log does not contain get_subscriber_by_email() call with no email value.
-		$I->loadConvertKitSettingsToolsScreen( $I );
-		$I->dontSeeInSource( 'API: get_subscriber_by_email(): [ email: ]' );
+		$I->loadConvertKitSettingsToolsScreen($I);
+		$I->dontSeeInSource('API: get_subscriber_by_email(): [ email: ]');
 	}
 
 	/**
 	 * Test that no API call to the subscribers endpoint is made to fetch a subscriber ID
 	 * by email address when a ConvertKit Form is submitted with an invalid email address format.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testWhenFormSubmittedWithInvalidEmailAddress( AcceptanceTester $I ) {
+	public function testWhenFormSubmittedWithInvalidEmailAddress(AcceptanceTester $I)
+	{
 		// Create Page with Shortcode.
-		$I->havePageInDatabase(
-			array(
-				'post_name'    => 'convertkit-subscriber-email-to-id-invalid-email',
-				'post_content' => 'Invalid Email',
-			)
-		);
+		$I->havePageInDatabase([
+			'post_name' 	=> 'convertkit-subscriber-email-to-id-invalid-email',
+			'post_content'	=> 'Invalid Email',
+		]);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage( '/convertkit-subscriber-email-to-id-invalid-email' );
+		$I->amOnPage('/convertkit-subscriber-email-to-id-invalid-email');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Generate email address for this test.
 		$emailAddress = 'invalid-email';
 
 		// Submit Form.
-		$I->fillField( 'email_address', $emailAddress );
-		$I->click( '.formkit-submit' );
+		$I->fillField('email_address', $emailAddress);
+		$I->click('.formkit-submit');
 
 		// Wait for JS to complete.
-		$I->wait( 2 );
+		$I->wait(2);
 
 		// Check log does not contain get_subscriber_by_email() call with no email value.
-		$I->loadConvertKitSettingsToolsScreen( $I );
-		$I->dontSeeInSource( 'API: get_subscriber_by_email(): [ email: ' . $emailAddress . ']' );
+		$I->loadConvertKitSettingsToolsScreen($I);
+		$I->dontSeeInSource('API: get_subscriber_by_email(): [ email: '.$emailAddress.']');
 	}
 
 	/**
 	 * Test that an API call to the subscribers endpoint is made to fetch a subscriber ID
 	 * by email address when a ConvertKit Form is submitted with a valid email address format.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testWhenFormSubmittedWithValidEmailAddress( AcceptanceTester $I ) {
+	public function testWhenFormSubmittedWithValidEmailAddress(AcceptanceTester $I)
+	{
 		// Create Page with Shortcode.
-		$I->havePageInDatabase(
-			array(
-				'post_name'    => 'convertkit-subscriber-email-to-id-valid-email',
-				'post_content' => 'Valid Email',
-			)
-		);
+		$I->havePageInDatabase([
+			'post_name' 	=> 'convertkit-subscriber-email-to-id-valid-email',
+			'post_content'	=> 'Valid Email',
+		]);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage( '/convertkit-subscriber-email-to-id-valid-email' );
+		$I->amOnPage('/convertkit-subscriber-email-to-id-valid-email');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Generate email address for this test.
 		$emailAddress = $I->generateEmailAddress();
 
 		// Submit Form.
-		$I->fillField( 'email_address', $emailAddress );
-		$I->click( '.formkit-submit' );
+		$I->fillField('email_address', $emailAddress);
+		$I->click('.formkit-submit');
 
 		// Wait for JS and AJAX request to complete.
-		$I->wait( 5 );
+		$I->wait(5);
 
 		// Check log does not contain get_subscriber_by_email() call with no email value.
-		$I->loadConvertKitSettingsToolsScreen( $I );
-		$I->seeInSource( 'API: get_subscriber_by_email(): [ email: ' . $emailAddress . ']' );
+		$I->loadConvertKitSettingsToolsScreen($I);
+		$I->seeInSource('API: get_subscriber_by_email(): [ email: '.$emailAddress.']');
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/general/SubscriberEmailToIDOnFormSubmitCest.php
+++ b/tests/acceptance/general/SubscriberEmailToIDOnFormSubmitCest.php
@@ -3,147 +3,153 @@
  * Tests that an API request is, or is not, made to the subscribers endpoint
  * when a ConvertKit Form is submitted.
  * 
- * @since 	1.9.6.7
+ * @since 1.9.6.7
  */
 class SubscriberEmailToIDOnFormSubmitCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
-		$I->setupConvertKitPluginDefaultForm($I);
-		$I->enableDebugLog($I);
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        $I->activateConvertKitPlugin($I);
+        $I->setupConvertKitPlugin($I);
+        $I->setupConvertKitPluginDefaultForm($I);
+        $I->enableDebugLog($I);
 
-		// Clear Log, so that entries from previous tests aren't included in this test.
-		$I->clearDebugLog($I);
-	}
+        // Clear Log, so that entries from previous tests aren't included in this test.
+        $I->clearDebugLog($I);
+    }
 
-	/**
-	 * Test that no API call to the subscribers endpoint is made to fetch a subscriber ID
-	 * by email address when a ConvertKit Form is submitted with no email address.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testWhenFormSubmittedWithNoEmailAddress(AcceptanceTester $I)
-	{
-		// Create Page with Shortcode.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-subscriber-email-to-id-no-email',
-			'post_content'	=> 'No Email',
-		]);
+    /**
+     * Test that no API call to the subscribers endpoint is made to fetch a subscriber ID
+     * by email address when a ConvertKit Form is submitted with no email address.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testWhenFormSubmittedWithNoEmailAddress(AcceptanceTester $I)
+    {
+        // Create Page with Shortcode.
+        $I->havePageInDatabase(
+            [
+            'post_name'     => 'convertkit-subscriber-email-to-id-no-email',
+            'post_content'    => 'No Email',
+            ]
+        );
 
-		// Load the Page on the frontend site.
-		$I->amOnPage('/convertkit-subscriber-email-to-id-no-email');
+        // Load the Page on the frontend site.
+        $I->amOnPage('/convertkit-subscriber-email-to-id-no-email');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Submit Form.
-		$I->click('.formkit-submit');
+        // Submit Form.
+        $I->click('.formkit-submit');
 
-		// Wait for JS to complete.
-		$I->wait(2);
+        // Wait for JS to complete.
+        $I->wait(2);
 
-		// Check log does not contain get_subscriber_by_email() call with no email value.
-		$I->loadConvertKitSettingsToolsScreen($I);
-		$I->dontSeeInSource('API: get_subscriber_by_email(): [ email: ]');
-	}
+        // Check log does not contain get_subscriber_by_email() call with no email value.
+        $I->loadConvertKitSettingsToolsScreen($I);
+        $I->dontSeeInSource('API: get_subscriber_by_email(): [ email: ]');
+    }
 
-	/**
-	 * Test that no API call to the subscribers endpoint is made to fetch a subscriber ID
-	 * by email address when a ConvertKit Form is submitted with an invalid email address format.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testWhenFormSubmittedWithInvalidEmailAddress(AcceptanceTester $I)
-	{
-		// Create Page with Shortcode.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-subscriber-email-to-id-invalid-email',
-			'post_content'	=> 'Invalid Email',
-		]);
+    /**
+     * Test that no API call to the subscribers endpoint is made to fetch a subscriber ID
+     * by email address when a ConvertKit Form is submitted with an invalid email address format.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testWhenFormSubmittedWithInvalidEmailAddress(AcceptanceTester $I)
+    {
+        // Create Page with Shortcode.
+        $I->havePageInDatabase(
+            [
+            'post_name'     => 'convertkit-subscriber-email-to-id-invalid-email',
+            'post_content'    => 'Invalid Email',
+            ]
+        );
 
-		// Load the Page on the frontend site.
-		$I->amOnPage('/convertkit-subscriber-email-to-id-invalid-email');
+        // Load the Page on the frontend site.
+        $I->amOnPage('/convertkit-subscriber-email-to-id-invalid-email');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Generate email address for this test.
-		$emailAddress = 'invalid-email';
+        // Generate email address for this test.
+        $emailAddress = 'invalid-email';
 
-		// Submit Form.
-		$I->fillField('email_address', $emailAddress);
-		$I->click('.formkit-submit');
+        // Submit Form.
+        $I->fillField('email_address', $emailAddress);
+        $I->click('.formkit-submit');
 
-		// Wait for JS to complete.
-		$I->wait(2);
+        // Wait for JS to complete.
+        $I->wait(2);
 
-		// Check log does not contain get_subscriber_by_email() call with no email value.
-		$I->loadConvertKitSettingsToolsScreen($I);
-		$I->dontSeeInSource('API: get_subscriber_by_email(): [ email: '.$emailAddress.']');
-	}
+        // Check log does not contain get_subscriber_by_email() call with no email value.
+        $I->loadConvertKitSettingsToolsScreen($I);
+        $I->dontSeeInSource('API: get_subscriber_by_email(): [ email: '.$emailAddress.']');
+    }
 
-	/**
-	 * Test that an API call to the subscribers endpoint is made to fetch a subscriber ID
-	 * by email address when a ConvertKit Form is submitted with a valid email address format.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testWhenFormSubmittedWithValidEmailAddress(AcceptanceTester $I)
-	{
-		// Create Page with Shortcode.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-subscriber-email-to-id-valid-email',
-			'post_content'	=> 'Valid Email',
-		]);
+    /**
+     * Test that an API call to the subscribers endpoint is made to fetch a subscriber ID
+     * by email address when a ConvertKit Form is submitted with a valid email address format.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testWhenFormSubmittedWithValidEmailAddress(AcceptanceTester $I)
+    {
+        // Create Page with Shortcode.
+        $I->havePageInDatabase(
+            [
+            'post_name'     => 'convertkit-subscriber-email-to-id-valid-email',
+            'post_content'    => 'Valid Email',
+            ]
+        );
 
-		// Load the Page on the frontend site.
-		$I->amOnPage('/convertkit-subscriber-email-to-id-valid-email');
+        // Load the Page on the frontend site.
+        $I->amOnPage('/convertkit-subscriber-email-to-id-valid-email');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Generate email address for this test.
-		$emailAddress = $I->generateEmailAddress();
+        // Generate email address for this test.
+        $emailAddress = $I->generateEmailAddress();
 
-		// Submit Form.
-		$I->fillField('email_address', $emailAddress);
-		$I->click('.formkit-submit');
+        // Submit Form.
+        $I->fillField('email_address', $emailAddress);
+        $I->click('.formkit-submit');
 
-		// Wait for JS and AJAX request to complete.
-		$I->wait(5);
+        // Wait for JS and AJAX request to complete.
+        $I->wait(5);
 
-		// Check log does not contain get_subscriber_by_email() call with no email value.
-		$I->loadConvertKitSettingsToolsScreen($I);
-		$I->seeInSource('API: get_subscriber_by_email(): [ email: '.$emailAddress.']');
-	}
+        // Check log does not contain get_subscriber_by_email() call with no email value.
+        $I->loadConvertKitSettingsToolsScreen($I);
+        $I->seeInSource('API: get_subscriber_by_email(): [ email: '.$emailAddress.']');
+    }
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/general/SubscriberEmailToIDOnFormSubmitCest.php
+++ b/tests/acceptance/general/SubscriberEmailToIDOnFormSubmitCest.php
@@ -2,154 +2,149 @@
 /**
  * Tests that an API request is, or is not, made to the subscribers endpoint
  * when a ConvertKit Form is submitted.
- * 
+ *
  * @since 1.9.6.7
  */
-class SubscriberEmailToIDOnFormSubmitCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        $I->activateConvertKitPlugin($I);
-        $I->setupConvertKitPlugin($I);
-        $I->setupConvertKitPluginDefaultForm($I);
-        $I->enableDebugLog($I);
+class SubscriberEmailToIDOnFormSubmitCest {
 
-        // Clear Log, so that entries from previous tests aren't included in this test.
-        $I->clearDebugLog($I);
-    }
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		$I->activateConvertKitPlugin( $I );
+		$I->setupConvertKitPlugin( $I );
+		$I->setupConvertKitPluginDefaultForm( $I );
+		$I->enableDebugLog( $I );
 
-    /**
-     * Test that no API call to the subscribers endpoint is made to fetch a subscriber ID
-     * by email address when a ConvertKit Form is submitted with no email address.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testWhenFormSubmittedWithNoEmailAddress(AcceptanceTester $I)
-    {
-        // Create Page with Shortcode.
-        $I->havePageInDatabase(
-            [
-            'post_name'     => 'convertkit-subscriber-email-to-id-no-email',
-            'post_content'    => 'No Email',
-            ]
-        );
+		// Clear Log, so that entries from previous tests aren't included in this test.
+		$I->clearDebugLog( $I );
+	}
 
-        // Load the Page on the frontend site.
-        $I->amOnPage('/convertkit-subscriber-email-to-id-no-email');
+	/**
+	 * Test that no API call to the subscribers endpoint is made to fetch a subscriber ID
+	 * by email address when a ConvertKit Form is submitted with no email address.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testWhenFormSubmittedWithNoEmailAddress( AcceptanceTester $I ) {
+		// Create Page with Shortcode.
+		$I->havePageInDatabase(
+			array(
+				'post_name'    => 'convertkit-subscriber-email-to-id-no-email',
+				'post_content' => 'No Email',
+			)
+		);
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Load the Page on the frontend site.
+		$I->amOnPage( '/convertkit-subscriber-email-to-id-no-email' );
 
-        // Submit Form.
-        $I->click('.formkit-submit');
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-        // Wait for JS to complete.
-        $I->wait(2);
+		// Submit Form.
+		$I->click( '.formkit-submit' );
 
-        // Check log does not contain get_subscriber_by_email() call with no email value.
-        $I->loadConvertKitSettingsToolsScreen($I);
-        $I->dontSeeInSource('API: get_subscriber_by_email(): [ email: ]');
-    }
+		// Wait for JS to complete.
+		$I->wait( 2 );
 
-    /**
-     * Test that no API call to the subscribers endpoint is made to fetch a subscriber ID
-     * by email address when a ConvertKit Form is submitted with an invalid email address format.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testWhenFormSubmittedWithInvalidEmailAddress(AcceptanceTester $I)
-    {
-        // Create Page with Shortcode.
-        $I->havePageInDatabase(
-            [
-            'post_name'     => 'convertkit-subscriber-email-to-id-invalid-email',
-            'post_content'    => 'Invalid Email',
-            ]
-        );
+		// Check log does not contain get_subscriber_by_email() call with no email value.
+		$I->loadConvertKitSettingsToolsScreen( $I );
+		$I->dontSeeInSource( 'API: get_subscriber_by_email(): [ email: ]' );
+	}
 
-        // Load the Page on the frontend site.
-        $I->amOnPage('/convertkit-subscriber-email-to-id-invalid-email');
+	/**
+	 * Test that no API call to the subscribers endpoint is made to fetch a subscriber ID
+	 * by email address when a ConvertKit Form is submitted with an invalid email address format.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testWhenFormSubmittedWithInvalidEmailAddress( AcceptanceTester $I ) {
+		// Create Page with Shortcode.
+		$I->havePageInDatabase(
+			array(
+				'post_name'    => 'convertkit-subscriber-email-to-id-invalid-email',
+				'post_content' => 'Invalid Email',
+			)
+		);
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Load the Page on the frontend site.
+		$I->amOnPage( '/convertkit-subscriber-email-to-id-invalid-email' );
 
-        // Generate email address for this test.
-        $emailAddress = 'invalid-email';
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-        // Submit Form.
-        $I->fillField('email_address', $emailAddress);
-        $I->click('.formkit-submit');
+		// Generate email address for this test.
+		$emailAddress = 'invalid-email';
 
-        // Wait for JS to complete.
-        $I->wait(2);
+		// Submit Form.
+		$I->fillField( 'email_address', $emailAddress );
+		$I->click( '.formkit-submit' );
 
-        // Check log does not contain get_subscriber_by_email() call with no email value.
-        $I->loadConvertKitSettingsToolsScreen($I);
-        $I->dontSeeInSource('API: get_subscriber_by_email(): [ email: '.$emailAddress.']');
-    }
+		// Wait for JS to complete.
+		$I->wait( 2 );
 
-    /**
-     * Test that an API call to the subscribers endpoint is made to fetch a subscriber ID
-     * by email address when a ConvertKit Form is submitted with a valid email address format.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testWhenFormSubmittedWithValidEmailAddress(AcceptanceTester $I)
-    {
-        // Create Page with Shortcode.
-        $I->havePageInDatabase(
-            [
-            'post_name'     => 'convertkit-subscriber-email-to-id-valid-email',
-            'post_content'    => 'Valid Email',
-            ]
-        );
+		// Check log does not contain get_subscriber_by_email() call with no email value.
+		$I->loadConvertKitSettingsToolsScreen( $I );
+		$I->dontSeeInSource( 'API: get_subscriber_by_email(): [ email: ' . $emailAddress . ']' );
+	}
 
-        // Load the Page on the frontend site.
-        $I->amOnPage('/convertkit-subscriber-email-to-id-valid-email');
+	/**
+	 * Test that an API call to the subscribers endpoint is made to fetch a subscriber ID
+	 * by email address when a ConvertKit Form is submitted with a valid email address format.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testWhenFormSubmittedWithValidEmailAddress( AcceptanceTester $I ) {
+		// Create Page with Shortcode.
+		$I->havePageInDatabase(
+			array(
+				'post_name'    => 'convertkit-subscriber-email-to-id-valid-email',
+				'post_content' => 'Valid Email',
+			)
+		);
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Load the Page on the frontend site.
+		$I->amOnPage( '/convertkit-subscriber-email-to-id-valid-email' );
 
-        // Generate email address for this test.
-        $emailAddress = $I->generateEmailAddress();
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-        // Submit Form.
-        $I->fillField('email_address', $emailAddress);
-        $I->click('.formkit-submit');
+		// Generate email address for this test.
+		$emailAddress = $I->generateEmailAddress();
 
-        // Wait for JS and AJAX request to complete.
-        $I->wait(5);
+		// Submit Form.
+		$I->fillField( 'email_address', $emailAddress );
+		$I->click( '.formkit-submit' );
 
-        // Check log does not contain get_subscriber_by_email() call with no email value.
-        $I->loadConvertKitSettingsToolsScreen($I);
-        $I->seeInSource('API: get_subscriber_by_email(): [ email: '.$emailAddress.']');
-    }
+		// Wait for JS and AJAX request to complete.
+		$I->wait( 5 );
 
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+		// Check log does not contain get_subscriber_by_email() call with no email value.
+		$I->loadConvertKitSettingsToolsScreen( $I );
+		$I->seeInSource( 'API: get_subscriber_by_email(): [ email: ' . $emailAddress . ']' );
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/general/UpgradePathsCest.php
+++ b/tests/acceptance/general/UpgradePathsCest.php
@@ -1,21 +1,21 @@
 <?php
 /**
  * Tests edge cases when upgrading between specific ConvertKit Plugin versions.
- * 
- * @since 	1.9.6.4
+ *
+ * @since   1.9.6.4
  */
 class UpgradePathsCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
-		// Activate and Setup ConvertKit plugin
+		// Activate and Setup ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
 		$I->enableDebugLog($I);
@@ -23,28 +23,30 @@ class UpgradePathsCest
 
 	/**
 	 * Check for undefined index errors for a Post when upgrading from 1.4.6 or earlier to 1.4.7 or later.
-	 * 
-	 * @since 	1.9.6.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testUndefinedIndexForPost(AcceptanceTester $I)
 	{
 		// Create a Post with Post Meta that does not include landing_page and tag keys,
 		// mirroring how 1.4.6 and earlier of the Plugin worked.
-		$postID = $I->havePageInDatabase([
-			'post_type' => 'post',
-			'post_status' => 'publish',
-			'post_title' => 'ConvertKit: Post: 1.4.6',
-			'post_name' => 'convertkit-post-1-4-6',
-			'meta_input' => [
-				// 1.4.6 and earlier wouldn't set a landing_page or tag meta keys if no values were specified
-				// in the Meta Box.
-				'_wp_convertkit_post_meta' => [
-					'form'         => '-1',
+		$postID = $I->havePageInDatabase(
+			[
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_title'  => 'ConvertKit: Post: 1.4.6',
+				'post_name'   => 'convertkit-post-1-4-6',
+				'meta_input'  => [
+					// 1.4.6 and earlier wouldn't set a landing_page or tag meta keys if no values were specified
+					// in the Meta Box.
+					'_wp_convertkit_post_meta' => [
+						'form' => '-1',
+					],
 				],
-			],
-		]);
+			]
+		);
 
 		// Load the Post on the frontend site.
 		$I->amOnPage('convertkit-post-1-4-6');
@@ -55,28 +57,30 @@ class UpgradePathsCest
 
 	/**
 	 * Check for undefined index errors for a Page when upgrading from 1.4.6 or earlier to 1.4.7 or later.
-	 * 
-	 * @since 	1.9.6.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testUndefinedIndexForPage(AcceptanceTester $I)
 	{
 		// Create a Page with Post Meta that does not include landing_page and tag keys,
 		// mirroring how 1.4.6 and earlier of the Plugin worked.
-		$postID = $I->havePageInDatabase([
-			'post_type' => 'post',
-			'post_status' => 'publish',
-			'post_title' => 'ConvertKit: Page: 1.4.6',
-			'post_name' => 'convertkit-page-1-4-6',
-			'meta_input' => [
-				// 1.4.6 and earlier wouldn't set a landing_page or tag meta keys if no values were specified
-				// in the Meta Box.
-				'_wp_convertkit_post_meta' => [
-					'form'         => '-1',
+		$postID = $I->havePageInDatabase(
+			[
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_title'  => 'ConvertKit: Page: 1.4.6',
+				'post_name'   => 'convertkit-page-1-4-6',
+				'meta_input'  => [
+					// 1.4.6 and earlier wouldn't set a landing_page or tag meta keys if no values were specified
+					// in the Meta Box.
+					'_wp_convertkit_post_meta' => [
+						'form' => '-1',
+					],
 				],
-			],
-		]);
+			]
+		);
 
 		// Load the Post on the frontend site.
 		$I->amOnPage('convertkit-page-1-4-6');
@@ -89,10 +93,10 @@ class UpgradePathsCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/general/UpgradePathsCest.php
+++ b/tests/acceptance/general/UpgradePathsCest.php
@@ -2,101 +2,105 @@
 /**
  * Tests edge cases when upgrading between specific ConvertKit Plugin versions.
  * 
- * @since 	1.9.6.4
+ * @since 1.9.6.4
  */
 class UpgradePathsCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		// Activate and Setup ConvertKit plugin
-		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
-	}
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.6.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        // Activate and Setup ConvertKit plugin
+        $I->activateConvertKitPlugin($I);
+        $I->setupConvertKitPlugin($I);
+        $I->enableDebugLog($I);
+    }
 
-	/**
-	 * Check for undefined index errors for a Post when upgrading from 1.4.6 or earlier to 1.4.7 or later.
-	 * 
-	 * @since 	1.9.6.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testUndefinedIndexForPost(AcceptanceTester $I)
-	{
-		// Create a Post with Post Meta that does not include landing_page and tag keys,
-		// mirroring how 1.4.6 and earlier of the Plugin worked.
-		$postID = $I->havePageInDatabase([
-			'post_type' => 'post',
-			'post_status' => 'publish',
-			'post_title' => 'ConvertKit: Post: 1.4.6',
-			'post_name' => 'convertkit-post-1-4-6',
-			'meta_input' => [
-				// 1.4.6 and earlier wouldn't set a landing_page or tag meta keys if no values were specified
-				// in the Meta Box.
-				'_wp_convertkit_post_meta' => [
-					'form'         => '-1',
-				],
-			],
-		]);
+    /**
+     * Check for undefined index errors for a Post when upgrading from 1.4.6 or earlier to 1.4.7 or later.
+     * 
+     * @since 1.9.6.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testUndefinedIndexForPost(AcceptanceTester $I)
+    {
+        // Create a Post with Post Meta that does not include landing_page and tag keys,
+        // mirroring how 1.4.6 and earlier of the Plugin worked.
+        $postID = $I->havePageInDatabase(
+            [
+            'post_type' => 'post',
+            'post_status' => 'publish',
+            'post_title' => 'ConvertKit: Post: 1.4.6',
+            'post_name' => 'convertkit-post-1-4-6',
+            'meta_input' => [
+            // 1.4.6 and earlier wouldn't set a landing_page or tag meta keys if no values were specified
+            // in the Meta Box.
+            '_wp_convertkit_post_meta' => [
+            'form'         => '-1',
+            ],
+            ],
+            ]
+        );
 
-		// Load the Post on the frontend site.
-		$I->amOnPage('convertkit-post-1-4-6');
+        // Load the Post on the frontend site.
+        $I->amOnPage('convertkit-post-1-4-6');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-	}
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
+    }
 
-	/**
-	 * Check for undefined index errors for a Page when upgrading from 1.4.6 or earlier to 1.4.7 or later.
-	 * 
-	 * @since 	1.9.6.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testUndefinedIndexForPage(AcceptanceTester $I)
-	{
-		// Create a Page with Post Meta that does not include landing_page and tag keys,
-		// mirroring how 1.4.6 and earlier of the Plugin worked.
-		$postID = $I->havePageInDatabase([
-			'post_type' => 'post',
-			'post_status' => 'publish',
-			'post_title' => 'ConvertKit: Page: 1.4.6',
-			'post_name' => 'convertkit-page-1-4-6',
-			'meta_input' => [
-				// 1.4.6 and earlier wouldn't set a landing_page or tag meta keys if no values were specified
-				// in the Meta Box.
-				'_wp_convertkit_post_meta' => [
-					'form'         => '-1',
-				],
-			],
-		]);
+    /**
+     * Check for undefined index errors for a Page when upgrading from 1.4.6 or earlier to 1.4.7 or later.
+     * 
+     * @since 1.9.6.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testUndefinedIndexForPage(AcceptanceTester $I)
+    {
+        // Create a Page with Post Meta that does not include landing_page and tag keys,
+        // mirroring how 1.4.6 and earlier of the Plugin worked.
+        $postID = $I->havePageInDatabase(
+            [
+            'post_type' => 'post',
+            'post_status' => 'publish',
+            'post_title' => 'ConvertKit: Page: 1.4.6',
+            'post_name' => 'convertkit-page-1-4-6',
+            'meta_input' => [
+            // 1.4.6 and earlier wouldn't set a landing_page or tag meta keys if no values were specified
+            // in the Meta Box.
+            '_wp_convertkit_post_meta' => [
+            'form'         => '-1',
+            ],
+            ],
+            ]
+        );
 
-		// Load the Post on the frontend site.
-		$I->amOnPage('convertkit-page-1-4-6');
+        // Load the Post on the frontend site.
+        $I->amOnPage('convertkit-page-1-4-6');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-	}
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
+    }
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/general/UpgradePathsCest.php
+++ b/tests/acceptance/general/UpgradePathsCest.php
@@ -1,106 +1,102 @@
 <?php
 /**
  * Tests edge cases when upgrading between specific ConvertKit Plugin versions.
- * 
+ *
  * @since 1.9.6.4
  */
-class UpgradePathsCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.6.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        // Activate and Setup ConvertKit plugin
-        $I->activateConvertKitPlugin($I);
-        $I->setupConvertKitPlugin($I);
-        $I->enableDebugLog($I);
-    }
+class UpgradePathsCest {
 
-    /**
-     * Check for undefined index errors for a Post when upgrading from 1.4.6 or earlier to 1.4.7 or later.
-     * 
-     * @since 1.9.6.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testUndefinedIndexForPost(AcceptanceTester $I)
-    {
-        // Create a Post with Post Meta that does not include landing_page and tag keys,
-        // mirroring how 1.4.6 and earlier of the Plugin worked.
-        $postID = $I->havePageInDatabase(
-            [
-            'post_type' => 'post',
-            'post_status' => 'publish',
-            'post_title' => 'ConvertKit: Post: 1.4.6',
-            'post_name' => 'convertkit-post-1-4-6',
-            'meta_input' => [
-            // 1.4.6 and earlier wouldn't set a landing_page or tag meta keys if no values were specified
-            // in the Meta Box.
-            '_wp_convertkit_post_meta' => [
-            'form'         => '-1',
-            ],
-            ],
-            ]
-        );
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.6.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		// Activate and Setup ConvertKit plugin
+		$I->activateConvertKitPlugin( $I );
+		$I->setupConvertKitPlugin( $I );
+		$I->enableDebugLog( $I );
+	}
 
-        // Load the Post on the frontend site.
-        $I->amOnPage('convertkit-post-1-4-6');
+	/**
+	 * Check for undefined index errors for a Post when upgrading from 1.4.6 or earlier to 1.4.7 or later.
+	 *
+	 * @since 1.9.6.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testUndefinedIndexForPost( AcceptanceTester $I ) {
+		// Create a Post with Post Meta that does not include landing_page and tag keys,
+		// mirroring how 1.4.6 and earlier of the Plugin worked.
+		$postID = $I->havePageInDatabase(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_title'  => 'ConvertKit: Post: 1.4.6',
+				'post_name'   => 'convertkit-post-1-4-6',
+				'meta_input'  => array(
+					// 1.4.6 and earlier wouldn't set a landing_page or tag meta keys if no values were specified
+					// in the Meta Box.
+					'_wp_convertkit_post_meta' => array(
+						'form' => '-1',
+					),
+				),
+			)
+		);
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-    }
+		// Load the Post on the frontend site.
+		$I->amOnPage( 'convertkit-post-1-4-6' );
 
-    /**
-     * Check for undefined index errors for a Page when upgrading from 1.4.6 or earlier to 1.4.7 or later.
-     * 
-     * @since 1.9.6.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testUndefinedIndexForPage(AcceptanceTester $I)
-    {
-        // Create a Page with Post Meta that does not include landing_page and tag keys,
-        // mirroring how 1.4.6 and earlier of the Plugin worked.
-        $postID = $I->havePageInDatabase(
-            [
-            'post_type' => 'post',
-            'post_status' => 'publish',
-            'post_title' => 'ConvertKit: Page: 1.4.6',
-            'post_name' => 'convertkit-page-1-4-6',
-            'meta_input' => [
-            // 1.4.6 and earlier wouldn't set a landing_page or tag meta keys if no values were specified
-            // in the Meta Box.
-            '_wp_convertkit_post_meta' => [
-            'form'         => '-1',
-            ],
-            ],
-            ]
-        );
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+	}
 
-        // Load the Post on the frontend site.
-        $I->amOnPage('convertkit-page-1-4-6');
+	/**
+	 * Check for undefined index errors for a Page when upgrading from 1.4.6 or earlier to 1.4.7 or later.
+	 *
+	 * @since 1.9.6.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testUndefinedIndexForPage( AcceptanceTester $I ) {
+		// Create a Page with Post Meta that does not include landing_page and tag keys,
+		// mirroring how 1.4.6 and earlier of the Plugin worked.
+		$postID = $I->havePageInDatabase(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_title'  => 'ConvertKit: Page: 1.4.6',
+				'post_name'   => 'convertkit-page-1-4-6',
+				'meta_input'  => array(
+					// 1.4.6 and earlier wouldn't set a landing_page or tag meta keys if no values were specified
+					// in the Meta Box.
+					'_wp_convertkit_post_meta' => array(
+						'form' => '-1',
+					),
+				),
+			)
+		);
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-    }
+		// Load the Post on the frontend site.
+		$I->amOnPage( 'convertkit-page-1-4-6' );
 
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/general/UpgradePathsCest.php
+++ b/tests/acceptance/general/UpgradePathsCest.php
@@ -1,102 +1,102 @@
 <?php
 /**
  * Tests edge cases when upgrading between specific ConvertKit Plugin versions.
- *
- * @since 1.9.6.4
+ * 
+ * @since 	1.9.6.4
  */
-class UpgradePathsCest {
-
+class UpgradePathsCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.6.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
+	public function _before(AcceptanceTester $I)
+	{
 		// Activate and Setup ConvertKit plugin
-		$I->activateConvertKitPlugin( $I );
-		$I->setupConvertKitPlugin( $I );
-		$I->enableDebugLog( $I );
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
 	}
 
 	/**
 	 * Check for undefined index errors for a Post when upgrading from 1.4.6 or earlier to 1.4.7 or later.
-	 *
-	 * @since 1.9.6.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testUndefinedIndexForPost( AcceptanceTester $I ) {
+	public function testUndefinedIndexForPost(AcceptanceTester $I)
+	{
 		// Create a Post with Post Meta that does not include landing_page and tag keys,
 		// mirroring how 1.4.6 and earlier of the Plugin worked.
-		$postID = $I->havePageInDatabase(
-			array(
-				'post_type'   => 'post',
-				'post_status' => 'publish',
-				'post_title'  => 'ConvertKit: Post: 1.4.6',
-				'post_name'   => 'convertkit-post-1-4-6',
-				'meta_input'  => array(
-					// 1.4.6 and earlier wouldn't set a landing_page or tag meta keys if no values were specified
-					// in the Meta Box.
-					'_wp_convertkit_post_meta' => array(
-						'form' => '-1',
-					),
-				),
-			)
-		);
+		$postID = $I->havePageInDatabase([
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_title' => 'ConvertKit: Post: 1.4.6',
+			'post_name' => 'convertkit-post-1-4-6',
+			'meta_input' => [
+				// 1.4.6 and earlier wouldn't set a landing_page or tag meta keys if no values were specified
+				// in the Meta Box.
+				'_wp_convertkit_post_meta' => [
+					'form'         => '-1',
+				],
+			],
+		]);
 
 		// Load the Post on the frontend site.
-		$I->amOnPage( 'convertkit-post-1-4-6' );
+		$I->amOnPage('convertkit-post-1-4-6');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 	}
 
 	/**
 	 * Check for undefined index errors for a Page when upgrading from 1.4.6 or earlier to 1.4.7 or later.
-	 *
-	 * @since 1.9.6.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testUndefinedIndexForPage( AcceptanceTester $I ) {
+	public function testUndefinedIndexForPage(AcceptanceTester $I)
+	{
 		// Create a Page with Post Meta that does not include landing_page and tag keys,
 		// mirroring how 1.4.6 and earlier of the Plugin worked.
-		$postID = $I->havePageInDatabase(
-			array(
-				'post_type'   => 'post',
-				'post_status' => 'publish',
-				'post_title'  => 'ConvertKit: Page: 1.4.6',
-				'post_name'   => 'convertkit-page-1-4-6',
-				'meta_input'  => array(
-					// 1.4.6 and earlier wouldn't set a landing_page or tag meta keys if no values were specified
-					// in the Meta Box.
-					'_wp_convertkit_post_meta' => array(
-						'form' => '-1',
-					),
-				),
-			)
-		);
+		$postID = $I->havePageInDatabase([
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_title' => 'ConvertKit: Page: 1.4.6',
+			'post_name' => 'convertkit-page-1-4-6',
+			'meta_input' => [
+				// 1.4.6 and earlier wouldn't set a landing_page or tag meta keys if no values were specified
+				// in the Meta Box.
+				'_wp_convertkit_post_meta' => [
+					'form'         => '-1',
+				],
+			],
+		]);
 
 		// Load the Post on the frontend site.
-		$I->amOnPage( 'convertkit-page-1-4-6' );
+		$I->amOnPage('convertkit-page-1-4-6');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/integrations/ContactForm7FormCest.php
+++ b/tests/acceptance/integrations/ContactForm7FormCest.php
@@ -1,137 +1,134 @@
 <?php
 /**
  * Tests for ConvertKit Forms integration with Contact Form 7.
- *
- * @since 1.9.6
+ * 
+ * @since 	1.9.6
  */
-class ContactForm7FormCest {
-
+class ContactForm7FormCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
-		$I->activateConvertKitPlugin( $I );
-		$I->activateThirdPartyPlugin( $I, 'contact-form-7' );
-		$I->setupConvertKitPlugin( $I );
-		$I->enableDebugLog( $I );
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'contact-form-7');
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
 	}
 
 	/**
 	 * Test that saving a Contact Form 7 to ConvertKit Form Mapping works.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testSettingsContactForm7ToConvertKitFormMapping( AcceptanceTester $I ) {
+	public function testSettingsContactForm7ToConvertKitFormMapping(AcceptanceTester $I)
+	{
 		// Create Contact Form 7 Form.
-		$contactForm7ID = $this->_createContactForm7Form( $I );
+		$contactForm7ID = $this->_createContactForm7Form($I);
 
 		// Load Contact Form 7 Plugin Settings
-		$I->amOnAdminPage( 'options-general.php?page=_wp_convertkit_settings&tab=contactform7' );
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=contactform7');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check that a Form Mapping option is displayed.
-		$I->seeElementInDOM( '#_wp_convertkit_integration_contactform7_settings_' . $contactForm7ID );
+		$I->seeElementInDOM('#_wp_convertkit_integration_contactform7_settings_' . $contactForm7ID);
 
 		// Change Form to value specified in the .env file.
-		$I->selectOption( '#_wp_convertkit_integration_contactform7_settings_' . $contactForm7ID, $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME'] );
+		$I->selectOption('#_wp_convertkit_integration_contactform7_settings_' . $contactForm7ID, $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME']);
 
-		$I->click( 'Save Changes' );
+		$I->click('Save Changes');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check the value of the Form field matches the input provided.
-		$I->seeOptionIsSelected( '#_wp_convertkit_integration_contactform7_settings_' . $contactForm7ID, $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME'] );
-
+		$I->seeOptionIsSelected('#_wp_convertkit_integration_contactform7_settings_' . $contactForm7ID, $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME']);
+		
 		// Create Page with Contact Form 7 Shortcode.
-		$I->havePageInDatabase(
-			array(
-				'post_title'   => 'ConvertKit: Contact Form 7 Shortcode',
-				'post_name'    => 'convertkit-contact-form-7-shortcode',
-				'post_content' => 'Form:
+		$I->havePageInDatabase([
+			'post_title'	=> 'ConvertKit: Contact Form 7 Shortcode',
+			'post_name' 	=> 'convertkit-contact-form-7-shortcode',
+			'post_content' 	=> 'Form:
 [contact-form-7 id="' . $contactForm7ID . '"]',
-			)
-		);
+		]);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage( '/convertkit-contact-form-7-shortcode' );
+		$I->amOnPage('/convertkit-contact-form-7-shortcode');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Define email address for this test.
 		$emailAddress = $I->generateEmailAddress();
 
 		// Complete Name and Email
-		$I->fillField( 'input[name=your-name]', 'ConvertKit Name' );
-		$I->fillField( 'input[name=your-email]', $emailAddress );
-		$I->fillField( 'input[name=your-subject]', 'ConvertKit Subject' );
+		$I->fillField('input[name=your-name]', 'ConvertKit Name');
+		$I->fillField('input[name=your-email]', $emailAddress);
+		$I->fillField('input[name=your-subject]', 'ConvertKit Subject');
 
 		// Submit Form.
-		$I->click( 'Submit' );
+		$I->click('Submit');
 
 		// Confirm the form submitted without errors.
-		$I->performOn(
-			'form.sent',
-			function ( $I ) {
-				$I->seeInSource( 'Thank you for your message. It has been sent.' );
-			}
-		);
+		$I->performOn('form.sent', function($I) {
+			$I->seeInSource('Thank you for your message. It has been sent.');
+		});
 
 		// Confirm that the email address was added to ConvertKit.
-		$I->apiCheckSubscriberExists( $I, $emailAddress );
+		$I->apiCheckSubscriberExists($I, $emailAddress);
 	}
 
 	/**
 	 * Creates a Contact Form 7 Form
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param  AcceptanceTester $I Tester
-	 * @return int                     Form ID
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 * @return 	int 					Form ID
 	 */
-	private function _createContactForm7Form( AcceptanceTester $I ) {
-		return $I->havePostInDatabase(
-			array(
-				'post_name'   => 'contact-form-7-form',
-				'post_title'  => 'Contact Form 7 Form',
-				'post_type'   => 'wpcf7_contact_form',
-				'post_status' => 'publish',
-				'meta_input'  => array(
-					// Don't attempt to send mail, as this will fail when run through a GitHub Action.
-					// @see https://contactform7.com/additional-settings/#skipping-mail
-					'_form'                => '[text* your-name] [email* your-email] [text* your-subject] [textarea your-message] [submit "Submit"]',
-					'_additional_settings' => 'skip_mail: on',
-				),
-			)
-		);
+	private function _createContactForm7Form(AcceptanceTester $I)
+	{
+		return $I->havePostInDatabase([
+			'post_name' 	=> 'contact-form-7-form',
+			'post_title'	=> 'Contact Form 7 Form',
+			'post_type'		=> 'wpcf7_contact_form',
+			'post_status'	=> 'publish',
+			'meta_input' => [
+				// Don't attempt to send mail, as this will fail when run through a GitHub Action.
+				// @see https://contactform7.com/additional-settings/#skipping-mail
+				'_form' => '[text* your-name] [email* your-email] [text* your-subject] [textarea your-message] [submit "Submit"]',
+				'_additional_settings' => 'skip_mail: on',
+			],
+		]);
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 
 		// We don't use deactivateThirdPartyPlugin(), as this checks for PHP warnings/errors.
 		// Contact Form 7 throws a warning on deactivation related to WordPress capabilities,
-		// which is outside of our control and would result in the test not completing.
+		// which is outside of our control and would result in the test not completing. 
 		$I->amOnPluginsPage();
-		$I->deactivatePlugin( 'contact-form-7' );
+		$I->deactivatePlugin('contact-form-7');
 	}
 }

--- a/tests/acceptance/integrations/ContactForm7FormCest.php
+++ b/tests/acceptance/integrations/ContactForm7FormCest.php
@@ -2,133 +2,139 @@
 /**
  * Tests for ConvertKit Forms integration with Contact Form 7.
  * 
- * @since 	1.9.6
+ * @since 1.9.6
  */
 class ContactForm7FormCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		$I->activateConvertKitPlugin($I);
-		$I->activateThirdPartyPlugin($I, 'contact-form-7');
-		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
-	}
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        $I->activateConvertKitPlugin($I);
+        $I->activateThirdPartyPlugin($I, 'contact-form-7');
+        $I->setupConvertKitPlugin($I);
+        $I->enableDebugLog($I);
+    }
 
-	/**
-	 * Test that saving a Contact Form 7 to ConvertKit Form Mapping works.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testSettingsContactForm7ToConvertKitFormMapping(AcceptanceTester $I)
-	{
-		// Create Contact Form 7 Form.
-		$contactForm7ID = $this->_createContactForm7Form($I);
+    /**
+     * Test that saving a Contact Form 7 to ConvertKit Form Mapping works.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testSettingsContactForm7ToConvertKitFormMapping(AcceptanceTester $I)
+    {
+        // Create Contact Form 7 Form.
+        $contactForm7ID = $this->_createContactForm7Form($I);
 
-		// Load Contact Form 7 Plugin Settings
-		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=contactform7');
+        // Load Contact Form 7 Plugin Settings
+        $I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=contactform7');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Check that a Form Mapping option is displayed.
-		$I->seeElementInDOM('#_wp_convertkit_integration_contactform7_settings_' . $contactForm7ID);
+        // Check that a Form Mapping option is displayed.
+        $I->seeElementInDOM('#_wp_convertkit_integration_contactform7_settings_' . $contactForm7ID);
 
-		// Change Form to value specified in the .env file.
-		$I->selectOption('#_wp_convertkit_integration_contactform7_settings_' . $contactForm7ID, $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME']);
+        // Change Form to value specified in the .env file.
+        $I->selectOption('#_wp_convertkit_integration_contactform7_settings_' . $contactForm7ID, $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME']);
 
-		$I->click('Save Changes');
+        $I->click('Save Changes');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Check the value of the Form field matches the input provided.
-		$I->seeOptionIsSelected('#_wp_convertkit_integration_contactform7_settings_' . $contactForm7ID, $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME']);
+        // Check the value of the Form field matches the input provided.
+        $I->seeOptionIsSelected('#_wp_convertkit_integration_contactform7_settings_' . $contactForm7ID, $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME']);
 		
-		// Create Page with Contact Form 7 Shortcode.
-		$I->havePageInDatabase([
-			'post_title'	=> 'ConvertKit: Contact Form 7 Shortcode',
-			'post_name' 	=> 'convertkit-contact-form-7-shortcode',
-			'post_content' 	=> 'Form:
+        // Create Page with Contact Form 7 Shortcode.
+        $I->havePageInDatabase(
+            [
+            'post_title'    => 'ConvertKit: Contact Form 7 Shortcode',
+            'post_name'     => 'convertkit-contact-form-7-shortcode',
+            'post_content'     => 'Form:
 [contact-form-7 id="' . $contactForm7ID . '"]',
-		]);
+            ]
+        );
 
-		// Load the Page on the frontend site.
-		$I->amOnPage('/convertkit-contact-form-7-shortcode');
+        // Load the Page on the frontend site.
+        $I->amOnPage('/convertkit-contact-form-7-shortcode');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Define email address for this test.
-		$emailAddress = $I->generateEmailAddress();
+        // Define email address for this test.
+        $emailAddress = $I->generateEmailAddress();
 
-		// Complete Name and Email
-		$I->fillField('input[name=your-name]', 'ConvertKit Name');
-		$I->fillField('input[name=your-email]', $emailAddress);
-		$I->fillField('input[name=your-subject]', 'ConvertKit Subject');
+        // Complete Name and Email
+        $I->fillField('input[name=your-name]', 'ConvertKit Name');
+        $I->fillField('input[name=your-email]', $emailAddress);
+        $I->fillField('input[name=your-subject]', 'ConvertKit Subject');
 
-		// Submit Form.
-		$I->click('Submit');
+        // Submit Form.
+        $I->click('Submit');
 
-		// Confirm the form submitted without errors.
-		$I->performOn('form.sent', function($I) {
-			$I->seeInSource('Thank you for your message. It has been sent.');
-		});
+        // Confirm the form submitted without errors.
+        $I->performOn(
+            'form.sent', function ($I) {
+                $I->seeInSource('Thank you for your message. It has been sent.');
+            }
+        );
 
-		// Confirm that the email address was added to ConvertKit.
-		$I->apiCheckSubscriberExists($I, $emailAddress);
-	}
+        // Confirm that the email address was added to ConvertKit.
+        $I->apiCheckSubscriberExists($I, $emailAddress);
+    }
 
-	/**
-	 * Creates a Contact Form 7 Form
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 * @return 	int 					Form ID
-	 */
-	private function _createContactForm7Form(AcceptanceTester $I)
-	{
-		return $I->havePostInDatabase([
-			'post_name' 	=> 'contact-form-7-form',
-			'post_title'	=> 'Contact Form 7 Form',
-			'post_type'		=> 'wpcf7_contact_form',
-			'post_status'	=> 'publish',
-			'meta_input' => [
-				// Don't attempt to send mail, as this will fail when run through a GitHub Action.
-				// @see https://contactform7.com/additional-settings/#skipping-mail
-				'_form' => '[text* your-name] [email* your-email] [text* your-subject] [textarea your-message] [submit "Submit"]',
-				'_additional_settings' => 'skip_mail: on',
-			],
-		]);
-	}
+    /**
+     * Creates a Contact Form 7 Form
+     * 
+     * @since 1.9.6
+     * 
+     * @param  AcceptanceTester $I Tester
+     * @return int                     Form ID
+     */
+    private function _createContactForm7Form(AcceptanceTester $I)
+    {
+        return $I->havePostInDatabase(
+            [
+            'post_name'     => 'contact-form-7-form',
+            'post_title'    => 'Contact Form 7 Form',
+            'post_type'        => 'wpcf7_contact_form',
+            'post_status'    => 'publish',
+            'meta_input' => [
+            // Don't attempt to send mail, as this will fail when run through a GitHub Action.
+            // @see https://contactform7.com/additional-settings/#skipping-mail
+            '_form' => '[text* your-name] [email* your-email] [text* your-subject] [textarea your-message] [submit "Submit"]',
+            '_additional_settings' => 'skip_mail: on',
+            ],
+            ]
+        );
+    }
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
 
-		// We don't use deactivateThirdPartyPlugin(), as this checks for PHP warnings/errors.
-		// Contact Form 7 throws a warning on deactivation related to WordPress capabilities,
-		// which is outside of our control and would result in the test not completing. 
-		$I->amOnPluginsPage();
-		$I->deactivatePlugin('contact-form-7');
-	}
+        // We don't use deactivateThirdPartyPlugin(), as this checks for PHP warnings/errors.
+        // Contact Form 7 throws a warning on deactivation related to WordPress capabilities,
+        // which is outside of our control and would result in the test not completing. 
+        $I->amOnPluginsPage();
+        $I->deactivatePlugin('contact-form-7');
+    }
 }

--- a/tests/acceptance/integrations/ContactForm7FormCest.php
+++ b/tests/acceptance/integrations/ContactForm7FormCest.php
@@ -1,17 +1,17 @@
 <?php
 /**
  * Tests for ConvertKit Forms integration with Contact Form 7.
- * 
- * @since 	1.9.6
+ *
+ * @since   1.9.6
  */
 class ContactForm7FormCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -23,17 +23,17 @@ class ContactForm7FormCest
 
 	/**
 	 * Test that saving a Contact Form 7 to ConvertKit Form Mapping works.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testSettingsContactForm7ToConvertKitFormMapping(AcceptanceTester $I)
 	{
 		// Create Contact Form 7 Form.
 		$contactForm7ID = $this->_createContactForm7Form($I);
 
-		// Load Contact Form 7 Plugin Settings
+		// Load Contact Form 7 Plugin Settings.
 		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=contactform7');
 
 		// Check that no PHP warnings or notices were output.
@@ -52,14 +52,16 @@ class ContactForm7FormCest
 
 		// Check the value of the Form field matches the input provided.
 		$I->seeOptionIsSelected('#_wp_convertkit_integration_contactform7_settings_' . $contactForm7ID, $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME']);
-		
+
 		// Create Page with Contact Form 7 Shortcode.
-		$I->havePageInDatabase([
-			'post_title'	=> 'ConvertKit: Contact Form 7 Shortcode',
-			'post_name' 	=> 'convertkit-contact-form-7-shortcode',
-			'post_content' 	=> 'Form:
+		$I->havePageInDatabase(
+			[
+				'post_title'   => 'ConvertKit: Contact Form 7 Shortcode',
+				'post_name'    => 'convertkit-contact-form-7-shortcode',
+				'post_content' => 'Form:
 [contact-form-7 id="' . $contactForm7ID . '"]',
-		]);
+			]
+		);
 
 		// Load the Page on the frontend site.
 		$I->amOnPage('/convertkit-contact-form-7-shortcode');
@@ -70,7 +72,7 @@ class ContactForm7FormCest
 		// Define email address for this test.
 		$emailAddress = $I->generateEmailAddress();
 
-		// Complete Name and Email
+		// Complete Name and Email.
 		$I->fillField('input[name=your-name]', 'ConvertKit Name');
 		$I->fillField('input[name=your-email]', $emailAddress);
 		$I->fillField('input[name=your-subject]', 'ConvertKit Subject');
@@ -79,9 +81,12 @@ class ContactForm7FormCest
 		$I->click('Submit');
 
 		// Confirm the form submitted without errors.
-		$I->performOn('form.sent', function($I) {
-			$I->seeInSource('Thank you for your message. It has been sent.');
-		});
+		$I->performOn(
+			'form.sent',
+			function($I) {
+				$I->seeInSource('Thank you for your message. It has been sent.');
+			}
+		);
 
 		// Confirm that the email address was added to ConvertKit.
 		$I->apiCheckSubscriberExists($I, $emailAddress);
@@ -89,36 +94,38 @@ class ContactForm7FormCest
 
 	/**
 	 * Creates a Contact Form 7 Form
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 * @return 	int 					Form ID
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 * @return  int                     Form ID
 	 */
 	private function _createContactForm7Form(AcceptanceTester $I)
 	{
-		return $I->havePostInDatabase([
-			'post_name' 	=> 'contact-form-7-form',
-			'post_title'	=> 'Contact Form 7 Form',
-			'post_type'		=> 'wpcf7_contact_form',
-			'post_status'	=> 'publish',
-			'meta_input' => [
-				// Don't attempt to send mail, as this will fail when run through a GitHub Action.
-				// @see https://contactform7.com/additional-settings/#skipping-mail
-				'_form' => '[text* your-name] [email* your-email] [text* your-subject] [textarea your-message] [submit "Submit"]',
-				'_additional_settings' => 'skip_mail: on',
-			],
-		]);
+		return $I->havePostInDatabase(
+			[
+				'post_name'   => 'contact-form-7-form',
+				'post_title'  => 'Contact Form 7 Form',
+				'post_type'   => 'wpcf7_contact_form',
+				'post_status' => 'publish',
+				'meta_input'  => [
+					// Don't attempt to send mail, as this will fail when run through a GitHub Action.
+					// @see https://contactform7.com/additional-settings/#skipping-mail.
+					'_form'                => '[text* your-name] [email* your-email] [text* your-subject] [textarea your-message] [submit "Submit"]',
+					'_additional_settings' => 'skip_mail: on',
+				],
+			]
+		);
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{
@@ -127,7 +134,7 @@ class ContactForm7FormCest
 
 		// We don't use deactivateThirdPartyPlugin(), as this checks for PHP warnings/errors.
 		// Contact Form 7 throws a warning on deactivation related to WordPress capabilities,
-		// which is outside of our control and would result in the test not completing. 
+		// which is outside of our control and would result in the test not completing.
 		$I->amOnPluginsPage();
 		$I->deactivatePlugin('contact-form-7');
 	}

--- a/tests/acceptance/integrations/ContactForm7FormCest.php
+++ b/tests/acceptance/integrations/ContactForm7FormCest.php
@@ -1,140 +1,137 @@
 <?php
 /**
  * Tests for ConvertKit Forms integration with Contact Form 7.
- * 
+ *
  * @since 1.9.6
  */
-class ContactForm7FormCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        $I->activateConvertKitPlugin($I);
-        $I->activateThirdPartyPlugin($I, 'contact-form-7');
-        $I->setupConvertKitPlugin($I);
-        $I->enableDebugLog($I);
-    }
+class ContactForm7FormCest {
 
-    /**
-     * Test that saving a Contact Form 7 to ConvertKit Form Mapping works.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testSettingsContactForm7ToConvertKitFormMapping(AcceptanceTester $I)
-    {
-        // Create Contact Form 7 Form.
-        $contactForm7ID = $this->_createContactForm7Form($I);
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		$I->activateConvertKitPlugin( $I );
+		$I->activateThirdPartyPlugin( $I, 'contact-form-7' );
+		$I->setupConvertKitPlugin( $I );
+		$I->enableDebugLog( $I );
+	}
 
-        // Load Contact Form 7 Plugin Settings
-        $I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=contactform7');
+	/**
+	 * Test that saving a Contact Form 7 to ConvertKit Form Mapping works.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testSettingsContactForm7ToConvertKitFormMapping( AcceptanceTester $I ) {
+		// Create Contact Form 7 Form.
+		$contactForm7ID = $this->_createContactForm7Form( $I );
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Load Contact Form 7 Plugin Settings
+		$I->amOnAdminPage( 'options-general.php?page=_wp_convertkit_settings&tab=contactform7' );
 
-        // Check that a Form Mapping option is displayed.
-        $I->seeElementInDOM('#_wp_convertkit_integration_contactform7_settings_' . $contactForm7ID);
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-        // Change Form to value specified in the .env file.
-        $I->selectOption('#_wp_convertkit_integration_contactform7_settings_' . $contactForm7ID, $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME']);
+		// Check that a Form Mapping option is displayed.
+		$I->seeElementInDOM( '#_wp_convertkit_integration_contactform7_settings_' . $contactForm7ID );
 
-        $I->click('Save Changes');
+		// Change Form to value specified in the .env file.
+		$I->selectOption( '#_wp_convertkit_integration_contactform7_settings_' . $contactForm7ID, $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME'] );
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		$I->click( 'Save Changes' );
 
-        // Check the value of the Form field matches the input provided.
-        $I->seeOptionIsSelected('#_wp_convertkit_integration_contactform7_settings_' . $contactForm7ID, $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME']);
-		
-        // Create Page with Contact Form 7 Shortcode.
-        $I->havePageInDatabase(
-            [
-            'post_title'    => 'ConvertKit: Contact Form 7 Shortcode',
-            'post_name'     => 'convertkit-contact-form-7-shortcode',
-            'post_content'     => 'Form:
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Check the value of the Form field matches the input provided.
+		$I->seeOptionIsSelected( '#_wp_convertkit_integration_contactform7_settings_' . $contactForm7ID, $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME'] );
+
+		// Create Page with Contact Form 7 Shortcode.
+		$I->havePageInDatabase(
+			array(
+				'post_title'   => 'ConvertKit: Contact Form 7 Shortcode',
+				'post_name'    => 'convertkit-contact-form-7-shortcode',
+				'post_content' => 'Form:
 [contact-form-7 id="' . $contactForm7ID . '"]',
-            ]
-        );
+			)
+		);
 
-        // Load the Page on the frontend site.
-        $I->amOnPage('/convertkit-contact-form-7-shortcode');
+		// Load the Page on the frontend site.
+		$I->amOnPage( '/convertkit-contact-form-7-shortcode' );
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-        // Define email address for this test.
-        $emailAddress = $I->generateEmailAddress();
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
 
-        // Complete Name and Email
-        $I->fillField('input[name=your-name]', 'ConvertKit Name');
-        $I->fillField('input[name=your-email]', $emailAddress);
-        $I->fillField('input[name=your-subject]', 'ConvertKit Subject');
+		// Complete Name and Email
+		$I->fillField( 'input[name=your-name]', 'ConvertKit Name' );
+		$I->fillField( 'input[name=your-email]', $emailAddress );
+		$I->fillField( 'input[name=your-subject]', 'ConvertKit Subject' );
 
-        // Submit Form.
-        $I->click('Submit');
+		// Submit Form.
+		$I->click( 'Submit' );
 
-        // Confirm the form submitted without errors.
-        $I->performOn(
-            'form.sent', function ($I) {
-                $I->seeInSource('Thank you for your message. It has been sent.');
-            }
-        );
+		// Confirm the form submitted without errors.
+		$I->performOn(
+			'form.sent',
+			function ( $I ) {
+				$I->seeInSource( 'Thank you for your message. It has been sent.' );
+			}
+		);
 
-        // Confirm that the email address was added to ConvertKit.
-        $I->apiCheckSubscriberExists($I, $emailAddress);
-    }
+		// Confirm that the email address was added to ConvertKit.
+		$I->apiCheckSubscriberExists( $I, $emailAddress );
+	}
 
-    /**
-     * Creates a Contact Form 7 Form
-     * 
-     * @since 1.9.6
-     * 
-     * @param  AcceptanceTester $I Tester
-     * @return int                     Form ID
-     */
-    private function _createContactForm7Form(AcceptanceTester $I)
-    {
-        return $I->havePostInDatabase(
-            [
-            'post_name'     => 'contact-form-7-form',
-            'post_title'    => 'Contact Form 7 Form',
-            'post_type'        => 'wpcf7_contact_form',
-            'post_status'    => 'publish',
-            'meta_input' => [
-            // Don't attempt to send mail, as this will fail when run through a GitHub Action.
-            // @see https://contactform7.com/additional-settings/#skipping-mail
-            '_form' => '[text* your-name] [email* your-email] [text* your-subject] [textarea your-message] [submit "Submit"]',
-            '_additional_settings' => 'skip_mail: on',
-            ],
-            ]
-        );
-    }
+	/**
+	 * Creates a Contact Form 7 Form
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param  AcceptanceTester $I Tester
+	 * @return int                     Form ID
+	 */
+	private function _createContactForm7Form( AcceptanceTester $I ) {
+		return $I->havePostInDatabase(
+			array(
+				'post_name'   => 'contact-form-7-form',
+				'post_title'  => 'Contact Form 7 Form',
+				'post_type'   => 'wpcf7_contact_form',
+				'post_status' => 'publish',
+				'meta_input'  => array(
+					// Don't attempt to send mail, as this will fail when run through a GitHub Action.
+					// @see https://contactform7.com/additional-settings/#skipping-mail
+					'_form'                => '[text* your-name] [email* your-email] [text* your-subject] [textarea your-message] [submit "Submit"]',
+					'_additional_settings' => 'skip_mail: on',
+				),
+			)
+		);
+	}
 
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
 
-        // We don't use deactivateThirdPartyPlugin(), as this checks for PHP warnings/errors.
-        // Contact Form 7 throws a warning on deactivation related to WordPress capabilities,
-        // which is outside of our control and would result in the test not completing. 
-        $I->amOnPluginsPage();
-        $I->deactivatePlugin('contact-form-7');
-    }
+		// We don't use deactivateThirdPartyPlugin(), as this checks for PHP warnings/errors.
+		// Contact Form 7 throws a warning on deactivation related to WordPress capabilities,
+		// which is outside of our control and would result in the test not completing.
+		$I->amOnPluginsPage();
+		$I->deactivatePlugin( 'contact-form-7' );
+	}
 }

--- a/tests/acceptance/integrations/ElementorBroadcastsCest.php
+++ b/tests/acceptance/integrations/ElementorBroadcastsCest.php
@@ -1,17 +1,17 @@
 <?php
 /**
  * Tests for the ConvertKit Broadcast's Elementor Widget.
- * 
- * @since 	1.9.7.8
+ *
+ * @since   1.9.7.8
  */
 class ElementorBroadcastsCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.8
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -23,10 +23,10 @@ class ElementorBroadcastsCest
 
 	/**
 	 * Test the Broadcasts widget is registered in Elementor.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.8
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsWidgetIsRegistered(AcceptanceTester $I)
 	{
@@ -46,21 +46,25 @@ class ElementorBroadcastsCest
 
 	/**
 	 * Test the Broadcasts block works when using valid parameters.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.8
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsWidgetWithValidParameters(AcceptanceTester $I)
 	{
 		// Create Page with Broadcasts widget in Elementor.
-		$pageID = $this->_createPageWithBroadcastsWidget($I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Valid Params', [
-			'date_format' 	=> 'F j, Y',
-			'limit' 		=> 10,
-		]);
+		$pageID = $this->_createPageWithBroadcastsWidget(
+			$I,
+			'ConvertKit: Page: Broadcasts: Elementor Widget: Valid Params',
+			[
+				'date_format' => 'F j, Y',
+				'limit'       => 10,
+			]
+		);
 
 		// Load Page.
-		$I->amOnPage('?p='.$pageID);
+		$I->amOnPage('?p=' . $pageID);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -72,26 +76,30 @@ class ElementorBroadcastsCest
 		$I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
 
 		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
+		$I->seeNumberOfElements('li.convertkit-broadcast', [ 1, 10 ]);
 	}
 
 	/**
 	 * Test the Broadcasts block's date format parameter works.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.8
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsWidgetWithDateFormatParameter(AcceptanceTester $I)
 	{
 		// Create Page with Broadcasts widget in Elementor.
-		$pageID = $this->_createPageWithBroadcastsWidget($I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Date Format', [
-			'date_format' => 'Y-m-d',
-			'limit' 	  => 10,
-		]);
+		$pageID = $this->_createPageWithBroadcastsWidget(
+			$I,
+			'ConvertKit: Page: Broadcasts: Elementor Widget: Date Format',
+			[
+				'date_format' => 'Y-m-d',
+				'limit'       => 10,
+			]
+		);
 
 		// Load Page.
-		$I->amOnPage('?p='.$pageID);
+		$I->amOnPage('?p=' . $pageID);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -103,26 +111,30 @@ class ElementorBroadcastsCest
 		$I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
 
 		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
+		$I->seeNumberOfElements('li.convertkit-broadcast', [ 1, 10 ]);
 	}
 
 	/**
 	 * Test the Broadcasts block's limit parameter works.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.8
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsWidgetWithLimitParameter(AcceptanceTester $I)
 	{
 		// Create Page with Broadcasts widget in Elementor.
-		$pageID = $this->_createPageWithBroadcastsWidget($I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Limit', [
-			'date_format' 	=> 'F j, Y',
-			'limit' 		=> 2,
-		]);
+		$pageID = $this->_createPageWithBroadcastsWidget(
+			$I,
+			'ConvertKit: Page: Broadcasts: Elementor Widget: Limit',
+			[
+				'date_format' => 'F j, Y',
+				'limit'       => 2,
+			]
+		);
 
 		// Load Page.
-		$I->amOnPage('?p='.$pageID);
+		$I->amOnPage('?p=' . $pageID);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -136,22 +148,26 @@ class ElementorBroadcastsCest
 
 	/**
 	 * Test the Broadcasts block's pagination works when enabled.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsWidgetWithPaginationEnabled(AcceptanceTester $I)
 	{
 		// Create Page with Broadcasts widget in Elementor.
-		$pageID = $this->_createPageWithBroadcastsWidget($I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Pagination', [
-			'date_format' 	=> 'F j, Y',
-			'limit' 		=> 1,
-			'paginate' 		=> 1,
-		]);
+		$pageID = $this->_createPageWithBroadcastsWidget(
+			$I,
+			'ConvertKit: Page: Broadcasts: Elementor Widget: Pagination',
+			[
+				'date_format' => 'F j, Y',
+				'limit'       => 1,
+				'paginate'    => 1,
+			]
+		);
 
 		// Load Page.
-		$I->amOnPage('?p='.$pageID);
+		$I->amOnPage('?p=' . $pageID);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -162,24 +178,28 @@ class ElementorBroadcastsCest
 
 	/**
 	 * Test the Broadcasts block's pagination labels work when defined.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsWidgetWithPaginationLabelParameters(AcceptanceTester $I)
 	{
 		// Create Page with Broadcasts widget in Elementor.
-		$pageID = $this->_createPageWithBroadcastsWidget($I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Valid Params', [
-			'date_format' 			=> 'F j, Y',
-			'limit' 				=> 1,
-			'paginate' 				=> 1,
-			'paginate_label_prev' 	=> 'Newer',
-			'paginate_label_next' 	=> 'Older',
-		]);
+		$pageID = $this->_createPageWithBroadcastsWidget(
+			$I,
+			'ConvertKit: Page: Broadcasts: Elementor Widget: Valid Params',
+			[
+				'date_format'         => 'F j, Y',
+				'limit'               => 1,
+				'paginate'            => 1,
+				'paginate_label_prev' => 'Newer',
+				'paginate_label_next' => 'Older',
+			]
+		);
 
 		// Load Page.
-		$I->amOnPage('?p='.$pageID);
+		$I->amOnPage('?p=' . $pageID);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -190,32 +210,36 @@ class ElementorBroadcastsCest
 
 	/**
 	 * Test the Broadcasts block's hex colors work when defined.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsWidgetWithHexColorParameters(AcceptanceTester $I)
 	{
 		// Define colors.
 		$backgroundColor = '#ee1616';
-		$textColor = '#1212c0';
-		$linkColor = '#ffffff';
+		$textColor       = '#1212c0';
+		$linkColor       = '#ffffff';
 
 		// Create Page with Broadcasts widget in Elementor.
-		$pageID = $this->_createPageWithBroadcastsWidget($I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Hex Colors', [
-			'date_format' 			=> 'F j, Y',
-			'limit' 				=> 1,
-			'paginate' 				=> 1,
-			'paginate_label_prev' 	=> 'Newer',
-			'paginate_label_next' 	=> 'Older',
-			'link_color'			=> $linkColor,
-			'background_color'		=> $backgroundColor,
-			'text_color'			=> $textColor,
-		]);
+		$pageID = $this->_createPageWithBroadcastsWidget(
+			$I,
+			'ConvertKit: Page: Broadcasts: Elementor Widget: Hex Colors',
+			[
+				'date_format'         => 'F j, Y',
+				'limit'               => 1,
+				'paginate'            => 1,
+				'paginate_label_prev' => 'Newer',
+				'paginate_label_next' => 'Older',
+				'link_color'          => $linkColor,
+				'background_color'    => $backgroundColor,
+				'text_color'          => $textColor,
+			]
+		);
 
 		// Load Page.
-		$I->amOnPage('?p='.$pageID);
+		$I->amOnPage('?p=' . $pageID);
 
 		// Wait for frontend web site to load.
 		$I->waitForElementVisible('body.page-template-default');
@@ -227,95 +251,97 @@ class ElementorBroadcastsCest
 		$I->seeBroadcastsOutput($I);
 
 		// Confirm that our stylesheet loaded.
-		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="'.$_ENV['TEST_SITE_WP_URL'].'/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
+		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
 
 		// Confirm that the chosen colors are applied as CSS styles.
-		$I->seeInSource('<div class="convertkit-broadcasts has-text-color has-background" style="color:'.$textColor.';background-color:'.$backgroundColor.'"');
-		$I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:'.$linkColor.'"');
-	
+		$I->seeInSource('<div class="convertkit-broadcasts has-text-color has-background" style="color:' . $textColor . ';background-color:' . $backgroundColor . '"');
+		$I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:' . $linkColor . '"');
+
 		// Test pagination.
 		$I->testBroadcastsPagination($I, 'Older', 'Newer');
 
 		// Confirm that link styles are still applied to refreshed data.
-		$I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:'.$linkColor.'"');
+		$I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:' . $linkColor . '"');
 	}
 
 	/**
 	 * Create a Page in the database comprising of Elementor Page Builder data
 	 * containing a ConvertKit Form widget.
-	 * 
+	 *
 	 * Codeception's dragAndDrop() method doesn't support dropping an element into an iframe, which is
 	 * how Elementor works for adding widgets to a Page.
-	 * 
+	 *
 	 * Therefore, we directly create a Page in the database, with Elementor's data structure
 	 * as if we added the Form widget to a Page edited in Elementor.
-	 * 
+	 *
 	 * testBroadcastsWidgetIsRegistered() above is a sanity check that the Form Widget is registered
 	 * and available to users in Elementor.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @param 	AcceptanceTester 	$I 			Tester.
-	 * @param 	string 				$title 		Page Title.
-	 * @param 	array 				$settings 	Widget settings.
-	 * @return 	int 							Page ID
+	 *
+	 * @since   1.9.7.8
+	 *
+	 * @param   AcceptanceTester $I          Tester.
+	 * @param   string           $title      Page Title.
+	 * @param   array            $settings   Widget settings.
+	 * @return  int                             Page ID
 	 */
 	private function _createPageWithBroadcastsWidget(AcceptanceTester $I, $title, $settings)
 	{
-		return $I->havePostInDatabase([
-			'post_title'	=> $title,
-			'post_type'		=> 'page',
-			'post_status'	=> 'publish',
-			'meta_input' => [
-				// Elementor.
-				'_elementor_data' => [
-					0 => [
-						'id' => '39bb59d',
-						'elType' => 'section',
-						'settings' => [],
-						'elements' => [
-							[
-								'id' => 'b7e0e57',
-								'elType' => 'column',
-								'settings' => [
-									'_column_size' => 100,
-									'_inline_size' => null,
-								],
-								'elements' => [
-									[
-										'id' => 'a73a905',
-										'elType' => 'widget',
-										'settings' => $settings,
-										'widgetType' => 'convertkit-elementor-broadcasts',
+		return $I->havePostInDatabase(
+			[
+				'post_title'  => $title,
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'meta_input'  => [
+					// Elementor.
+					'_elementor_data'          => [
+						0 => [
+							'id'       => '39bb59d',
+							'elType'   => 'section',
+							'settings' => [],
+							'elements' => [
+								[
+									'id'       => 'b7e0e57',
+									'elType'   => 'column',
+									'settings' => [
+										'_column_size' => 100,
+										'_inline_size' => null,
+									],
+									'elements' => [
+										[
+											'id'         => 'a73a905',
+											'elType'     => 'widget',
+											'settings'   => $settings,
+											'widgetType' => 'convertkit-elementor-broadcasts',
+										],
 									],
 								],
 							],
 						],
 					],
-				],
-				'_elementor_version' => '3.6.1',
-				'_elementor_edit_mode' => 'builder',
-				'_elementor_template_type' => 'wp-page',
+					'_elementor_version'       => '3.6.1',
+					'_elementor_edit_mode'     => 'builder',
+					'_elementor_template_type' => 'wp-page',
 
-				// Configure ConvertKit Plugin to not display a default Form,
-				// as we are testing for the Form in Elementor.
-				'_wp_convertkit_post_meta' => [
-					'form'         => '-1',
-					'landing_page' => '',
-					'tag'          => '',
+					// Configure ConvertKit Plugin to not display a default Form,
+					// as we are testing for the Form in Elementor.
+					'_wp_convertkit_post_meta' => [
+						'form'         => '-1',
+						'landing_page' => '',
+						'tag'          => '',
+					],
 				],
-			],
-		]);
+			]
+		);
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.8
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/integrations/ElementorBroadcastsCest.php
+++ b/tests/acceptance/integrations/ElementorBroadcastsCest.php
@@ -2,325 +2,339 @@
 /**
  * Tests for the ConvertKit Broadcast's Elementor Widget.
  * 
- * @since 	1.9.7.8
+ * @since 1.9.7.8
  */
 class ElementorBroadcastsCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		$I->activateConvertKitPlugin($I);
-		$I->activateThirdPartyPlugin($I, 'elementor');
-		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
-	}
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.7.8
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        $I->activateConvertKitPlugin($I);
+        $I->activateThirdPartyPlugin($I, 'elementor');
+        $I->setupConvertKitPlugin($I);
+        $I->enableDebugLog($I);
+    }
 
-	/**
-	 * Test the Broadcasts widget is registered in Elementor.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsWidgetIsRegistered(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Elementor: Registered');
+    /**
+     * Test the Broadcasts widget is registered in Elementor.
+     * 
+     * @since 1.9.7.8
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsWidgetIsRegistered(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Elementor: Registered');
 
-		// Click Edit with Elementor button.
-		$I->click('#elementor-switch-mode-button');
+        // Click Edit with Elementor button.
+        $I->click('#elementor-switch-mode-button');
 
-		// When Elementor loads, search for the ConvertKit Broadcasts block.
-		$I->waitForElementVisible('#elementor-panel-elements-search-input');
-		$I->fillField('#elementor-panel-elements-search-input', 'ConvertKit Broadcasts');
+        // When Elementor loads, search for the ConvertKit Broadcasts block.
+        $I->waitForElementVisible('#elementor-panel-elements-search-input');
+        $I->fillField('#elementor-panel-elements-search-input', 'ConvertKit Broadcasts');
 
-		// Confirm that the Broadcasts widget is displayed as an option.
-		$I->seeElementInDOM('#elementor-panel-elements .elementor-element');
-	}
+        // Confirm that the Broadcasts widget is displayed as an option.
+        $I->seeElementInDOM('#elementor-panel-elements .elementor-element');
+    }
 
-	/**
-	 * Test the Broadcasts block works when using valid parameters.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsWidgetWithValidParameters(AcceptanceTester $I)
-	{
-		// Create Page with Broadcasts widget in Elementor.
-		$pageID = $this->_createPageWithBroadcastsWidget($I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Valid Params', [
-			'date_format' 	=> 'F j, Y',
-			'limit' 		=> 10,
-		]);
+    /**
+     * Test the Broadcasts block works when using valid parameters.
+     * 
+     * @since 1.9.7.8
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsWidgetWithValidParameters(AcceptanceTester $I)
+    {
+        // Create Page with Broadcasts widget in Elementor.
+        $pageID = $this->_createPageWithBroadcastsWidget(
+            $I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Valid Params', [
+            'date_format'     => 'F j, Y',
+            'limit'         => 10,
+            ]
+        );
 
-		// Load Page.
-		$I->amOnPage('?p='.$pageID);
+        // Load Page.
+        $I->amOnPage('?p='.$pageID);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the block displays.
-		$I->seeBroadcastsOutput($I);
+        // Confirm that the block displays.
+        $I->seeBroadcastsOutput($I);
 
-		// Confirm that the default date format is as expected.
-		$I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
+        // Confirm that the default date format is as expected.
+        $I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
 
-		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
-	}
+        // Confirm that the default expected number of Broadcasts are displayed.
+        $I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
+    }
 
-	/**
-	 * Test the Broadcasts block's date format parameter works.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsWidgetWithDateFormatParameter(AcceptanceTester $I)
-	{
-		// Create Page with Broadcasts widget in Elementor.
-		$pageID = $this->_createPageWithBroadcastsWidget($I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Date Format', [
-			'date_format' => 'Y-m-d',
-			'limit' 	  => 10,
-		]);
+    /**
+     * Test the Broadcasts block's date format parameter works.
+     * 
+     * @since 1.9.7.8
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsWidgetWithDateFormatParameter(AcceptanceTester $I)
+    {
+        // Create Page with Broadcasts widget in Elementor.
+        $pageID = $this->_createPageWithBroadcastsWidget(
+            $I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Date Format', [
+            'date_format' => 'Y-m-d',
+            'limit'       => 10,
+            ]
+        );
 
-		// Load Page.
-		$I->amOnPage('?p='.$pageID);
+        // Load Page.
+        $I->amOnPage('?p='.$pageID);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the block displays.
-		$I->seeBroadcastsOutput($I);
+        // Confirm that the block displays.
+        $I->seeBroadcastsOutput($I);
 
-		// Confirm that the date format is as expected.
-		$I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
+        // Confirm that the date format is as expected.
+        $I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
 
-		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
-	}
+        // Confirm that the default expected number of Broadcasts are displayed.
+        $I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
+    }
 
-	/**
-	 * Test the Broadcasts block's limit parameter works.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsWidgetWithLimitParameter(AcceptanceTester $I)
-	{
-		// Create Page with Broadcasts widget in Elementor.
-		$pageID = $this->_createPageWithBroadcastsWidget($I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Limit', [
-			'date_format' 	=> 'F j, Y',
-			'limit' 		=> 2,
-		]);
+    /**
+     * Test the Broadcasts block's limit parameter works.
+     * 
+     * @since 1.9.7.8
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsWidgetWithLimitParameter(AcceptanceTester $I)
+    {
+        // Create Page with Broadcasts widget in Elementor.
+        $pageID = $this->_createPageWithBroadcastsWidget(
+            $I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Limit', [
+            'date_format'     => 'F j, Y',
+            'limit'         => 2,
+            ]
+        );
 
-		// Load Page.
-		$I->amOnPage('?p='.$pageID);
+        // Load Page.
+        $I->amOnPage('?p='.$pageID);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the block displays.
-		$I->seeBroadcastsOutput($I);
+        // Confirm that the block displays.
+        $I->seeBroadcastsOutput($I);
 
-		// Confirm that the expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', 2);
-	}
+        // Confirm that the expected number of Broadcasts are displayed.
+        $I->seeNumberOfElements('li.convertkit-broadcast', 2);
+    }
 
-	/**
-	 * Test the Broadcasts block's pagination works when enabled.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsWidgetWithPaginationEnabled(AcceptanceTester $I)
-	{
-		// Create Page with Broadcasts widget in Elementor.
-		$pageID = $this->_createPageWithBroadcastsWidget($I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Pagination', [
-			'date_format' 	=> 'F j, Y',
-			'limit' 		=> 1,
-			'paginate' 		=> 1,
-		]);
+    /**
+     * Test the Broadcasts block's pagination works when enabled.
+     * 
+     * @since 1.9.7.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsWidgetWithPaginationEnabled(AcceptanceTester $I)
+    {
+        // Create Page with Broadcasts widget in Elementor.
+        $pageID = $this->_createPageWithBroadcastsWidget(
+            $I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Pagination', [
+            'date_format'     => 'F j, Y',
+            'limit'         => 1,
+            'paginate'         => 1,
+            ]
+        );
 
-		// Load Page.
-		$I->amOnPage('?p='.$pageID);
+        // Load Page.
+        $I->amOnPage('?p='.$pageID);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Previous', 'Next');
-	}
+        // Test pagination.
+        $I->testBroadcastsPagination($I, 'Previous', 'Next');
+    }
 
-	/**
-	 * Test the Broadcasts block's pagination labels work when defined.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsWidgetWithPaginationLabelParameters(AcceptanceTester $I)
-	{
-		// Create Page with Broadcasts widget in Elementor.
-		$pageID = $this->_createPageWithBroadcastsWidget($I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Valid Params', [
-			'date_format' 			=> 'F j, Y',
-			'limit' 				=> 1,
-			'paginate' 				=> 1,
-			'paginate_label_prev' 	=> 'Newer',
-			'paginate_label_next' 	=> 'Older',
-		]);
+    /**
+     * Test the Broadcasts block's pagination labels work when defined.
+     * 
+     * @since 1.9.7.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsWidgetWithPaginationLabelParameters(AcceptanceTester $I)
+    {
+        // Create Page with Broadcasts widget in Elementor.
+        $pageID = $this->_createPageWithBroadcastsWidget(
+            $I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Valid Params', [
+            'date_format'             => 'F j, Y',
+            'limit'                 => 1,
+            'paginate'                 => 1,
+            'paginate_label_prev'     => 'Newer',
+            'paginate_label_next'     => 'Older',
+            ]
+        );
 
-		// Load Page.
-		$I->amOnPage('?p='.$pageID);
+        // Load Page.
+        $I->amOnPage('?p='.$pageID);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Older', 'Newer');
-	}
+        // Test pagination.
+        $I->testBroadcastsPagination($I, 'Older', 'Newer');
+    }
 
-	/**
-	 * Test the Broadcasts block's hex colors work when defined.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBroadcastsWidgetWithHexColorParameters(AcceptanceTester $I)
-	{
-		// Define colors.
-		$backgroundColor = '#ee1616';
-		$textColor = '#1212c0';
-		$linkColor = '#ffffff';
+    /**
+     * Test the Broadcasts block's hex colors work when defined.
+     * 
+     * @since 1.9.8.5
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBroadcastsWidgetWithHexColorParameters(AcceptanceTester $I)
+    {
+        // Define colors.
+        $backgroundColor = '#ee1616';
+        $textColor = '#1212c0';
+        $linkColor = '#ffffff';
 
-		// Create Page with Broadcasts widget in Elementor.
-		$pageID = $this->_createPageWithBroadcastsWidget($I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Hex Colors', [
-			'date_format' 			=> 'F j, Y',
-			'limit' 				=> 1,
-			'paginate' 				=> 1,
-			'paginate_label_prev' 	=> 'Newer',
-			'paginate_label_next' 	=> 'Older',
-			'link_color'			=> $linkColor,
-			'background_color'		=> $backgroundColor,
-			'text_color'			=> $textColor,
-		]);
+        // Create Page with Broadcasts widget in Elementor.
+        $pageID = $this->_createPageWithBroadcastsWidget(
+            $I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Hex Colors', [
+            'date_format'             => 'F j, Y',
+            'limit'                 => 1,
+            'paginate'                 => 1,
+            'paginate_label_prev'     => 'Newer',
+            'paginate_label_next'     => 'Older',
+            'link_color'            => $linkColor,
+            'background_color'        => $backgroundColor,
+            'text_color'            => $textColor,
+            ]
+        );
 
-		// Load Page.
-		$I->amOnPage('?p='.$pageID);
+        // Load Page.
+        $I->amOnPage('?p='.$pageID);
 
-		// Wait for frontend web site to load.
-		$I->waitForElementVisible('body.page-template-default');
+        // Wait for frontend web site to load.
+        $I->waitForElementVisible('body.page-template-default');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the block displays.
-		$I->seeBroadcastsOutput($I);
+        // Confirm that the block displays.
+        $I->seeBroadcastsOutput($I);
 
-		// Confirm that our stylesheet loaded.
-		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="'.$_ENV['TEST_SITE_WP_URL'].'/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
+        // Confirm that our stylesheet loaded.
+        $I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="'.$_ENV['TEST_SITE_WP_URL'].'/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
 
-		// Confirm that the chosen colors are applied as CSS styles.
-		$I->seeInSource('<div class="convertkit-broadcasts has-text-color has-background" style="color:'.$textColor.';background-color:'.$backgroundColor.'"');
-		$I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:'.$linkColor.'"');
+        // Confirm that the chosen colors are applied as CSS styles.
+        $I->seeInSource('<div class="convertkit-broadcasts has-text-color has-background" style="color:'.$textColor.';background-color:'.$backgroundColor.'"');
+        $I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:'.$linkColor.'"');
 	
-		// Test pagination.
-		$I->testBroadcastsPagination($I, 'Older', 'Newer');
+        // Test pagination.
+        $I->testBroadcastsPagination($I, 'Older', 'Newer');
 
-		// Confirm that link styles are still applied to refreshed data.
-		$I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:'.$linkColor.'"');
-	}
+        // Confirm that link styles are still applied to refreshed data.
+        $I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:'.$linkColor.'"');
+    }
 
-	/**
-	 * Create a Page in the database comprising of Elementor Page Builder data
-	 * containing a ConvertKit Form widget.
-	 * 
-	 * Codeception's dragAndDrop() method doesn't support dropping an element into an iframe, which is
-	 * how Elementor works for adding widgets to a Page.
-	 * 
-	 * Therefore, we directly create a Page in the database, with Elementor's data structure
-	 * as if we added the Form widget to a Page edited in Elementor.
-	 * 
-	 * testBroadcastsWidgetIsRegistered() above is a sanity check that the Form Widget is registered
-	 * and available to users in Elementor.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @param 	AcceptanceTester 	$I 			Tester.
-	 * @param 	string 				$title 		Page Title.
-	 * @param 	array 				$settings 	Widget settings.
-	 * @return 	int 							Page ID
-	 */
-	private function _createPageWithBroadcastsWidget(AcceptanceTester $I, $title, $settings)
-	{
-		return $I->havePostInDatabase([
-			'post_title'	=> $title,
-			'post_type'		=> 'page',
-			'post_status'	=> 'publish',
-			'meta_input' => [
-				// Elementor.
-				'_elementor_data' => [
-					0 => [
-						'id' => '39bb59d',
-						'elType' => 'section',
-						'settings' => [],
-						'elements' => [
-							[
-								'id' => 'b7e0e57',
-								'elType' => 'column',
-								'settings' => [
-									'_column_size' => 100,
-									'_inline_size' => null,
-								],
-								'elements' => [
-									[
-										'id' => 'a73a905',
-										'elType' => 'widget',
-										'settings' => $settings,
-										'widgetType' => 'convertkit-elementor-broadcasts',
-									],
-								],
-							],
-						],
-					],
-				],
-				'_elementor_version' => '3.6.1',
-				'_elementor_edit_mode' => 'builder',
-				'_elementor_template_type' => 'wp-page',
+    /**
+     * Create a Page in the database comprising of Elementor Page Builder data
+     * containing a ConvertKit Form widget.
+     * 
+     * Codeception's dragAndDrop() method doesn't support dropping an element into an iframe, which is
+     * how Elementor works for adding widgets to a Page.
+     * 
+     * Therefore, we directly create a Page in the database, with Elementor's data structure
+     * as if we added the Form widget to a Page edited in Elementor.
+     * 
+     * testBroadcastsWidgetIsRegistered() above is a sanity check that the Form Widget is registered
+     * and available to users in Elementor.
+     * 
+     * @since 1.9.7.8
+     * 
+     * @param  AcceptanceTester $I        Tester.
+     * @param  string           $title    Page Title.
+     * @param  array            $settings Widget settings.
+     * @return int                             Page ID
+     */
+    private function _createPageWithBroadcastsWidget(AcceptanceTester $I, $title, $settings)
+    {
+        return $I->havePostInDatabase(
+            [
+            'post_title'    => $title,
+            'post_type'        => 'page',
+            'post_status'    => 'publish',
+            'meta_input' => [
+            // Elementor.
+            '_elementor_data' => [
+            0 => [
+            'id' => '39bb59d',
+            'elType' => 'section',
+            'settings' => [],
+            'elements' => [
+            [
+            'id' => 'b7e0e57',
+            'elType' => 'column',
+            'settings' => [
+            '_column_size' => 100,
+            '_inline_size' => null,
+            ],
+            'elements' => [
+            [
+            'id' => 'a73a905',
+            'elType' => 'widget',
+            'settings' => $settings,
+            'widgetType' => 'convertkit-elementor-broadcasts',
+            ],
+            ],
+            ],
+            ],
+            ],
+            ],
+            '_elementor_version' => '3.6.1',
+            '_elementor_edit_mode' => 'builder',
+            '_elementor_template_type' => 'wp-page',
 
-				// Configure ConvertKit Plugin to not display a default Form,
-				// as we are testing for the Form in Elementor.
-				'_wp_convertkit_post_meta' => [
-					'form'         => '-1',
-					'landing_page' => '',
-					'tag'          => '',
-				],
-			],
-		]);
-	}
+            // Configure ConvertKit Plugin to not display a default Form,
+            // as we are testing for the Form in Elementor.
+            '_wp_convertkit_post_meta' => [
+            'form'         => '-1',
+            'landing_page' => '',
+            'tag'          => '',
+            ],
+            ],
+            ]
+        );
+    }
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateThirdPartyPlugin($I, 'elementor');
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.7.8
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateThirdPartyPlugin($I, 'elementor');
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/integrations/ElementorBroadcastsCest.php
+++ b/tests/acceptance/integrations/ElementorBroadcastsCest.php
@@ -1,342 +1,326 @@
 <?php
 /**
  * Tests for the ConvertKit Broadcast's Elementor Widget.
- *
- * @since 1.9.7.8
+ * 
+ * @since 	1.9.7.8
  */
-class ElementorBroadcastsCest {
-
+class ElementorBroadcastsCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.7.8
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.8
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
-		$I->activateConvertKitPlugin( $I );
-		$I->activateThirdPartyPlugin( $I, 'elementor' );
-		$I->setupConvertKitPlugin( $I );
-		$I->enableDebugLog( $I );
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'elementor');
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
 	}
 
 	/**
 	 * Test the Broadcasts widget is registered in Elementor.
-	 *
-	 * @since 1.9.7.8
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.8
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsWidgetIsRegistered( AcceptanceTester $I ) {
+	public function testBroadcastsWidgetIsRegistered(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Elementor: Registered' );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Elementor: Registered');
 
 		// Click Edit with Elementor button.
-		$I->click( '#elementor-switch-mode-button' );
+		$I->click('#elementor-switch-mode-button');
 
 		// When Elementor loads, search for the ConvertKit Broadcasts block.
-		$I->waitForElementVisible( '#elementor-panel-elements-search-input' );
-		$I->fillField( '#elementor-panel-elements-search-input', 'ConvertKit Broadcasts' );
+		$I->waitForElementVisible('#elementor-panel-elements-search-input');
+		$I->fillField('#elementor-panel-elements-search-input', 'ConvertKit Broadcasts');
 
 		// Confirm that the Broadcasts widget is displayed as an option.
-		$I->seeElementInDOM( '#elementor-panel-elements .elementor-element' );
+		$I->seeElementInDOM('#elementor-panel-elements .elementor-element');
 	}
 
 	/**
 	 * Test the Broadcasts block works when using valid parameters.
-	 *
-	 * @since 1.9.7.8
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.8
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsWidgetWithValidParameters( AcceptanceTester $I ) {
+	public function testBroadcastsWidgetWithValidParameters(AcceptanceTester $I)
+	{
 		// Create Page with Broadcasts widget in Elementor.
-		$pageID = $this->_createPageWithBroadcastsWidget(
-			$I,
-			'ConvertKit: Page: Broadcasts: Elementor Widget: Valid Params',
-			array(
-				'date_format' => 'F j, Y',
-				'limit'       => 10,
-			)
-		);
+		$pageID = $this->_createPageWithBroadcastsWidget($I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Valid Params', [
+			'date_format' 	=> 'F j, Y',
+			'limit' 		=> 10,
+		]);
 
 		// Load Page.
-		$I->amOnPage( '?p=' . $pageID );
+		$I->amOnPage('?p='.$pageID);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the block displays.
-		$I->seeBroadcastsOutput( $I );
+		$I->seeBroadcastsOutput($I);
 
 		// Confirm that the default date format is as expected.
-		$I->seeInSource( '<time datetime="2022-04-08">April 8, 2022</time>' );
+		$I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
 
 		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements( 'li.convertkit-broadcast', array( 1, 10 ) );
+		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
 	}
 
 	/**
 	 * Test the Broadcasts block's date format parameter works.
-	 *
-	 * @since 1.9.7.8
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.8
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsWidgetWithDateFormatParameter( AcceptanceTester $I ) {
+	public function testBroadcastsWidgetWithDateFormatParameter(AcceptanceTester $I)
+	{
 		// Create Page with Broadcasts widget in Elementor.
-		$pageID = $this->_createPageWithBroadcastsWidget(
-			$I,
-			'ConvertKit: Page: Broadcasts: Elementor Widget: Date Format',
-			array(
-				'date_format' => 'Y-m-d',
-				'limit'       => 10,
-			)
-		);
+		$pageID = $this->_createPageWithBroadcastsWidget($I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Date Format', [
+			'date_format' => 'Y-m-d',
+			'limit' 	  => 10,
+		]);
 
 		// Load Page.
-		$I->amOnPage( '?p=' . $pageID );
+		$I->amOnPage('?p='.$pageID);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the block displays.
-		$I->seeBroadcastsOutput( $I );
+		$I->seeBroadcastsOutput($I);
 
 		// Confirm that the date format is as expected.
-		$I->seeInSource( '<time datetime="2022-04-08">2022-04-08</time>' );
+		$I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
 
 		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements( 'li.convertkit-broadcast', array( 1, 10 ) );
+		$I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
 	}
 
 	/**
 	 * Test the Broadcasts block's limit parameter works.
-	 *
-	 * @since 1.9.7.8
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.8
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsWidgetWithLimitParameter( AcceptanceTester $I ) {
+	public function testBroadcastsWidgetWithLimitParameter(AcceptanceTester $I)
+	{
 		// Create Page with Broadcasts widget in Elementor.
-		$pageID = $this->_createPageWithBroadcastsWidget(
-			$I,
-			'ConvertKit: Page: Broadcasts: Elementor Widget: Limit',
-			array(
-				'date_format' => 'F j, Y',
-				'limit'       => 2,
-			)
-		);
+		$pageID = $this->_createPageWithBroadcastsWidget($I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Limit', [
+			'date_format' 	=> 'F j, Y',
+			'limit' 		=> 2,
+		]);
 
 		// Load Page.
-		$I->amOnPage( '?p=' . $pageID );
+		$I->amOnPage('?p='.$pageID);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the block displays.
-		$I->seeBroadcastsOutput( $I );
+		$I->seeBroadcastsOutput($I);
 
 		// Confirm that the expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements( 'li.convertkit-broadcast', 2 );
+		$I->seeNumberOfElements('li.convertkit-broadcast', 2);
 	}
 
 	/**
 	 * Test the Broadcasts block's pagination works when enabled.
-	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsWidgetWithPaginationEnabled( AcceptanceTester $I ) {
+	public function testBroadcastsWidgetWithPaginationEnabled(AcceptanceTester $I)
+	{
 		// Create Page with Broadcasts widget in Elementor.
-		$pageID = $this->_createPageWithBroadcastsWidget(
-			$I,
-			'ConvertKit: Page: Broadcasts: Elementor Widget: Pagination',
-			array(
-				'date_format' => 'F j, Y',
-				'limit'       => 1,
-				'paginate'    => 1,
-			)
-		);
+		$pageID = $this->_createPageWithBroadcastsWidget($I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Pagination', [
+			'date_format' 	=> 'F j, Y',
+			'limit' 		=> 1,
+			'paginate' 		=> 1,
+		]);
 
 		// Load Page.
-		$I->amOnPage( '?p=' . $pageID );
+		$I->amOnPage('?p='.$pageID);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Test pagination.
-		$I->testBroadcastsPagination( $I, 'Previous', 'Next' );
+		$I->testBroadcastsPagination($I, 'Previous', 'Next');
 	}
 
 	/**
 	 * Test the Broadcasts block's pagination labels work when defined.
-	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsWidgetWithPaginationLabelParameters( AcceptanceTester $I ) {
+	public function testBroadcastsWidgetWithPaginationLabelParameters(AcceptanceTester $I)
+	{
 		// Create Page with Broadcasts widget in Elementor.
-		$pageID = $this->_createPageWithBroadcastsWidget(
-			$I,
-			'ConvertKit: Page: Broadcasts: Elementor Widget: Valid Params',
-			array(
-				'date_format'         => 'F j, Y',
-				'limit'               => 1,
-				'paginate'            => 1,
-				'paginate_label_prev' => 'Newer',
-				'paginate_label_next' => 'Older',
-			)
-		);
+		$pageID = $this->_createPageWithBroadcastsWidget($I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Valid Params', [
+			'date_format' 			=> 'F j, Y',
+			'limit' 				=> 1,
+			'paginate' 				=> 1,
+			'paginate_label_prev' 	=> 'Newer',
+			'paginate_label_next' 	=> 'Older',
+		]);
 
 		// Load Page.
-		$I->amOnPage( '?p=' . $pageID );
+		$I->amOnPage('?p='.$pageID);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Test pagination.
-		$I->testBroadcastsPagination( $I, 'Older', 'Newer' );
+		$I->testBroadcastsPagination($I, 'Older', 'Newer');
 	}
 
 	/**
 	 * Test the Broadcasts block's hex colors work when defined.
-	 *
-	 * @since 1.9.8.5
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBroadcastsWidgetWithHexColorParameters( AcceptanceTester $I ) {
+	public function testBroadcastsWidgetWithHexColorParameters(AcceptanceTester $I)
+	{
 		// Define colors.
 		$backgroundColor = '#ee1616';
-		$textColor       = '#1212c0';
-		$linkColor       = '#ffffff';
+		$textColor = '#1212c0';
+		$linkColor = '#ffffff';
 
 		// Create Page with Broadcasts widget in Elementor.
-		$pageID = $this->_createPageWithBroadcastsWidget(
-			$I,
-			'ConvertKit: Page: Broadcasts: Elementor Widget: Hex Colors',
-			array(
-				'date_format'         => 'F j, Y',
-				'limit'               => 1,
-				'paginate'            => 1,
-				'paginate_label_prev' => 'Newer',
-				'paginate_label_next' => 'Older',
-				'link_color'          => $linkColor,
-				'background_color'    => $backgroundColor,
-				'text_color'          => $textColor,
-			)
-		);
+		$pageID = $this->_createPageWithBroadcastsWidget($I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Hex Colors', [
+			'date_format' 			=> 'F j, Y',
+			'limit' 				=> 1,
+			'paginate' 				=> 1,
+			'paginate_label_prev' 	=> 'Newer',
+			'paginate_label_next' 	=> 'Older',
+			'link_color'			=> $linkColor,
+			'background_color'		=> $backgroundColor,
+			'text_color'			=> $textColor,
+		]);
 
 		// Load Page.
-		$I->amOnPage( '?p=' . $pageID );
+		$I->amOnPage('?p='.$pageID);
 
 		// Wait for frontend web site to load.
-		$I->waitForElementVisible( 'body.page-template-default' );
+		$I->waitForElementVisible('body.page-template-default');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the block displays.
-		$I->seeBroadcastsOutput( $I );
+		$I->seeBroadcastsOutput($I);
 
 		// Confirm that our stylesheet loaded.
-		$I->seeInSource( '<link rel="stylesheet" id="convertkit-broadcasts-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css' );
+		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="'.$_ENV['TEST_SITE_WP_URL'].'/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
 
 		// Confirm that the chosen colors are applied as CSS styles.
-		$I->seeInSource( '<div class="convertkit-broadcasts has-text-color has-background" style="color:' . $textColor . ';background-color:' . $backgroundColor . '"' );
-		$I->seeInSource( '<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:' . $linkColor . '"' );
-
+		$I->seeInSource('<div class="convertkit-broadcasts has-text-color has-background" style="color:'.$textColor.';background-color:'.$backgroundColor.'"');
+		$I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:'.$linkColor.'"');
+	
 		// Test pagination.
-		$I->testBroadcastsPagination( $I, 'Older', 'Newer' );
+		$I->testBroadcastsPagination($I, 'Older', 'Newer');
 
 		// Confirm that link styles are still applied to refreshed data.
-		$I->seeInSource( '<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:' . $linkColor . '"' );
+		$I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:'.$linkColor.'"');
 	}
 
 	/**
 	 * Create a Page in the database comprising of Elementor Page Builder data
 	 * containing a ConvertKit Form widget.
-	 *
+	 * 
 	 * Codeception's dragAndDrop() method doesn't support dropping an element into an iframe, which is
 	 * how Elementor works for adding widgets to a Page.
-	 *
+	 * 
 	 * Therefore, we directly create a Page in the database, with Elementor's data structure
 	 * as if we added the Form widget to a Page edited in Elementor.
-	 *
+	 * 
 	 * testBroadcastsWidgetIsRegistered() above is a sanity check that the Form Widget is registered
 	 * and available to users in Elementor.
-	 *
-	 * @since 1.9.7.8
-	 *
-	 * @param  AcceptanceTester $I        Tester.
-	 * @param  string           $title    Page Title.
-	 * @param  array            $settings Widget settings.
-	 * @return int                             Page ID
+	 * 
+	 * @since 	1.9.7.8
+	 * 
+	 * @param 	AcceptanceTester 	$I 			Tester.
+	 * @param 	string 				$title 		Page Title.
+	 * @param 	array 				$settings 	Widget settings.
+	 * @return 	int 							Page ID
 	 */
-	private function _createPageWithBroadcastsWidget( AcceptanceTester $I, $title, $settings ) {
-		return $I->havePostInDatabase(
-			array(
-				'post_title'  => $title,
-				'post_type'   => 'page',
-				'post_status' => 'publish',
-				'meta_input'  => array(
-					// Elementor.
-					'_elementor_data'          => array(
-						0 => array(
-							'id'       => '39bb59d',
-							'elType'   => 'section',
-							'settings' => array(),
-							'elements' => array(
-								array(
-									'id'       => 'b7e0e57',
-									'elType'   => 'column',
-									'settings' => array(
-										'_column_size' => 100,
-										'_inline_size' => null,
-									),
-									'elements' => array(
-										array(
-											'id'         => 'a73a905',
-											'elType'     => 'widget',
-											'settings'   => $settings,
-											'widgetType' => 'convertkit-elementor-broadcasts',
-										),
-									),
-								),
-							),
-						),
-					),
-					'_elementor_version'       => '3.6.1',
-					'_elementor_edit_mode'     => 'builder',
-					'_elementor_template_type' => 'wp-page',
+	private function _createPageWithBroadcastsWidget(AcceptanceTester $I, $title, $settings)
+	{
+		return $I->havePostInDatabase([
+			'post_title'	=> $title,
+			'post_type'		=> 'page',
+			'post_status'	=> 'publish',
+			'meta_input' => [
+				// Elementor.
+				'_elementor_data' => [
+					0 => [
+						'id' => '39bb59d',
+						'elType' => 'section',
+						'settings' => [],
+						'elements' => [
+							[
+								'id' => 'b7e0e57',
+								'elType' => 'column',
+								'settings' => [
+									'_column_size' => 100,
+									'_inline_size' => null,
+								],
+								'elements' => [
+									[
+										'id' => 'a73a905',
+										'elType' => 'widget',
+										'settings' => $settings,
+										'widgetType' => 'convertkit-elementor-broadcasts',
+									],
+								],
+							],
+						],
+					],
+				],
+				'_elementor_version' => '3.6.1',
+				'_elementor_edit_mode' => 'builder',
+				'_elementor_template_type' => 'wp-page',
 
-					// Configure ConvertKit Plugin to not display a default Form,
-					// as we are testing for the Form in Elementor.
-					'_wp_convertkit_post_meta' => array(
-						'form'         => '-1',
-						'landing_page' => '',
-						'tag'          => '',
-					),
-				),
-			)
-		);
+				// Configure ConvertKit Plugin to not display a default Form,
+				// as we are testing for the Form in Elementor.
+				'_wp_convertkit_post_meta' => [
+					'form'         => '-1',
+					'landing_page' => '',
+					'tag'          => '',
+				],
+			],
+		]);
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.7.8
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.8
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateThirdPartyPlugin( $I, 'elementor' );
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateThirdPartyPlugin($I, 'elementor');
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/integrations/ElementorBroadcastsCest.php
+++ b/tests/acceptance/integrations/ElementorBroadcastsCest.php
@@ -1,340 +1,342 @@
 <?php
 /**
  * Tests for the ConvertKit Broadcast's Elementor Widget.
- * 
+ *
  * @since 1.9.7.8
  */
-class ElementorBroadcastsCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.7.8
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        $I->activateConvertKitPlugin($I);
-        $I->activateThirdPartyPlugin($I, 'elementor');
-        $I->setupConvertKitPlugin($I);
-        $I->enableDebugLog($I);
-    }
+class ElementorBroadcastsCest {
 
-    /**
-     * Test the Broadcasts widget is registered in Elementor.
-     * 
-     * @since 1.9.7.8
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsWidgetIsRegistered(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Elementor: Registered');
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.7.8
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		$I->activateConvertKitPlugin( $I );
+		$I->activateThirdPartyPlugin( $I, 'elementor' );
+		$I->setupConvertKitPlugin( $I );
+		$I->enableDebugLog( $I );
+	}
 
-        // Click Edit with Elementor button.
-        $I->click('#elementor-switch-mode-button');
+	/**
+	 * Test the Broadcasts widget is registered in Elementor.
+	 *
+	 * @since 1.9.7.8
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsWidgetIsRegistered( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Broadcasts: Elementor: Registered' );
 
-        // When Elementor loads, search for the ConvertKit Broadcasts block.
-        $I->waitForElementVisible('#elementor-panel-elements-search-input');
-        $I->fillField('#elementor-panel-elements-search-input', 'ConvertKit Broadcasts');
+		// Click Edit with Elementor button.
+		$I->click( '#elementor-switch-mode-button' );
 
-        // Confirm that the Broadcasts widget is displayed as an option.
-        $I->seeElementInDOM('#elementor-panel-elements .elementor-element');
-    }
+		// When Elementor loads, search for the ConvertKit Broadcasts block.
+		$I->waitForElementVisible( '#elementor-panel-elements-search-input' );
+		$I->fillField( '#elementor-panel-elements-search-input', 'ConvertKit Broadcasts' );
 
-    /**
-     * Test the Broadcasts block works when using valid parameters.
-     * 
-     * @since 1.9.7.8
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsWidgetWithValidParameters(AcceptanceTester $I)
-    {
-        // Create Page with Broadcasts widget in Elementor.
-        $pageID = $this->_createPageWithBroadcastsWidget(
-            $I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Valid Params', [
-            'date_format'     => 'F j, Y',
-            'limit'         => 10,
-            ]
-        );
+		// Confirm that the Broadcasts widget is displayed as an option.
+		$I->seeElementInDOM( '#elementor-panel-elements .elementor-element' );
+	}
 
-        // Load Page.
-        $I->amOnPage('?p='.$pageID);
+	/**
+	 * Test the Broadcasts block works when using valid parameters.
+	 *
+	 * @since 1.9.7.8
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsWidgetWithValidParameters( AcceptanceTester $I ) {
+		// Create Page with Broadcasts widget in Elementor.
+		$pageID = $this->_createPageWithBroadcastsWidget(
+			$I,
+			'ConvertKit: Page: Broadcasts: Elementor Widget: Valid Params',
+			array(
+				'date_format' => 'F j, Y',
+				'limit'       => 10,
+			)
+		);
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Load Page.
+		$I->amOnPage( '?p=' . $pageID );
 
-        // Confirm that the block displays.
-        $I->seeBroadcastsOutput($I);
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-        // Confirm that the default date format is as expected.
-        $I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
+		// Confirm that the block displays.
+		$I->seeBroadcastsOutput( $I );
 
-        // Confirm that the default expected number of Broadcasts are displayed.
-        $I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
-    }
+		// Confirm that the default date format is as expected.
+		$I->seeInSource( '<time datetime="2022-04-08">April 8, 2022</time>' );
 
-    /**
-     * Test the Broadcasts block's date format parameter works.
-     * 
-     * @since 1.9.7.8
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsWidgetWithDateFormatParameter(AcceptanceTester $I)
-    {
-        // Create Page with Broadcasts widget in Elementor.
-        $pageID = $this->_createPageWithBroadcastsWidget(
-            $I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Date Format', [
-            'date_format' => 'Y-m-d',
-            'limit'       => 10,
-            ]
-        );
+		// Confirm that the default expected number of Broadcasts are displayed.
+		$I->seeNumberOfElements( 'li.convertkit-broadcast', array( 1, 10 ) );
+	}
 
-        // Load Page.
-        $I->amOnPage('?p='.$pageID);
+	/**
+	 * Test the Broadcasts block's date format parameter works.
+	 *
+	 * @since 1.9.7.8
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsWidgetWithDateFormatParameter( AcceptanceTester $I ) {
+		// Create Page with Broadcasts widget in Elementor.
+		$pageID = $this->_createPageWithBroadcastsWidget(
+			$I,
+			'ConvertKit: Page: Broadcasts: Elementor Widget: Date Format',
+			array(
+				'date_format' => 'Y-m-d',
+				'limit'       => 10,
+			)
+		);
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Load Page.
+		$I->amOnPage( '?p=' . $pageID );
 
-        // Confirm that the block displays.
-        $I->seeBroadcastsOutput($I);
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-        // Confirm that the date format is as expected.
-        $I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
+		// Confirm that the block displays.
+		$I->seeBroadcastsOutput( $I );
 
-        // Confirm that the default expected number of Broadcasts are displayed.
-        $I->seeNumberOfElements('li.convertkit-broadcast', [1,10]);
-    }
+		// Confirm that the date format is as expected.
+		$I->seeInSource( '<time datetime="2022-04-08">2022-04-08</time>' );
 
-    /**
-     * Test the Broadcasts block's limit parameter works.
-     * 
-     * @since 1.9.7.8
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsWidgetWithLimitParameter(AcceptanceTester $I)
-    {
-        // Create Page with Broadcasts widget in Elementor.
-        $pageID = $this->_createPageWithBroadcastsWidget(
-            $I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Limit', [
-            'date_format'     => 'F j, Y',
-            'limit'         => 2,
-            ]
-        );
+		// Confirm that the default expected number of Broadcasts are displayed.
+		$I->seeNumberOfElements( 'li.convertkit-broadcast', array( 1, 10 ) );
+	}
 
-        // Load Page.
-        $I->amOnPage('?p='.$pageID);
+	/**
+	 * Test the Broadcasts block's limit parameter works.
+	 *
+	 * @since 1.9.7.8
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsWidgetWithLimitParameter( AcceptanceTester $I ) {
+		// Create Page with Broadcasts widget in Elementor.
+		$pageID = $this->_createPageWithBroadcastsWidget(
+			$I,
+			'ConvertKit: Page: Broadcasts: Elementor Widget: Limit',
+			array(
+				'date_format' => 'F j, Y',
+				'limit'       => 2,
+			)
+		);
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Load Page.
+		$I->amOnPage( '?p=' . $pageID );
 
-        // Confirm that the block displays.
-        $I->seeBroadcastsOutput($I);
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-        // Confirm that the expected number of Broadcasts are displayed.
-        $I->seeNumberOfElements('li.convertkit-broadcast', 2);
-    }
+		// Confirm that the block displays.
+		$I->seeBroadcastsOutput( $I );
 
-    /**
-     * Test the Broadcasts block's pagination works when enabled.
-     * 
-     * @since 1.9.7.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsWidgetWithPaginationEnabled(AcceptanceTester $I)
-    {
-        // Create Page with Broadcasts widget in Elementor.
-        $pageID = $this->_createPageWithBroadcastsWidget(
-            $I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Pagination', [
-            'date_format'     => 'F j, Y',
-            'limit'         => 1,
-            'paginate'         => 1,
-            ]
-        );
+		// Confirm that the expected number of Broadcasts are displayed.
+		$I->seeNumberOfElements( 'li.convertkit-broadcast', 2 );
+	}
 
-        // Load Page.
-        $I->amOnPage('?p='.$pageID);
+	/**
+	 * Test the Broadcasts block's pagination works when enabled.
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsWidgetWithPaginationEnabled( AcceptanceTester $I ) {
+		// Create Page with Broadcasts widget in Elementor.
+		$pageID = $this->_createPageWithBroadcastsWidget(
+			$I,
+			'ConvertKit: Page: Broadcasts: Elementor Widget: Pagination',
+			array(
+				'date_format' => 'F j, Y',
+				'limit'       => 1,
+				'paginate'    => 1,
+			)
+		);
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Load Page.
+		$I->amOnPage( '?p=' . $pageID );
 
-        // Test pagination.
-        $I->testBroadcastsPagination($I, 'Previous', 'Next');
-    }
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-    /**
-     * Test the Broadcasts block's pagination labels work when defined.
-     * 
-     * @since 1.9.7.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsWidgetWithPaginationLabelParameters(AcceptanceTester $I)
-    {
-        // Create Page with Broadcasts widget in Elementor.
-        $pageID = $this->_createPageWithBroadcastsWidget(
-            $I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Valid Params', [
-            'date_format'             => 'F j, Y',
-            'limit'                 => 1,
-            'paginate'                 => 1,
-            'paginate_label_prev'     => 'Newer',
-            'paginate_label_next'     => 'Older',
-            ]
-        );
+		// Test pagination.
+		$I->testBroadcastsPagination( $I, 'Previous', 'Next' );
+	}
 
-        // Load Page.
-        $I->amOnPage('?p='.$pageID);
+	/**
+	 * Test the Broadcasts block's pagination labels work when defined.
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsWidgetWithPaginationLabelParameters( AcceptanceTester $I ) {
+		// Create Page with Broadcasts widget in Elementor.
+		$pageID = $this->_createPageWithBroadcastsWidget(
+			$I,
+			'ConvertKit: Page: Broadcasts: Elementor Widget: Valid Params',
+			array(
+				'date_format'         => 'F j, Y',
+				'limit'               => 1,
+				'paginate'            => 1,
+				'paginate_label_prev' => 'Newer',
+				'paginate_label_next' => 'Older',
+			)
+		);
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Load Page.
+		$I->amOnPage( '?p=' . $pageID );
 
-        // Test pagination.
-        $I->testBroadcastsPagination($I, 'Older', 'Newer');
-    }
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-    /**
-     * Test the Broadcasts block's hex colors work when defined.
-     * 
-     * @since 1.9.8.5
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBroadcastsWidgetWithHexColorParameters(AcceptanceTester $I)
-    {
-        // Define colors.
-        $backgroundColor = '#ee1616';
-        $textColor = '#1212c0';
-        $linkColor = '#ffffff';
+		// Test pagination.
+		$I->testBroadcastsPagination( $I, 'Older', 'Newer' );
+	}
 
-        // Create Page with Broadcasts widget in Elementor.
-        $pageID = $this->_createPageWithBroadcastsWidget(
-            $I, 'ConvertKit: Page: Broadcasts: Elementor Widget: Hex Colors', [
-            'date_format'             => 'F j, Y',
-            'limit'                 => 1,
-            'paginate'                 => 1,
-            'paginate_label_prev'     => 'Newer',
-            'paginate_label_next'     => 'Older',
-            'link_color'            => $linkColor,
-            'background_color'        => $backgroundColor,
-            'text_color'            => $textColor,
-            ]
-        );
+	/**
+	 * Test the Broadcasts block's hex colors work when defined.
+	 *
+	 * @since 1.9.8.5
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBroadcastsWidgetWithHexColorParameters( AcceptanceTester $I ) {
+		// Define colors.
+		$backgroundColor = '#ee1616';
+		$textColor       = '#1212c0';
+		$linkColor       = '#ffffff';
 
-        // Load Page.
-        $I->amOnPage('?p='.$pageID);
+		// Create Page with Broadcasts widget in Elementor.
+		$pageID = $this->_createPageWithBroadcastsWidget(
+			$I,
+			'ConvertKit: Page: Broadcasts: Elementor Widget: Hex Colors',
+			array(
+				'date_format'         => 'F j, Y',
+				'limit'               => 1,
+				'paginate'            => 1,
+				'paginate_label_prev' => 'Newer',
+				'paginate_label_next' => 'Older',
+				'link_color'          => $linkColor,
+				'background_color'    => $backgroundColor,
+				'text_color'          => $textColor,
+			)
+		);
 
-        // Wait for frontend web site to load.
-        $I->waitForElementVisible('body.page-template-default');
+		// Load Page.
+		$I->amOnPage( '?p=' . $pageID );
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible( 'body.page-template-default' );
 
-        // Confirm that the block displays.
-        $I->seeBroadcastsOutput($I);
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-        // Confirm that our stylesheet loaded.
-        $I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="'.$_ENV['TEST_SITE_WP_URL'].'/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
+		// Confirm that the block displays.
+		$I->seeBroadcastsOutput( $I );
 
-        // Confirm that the chosen colors are applied as CSS styles.
-        $I->seeInSource('<div class="convertkit-broadcasts has-text-color has-background" style="color:'.$textColor.';background-color:'.$backgroundColor.'"');
-        $I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:'.$linkColor.'"');
-	
-        // Test pagination.
-        $I->testBroadcastsPagination($I, 'Older', 'Newer');
+		// Confirm that our stylesheet loaded.
+		$I->seeInSource( '<link rel="stylesheet" id="convertkit-broadcasts-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css' );
 
-        // Confirm that link styles are still applied to refreshed data.
-        $I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:'.$linkColor.'"');
-    }
+		// Confirm that the chosen colors are applied as CSS styles.
+		$I->seeInSource( '<div class="convertkit-broadcasts has-text-color has-background" style="color:' . $textColor . ';background-color:' . $backgroundColor . '"' );
+		$I->seeInSource( '<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:' . $linkColor . '"' );
 
-    /**
-     * Create a Page in the database comprising of Elementor Page Builder data
-     * containing a ConvertKit Form widget.
-     * 
-     * Codeception's dragAndDrop() method doesn't support dropping an element into an iframe, which is
-     * how Elementor works for adding widgets to a Page.
-     * 
-     * Therefore, we directly create a Page in the database, with Elementor's data structure
-     * as if we added the Form widget to a Page edited in Elementor.
-     * 
-     * testBroadcastsWidgetIsRegistered() above is a sanity check that the Form Widget is registered
-     * and available to users in Elementor.
-     * 
-     * @since 1.9.7.8
-     * 
-     * @param  AcceptanceTester $I        Tester.
-     * @param  string           $title    Page Title.
-     * @param  array            $settings Widget settings.
-     * @return int                             Page ID
-     */
-    private function _createPageWithBroadcastsWidget(AcceptanceTester $I, $title, $settings)
-    {
-        return $I->havePostInDatabase(
-            [
-            'post_title'    => $title,
-            'post_type'        => 'page',
-            'post_status'    => 'publish',
-            'meta_input' => [
-            // Elementor.
-            '_elementor_data' => [
-            0 => [
-            'id' => '39bb59d',
-            'elType' => 'section',
-            'settings' => [],
-            'elements' => [
-            [
-            'id' => 'b7e0e57',
-            'elType' => 'column',
-            'settings' => [
-            '_column_size' => 100,
-            '_inline_size' => null,
-            ],
-            'elements' => [
-            [
-            'id' => 'a73a905',
-            'elType' => 'widget',
-            'settings' => $settings,
-            'widgetType' => 'convertkit-elementor-broadcasts',
-            ],
-            ],
-            ],
-            ],
-            ],
-            ],
-            '_elementor_version' => '3.6.1',
-            '_elementor_edit_mode' => 'builder',
-            '_elementor_template_type' => 'wp-page',
+		// Test pagination.
+		$I->testBroadcastsPagination( $I, 'Older', 'Newer' );
 
-            // Configure ConvertKit Plugin to not display a default Form,
-            // as we are testing for the Form in Elementor.
-            '_wp_convertkit_post_meta' => [
-            'form'         => '-1',
-            'landing_page' => '',
-            'tag'          => '',
-            ],
-            ],
-            ]
-        );
-    }
+		// Confirm that link styles are still applied to refreshed data.
+		$I->seeInSource( '<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:' . $linkColor . '"' );
+	}
 
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.7.8
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateThirdPartyPlugin($I, 'elementor');
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+	/**
+	 * Create a Page in the database comprising of Elementor Page Builder data
+	 * containing a ConvertKit Form widget.
+	 *
+	 * Codeception's dragAndDrop() method doesn't support dropping an element into an iframe, which is
+	 * how Elementor works for adding widgets to a Page.
+	 *
+	 * Therefore, we directly create a Page in the database, with Elementor's data structure
+	 * as if we added the Form widget to a Page edited in Elementor.
+	 *
+	 * testBroadcastsWidgetIsRegistered() above is a sanity check that the Form Widget is registered
+	 * and available to users in Elementor.
+	 *
+	 * @since 1.9.7.8
+	 *
+	 * @param  AcceptanceTester $I        Tester.
+	 * @param  string           $title    Page Title.
+	 * @param  array            $settings Widget settings.
+	 * @return int                             Page ID
+	 */
+	private function _createPageWithBroadcastsWidget( AcceptanceTester $I, $title, $settings ) {
+		return $I->havePostInDatabase(
+			array(
+				'post_title'  => $title,
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'meta_input'  => array(
+					// Elementor.
+					'_elementor_data'          => array(
+						0 => array(
+							'id'       => '39bb59d',
+							'elType'   => 'section',
+							'settings' => array(),
+							'elements' => array(
+								array(
+									'id'       => 'b7e0e57',
+									'elType'   => 'column',
+									'settings' => array(
+										'_column_size' => 100,
+										'_inline_size' => null,
+									),
+									'elements' => array(
+										array(
+											'id'         => 'a73a905',
+											'elType'     => 'widget',
+											'settings'   => $settings,
+											'widgetType' => 'convertkit-elementor-broadcasts',
+										),
+									),
+								),
+							),
+						),
+					),
+					'_elementor_version'       => '3.6.1',
+					'_elementor_edit_mode'     => 'builder',
+					'_elementor_template_type' => 'wp-page',
+
+					// Configure ConvertKit Plugin to not display a default Form,
+					// as we are testing for the Form in Elementor.
+					'_wp_convertkit_post_meta' => array(
+						'form'         => '-1',
+						'landing_page' => '',
+						'tag'          => '',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.7.8
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateThirdPartyPlugin( $I, 'elementor' );
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/integrations/ElementorFormCest.php
+++ b/tests/acceptance/integrations/ElementorFormCest.php
@@ -2,197 +2,199 @@
 /**
  * Tests for the ConvertKit Form's Elementor Widget.
  * 
- * @since 	1.9.6
+ * @since 1.9.6
  */
 class ElementorFormCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		$I->activateConvertKitPlugin($I);
-		$I->activateThirdPartyPlugin($I, 'elementor');
-		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
-	}
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        $I->activateConvertKitPlugin($I);
+        $I->activateThirdPartyPlugin($I, 'elementor');
+        $I->setupConvertKitPlugin($I);
+        $I->enableDebugLog($I);
+    }
 
-	/**
-	 * Test the Form widget is registered in Elementor.
-	 * 
-	 * @since 	1.9.7.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testFormWidgetIsRegistered(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Elementor: Valid Form Param');
+    /**
+     * Test the Form widget is registered in Elementor.
+     * 
+     * @since 1.9.7.2
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testFormWidgetIsRegistered(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Elementor: Valid Form Param');
 
-		// Click Edit with Elementor button.
-		$I->click('#elementor-switch-mode-button');
+        // Click Edit with Elementor button.
+        $I->click('#elementor-switch-mode-button');
 
-		// When Elementor loads, search for the ConvertKit Form block.
-		$I->waitForElementVisible('#elementor-panel-elements-search-input');
-		$I->fillField('#elementor-panel-elements-search-input', 'ConvertKit Form');
+        // When Elementor loads, search for the ConvertKit Form block.
+        $I->waitForElementVisible('#elementor-panel-elements-search-input');
+        $I->fillField('#elementor-panel-elements-search-input', 'ConvertKit Form');
 
-		// Confirm that the Form widget is displayed as an option.
-		$I->seeElementInDOM('#elementor-panel-elements .elementor-element');
-	}
+        // Confirm that the Form widget is displayed as an option.
+        $I->seeElementInDOM('#elementor-panel-elements .elementor-element');
+    }
 
-	/**
-	 * Test the Form widget works when a valid Form is selected.
-	 * 
-	 * @since 	1.9.7.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testFormWidgetWithValidFormParameter(AcceptanceTester $I)
-	{
-		// Create Page with Form widget in Elementor.
-		$pageID = $this->_createPageWithFormWidget($I, 'ConvertKit: Page: Form: Elementor Widget: Valid Form Param', $_ENV['CONVERTKIT_API_FORM_ID']);
+    /**
+     * Test the Form widget works when a valid Form is selected.
+     * 
+     * @since 1.9.7.2
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testFormWidgetWithValidFormParameter(AcceptanceTester $I)
+    {
+        // Create Page with Form widget in Elementor.
+        $pageID = $this->_createPageWithFormWidget($I, 'ConvertKit: Page: Form: Elementor Widget: Valid Form Param', $_ENV['CONVERTKIT_API_FORM_ID']);
 
-		// Load Page.
-		$I->amOnPage('?p='.$pageID);
+        // Load Page.
+        $I->amOnPage('?p='.$pageID);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the ConvertKit Form is displayed.
-		$I->seeElementInDOM('form[data-sv-form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]');
-	}
+        // Confirm that the ConvertKit Form is displayed.
+        $I->seeElementInDOM('form[data-sv-form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]');
+    }
 
-	/**
-	 * Test the Form widget works when a valid Legacy Form is selected.
-	 * 
-	 * @since 	1.9.7.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testFormWidgetWithValidLegacyFormParameter(AcceptanceTester $I)
-	{
-		// Create Page with Form widget in Elementor.
-		$pageID = $this->_createPageWithFormWidget($I, 'ConvertKit: Legacy Form: Elementor Widget: Valid Form Param', $_ENV['CONVERTKIT_API_LEGACY_FORM_ID']);
+    /**
+     * Test the Form widget works when a valid Legacy Form is selected.
+     * 
+     * @since 1.9.7.2
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testFormWidgetWithValidLegacyFormParameter(AcceptanceTester $I)
+    {
+        // Create Page with Form widget in Elementor.
+        $pageID = $this->_createPageWithFormWidget($I, 'ConvertKit: Legacy Form: Elementor Widget: Valid Form Param', $_ENV['CONVERTKIT_API_LEGACY_FORM_ID']);
 
-		// Load Page.
-		$I->amOnPage('?p='.$pageID);
+        // Load Page.
+        $I->amOnPage('?p='.$pageID);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the ConvertKit Form is displayed.
-		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
-	}
+        // Confirm that the ConvertKit Form is displayed.
+        $I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
+    }
 
-	/**
-	 * Test the Form widget works when no Form is selected.
-	 * 
-	 * @since 	1.9.7.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testFormWidgetWithNoFormParameter(AcceptanceTester $I)
-	{
-		// Create Page with Form widget in Elementor.
-		$pageID = $this->_createPageWithFormWidget($I, 'ConvertKit: Page: Form: Elementor Widget: No Form Param', '');
+    /**
+     * Test the Form widget works when no Form is selected.
+     * 
+     * @since 1.9.7.2
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testFormWidgetWithNoFormParameter(AcceptanceTester $I)
+    {
+        // Create Page with Form widget in Elementor.
+        $pageID = $this->_createPageWithFormWidget($I, 'ConvertKit: Page: Form: Elementor Widget: No Form Param', '');
 
-		// Load Page.
-		$I->amOnPage('?p='.$pageID);
+        // Load Page.
+        $I->amOnPage('?p='.$pageID);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that no ConvertKit Form is displayed.
-		$I->dontSeeElementInDOM('form[data-sv-form]');
-	}
+        // Confirm that no ConvertKit Form is displayed.
+        $I->dontSeeElementInDOM('form[data-sv-form]');
+    }
 
-	/**
-	 * Create a Page in the database comprising of Elementor Page Builder data
-	 * containing a ConvertKit Form widget.
-	 * 
-	 * Codeception's dragAndDrop() method doesn't support dropping an element into an iframe, which is
-	 * how Elementor works for adding widgets to a Page.
-	 * 
-	 * Therefore, we directly create a Page in the database, with Elementor's data structure
-	 * as if we added the Form widget to a Page edited in Elementor.
-	 * 
-	 * testFormWidgetIsRegistered() above is a sanity check that the Form Widget is registered
-	 * and available to users in Elementor.
-	 * 
-	 * @since 	1.9.7.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 		Tester.
-	 * @param 	string 				$title 	Page Title.
-	 * @param 	int 				$formID ConvertKit Form ID.
-	 * @return 	int 						Page ID
-	 */
-	private function _createPageWithFormWidget(AcceptanceTester $I, $title, $formID)
-	{
-		return $I->havePostInDatabase([
-			'post_title'	=> $title,
-			'post_type'		=> 'page',
-			'post_status'	=> 'publish',
-			'meta_input' => [
-				// Elementor.
-				'_elementor_data' => [
-					0 => [
-						'id' => '39bb59d',
-						'elType' => 'section',
-						'settings' => [],
-						'elements' => [
-							[
-								'id' => 'b7e0e57',
-								'elType' => 'column',
-								'settings' => [
-									'_column_size' => 100,
-									'_inline_size' => null,
-								],
-								'elements' => [
-									[
-										'id' => 'a73a905',
-										'elType' => 'widget',
-										'settings' => [
-											'form' => (string) $formID,
-										],
-										'widgetType' => 'convertkit-elementor-form',
-									],
-								],
-							],
-						],
-					],
-				],
-				'_elementor_version' => '3.6.1',
-				'_elementor_edit_mode' => 'builder',
-				'_elementor_template_type' => 'wp-page',
+    /**
+     * Create a Page in the database comprising of Elementor Page Builder data
+     * containing a ConvertKit Form widget.
+     * 
+     * Codeception's dragAndDrop() method doesn't support dropping an element into an iframe, which is
+     * how Elementor works for adding widgets to a Page.
+     * 
+     * Therefore, we directly create a Page in the database, with Elementor's data structure
+     * as if we added the Form widget to a Page edited in Elementor.
+     * 
+     * testFormWidgetIsRegistered() above is a sanity check that the Form Widget is registered
+     * and available to users in Elementor.
+     * 
+     * @since 1.9.7.2
+     * 
+     * @param  AcceptanceTester $I      Tester.
+     * @param  string           $title  Page Title.
+     * @param  int              $formID ConvertKit Form ID.
+     * @return int                         Page ID
+     */
+    private function _createPageWithFormWidget(AcceptanceTester $I, $title, $formID)
+    {
+        return $I->havePostInDatabase(
+            [
+            'post_title'    => $title,
+            'post_type'        => 'page',
+            'post_status'    => 'publish',
+            'meta_input' => [
+            // Elementor.
+            '_elementor_data' => [
+            0 => [
+            'id' => '39bb59d',
+            'elType' => 'section',
+            'settings' => [],
+            'elements' => [
+            [
+            'id' => 'b7e0e57',
+            'elType' => 'column',
+            'settings' => [
+            '_column_size' => 100,
+            '_inline_size' => null,
+            ],
+            'elements' => [
+            [
+            'id' => 'a73a905',
+            'elType' => 'widget',
+            'settings' => [
+            'form' => (string) $formID,
+            ],
+            'widgetType' => 'convertkit-elementor-form',
+            ],
+            ],
+            ],
+            ],
+            ],
+            ],
+            '_elementor_version' => '3.6.1',
+            '_elementor_edit_mode' => 'builder',
+            '_elementor_template_type' => 'wp-page',
 
-				// Configure ConvertKit Plugin to not display a default Form,
-				// as we are testing for the Form in Elementor.
-				'_wp_convertkit_post_meta' => [
-					'form'         => '-1',
-					'landing_page' => '',
-					'tag'          => '',
-				],
-			],
-		]);
-	}
+            // Configure ConvertKit Plugin to not display a default Form,
+            // as we are testing for the Form in Elementor.
+            '_wp_convertkit_post_meta' => [
+            'form'         => '-1',
+            'landing_page' => '',
+            'tag'          => '',
+            ],
+            ],
+            ]
+        );
+    }
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateThirdPartyPlugin($I, 'elementor');
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateThirdPartyPlugin($I, 'elementor');
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/integrations/ElementorFormCest.php
+++ b/tests/acceptance/integrations/ElementorFormCest.php
@@ -1,17 +1,17 @@
 <?php
 /**
  * Tests for the ConvertKit Form's Elementor Widget.
- * 
- * @since 	1.9.6
+ *
+ * @since   1.9.6
  */
 class ElementorFormCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -23,10 +23,10 @@ class ElementorFormCest
 
 	/**
 	 * Test the Form widget is registered in Elementor.
-	 * 
-	 * @since 	1.9.7.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testFormWidgetIsRegistered(AcceptanceTester $I)
 	{
@@ -46,10 +46,10 @@ class ElementorFormCest
 
 	/**
 	 * Test the Form widget works when a valid Form is selected.
-	 * 
-	 * @since 	1.9.7.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testFormWidgetWithValidFormParameter(AcceptanceTester $I)
 	{
@@ -57,21 +57,21 @@ class ElementorFormCest
 		$pageID = $this->_createPageWithFormWidget($I, 'ConvertKit: Page: Form: Elementor Widget: Valid Form Param', $_ENV['CONVERTKIT_API_FORM_ID']);
 
 		// Load Page.
-		$I->amOnPage('?p='.$pageID);
+		$I->amOnPage('?p=' . $pageID);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the ConvertKit Form is displayed.
-		$I->seeElementInDOM('form[data-sv-form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]');
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 	}
 
 	/**
 	 * Test the Form widget works when a valid Legacy Form is selected.
-	 * 
-	 * @since 	1.9.7.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testFormWidgetWithValidLegacyFormParameter(AcceptanceTester $I)
 	{
@@ -79,7 +79,7 @@ class ElementorFormCest
 		$pageID = $this->_createPageWithFormWidget($I, 'ConvertKit: Legacy Form: Elementor Widget: Valid Form Param', $_ENV['CONVERTKIT_API_LEGACY_FORM_ID']);
 
 		// Load Page.
-		$I->amOnPage('?p='.$pageID);
+		$I->amOnPage('?p=' . $pageID);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -90,10 +90,10 @@ class ElementorFormCest
 
 	/**
 	 * Test the Form widget works when no Form is selected.
-	 * 
-	 * @since 	1.9.7.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testFormWidgetWithNoFormParameter(AcceptanceTester $I)
 	{
@@ -101,7 +101,7 @@ class ElementorFormCest
 		$pageID = $this->_createPageWithFormWidget($I, 'ConvertKit: Page: Form: Elementor Widget: No Form Param', '');
 
 		// Load Page.
-		$I->amOnPage('?p='.$pageID);
+		$I->amOnPage('?p=' . $pageID);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -113,81 +113,83 @@ class ElementorFormCest
 	/**
 	 * Create a Page in the database comprising of Elementor Page Builder data
 	 * containing a ConvertKit Form widget.
-	 * 
+	 *
 	 * Codeception's dragAndDrop() method doesn't support dropping an element into an iframe, which is
 	 * how Elementor works for adding widgets to a Page.
-	 * 
+	 *
 	 * Therefore, we directly create a Page in the database, with Elementor's data structure
 	 * as if we added the Form widget to a Page edited in Elementor.
-	 * 
+	 *
 	 * testFormWidgetIsRegistered() above is a sanity check that the Form Widget is registered
 	 * and available to users in Elementor.
-	 * 
-	 * @since 	1.9.7.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 		Tester.
-	 * @param 	string 				$title 	Page Title.
-	 * @param 	int 				$formID ConvertKit Form ID.
-	 * @return 	int 						Page ID
+	 *
+	 * @since   1.9.7.2
+	 *
+	 * @param   AcceptanceTester $I      Tester.
+	 * @param   string           $title  Page Title.
+	 * @param   int              $formID ConvertKit Form ID.
+	 * @return  int                         Page ID
 	 */
 	private function _createPageWithFormWidget(AcceptanceTester $I, $title, $formID)
 	{
-		return $I->havePostInDatabase([
-			'post_title'	=> $title,
-			'post_type'		=> 'page',
-			'post_status'	=> 'publish',
-			'meta_input' => [
-				// Elementor.
-				'_elementor_data' => [
-					0 => [
-						'id' => '39bb59d',
-						'elType' => 'section',
-						'settings' => [],
-						'elements' => [
-							[
-								'id' => 'b7e0e57',
-								'elType' => 'column',
-								'settings' => [
-									'_column_size' => 100,
-									'_inline_size' => null,
-								],
-								'elements' => [
-									[
-										'id' => 'a73a905',
-										'elType' => 'widget',
-										'settings' => [
-											'form' => (string) $formID,
+		return $I->havePostInDatabase(
+			[
+				'post_title'  => $title,
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'meta_input'  => [
+					// Elementor.
+					'_elementor_data'          => [
+						0 => [
+							'id'       => '39bb59d',
+							'elType'   => 'section',
+							'settings' => [],
+							'elements' => [
+								[
+									'id'       => 'b7e0e57',
+									'elType'   => 'column',
+									'settings' => [
+										'_column_size' => 100,
+										'_inline_size' => null,
+									],
+									'elements' => [
+										[
+											'id'         => 'a73a905',
+											'elType'     => 'widget',
+											'settings'   => [
+												'form' => (string) $formID,
+											],
+											'widgetType' => 'convertkit-elementor-form',
 										],
-										'widgetType' => 'convertkit-elementor-form',
 									],
 								],
 							],
 						],
 					],
-				],
-				'_elementor_version' => '3.6.1',
-				'_elementor_edit_mode' => 'builder',
-				'_elementor_template_type' => 'wp-page',
+					'_elementor_version'       => '3.6.1',
+					'_elementor_edit_mode'     => 'builder',
+					'_elementor_template_type' => 'wp-page',
 
-				// Configure ConvertKit Plugin to not display a default Form,
-				// as we are testing for the Form in Elementor.
-				'_wp_convertkit_post_meta' => [
-					'form'         => '-1',
-					'landing_page' => '',
-					'tag'          => '',
+					// Configure ConvertKit Plugin to not display a default Form,
+					// as we are testing for the Form in Elementor.
+					'_wp_convertkit_post_meta' => [
+						'form'         => '-1',
+						'landing_page' => '',
+						'tag'          => '',
+					],
 				],
-			],
-		]);
+			]
+		);
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/integrations/ElementorFormCest.php
+++ b/tests/acceptance/integrations/ElementorFormCest.php
@@ -1,193 +1,198 @@
 <?php
 /**
  * Tests for the ConvertKit Form's Elementor Widget.
- *
- * @since 1.9.6
+ * 
+ * @since 	1.9.6
  */
-class ElementorFormCest {
-
+class ElementorFormCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
-		$I->activateConvertKitPlugin( $I );
-		$I->activateThirdPartyPlugin( $I, 'elementor' );
-		$I->setupConvertKitPlugin( $I );
-		$I->enableDebugLog( $I );
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'elementor');
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
 	}
 
 	/**
 	 * Test the Form widget is registered in Elementor.
-	 *
-	 * @since 1.9.7.2
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testFormWidgetIsRegistered( AcceptanceTester $I ) {
+	public function testFormWidgetIsRegistered(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Form: Elementor: Valid Form Param' );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Elementor: Valid Form Param');
 
 		// Click Edit with Elementor button.
-		$I->click( '#elementor-switch-mode-button' );
+		$I->click('#elementor-switch-mode-button');
 
 		// When Elementor loads, search for the ConvertKit Form block.
-		$I->waitForElementVisible( '#elementor-panel-elements-search-input' );
-		$I->fillField( '#elementor-panel-elements-search-input', 'ConvertKit Form' );
+		$I->waitForElementVisible('#elementor-panel-elements-search-input');
+		$I->fillField('#elementor-panel-elements-search-input', 'ConvertKit Form');
 
 		// Confirm that the Form widget is displayed as an option.
-		$I->seeElementInDOM( '#elementor-panel-elements .elementor-element' );
+		$I->seeElementInDOM('#elementor-panel-elements .elementor-element');
 	}
 
 	/**
 	 * Test the Form widget works when a valid Form is selected.
-	 *
-	 * @since 1.9.7.2
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testFormWidgetWithValidFormParameter( AcceptanceTester $I ) {
+	public function testFormWidgetWithValidFormParameter(AcceptanceTester $I)
+	{
 		// Create Page with Form widget in Elementor.
-		$pageID = $this->_createPageWithFormWidget( $I, 'ConvertKit: Page: Form: Elementor Widget: Valid Form Param', $_ENV['CONVERTKIT_API_FORM_ID'] );
+		$pageID = $this->_createPageWithFormWidget($I, 'ConvertKit: Page: Form: Elementor Widget: Valid Form Param', $_ENV['CONVERTKIT_API_FORM_ID']);
 
 		// Load Page.
-		$I->amOnPage( '?p=' . $pageID );
+		$I->amOnPage('?p='.$pageID);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the ConvertKit Form is displayed.
-		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		$I->seeElementInDOM('form[data-sv-form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]');
 	}
 
 	/**
 	 * Test the Form widget works when a valid Legacy Form is selected.
-	 *
-	 * @since 1.9.7.2
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testFormWidgetWithValidLegacyFormParameter( AcceptanceTester $I ) {
+	public function testFormWidgetWithValidLegacyFormParameter(AcceptanceTester $I)
+	{
 		// Create Page with Form widget in Elementor.
-		$pageID = $this->_createPageWithFormWidget( $I, 'ConvertKit: Legacy Form: Elementor Widget: Valid Form Param', $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] );
+		$pageID = $this->_createPageWithFormWidget($I, 'ConvertKit: Legacy Form: Elementor Widget: Valid Form Param', $_ENV['CONVERTKIT_API_LEGACY_FORM_ID']);
 
 		// Load Page.
-		$I->amOnPage( '?p=' . $pageID );
+		$I->amOnPage('?p='.$pageID);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the ConvertKit Form is displayed.
-		$I->seeInSource( '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">' );
+		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
 	}
 
 	/**
 	 * Test the Form widget works when no Form is selected.
-	 *
-	 * @since 1.9.7.2
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testFormWidgetWithNoFormParameter( AcceptanceTester $I ) {
+	public function testFormWidgetWithNoFormParameter(AcceptanceTester $I)
+	{
 		// Create Page with Form widget in Elementor.
-		$pageID = $this->_createPageWithFormWidget( $I, 'ConvertKit: Page: Form: Elementor Widget: No Form Param', '' );
+		$pageID = $this->_createPageWithFormWidget($I, 'ConvertKit: Page: Form: Elementor Widget: No Form Param', '');
 
 		// Load Page.
-		$I->amOnPage( '?p=' . $pageID );
+		$I->amOnPage('?p='.$pageID);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that no ConvertKit Form is displayed.
-		$I->dontSeeElementInDOM( 'form[data-sv-form]' );
+		$I->dontSeeElementInDOM('form[data-sv-form]');
 	}
 
 	/**
 	 * Create a Page in the database comprising of Elementor Page Builder data
 	 * containing a ConvertKit Form widget.
-	 *
+	 * 
 	 * Codeception's dragAndDrop() method doesn't support dropping an element into an iframe, which is
 	 * how Elementor works for adding widgets to a Page.
-	 *
+	 * 
 	 * Therefore, we directly create a Page in the database, with Elementor's data structure
 	 * as if we added the Form widget to a Page edited in Elementor.
-	 *
+	 * 
 	 * testFormWidgetIsRegistered() above is a sanity check that the Form Widget is registered
 	 * and available to users in Elementor.
-	 *
-	 * @since 1.9.7.2
-	 *
-	 * @param  AcceptanceTester $I      Tester.
-	 * @param  string           $title  Page Title.
-	 * @param  int              $formID ConvertKit Form ID.
-	 * @return int                         Page ID
+	 * 
+	 * @since 	1.9.7.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 		Tester.
+	 * @param 	string 				$title 	Page Title.
+	 * @param 	int 				$formID ConvertKit Form ID.
+	 * @return 	int 						Page ID
 	 */
-	private function _createPageWithFormWidget( AcceptanceTester $I, $title, $formID ) {
-		return $I->havePostInDatabase(
-			array(
-				'post_title'  => $title,
-				'post_type'   => 'page',
-				'post_status' => 'publish',
-				'meta_input'  => array(
-					// Elementor.
-					'_elementor_data'          => array(
-						0 => array(
-							'id'       => '39bb59d',
-							'elType'   => 'section',
-							'settings' => array(),
-							'elements' => array(
-								array(
-									'id'       => 'b7e0e57',
-									'elType'   => 'column',
-									'settings' => array(
-										'_column_size' => 100,
-										'_inline_size' => null,
-									),
-									'elements' => array(
-										array(
-											'id'         => 'a73a905',
-											'elType'     => 'widget',
-											'settings'   => array(
-												'form' => (string) $formID,
-											),
-											'widgetType' => 'convertkit-elementor-form',
-										),
-									),
-								),
-							),
-						),
-					),
-					'_elementor_version'       => '3.6.1',
-					'_elementor_edit_mode'     => 'builder',
-					'_elementor_template_type' => 'wp-page',
+	private function _createPageWithFormWidget(AcceptanceTester $I, $title, $formID)
+	{
+		return $I->havePostInDatabase([
+			'post_title'	=> $title,
+			'post_type'		=> 'page',
+			'post_status'	=> 'publish',
+			'meta_input' => [
+				// Elementor.
+				'_elementor_data' => [
+					0 => [
+						'id' => '39bb59d',
+						'elType' => 'section',
+						'settings' => [],
+						'elements' => [
+							[
+								'id' => 'b7e0e57',
+								'elType' => 'column',
+								'settings' => [
+									'_column_size' => 100,
+									'_inline_size' => null,
+								],
+								'elements' => [
+									[
+										'id' => 'a73a905',
+										'elType' => 'widget',
+										'settings' => [
+											'form' => (string) $formID,
+										],
+										'widgetType' => 'convertkit-elementor-form',
+									],
+								],
+							],
+						],
+					],
+				],
+				'_elementor_version' => '3.6.1',
+				'_elementor_edit_mode' => 'builder',
+				'_elementor_template_type' => 'wp-page',
 
-					// Configure ConvertKit Plugin to not display a default Form,
-					// as we are testing for the Form in Elementor.
-					'_wp_convertkit_post_meta' => array(
-						'form'         => '-1',
-						'landing_page' => '',
-						'tag'          => '',
-					),
-				),
-			)
-		);
+				// Configure ConvertKit Plugin to not display a default Form,
+				// as we are testing for the Form in Elementor.
+				'_wp_convertkit_post_meta' => [
+					'form'         => '-1',
+					'landing_page' => '',
+					'tag'          => '',
+				],
+			],
+		]);
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateThirdPartyPlugin( $I, 'elementor' );
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateThirdPartyPlugin($I, 'elementor');
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/integrations/ElementorFormCest.php
+++ b/tests/acceptance/integrations/ElementorFormCest.php
@@ -1,200 +1,193 @@
 <?php
 /**
  * Tests for the ConvertKit Form's Elementor Widget.
- * 
+ *
  * @since 1.9.6
  */
-class ElementorFormCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        $I->activateConvertKitPlugin($I);
-        $I->activateThirdPartyPlugin($I, 'elementor');
-        $I->setupConvertKitPlugin($I);
-        $I->enableDebugLog($I);
-    }
+class ElementorFormCest {
 
-    /**
-     * Test the Form widget is registered in Elementor.
-     * 
-     * @since 1.9.7.2
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testFormWidgetIsRegistered(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Elementor: Valid Form Param');
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		$I->activateConvertKitPlugin( $I );
+		$I->activateThirdPartyPlugin( $I, 'elementor' );
+		$I->setupConvertKitPlugin( $I );
+		$I->enableDebugLog( $I );
+	}
 
-        // Click Edit with Elementor button.
-        $I->click('#elementor-switch-mode-button');
+	/**
+	 * Test the Form widget is registered in Elementor.
+	 *
+	 * @since 1.9.7.2
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testFormWidgetIsRegistered( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Form: Elementor: Valid Form Param' );
 
-        // When Elementor loads, search for the ConvertKit Form block.
-        $I->waitForElementVisible('#elementor-panel-elements-search-input');
-        $I->fillField('#elementor-panel-elements-search-input', 'ConvertKit Form');
+		// Click Edit with Elementor button.
+		$I->click( '#elementor-switch-mode-button' );
 
-        // Confirm that the Form widget is displayed as an option.
-        $I->seeElementInDOM('#elementor-panel-elements .elementor-element');
-    }
+		// When Elementor loads, search for the ConvertKit Form block.
+		$I->waitForElementVisible( '#elementor-panel-elements-search-input' );
+		$I->fillField( '#elementor-panel-elements-search-input', 'ConvertKit Form' );
 
-    /**
-     * Test the Form widget works when a valid Form is selected.
-     * 
-     * @since 1.9.7.2
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testFormWidgetWithValidFormParameter(AcceptanceTester $I)
-    {
-        // Create Page with Form widget in Elementor.
-        $pageID = $this->_createPageWithFormWidget($I, 'ConvertKit: Page: Form: Elementor Widget: Valid Form Param', $_ENV['CONVERTKIT_API_FORM_ID']);
+		// Confirm that the Form widget is displayed as an option.
+		$I->seeElementInDOM( '#elementor-panel-elements .elementor-element' );
+	}
 
-        // Load Page.
-        $I->amOnPage('?p='.$pageID);
+	/**
+	 * Test the Form widget works when a valid Form is selected.
+	 *
+	 * @since 1.9.7.2
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testFormWidgetWithValidFormParameter( AcceptanceTester $I ) {
+		// Create Page with Form widget in Elementor.
+		$pageID = $this->_createPageWithFormWidget( $I, 'ConvertKit: Page: Form: Elementor Widget: Valid Form Param', $_ENV['CONVERTKIT_API_FORM_ID'] );
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Load Page.
+		$I->amOnPage( '?p=' . $pageID );
 
-        // Confirm that the ConvertKit Form is displayed.
-        $I->seeElementInDOM('form[data-sv-form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]');
-    }
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-    /**
-     * Test the Form widget works when a valid Legacy Form is selected.
-     * 
-     * @since 1.9.7.2
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testFormWidgetWithValidLegacyFormParameter(AcceptanceTester $I)
-    {
-        // Create Page with Form widget in Elementor.
-        $pageID = $this->_createPageWithFormWidget($I, 'ConvertKit: Legacy Form: Elementor Widget: Valid Form Param', $_ENV['CONVERTKIT_API_LEGACY_FORM_ID']);
+		// Confirm that the ConvertKit Form is displayed.
+		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+	}
 
-        // Load Page.
-        $I->amOnPage('?p='.$pageID);
+	/**
+	 * Test the Form widget works when a valid Legacy Form is selected.
+	 *
+	 * @since 1.9.7.2
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testFormWidgetWithValidLegacyFormParameter( AcceptanceTester $I ) {
+		// Create Page with Form widget in Elementor.
+		$pageID = $this->_createPageWithFormWidget( $I, 'ConvertKit: Legacy Form: Elementor Widget: Valid Form Param', $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] );
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Load Page.
+		$I->amOnPage( '?p=' . $pageID );
 
-        // Confirm that the ConvertKit Form is displayed.
-        $I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
-    }
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-    /**
-     * Test the Form widget works when no Form is selected.
-     * 
-     * @since 1.9.7.2
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testFormWidgetWithNoFormParameter(AcceptanceTester $I)
-    {
-        // Create Page with Form widget in Elementor.
-        $pageID = $this->_createPageWithFormWidget($I, 'ConvertKit: Page: Form: Elementor Widget: No Form Param', '');
+		// Confirm that the ConvertKit Form is displayed.
+		$I->seeInSource( '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">' );
+	}
 
-        // Load Page.
-        $I->amOnPage('?p='.$pageID);
+	/**
+	 * Test the Form widget works when no Form is selected.
+	 *
+	 * @since 1.9.7.2
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testFormWidgetWithNoFormParameter( AcceptanceTester $I ) {
+		// Create Page with Form widget in Elementor.
+		$pageID = $this->_createPageWithFormWidget( $I, 'ConvertKit: Page: Form: Elementor Widget: No Form Param', '' );
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Load Page.
+		$I->amOnPage( '?p=' . $pageID );
 
-        // Confirm that no ConvertKit Form is displayed.
-        $I->dontSeeElementInDOM('form[data-sv-form]');
-    }
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-    /**
-     * Create a Page in the database comprising of Elementor Page Builder data
-     * containing a ConvertKit Form widget.
-     * 
-     * Codeception's dragAndDrop() method doesn't support dropping an element into an iframe, which is
-     * how Elementor works for adding widgets to a Page.
-     * 
-     * Therefore, we directly create a Page in the database, with Elementor's data structure
-     * as if we added the Form widget to a Page edited in Elementor.
-     * 
-     * testFormWidgetIsRegistered() above is a sanity check that the Form Widget is registered
-     * and available to users in Elementor.
-     * 
-     * @since 1.9.7.2
-     * 
-     * @param  AcceptanceTester $I      Tester.
-     * @param  string           $title  Page Title.
-     * @param  int              $formID ConvertKit Form ID.
-     * @return int                         Page ID
-     */
-    private function _createPageWithFormWidget(AcceptanceTester $I, $title, $formID)
-    {
-        return $I->havePostInDatabase(
-            [
-            'post_title'    => $title,
-            'post_type'        => 'page',
-            'post_status'    => 'publish',
-            'meta_input' => [
-            // Elementor.
-            '_elementor_data' => [
-            0 => [
-            'id' => '39bb59d',
-            'elType' => 'section',
-            'settings' => [],
-            'elements' => [
-            [
-            'id' => 'b7e0e57',
-            'elType' => 'column',
-            'settings' => [
-            '_column_size' => 100,
-            '_inline_size' => null,
-            ],
-            'elements' => [
-            [
-            'id' => 'a73a905',
-            'elType' => 'widget',
-            'settings' => [
-            'form' => (string) $formID,
-            ],
-            'widgetType' => 'convertkit-elementor-form',
-            ],
-            ],
-            ],
-            ],
-            ],
-            ],
-            '_elementor_version' => '3.6.1',
-            '_elementor_edit_mode' => 'builder',
-            '_elementor_template_type' => 'wp-page',
+		// Confirm that no ConvertKit Form is displayed.
+		$I->dontSeeElementInDOM( 'form[data-sv-form]' );
+	}
 
-            // Configure ConvertKit Plugin to not display a default Form,
-            // as we are testing for the Form in Elementor.
-            '_wp_convertkit_post_meta' => [
-            'form'         => '-1',
-            'landing_page' => '',
-            'tag'          => '',
-            ],
-            ],
-            ]
-        );
-    }
+	/**
+	 * Create a Page in the database comprising of Elementor Page Builder data
+	 * containing a ConvertKit Form widget.
+	 *
+	 * Codeception's dragAndDrop() method doesn't support dropping an element into an iframe, which is
+	 * how Elementor works for adding widgets to a Page.
+	 *
+	 * Therefore, we directly create a Page in the database, with Elementor's data structure
+	 * as if we added the Form widget to a Page edited in Elementor.
+	 *
+	 * testFormWidgetIsRegistered() above is a sanity check that the Form Widget is registered
+	 * and available to users in Elementor.
+	 *
+	 * @since 1.9.7.2
+	 *
+	 * @param  AcceptanceTester $I      Tester.
+	 * @param  string           $title  Page Title.
+	 * @param  int              $formID ConvertKit Form ID.
+	 * @return int                         Page ID
+	 */
+	private function _createPageWithFormWidget( AcceptanceTester $I, $title, $formID ) {
+		return $I->havePostInDatabase(
+			array(
+				'post_title'  => $title,
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'meta_input'  => array(
+					// Elementor.
+					'_elementor_data'          => array(
+						0 => array(
+							'id'       => '39bb59d',
+							'elType'   => 'section',
+							'settings' => array(),
+							'elements' => array(
+								array(
+									'id'       => 'b7e0e57',
+									'elType'   => 'column',
+									'settings' => array(
+										'_column_size' => 100,
+										'_inline_size' => null,
+									),
+									'elements' => array(
+										array(
+											'id'         => 'a73a905',
+											'elType'     => 'widget',
+											'settings'   => array(
+												'form' => (string) $formID,
+											),
+											'widgetType' => 'convertkit-elementor-form',
+										),
+									),
+								),
+							),
+						),
+					),
+					'_elementor_version'       => '3.6.1',
+					'_elementor_edit_mode'     => 'builder',
+					'_elementor_template_type' => 'wp-page',
 
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateThirdPartyPlugin($I, 'elementor');
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+					// Configure ConvertKit Plugin to not display a default Form,
+					// as we are testing for the Form in Elementor.
+					'_wp_convertkit_post_meta' => array(
+						'form'         => '-1',
+						'landing_page' => '',
+						'tag'          => '',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateThirdPartyPlugin( $I, 'elementor' );
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/integrations/ElementorProductCest.php
+++ b/tests/acceptance/integrations/ElementorProductCest.php
@@ -1,17 +1,17 @@
 <?php
 /**
  * Tests for the ConvertKit Product Elementor Widget.
- * 
- * @since 	2.0.0
+ *
+ * @since   2.0.0
  */
 class ElementorProductCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	2.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   2.0.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -23,10 +23,10 @@ class ElementorProductCest
 
 	/**
 	 * Test the Product widget is registered in Elementor.
-	 * 
-	 * @since 	2.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   2.0.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testProductWidgetIsRegistered(AcceptanceTester $I)
 	{
@@ -46,21 +46,25 @@ class ElementorProductCest
 
 	/**
 	 * Test the Product block works when using valid parameters.
-	 * 
-	 * @since 	2.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   2.0.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testProductWidgetWithValidParameters(AcceptanceTester $I)
 	{
 		// Create Page with Product widget in Elementor.
-		$pageID = $this->_createPageWithProductWidget($I, 'ConvertKit: Page: Product: Elementor Widget: Valid Params', [
-			'product' => $_ENV['CONVERTKIT_API_PRODUCT_ID'],
-			'text'	  => 'Buy my product',
-		]);
+		$pageID = $this->_createPageWithProductWidget(
+			$I,
+			'ConvertKit: Page: Product: Elementor Widget: Valid Params',
+			[
+				'product' => $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+				'text'    => 'Buy my product',
+			]
+		);
 
 		// Load Page.
-		$I->amOnPage('?p='.$pageID);
+		$I->amOnPage('?p=' . $pageID);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -71,27 +75,31 @@ class ElementorProductCest
 
 	/**
 	 * Test the Product block's hex colors work when defined.
-	 * 
-	 * @since 	2.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   2.0.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testProductWidgetWithHexColorParameters(AcceptanceTester $I)
 	{
 		// Define colors.
 		$backgroundColor = '#ee1616';
-		$textColor = '#1212c0';
+		$textColor       = '#1212c0';
 
 		// Create Page with Product widget in Elementor.
-		$pageID = $this->_createPageWithProductWidget($I, 'ConvertKit: Page: Product: Elementor Widget: Hex Colors', [
-			'product' 				=> $_ENV['CONVERTKIT_API_PRODUCT_ID'],
-			'text'	  				=> 'Buy my product',
-			'background_color'		=> $backgroundColor,
-			'text_color'			=> $textColor,
-		]);
+		$pageID = $this->_createPageWithProductWidget(
+			$I,
+			'ConvertKit: Page: Product: Elementor Widget: Hex Colors',
+			[
+				'product'          => $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+				'text'             => 'Buy my product',
+				'background_color' => $backgroundColor,
+				'text_color'       => $textColor,
+			]
+		);
 
 		// Load Page.
-		$I->amOnPage('?p='.$pageID);
+		$I->amOnPage('?p=' . $pageID);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -103,79 +111,81 @@ class ElementorProductCest
 	/**
 	 * Create a Page in the database comprising of Elementor Page Builder data
 	 * containing a ConvertKit Product widget.
-	 * 
+	 *
 	 * Codeception's dragAndDrop() method doesn't support dropping an element into an iframe, which is
 	 * how Elementor works for adding widgets to a Page.
-	 * 
+	 *
 	 * Therefore, we directly create a Page in the database, with Elementor's data structure
 	 * as if we added the Product widget to a Page edited in Elementor.
-	 * 
+	 *
 	 * testProductWidgetIsRegistered() above is a sanity check that the Product Widget is registered
 	 * and available to users in Elementor.
-	 * 
-	 * @since 	2.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 			Tester.
-	 * @param 	string 				$title 		Page Title.
-	 * @param 	array 				$settings 	Widget settings.
-	 * @return 	int 							Page ID
+	 *
+	 * @since   2.0.0
+	 *
+	 * @param   AcceptanceTester $I          Tester.
+	 * @param   string           $title      Page Title.
+	 * @param   array            $settings   Widget settings.
+	 * @return  int                             Page ID
 	 */
 	private function _createPageWithProductWidget(AcceptanceTester $I, $title, $settings)
 	{
-		return $I->havePostInDatabase([
-			'post_title'	=> $title,
-			'post_type'		=> 'page',
-			'post_status'	=> 'publish',
-			'meta_input' => [
-				// Elementor.
-				'_elementor_data' => [
-					0 => [
-						'id' => '39bb59d',
-						'elType' => 'section',
-						'settings' => [],
-						'elements' => [
-							[
-								'id' => 'b7e0e57',
-								'elType' => 'column',
-								'settings' => [
-									'_column_size' => 100,
-									'_inline_size' => null,
-								],
-								'elements' => [
-									[
-										'id' => 'a73a905',
-										'elType' => 'widget',
-										'settings' => $settings,
-										'widgetType' => 'convertkit-elementor-product',
+		return $I->havePostInDatabase(
+			[
+				'post_title'  => $title,
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'meta_input'  => [
+					// Elementor.
+					'_elementor_data'          => [
+						0 => [
+							'id'       => '39bb59d',
+							'elType'   => 'section',
+							'settings' => [],
+							'elements' => [
+								[
+									'id'       => 'b7e0e57',
+									'elType'   => 'column',
+									'settings' => [
+										'_column_size' => 100,
+										'_inline_size' => null,
+									],
+									'elements' => [
+										[
+											'id'         => 'a73a905',
+											'elType'     => 'widget',
+											'settings'   => $settings,
+											'widgetType' => 'convertkit-elementor-product',
+										],
 									],
 								],
 							],
 						],
 					],
-				],
-				'_elementor_version' => '3.6.1',
-				'_elementor_edit_mode' => 'builder',
-				'_elementor_template_type' => 'wp-page',
+					'_elementor_version'       => '3.6.1',
+					'_elementor_edit_mode'     => 'builder',
+					'_elementor_template_type' => 'wp-page',
 
-				// Configure ConvertKit Plugin to not display a default Form,
-				// as we are testing for the Form in Elementor.
-				'_wp_convertkit_post_meta' => [
-					'form'         => '-1',
-					'landing_page' => '',
-					'tag'          => '',
+					// Configure ConvertKit Plugin to not display a default Form,
+					// as we are testing for the Form in Elementor.
+					'_wp_convertkit_post_meta' => [
+						'form'         => '-1',
+						'landing_page' => '',
+						'tag'          => '',
+					],
 				],
-			],
-		]);
+			]
+		);
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	2.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   2.0.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/integrations/ElementorProductCest.php
+++ b/tests/acceptance/integrations/ElementorProductCest.php
@@ -1,190 +1,186 @@
 <?php
 /**
  * Tests for the ConvertKit Product Elementor Widget.
- *
- * @since 2.0.0
+ * 
+ * @since 	2.0.0
  */
-class ElementorProductCest {
-
+class ElementorProductCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	2.0.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
-		$I->activateConvertKitPlugin( $I );
-		$I->activateThirdPartyPlugin( $I, 'elementor' );
-		$I->setupConvertKitPlugin( $I );
-		$I->enableDebugLog( $I );
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'elementor');
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
 	}
 
 	/**
 	 * Test the Product widget is registered in Elementor.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	2.0.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testProductWidgetIsRegistered( AcceptanceTester $I ) {
+	public function testProductWidgetIsRegistered(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Product: Elementor: Registered' );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Elementor: Registered');
 
 		// Click Edit with Elementor button.
-		$I->click( '#elementor-switch-mode-button' );
+		$I->click('#elementor-switch-mode-button');
 
 		// When Elementor loads, search for the ConvertKit Product block.
-		$I->waitForElementVisible( '#elementor-panel-elements-search-input' );
-		$I->fillField( '#elementor-panel-elements-search-input', 'ConvertKit Product' );
+		$I->waitForElementVisible('#elementor-panel-elements-search-input');
+		$I->fillField('#elementor-panel-elements-search-input', 'ConvertKit Product');
 
 		// Confirm that the Product widget is displayed as an option.
-		$I->seeElementInDOM( '#elementor-panel-elements .elementor-element' );
+		$I->seeElementInDOM('#elementor-panel-elements .elementor-element');
 	}
 
 	/**
 	 * Test the Product block works when using valid parameters.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	2.0.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testProductWidgetWithValidParameters( AcceptanceTester $I ) {
+	public function testProductWidgetWithValidParameters(AcceptanceTester $I)
+	{
 		// Create Page with Product widget in Elementor.
-		$pageID = $this->_createPageWithProductWidget(
-			$I,
-			'ConvertKit: Page: Product: Elementor Widget: Valid Params',
-			array(
-				'product' => $_ENV['CONVERTKIT_API_PRODUCT_ID'],
-				'text'    => 'Buy my product',
-			)
-		);
+		$pageID = $this->_createPageWithProductWidget($I, 'ConvertKit: Page: Product: Elementor Widget: Valid Params', [
+			'product' => $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+			'text'	  => 'Buy my product',
+		]);
 
 		// Load Page.
-		$I->amOnPage( '?p=' . $pageID );
+		$I->amOnPage('?p='.$pageID);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the block displays.
-		$I->seeProductOutput( $I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product' );
+		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
 	}
 
 	/**
 	 * Test the Product block's hex colors work when defined.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	2.0.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testProductWidgetWithHexColorParameters( AcceptanceTester $I ) {
+	public function testProductWidgetWithHexColorParameters(AcceptanceTester $I)
+	{
 		// Define colors.
 		$backgroundColor = '#ee1616';
-		$textColor       = '#1212c0';
+		$textColor = '#1212c0';
 
 		// Create Page with Product widget in Elementor.
-		$pageID = $this->_createPageWithProductWidget(
-			$I,
-			'ConvertKit: Page: Product: Elementor Widget: Hex Colors',
-			array(
-				'product'          => $_ENV['CONVERTKIT_API_PRODUCT_ID'],
-				'text'             => 'Buy my product',
-				'background_color' => $backgroundColor,
-				'text_color'       => $textColor,
-			)
-		);
+		$pageID = $this->_createPageWithProductWidget($I, 'ConvertKit: Page: Product: Elementor Widget: Hex Colors', [
+			'product' 				=> $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+			'text'	  				=> 'Buy my product',
+			'background_color'		=> $backgroundColor,
+			'text_color'			=> $textColor,
+		]);
 
 		// Load Page.
-		$I->amOnPage( '?p=' . $pageID );
+		$I->amOnPage('?p='.$pageID);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the block displays.
-		$I->seeProductOutput( $I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product', $textColor, $backgroundColor );
+		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product', $textColor, $backgroundColor);
 	}
 
 	/**
 	 * Create a Page in the database comprising of Elementor Page Builder data
 	 * containing a ConvertKit Product widget.
-	 *
+	 * 
 	 * Codeception's dragAndDrop() method doesn't support dropping an element into an iframe, which is
 	 * how Elementor works for adding widgets to a Page.
-	 *
+	 * 
 	 * Therefore, we directly create a Page in the database, with Elementor's data structure
 	 * as if we added the Product widget to a Page edited in Elementor.
-	 *
+	 * 
 	 * testProductWidgetIsRegistered() above is a sanity check that the Product Widget is registered
 	 * and available to users in Elementor.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param  AcceptanceTester $I        Tester.
-	 * @param  string           $title    Page Title.
-	 * @param  array            $settings Widget settings.
-	 * @return int                             Page ID
+	 * 
+	 * @since 	2.0.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 			Tester.
+	 * @param 	string 				$title 		Page Title.
+	 * @param 	array 				$settings 	Widget settings.
+	 * @return 	int 							Page ID
 	 */
-	private function _createPageWithProductWidget( AcceptanceTester $I, $title, $settings ) {
-		return $I->havePostInDatabase(
-			array(
-				'post_title'  => $title,
-				'post_type'   => 'page',
-				'post_status' => 'publish',
-				'meta_input'  => array(
-					// Elementor.
-					'_elementor_data'          => array(
-						0 => array(
-							'id'       => '39bb59d',
-							'elType'   => 'section',
-							'settings' => array(),
-							'elements' => array(
-								array(
-									'id'       => 'b7e0e57',
-									'elType'   => 'column',
-									'settings' => array(
-										'_column_size' => 100,
-										'_inline_size' => null,
-									),
-									'elements' => array(
-										array(
-											'id'         => 'a73a905',
-											'elType'     => 'widget',
-											'settings'   => $settings,
-											'widgetType' => 'convertkit-elementor-product',
-										),
-									),
-								),
-							),
-						),
-					),
-					'_elementor_version'       => '3.6.1',
-					'_elementor_edit_mode'     => 'builder',
-					'_elementor_template_type' => 'wp-page',
+	private function _createPageWithProductWidget(AcceptanceTester $I, $title, $settings)
+	{
+		return $I->havePostInDatabase([
+			'post_title'	=> $title,
+			'post_type'		=> 'page',
+			'post_status'	=> 'publish',
+			'meta_input' => [
+				// Elementor.
+				'_elementor_data' => [
+					0 => [
+						'id' => '39bb59d',
+						'elType' => 'section',
+						'settings' => [],
+						'elements' => [
+							[
+								'id' => 'b7e0e57',
+								'elType' => 'column',
+								'settings' => [
+									'_column_size' => 100,
+									'_inline_size' => null,
+								],
+								'elements' => [
+									[
+										'id' => 'a73a905',
+										'elType' => 'widget',
+										'settings' => $settings,
+										'widgetType' => 'convertkit-elementor-product',
+									],
+								],
+							],
+						],
+					],
+				],
+				'_elementor_version' => '3.6.1',
+				'_elementor_edit_mode' => 'builder',
+				'_elementor_template_type' => 'wp-page',
 
-					// Configure ConvertKit Plugin to not display a default Form,
-					// as we are testing for the Form in Elementor.
-					'_wp_convertkit_post_meta' => array(
-						'form'         => '-1',
-						'landing_page' => '',
-						'tag'          => '',
-					),
-				),
-			)
-		);
+				// Configure ConvertKit Plugin to not display a default Form,
+				// as we are testing for the Form in Elementor.
+				'_wp_convertkit_post_meta' => [
+					'form'         => '-1',
+					'landing_page' => '',
+					'tag'          => '',
+				],
+			],
+		]);
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	2.0.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateThirdPartyPlugin( $I, 'elementor' );
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateThirdPartyPlugin($I, 'elementor');
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/integrations/ElementorProductCest.php
+++ b/tests/acceptance/integrations/ElementorProductCest.php
@@ -1,192 +1,190 @@
 <?php
 /**
  * Tests for the ConvertKit Product Elementor Widget.
- * 
+ *
  * @since 2.0.0
  */
-class ElementorProductCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 2.0.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        $I->activateConvertKitPlugin($I);
-        $I->activateThirdPartyPlugin($I, 'elementor');
-        $I->setupConvertKitPlugin($I);
-        $I->enableDebugLog($I);
-    }
+class ElementorProductCest {
 
-    /**
-     * Test the Product widget is registered in Elementor.
-     * 
-     * @since 2.0.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testProductWidgetIsRegistered(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Elementor: Registered');
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		$I->activateConvertKitPlugin( $I );
+		$I->activateThirdPartyPlugin( $I, 'elementor' );
+		$I->setupConvertKitPlugin( $I );
+		$I->enableDebugLog( $I );
+	}
 
-        // Click Edit with Elementor button.
-        $I->click('#elementor-switch-mode-button');
+	/**
+	 * Test the Product widget is registered in Elementor.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testProductWidgetIsRegistered( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Product: Elementor: Registered' );
 
-        // When Elementor loads, search for the ConvertKit Product block.
-        $I->waitForElementVisible('#elementor-panel-elements-search-input');
-        $I->fillField('#elementor-panel-elements-search-input', 'ConvertKit Product');
+		// Click Edit with Elementor button.
+		$I->click( '#elementor-switch-mode-button' );
 
-        // Confirm that the Product widget is displayed as an option.
-        $I->seeElementInDOM('#elementor-panel-elements .elementor-element');
-    }
+		// When Elementor loads, search for the ConvertKit Product block.
+		$I->waitForElementVisible( '#elementor-panel-elements-search-input' );
+		$I->fillField( '#elementor-panel-elements-search-input', 'ConvertKit Product' );
 
-    /**
-     * Test the Product block works when using valid parameters.
-     * 
-     * @since 2.0.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testProductWidgetWithValidParameters(AcceptanceTester $I)
-    {
-        // Create Page with Product widget in Elementor.
-        $pageID = $this->_createPageWithProductWidget(
-            $I, 'ConvertKit: Page: Product: Elementor Widget: Valid Params', [
-            'product' => $_ENV['CONVERTKIT_API_PRODUCT_ID'],
-            'text'      => 'Buy my product',
-            ]
-        );
+		// Confirm that the Product widget is displayed as an option.
+		$I->seeElementInDOM( '#elementor-panel-elements .elementor-element' );
+	}
 
-        // Load Page.
-        $I->amOnPage('?p='.$pageID);
+	/**
+	 * Test the Product block works when using valid parameters.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testProductWidgetWithValidParameters( AcceptanceTester $I ) {
+		// Create Page with Product widget in Elementor.
+		$pageID = $this->_createPageWithProductWidget(
+			$I,
+			'ConvertKit: Page: Product: Elementor Widget: Valid Params',
+			array(
+				'product' => $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+				'text'    => 'Buy my product',
+			)
+		);
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Load Page.
+		$I->amOnPage( '?p=' . $pageID );
 
-        // Confirm that the block displays.
-        $I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
-    }
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-    /**
-     * Test the Product block's hex colors work when defined.
-     * 
-     * @since 2.0.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testProductWidgetWithHexColorParameters(AcceptanceTester $I)
-    {
-        // Define colors.
-        $backgroundColor = '#ee1616';
-        $textColor = '#1212c0';
+		// Confirm that the block displays.
+		$I->seeProductOutput( $I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product' );
+	}
 
-        // Create Page with Product widget in Elementor.
-        $pageID = $this->_createPageWithProductWidget(
-            $I, 'ConvertKit: Page: Product: Elementor Widget: Hex Colors', [
-            'product'                 => $_ENV['CONVERTKIT_API_PRODUCT_ID'],
-            'text'                      => 'Buy my product',
-            'background_color'        => $backgroundColor,
-            'text_color'            => $textColor,
-            ]
-        );
+	/**
+	 * Test the Product block's hex colors work when defined.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testProductWidgetWithHexColorParameters( AcceptanceTester $I ) {
+		// Define colors.
+		$backgroundColor = '#ee1616';
+		$textColor       = '#1212c0';
 
-        // Load Page.
-        $I->amOnPage('?p='.$pageID);
+		// Create Page with Product widget in Elementor.
+		$pageID = $this->_createPageWithProductWidget(
+			$I,
+			'ConvertKit: Page: Product: Elementor Widget: Hex Colors',
+			array(
+				'product'          => $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+				'text'             => 'Buy my product',
+				'background_color' => $backgroundColor,
+				'text_color'       => $textColor,
+			)
+		);
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Load Page.
+		$I->amOnPage( '?p=' . $pageID );
 
-        // Confirm that the block displays.
-        $I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product', $textColor, $backgroundColor);
-    }
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-    /**
-     * Create a Page in the database comprising of Elementor Page Builder data
-     * containing a ConvertKit Product widget.
-     * 
-     * Codeception's dragAndDrop() method doesn't support dropping an element into an iframe, which is
-     * how Elementor works for adding widgets to a Page.
-     * 
-     * Therefore, we directly create a Page in the database, with Elementor's data structure
-     * as if we added the Product widget to a Page edited in Elementor.
-     * 
-     * testProductWidgetIsRegistered() above is a sanity check that the Product Widget is registered
-     * and available to users in Elementor.
-     * 
-     * @since 2.0.0
-     * 
-     * @param  AcceptanceTester $I        Tester.
-     * @param  string           $title    Page Title.
-     * @param  array            $settings Widget settings.
-     * @return int                             Page ID
-     */
-    private function _createPageWithProductWidget(AcceptanceTester $I, $title, $settings)
-    {
-        return $I->havePostInDatabase(
-            [
-            'post_title'    => $title,
-            'post_type'        => 'page',
-            'post_status'    => 'publish',
-            'meta_input' => [
-            // Elementor.
-            '_elementor_data' => [
-            0 => [
-            'id' => '39bb59d',
-            'elType' => 'section',
-            'settings' => [],
-            'elements' => [
-            [
-            'id' => 'b7e0e57',
-            'elType' => 'column',
-            'settings' => [
-            '_column_size' => 100,
-            '_inline_size' => null,
-            ],
-            'elements' => [
-            [
-            'id' => 'a73a905',
-            'elType' => 'widget',
-            'settings' => $settings,
-            'widgetType' => 'convertkit-elementor-product',
-            ],
-            ],
-            ],
-            ],
-            ],
-            ],
-            '_elementor_version' => '3.6.1',
-            '_elementor_edit_mode' => 'builder',
-            '_elementor_template_type' => 'wp-page',
+		// Confirm that the block displays.
+		$I->seeProductOutput( $I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product', $textColor, $backgroundColor );
+	}
 
-            // Configure ConvertKit Plugin to not display a default Form,
-            // as we are testing for the Form in Elementor.
-            '_wp_convertkit_post_meta' => [
-            'form'         => '-1',
-            'landing_page' => '',
-            'tag'          => '',
-            ],
-            ],
-            ]
-        );
-    }
+	/**
+	 * Create a Page in the database comprising of Elementor Page Builder data
+	 * containing a ConvertKit Product widget.
+	 *
+	 * Codeception's dragAndDrop() method doesn't support dropping an element into an iframe, which is
+	 * how Elementor works for adding widgets to a Page.
+	 *
+	 * Therefore, we directly create a Page in the database, with Elementor's data structure
+	 * as if we added the Product widget to a Page edited in Elementor.
+	 *
+	 * testProductWidgetIsRegistered() above is a sanity check that the Product Widget is registered
+	 * and available to users in Elementor.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param  AcceptanceTester $I        Tester.
+	 * @param  string           $title    Page Title.
+	 * @param  array            $settings Widget settings.
+	 * @return int                             Page ID
+	 */
+	private function _createPageWithProductWidget( AcceptanceTester $I, $title, $settings ) {
+		return $I->havePostInDatabase(
+			array(
+				'post_title'  => $title,
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'meta_input'  => array(
+					// Elementor.
+					'_elementor_data'          => array(
+						0 => array(
+							'id'       => '39bb59d',
+							'elType'   => 'section',
+							'settings' => array(),
+							'elements' => array(
+								array(
+									'id'       => 'b7e0e57',
+									'elType'   => 'column',
+									'settings' => array(
+										'_column_size' => 100,
+										'_inline_size' => null,
+									),
+									'elements' => array(
+										array(
+											'id'         => 'a73a905',
+											'elType'     => 'widget',
+											'settings'   => $settings,
+											'widgetType' => 'convertkit-elementor-product',
+										),
+									),
+								),
+							),
+						),
+					),
+					'_elementor_version'       => '3.6.1',
+					'_elementor_edit_mode'     => 'builder',
+					'_elementor_template_type' => 'wp-page',
 
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 2.0.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateThirdPartyPlugin($I, 'elementor');
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+					// Configure ConvertKit Plugin to not display a default Form,
+					// as we are testing for the Form in Elementor.
+					'_wp_convertkit_post_meta' => array(
+						'form'         => '-1',
+						'landing_page' => '',
+						'tag'          => '',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateThirdPartyPlugin( $I, 'elementor' );
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/integrations/WishListMemberCest.php
+++ b/tests/acceptance/integrations/WishListMemberCest.php
@@ -1,176 +1,175 @@
 <?php
 /**
  * Tests for ConvertKit Forms integration with WishList Member.
- * 
+ *
  * @since 1.9.6
  */
-class WishListMemberCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        $I->activateConvertKitPlugin($I);
-        $I->activateThirdPartyPlugin($I, 'wishlist-member');
-        $I->setupConvertKitPlugin($I);
-        $I->enableDebugLog($I);
-        $this->_setupWishListMemberPlugin($I);
-    }
+class WishListMemberCest {
 
-    /**
-     * Test that saving a WishList Member Level to ConvertKit Form Mapping works.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testSettingsWishListMemberLevelToConvertKitFormMapping(AcceptanceTester $I)
-    {
-        // Get WishList Member Level ID defined.
-        $wlmLevelID = $this->_getWishListMemberLevelID($I);
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		$I->activateConvertKitPlugin( $I );
+		$I->activateThirdPartyPlugin( $I, 'wishlist-member' );
+		$I->setupConvertKitPlugin( $I );
+		$I->enableDebugLog( $I );
+		$this->_setupWishListMemberPlugin( $I );
+	}
 
-        // Define email address for this test.
-        $emailAddress = $I->generateEmailAddress();
+	/**
+	 * Test that saving a WishList Member Level to ConvertKit Form Mapping works.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testSettingsWishListMemberLevelToConvertKitFormMapping( AcceptanceTester $I ) {
+		// Get WishList Member Level ID defined.
+		$wlmLevelID = $this->_getWishListMemberLevelID( $I );
 
-        // Create a test WordPress User.
-        $userID = $this->_createUser($I, $emailAddress);
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
 
-        // Load WishList Member Plugin Settings
-        $I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=wishlist-member');
+		// Create a test WordPress User.
+		$userID = $this->_createUser( $I, $emailAddress );
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Load WishList Member Plugin Settings
+		$I->amOnAdminPage( 'options-general.php?page=_wp_convertkit_settings&tab=wishlist-member' );
 
-        // Check that a Form Mapping option is displayed.
-        $I->seeElementInDOM('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form');
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-        // Change Form to value specified in the .env file.
-        $I->selectOption('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form', $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME']);
+		// Check that a Form Mapping option is displayed.
+		$I->seeElementInDOM( '#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form' );
 
-        // Save Changes.
-        $I->click('Save Changes');
+		// Change Form to value specified in the .env file.
+		$I->selectOption( '#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form', $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME'] );
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Save Changes.
+		$I->click( 'Save Changes' );
 
-        // Check the value of the Form field matches the input provided.
-        $I->seeOptionIsSelected('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form', $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME']);
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-        // Edit the Test User.
-        $I->amOnAdminPage('user-edit.php?user_id=' . $userID . '&wp_http_referer=%2Fwp-admin%2Fusers.php');
+		// Check the value of the Form field matches the input provided.
+		$I->seeOptionIsSelected( '#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form', $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME'] );
 
-        // Map the User to the Bronze WLM Level.
-        $I->checkOption('#WishListMemberUserProfile input[value="'. $wlmLevelID . '"]');
-		
-        // Save Changes.
-        $I->click('Update Member Profile');
+		// Edit the Test User.
+		$I->amOnAdminPage( 'user-edit.php?user_id=' . $userID . '&wp_http_referer=%2Fwp-admin%2Fusers.php' );
 
-        // Confirm that the User is still assigned to the Bronze WLM Level.
-        $I->seeCheckboxIsChecked('#WishListMemberUserProfile input[value="'. $wlmLevelID . '"]');
-		
-        // Confirm that the email address was added to ConvertKit.
-        $I->apiCheckSubscriberExists($I, $emailAddress);
-    }
+		// Map the User to the Bronze WLM Level.
+		$I->checkOption( '#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]' );
 
-    /**
-     * Returns the WishList Member Level ID created when setupWishListMemberPlugin() was called.
-     * 
-     * @since 1.9.6
-     * 
-     * @param  AcceptanceTester $I Tester
-     * @return int                     Level ID
-     */
-    private function _getWishListMemberLevelID(AcceptanceTester $I)
-    {
-        $table = $I->grabPrefixedTableNameFor('wlm_options');
-        $wlmLevels = $I->grabAllFromDatabase($table, 'option_value', ['option_name' => 'wpm_levels']);
-        $wlmLevels = unserialize($wlmLevels[0]['option_value']);
-        return array_key_first($wlmLevels);
-    }
+		// Save Changes.
+		$I->click( 'Update Member Profile' );
 
-    /**
-     * Creates a WordPress User, returning their User ID.
-     * 
-     * @since 1.9.6
-     * 
-     * @param  AcceptanceTester $I            Tester
-     * @param  string           $emailAddress Email Address
-     * @return int                                 User ID
-     */
-    private function _createUser(AcceptanceTester $I, $emailAddress)
-    {
-        return $I->haveUserInDatabase(
-            'wlm_test_user', 'subscriber', [
-            'user_email' => $emailAddress,
-            'first_name' => 'Test',
-            'last_name' => 'User',
-            'display_name' => 'Test User',
-            ]
-        );
-    }
+		// Confirm that the User is still assigned to the Bronze WLM Level.
+		$I->seeCheckboxIsChecked( '#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]' );
 
-    /**
-     * Helper method to setup the WishList Member Plugin.
-     * 
-     * @since 1.9.6
-     *
-     * @param AcceptanceTester $I Tester
-     */
-    private function _setupWishListMemberPlugin($I)
-    {
-        // Prevent WishList Member from asking for a license key by populating the WLM options table.
-        $I->updateInDatabase(
-            $I->grabPrefixedTableNameFor('wlm_options'), [
-            'option_value' => '1',
-            ], [
-            'option_name' => 'LicenseStatus',
-            ]
-        );
+		// Confirm that the email address was added to ConvertKit.
+		$I->apiCheckSubscriberExists( $I, $emailAddress );
+	}
 
-        // Load WishList Member Settings screen, which will load the first time configuration wizard.
-        $I->amOnAdminPage('admin.php?page=WishListMember');
+	/**
+	 * Returns the WishList Member Level ID created when setupWishListMemberPlugin() was called.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param  AcceptanceTester $I Tester
+	 * @return int                     Level ID
+	 */
+	private function _getWishListMemberLevelID( AcceptanceTester $I ) {
+		$table     = $I->grabPrefixedTableNameFor( 'wlm_options' );
+		$wlmLevels = $I->grabAllFromDatabase( $table, 'option_value', array( 'option_name' => 'wpm_levels' ) );
+		$wlmLevels = unserialize( $wlmLevels[0]['option_value'] );
+		return array_key_first( $wlmLevels );
+	}
 
-        // Step 1
-        $I->fillField('input[name="name"]', 'Bronze');
-        $I->click('.step-1 a[next-screen="step-2"]');
+	/**
+	 * Creates a WordPress User, returning their User ID.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param  AcceptanceTester $I            Tester
+	 * @param  string           $emailAddress Email Address
+	 * @return int                                 User ID
+	 */
+	private function _createUser( AcceptanceTester $I, $emailAddress ) {
+		return $I->haveUserInDatabase(
+			'wlm_test_user',
+			'subscriber',
+			array(
+				'user_email'   => $emailAddress,
+				'first_name'   => 'Test',
+				'last_name'    => 'User',
+				'display_name' => 'Test User',
+			)
+		);
+	}
 
-        // Step 2
-        $I->click('.step-2 a[next-screen="step-3"]');
+	/**
+	 * Helper method to setup the WishList Member Plugin.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	private function _setupWishListMemberPlugin( $I ) {
+		// Prevent WishList Member from asking for a license key by populating the WLM options table.
+		$I->updateInDatabase(
+			$I->grabPrefixedTableNameFor( 'wlm_options' ),
+			array(
+				'option_value' => '1',
+			),
+			array(
+				'option_name' => 'LicenseStatus',
+			)
+		);
 
-        // Step 3
-        $I->click('.step-3 a[next-screen="step-4"]');
+		// Load WishList Member Settings screen, which will load the first time configuration wizard.
+		$I->amOnAdminPage( 'admin.php?page=WishListMember' );
 
-        // Step 4
-        $I->click('.step-4 a[next-screen="step-5"]');
+		// Step 1
+		$I->fillField( 'input[name="name"]', 'Bronze' );
+		$I->click( '.step-1 a[next-screen="step-2"]' );
 
-        // Save
-        $I->click('.step-5 a.save-btn');
+		// Step 2
+		$I->click( '.step-2 a[next-screen="step-3"]' );
 
-        $I->performOn(
-            '.-congrats-gs', function ($I) {
-                $I->click('a.next-btn');
-                $I->seeInSource('Bronze');
-            }
-        );
-    }
+		// Step 3
+		$I->click( '.step-3 a[next-screen="step-4"]' );
 
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+		// Step 4
+		$I->click( '.step-4 a[next-screen="step-5"]' );
+
+		// Save
+		$I->click( '.step-5 a.save-btn' );
+
+		$I->performOn(
+			'.-congrats-gs',
+			function ( $I ) {
+				$I->click( 'a.next-btn' );
+				$I->seeInSource( 'Bronze' );
+			}
+		);
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/integrations/WishListMemberCest.php
+++ b/tests/acceptance/integrations/WishListMemberCest.php
@@ -1,175 +1,168 @@
 <?php
 /**
  * Tests for ConvertKit Forms integration with WishList Member.
- *
- * @since 1.9.6
+ * 
+ * @since 	1.9.6
  */
-class WishListMemberCest {
-
+class WishListMemberCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
-		$I->activateConvertKitPlugin( $I );
-		$I->activateThirdPartyPlugin( $I, 'wishlist-member' );
-		$I->setupConvertKitPlugin( $I );
-		$I->enableDebugLog( $I );
-		$this->_setupWishListMemberPlugin( $I );
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'wishlist-member');
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
+		$this->_setupWishListMemberPlugin($I);
 	}
 
 	/**
 	 * Test that saving a WishList Member Level to ConvertKit Form Mapping works.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testSettingsWishListMemberLevelToConvertKitFormMapping( AcceptanceTester $I ) {
+	public function testSettingsWishListMemberLevelToConvertKitFormMapping(AcceptanceTester $I)
+	{
 		// Get WishList Member Level ID defined.
-		$wlmLevelID = $this->_getWishListMemberLevelID( $I );
+		$wlmLevelID = $this->_getWishListMemberLevelID($I);
 
 		// Define email address for this test.
 		$emailAddress = $I->generateEmailAddress();
 
 		// Create a test WordPress User.
-		$userID = $this->_createUser( $I, $emailAddress );
+		$userID = $this->_createUser($I, $emailAddress);
 
 		// Load WishList Member Plugin Settings
-		$I->amOnAdminPage( 'options-general.php?page=_wp_convertkit_settings&tab=wishlist-member' );
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=wishlist-member');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check that a Form Mapping option is displayed.
-		$I->seeElementInDOM( '#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form' );
+		$I->seeElementInDOM('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form');
 
 		// Change Form to value specified in the .env file.
-		$I->selectOption( '#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form', $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME'] );
+		$I->selectOption('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form', $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME']);
 
 		// Save Changes.
-		$I->click( 'Save Changes' );
+		$I->click('Save Changes');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check the value of the Form field matches the input provided.
-		$I->seeOptionIsSelected( '#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form', $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME'] );
+		$I->seeOptionIsSelected('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form', $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME']);
 
 		// Edit the Test User.
-		$I->amOnAdminPage( 'user-edit.php?user_id=' . $userID . '&wp_http_referer=%2Fwp-admin%2Fusers.php' );
+		$I->amOnAdminPage('user-edit.php?user_id=' . $userID . '&wp_http_referer=%2Fwp-admin%2Fusers.php');
 
 		// Map the User to the Bronze WLM Level.
-		$I->checkOption( '#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]' );
-
+		$I->checkOption('#WishListMemberUserProfile input[value="'. $wlmLevelID . '"]');
+		
 		// Save Changes.
-		$I->click( 'Update Member Profile' );
+		$I->click('Update Member Profile');
 
 		// Confirm that the User is still assigned to the Bronze WLM Level.
-		$I->seeCheckboxIsChecked( '#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]' );
-
+		$I->seeCheckboxIsChecked('#WishListMemberUserProfile input[value="'. $wlmLevelID . '"]');
+		
 		// Confirm that the email address was added to ConvertKit.
-		$I->apiCheckSubscriberExists( $I, $emailAddress );
+		$I->apiCheckSubscriberExists($I, $emailAddress);
 	}
 
 	/**
 	 * Returns the WishList Member Level ID created when setupWishListMemberPlugin() was called.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param  AcceptanceTester $I Tester
-	 * @return int                     Level ID
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 * @return 	int 					Level ID
 	 */
-	private function _getWishListMemberLevelID( AcceptanceTester $I ) {
-		$table     = $I->grabPrefixedTableNameFor( 'wlm_options' );
-		$wlmLevels = $I->grabAllFromDatabase( $table, 'option_value', array( 'option_name' => 'wpm_levels' ) );
+	private function _getWishListMemberLevelID(AcceptanceTester $I)
+	{
+		$table = $I->grabPrefixedTableNameFor('wlm_options');
+		$wlmLevels = $I->grabAllFromDatabase($table, 'option_value', ['option_name' => 'wpm_levels']);
 		$wlmLevels = unserialize( $wlmLevels[0]['option_value'] );
 		return array_key_first( $wlmLevels );
 	}
 
 	/**
 	 * Creates a WordPress User, returning their User ID.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param  AcceptanceTester $I            Tester
-	 * @param  string           $emailAddress Email Address
-	 * @return int                                 User ID
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 				Tester
+	 * @param 	string 				$emailAddress 	Email Address
+	 * @return 	int 								User ID
 	 */
-	private function _createUser( AcceptanceTester $I, $emailAddress ) {
-		return $I->haveUserInDatabase(
-			'wlm_test_user',
-			'subscriber',
-			array(
-				'user_email'   => $emailAddress,
-				'first_name'   => 'Test',
-				'last_name'    => 'User',
-				'display_name' => 'Test User',
-			)
-		);
+	private function _createUser(AcceptanceTester $I, $emailAddress)
+	{
+		return $I->haveUserInDatabase('wlm_test_user', 'subscriber', [
+			'user_email' => $emailAddress,
+			'first_name' => 'Test',
+			'last_name' => 'User',
+			'display_name' => 'Test User',
+		]);
 	}
 
 	/**
 	 * Helper method to setup the WishList Member Plugin.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
 	 */
-	private function _setupWishListMemberPlugin( $I ) {
+	private function _setupWishListMemberPlugin($I)
+	{
 		// Prevent WishList Member from asking for a license key by populating the WLM options table.
-		$I->updateInDatabase(
-			$I->grabPrefixedTableNameFor( 'wlm_options' ),
-			array(
-				'option_value' => '1',
-			),
-			array(
-				'option_name' => 'LicenseStatus',
-			)
-		);
+		$I->updateInDatabase($I->grabPrefixedTableNameFor('wlm_options'), [
+			'option_value' => '1',
+		], [
+			'option_name' => 'LicenseStatus',
+		]);
 
 		// Load WishList Member Settings screen, which will load the first time configuration wizard.
-		$I->amOnAdminPage( 'admin.php?page=WishListMember' );
+		$I->amOnAdminPage('admin.php?page=WishListMember');
 
 		// Step 1
-		$I->fillField( 'input[name="name"]', 'Bronze' );
-		$I->click( '.step-1 a[next-screen="step-2"]' );
+		$I->fillField('input[name="name"]', 'Bronze');
+		$I->click('.step-1 a[next-screen="step-2"]');
 
 		// Step 2
-		$I->click( '.step-2 a[next-screen="step-3"]' );
+		$I->click('.step-2 a[next-screen="step-3"]');
 
 		// Step 3
-		$I->click( '.step-3 a[next-screen="step-4"]' );
+		$I->click('.step-3 a[next-screen="step-4"]');
 
 		// Step 4
-		$I->click( '.step-4 a[next-screen="step-5"]' );
+		$I->click('.step-4 a[next-screen="step-5"]');
 
 		// Save
-		$I->click( '.step-5 a.save-btn' );
+		$I->click('.step-5 a.save-btn');
 
-		$I->performOn(
-			'.-congrats-gs',
-			function ( $I ) {
-				$I->click( 'a.next-btn' );
-				$I->seeInSource( 'Bronze' );
-			}
-		);
+		$I->performOn('.-congrats-gs', function($I) {
+			$I->click('a.next-btn');
+			$I->seeInSource('Bronze');
+		});
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/integrations/WishListMemberCest.php
+++ b/tests/acceptance/integrations/WishListMemberCest.php
@@ -2,167 +2,173 @@
 /**
  * Tests for ConvertKit Forms integration with WishList Member.
  * 
- * @since 	1.9.6
+ * @since 1.9.6
  */
 class WishListMemberCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		$I->activateConvertKitPlugin($I);
-		$I->activateThirdPartyPlugin($I, 'wishlist-member');
-		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
-		$this->_setupWishListMemberPlugin($I);
-	}
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        $I->activateConvertKitPlugin($I);
+        $I->activateThirdPartyPlugin($I, 'wishlist-member');
+        $I->setupConvertKitPlugin($I);
+        $I->enableDebugLog($I);
+        $this->_setupWishListMemberPlugin($I);
+    }
 
-	/**
-	 * Test that saving a WishList Member Level to ConvertKit Form Mapping works.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testSettingsWishListMemberLevelToConvertKitFormMapping(AcceptanceTester $I)
-	{
-		// Get WishList Member Level ID defined.
-		$wlmLevelID = $this->_getWishListMemberLevelID($I);
+    /**
+     * Test that saving a WishList Member Level to ConvertKit Form Mapping works.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testSettingsWishListMemberLevelToConvertKitFormMapping(AcceptanceTester $I)
+    {
+        // Get WishList Member Level ID defined.
+        $wlmLevelID = $this->_getWishListMemberLevelID($I);
 
-		// Define email address for this test.
-		$emailAddress = $I->generateEmailAddress();
+        // Define email address for this test.
+        $emailAddress = $I->generateEmailAddress();
 
-		// Create a test WordPress User.
-		$userID = $this->_createUser($I, $emailAddress);
+        // Create a test WordPress User.
+        $userID = $this->_createUser($I, $emailAddress);
 
-		// Load WishList Member Plugin Settings
-		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=wishlist-member');
+        // Load WishList Member Plugin Settings
+        $I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=wishlist-member');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Check that a Form Mapping option is displayed.
-		$I->seeElementInDOM('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form');
+        // Check that a Form Mapping option is displayed.
+        $I->seeElementInDOM('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form');
 
-		// Change Form to value specified in the .env file.
-		$I->selectOption('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form', $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME']);
+        // Change Form to value specified in the .env file.
+        $I->selectOption('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form', $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME']);
 
-		// Save Changes.
-		$I->click('Save Changes');
+        // Save Changes.
+        $I->click('Save Changes');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Check the value of the Form field matches the input provided.
-		$I->seeOptionIsSelected('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form', $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME']);
+        // Check the value of the Form field matches the input provided.
+        $I->seeOptionIsSelected('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form', $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME']);
 
-		// Edit the Test User.
-		$I->amOnAdminPage('user-edit.php?user_id=' . $userID . '&wp_http_referer=%2Fwp-admin%2Fusers.php');
+        // Edit the Test User.
+        $I->amOnAdminPage('user-edit.php?user_id=' . $userID . '&wp_http_referer=%2Fwp-admin%2Fusers.php');
 
-		// Map the User to the Bronze WLM Level.
-		$I->checkOption('#WishListMemberUserProfile input[value="'. $wlmLevelID . '"]');
+        // Map the User to the Bronze WLM Level.
+        $I->checkOption('#WishListMemberUserProfile input[value="'. $wlmLevelID . '"]');
 		
-		// Save Changes.
-		$I->click('Update Member Profile');
+        // Save Changes.
+        $I->click('Update Member Profile');
 
-		// Confirm that the User is still assigned to the Bronze WLM Level.
-		$I->seeCheckboxIsChecked('#WishListMemberUserProfile input[value="'. $wlmLevelID . '"]');
+        // Confirm that the User is still assigned to the Bronze WLM Level.
+        $I->seeCheckboxIsChecked('#WishListMemberUserProfile input[value="'. $wlmLevelID . '"]');
 		
-		// Confirm that the email address was added to ConvertKit.
-		$I->apiCheckSubscriberExists($I, $emailAddress);
-	}
+        // Confirm that the email address was added to ConvertKit.
+        $I->apiCheckSubscriberExists($I, $emailAddress);
+    }
 
-	/**
-	 * Returns the WishList Member Level ID created when setupWishListMemberPlugin() was called.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 * @return 	int 					Level ID
-	 */
-	private function _getWishListMemberLevelID(AcceptanceTester $I)
-	{
-		$table = $I->grabPrefixedTableNameFor('wlm_options');
-		$wlmLevels = $I->grabAllFromDatabase($table, 'option_value', ['option_name' => 'wpm_levels']);
-		$wlmLevels = unserialize( $wlmLevels[0]['option_value'] );
-		return array_key_first( $wlmLevels );
-	}
+    /**
+     * Returns the WishList Member Level ID created when setupWishListMemberPlugin() was called.
+     * 
+     * @since 1.9.6
+     * 
+     * @param  AcceptanceTester $I Tester
+     * @return int                     Level ID
+     */
+    private function _getWishListMemberLevelID(AcceptanceTester $I)
+    {
+        $table = $I->grabPrefixedTableNameFor('wlm_options');
+        $wlmLevels = $I->grabAllFromDatabase($table, 'option_value', ['option_name' => 'wpm_levels']);
+        $wlmLevels = unserialize($wlmLevels[0]['option_value']);
+        return array_key_first($wlmLevels);
+    }
 
-	/**
-	 * Creates a WordPress User, returning their User ID.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 				Tester
-	 * @param 	string 				$emailAddress 	Email Address
-	 * @return 	int 								User ID
-	 */
-	private function _createUser(AcceptanceTester $I, $emailAddress)
-	{
-		return $I->haveUserInDatabase('wlm_test_user', 'subscriber', [
-			'user_email' => $emailAddress,
-			'first_name' => 'Test',
-			'last_name' => 'User',
-			'display_name' => 'Test User',
-		]);
-	}
+    /**
+     * Creates a WordPress User, returning their User ID.
+     * 
+     * @since 1.9.6
+     * 
+     * @param  AcceptanceTester $I            Tester
+     * @param  string           $emailAddress Email Address
+     * @return int                                 User ID
+     */
+    private function _createUser(AcceptanceTester $I, $emailAddress)
+    {
+        return $I->haveUserInDatabase(
+            'wlm_test_user', 'subscriber', [
+            'user_email' => $emailAddress,
+            'first_name' => 'Test',
+            'last_name' => 'User',
+            'display_name' => 'Test User',
+            ]
+        );
+    }
 
-	/**
-	 * Helper method to setup the WishList Member Plugin.
-	 * 
-	 * @since 	1.9.6
-	 */
-	private function _setupWishListMemberPlugin($I)
-	{
-		// Prevent WishList Member from asking for a license key by populating the WLM options table.
-		$I->updateInDatabase($I->grabPrefixedTableNameFor('wlm_options'), [
-			'option_value' => '1',
-		], [
-			'option_name' => 'LicenseStatus',
-		]);
+    /**
+     * Helper method to setup the WishList Member Plugin.
+     * 
+     * @since 1.9.6
+     */
+    private function _setupWishListMemberPlugin($I)
+    {
+        // Prevent WishList Member from asking for a license key by populating the WLM options table.
+        $I->updateInDatabase(
+            $I->grabPrefixedTableNameFor('wlm_options'), [
+            'option_value' => '1',
+            ], [
+            'option_name' => 'LicenseStatus',
+            ]
+        );
 
-		// Load WishList Member Settings screen, which will load the first time configuration wizard.
-		$I->amOnAdminPage('admin.php?page=WishListMember');
+        // Load WishList Member Settings screen, which will load the first time configuration wizard.
+        $I->amOnAdminPage('admin.php?page=WishListMember');
 
-		// Step 1
-		$I->fillField('input[name="name"]', 'Bronze');
-		$I->click('.step-1 a[next-screen="step-2"]');
+        // Step 1
+        $I->fillField('input[name="name"]', 'Bronze');
+        $I->click('.step-1 a[next-screen="step-2"]');
 
-		// Step 2
-		$I->click('.step-2 a[next-screen="step-3"]');
+        // Step 2
+        $I->click('.step-2 a[next-screen="step-3"]');
 
-		// Step 3
-		$I->click('.step-3 a[next-screen="step-4"]');
+        // Step 3
+        $I->click('.step-3 a[next-screen="step-4"]');
 
-		// Step 4
-		$I->click('.step-4 a[next-screen="step-5"]');
+        // Step 4
+        $I->click('.step-4 a[next-screen="step-5"]');
 
-		// Save
-		$I->click('.step-5 a.save-btn');
+        // Save
+        $I->click('.step-5 a.save-btn');
 
-		$I->performOn('.-congrats-gs', function($I) {
-			$I->click('a.next-btn');
-			$I->seeInSource('Bronze');
-		});
-	}
+        $I->performOn(
+            '.-congrats-gs', function ($I) {
+                $I->click('a.next-btn');
+                $I->seeInSource('Bronze');
+            }
+        );
+    }
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/integrations/WishListMemberCest.php
+++ b/tests/acceptance/integrations/WishListMemberCest.php
@@ -1,17 +1,17 @@
 <?php
 /**
  * Tests for ConvertKit Forms integration with WishList Member.
- * 
- * @since 	1.9.6
+ *
+ * @since   1.9.6
  */
 class WishListMemberCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -24,10 +24,10 @@ class WishListMemberCest
 
 	/**
 	 * Test that saving a WishList Member Level to ConvertKit Form Mapping works.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testSettingsWishListMemberLevelToConvertKitFormMapping(AcceptanceTester $I)
 	{
@@ -40,7 +40,7 @@ class WishListMemberCest
 		// Create a test WordPress User.
 		$userID = $this->_createUser($I, $emailAddress);
 
-		// Load WishList Member Plugin Settings
+		// Load WishList Member Plugin Settings.
 		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=wishlist-member');
 
 		// Check that no PHP warnings or notices were output.
@@ -65,100 +65,113 @@ class WishListMemberCest
 		$I->amOnAdminPage('user-edit.php?user_id=' . $userID . '&wp_http_referer=%2Fwp-admin%2Fusers.php');
 
 		// Map the User to the Bronze WLM Level.
-		$I->checkOption('#WishListMemberUserProfile input[value="'. $wlmLevelID . '"]');
-		
+		$I->checkOption('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
+
 		// Save Changes.
 		$I->click('Update Member Profile');
 
 		// Confirm that the User is still assigned to the Bronze WLM Level.
-		$I->seeCheckboxIsChecked('#WishListMemberUserProfile input[value="'. $wlmLevelID . '"]');
-		
+		$I->seeCheckboxIsChecked('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
+
 		// Confirm that the email address was added to ConvertKit.
 		$I->apiCheckSubscriberExists($I, $emailAddress);
 	}
 
 	/**
 	 * Returns the WishList Member Level ID created when setupWishListMemberPlugin() was called.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 * @return 	int 					Level ID
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 * @return  int                     Level ID
 	 */
 	private function _getWishListMemberLevelID(AcceptanceTester $I)
 	{
-		$table = $I->grabPrefixedTableNameFor('wlm_options');
-		$wlmLevels = $I->grabAllFromDatabase($table, 'option_value', ['option_name' => 'wpm_levels']);
+		$table     = $I->grabPrefixedTableNameFor('wlm_options');
+		$wlmLevels = $I->grabAllFromDatabase($table, 'option_value', [ 'option_name' => 'wpm_levels' ]);
 		$wlmLevels = unserialize( $wlmLevels[0]['option_value'] );
 		return array_key_first( $wlmLevels );
 	}
 
 	/**
 	 * Creates a WordPress User, returning their User ID.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 				Tester
-	 * @param 	string 				$emailAddress 	Email Address
-	 * @return 	int 								User ID
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I              Tester.
+	 * @param   string           $emailAddress   Email Address.
+	 * @return  int                                 User ID
 	 */
 	private function _createUser(AcceptanceTester $I, $emailAddress)
 	{
-		return $I->haveUserInDatabase('wlm_test_user', 'subscriber', [
-			'user_email' => $emailAddress,
-			'first_name' => 'Test',
-			'last_name' => 'User',
-			'display_name' => 'Test User',
-		]);
+		return $I->haveUserInDatabase(
+			'wlm_test_user',
+			'subscriber',
+			[
+				'user_email'   => $emailAddress,
+				'first_name'   => 'Test',
+				'last_name'    => 'User',
+				'display_name' => 'Test User',
+			]
+		);
 	}
 
 	/**
 	 * Helper method to setup the WishList Member Plugin.
-	 * 
-	 * @since 	1.9.6
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I              Tester.
 	 */
 	private function _setupWishListMemberPlugin($I)
 	{
 		// Prevent WishList Member from asking for a license key by populating the WLM options table.
-		$I->updateInDatabase($I->grabPrefixedTableNameFor('wlm_options'), [
-			'option_value' => '1',
-		], [
-			'option_name' => 'LicenseStatus',
-		]);
+		$I->updateInDatabase(
+			$I->grabPrefixedTableNameFor('wlm_options'),
+			[
+				'option_value' => '1',
+			],
+			[
+				'option_name' => 'LicenseStatus',
+			]
+		);
 
 		// Load WishList Member Settings screen, which will load the first time configuration wizard.
 		$I->amOnAdminPage('admin.php?page=WishListMember');
 
-		// Step 1
+		// Step 1.
 		$I->fillField('input[name="name"]', 'Bronze');
 		$I->click('.step-1 a[next-screen="step-2"]');
 
-		// Step 2
+		// Step 2.
 		$I->click('.step-2 a[next-screen="step-3"]');
 
-		// Step 3
+		// Step 3.
 		$I->click('.step-3 a[next-screen="step-4"]');
 
-		// Step 4
+		// Step 4.
 		$I->click('.step-4 a[next-screen="step-5"]');
 
-		// Save
+		// Save.
 		$I->click('.step-5 a.save-btn');
 
-		$I->performOn('.-congrats-gs', function($I) {
-			$I->click('a.next-btn');
-			$I->seeInSource('Bronze');
-		});
+		$I->performOn(
+			'.-congrats-gs',
+			function($I) {
+				$I->click('a.next-btn');
+				$I->seeInSource('Bronze');
+			}
+		);
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/integrations/WishListMemberCest.php
+++ b/tests/acceptance/integrations/WishListMemberCest.php
@@ -118,6 +118,8 @@ class WishListMemberCest
      * Helper method to setup the WishList Member Plugin.
      * 
      * @since 1.9.6
+     *
+     * @param AcceptanceTester $I Tester
      */
     private function _setupWishListMemberPlugin($I)
     {

--- a/tests/acceptance/integrations/WooCommerceProductFormCest.php
+++ b/tests/acceptance/integrations/WooCommerceProductFormCest.php
@@ -156,7 +156,6 @@ class WooCommerceProductFormCest
 		$I->addVisualEditorShortcode(
 			$I,
 			'ConvertKit Form',
-			'convertkit-form',
 			[
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			],
@@ -169,7 +168,6 @@ class WooCommerceProductFormCest
 		$I->addVisualEditorShortcode(
 			$I,
 			'ConvertKit Form',
-			'convertkit-form',
 			[
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			],
@@ -204,7 +202,6 @@ class WooCommerceProductFormCest
 		// and confirming that the expected shortcode is displayed in the Excerpt field.
 		$I->addTextEditorShortcode(
 			$I,
-			'ConvertKit Form',
 			'convertkit-form',
 			[
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
@@ -217,7 +214,6 @@ class WooCommerceProductFormCest
 		// and confirming that the expected shortcode is displayed in the Excerpt field.
 		$I->addTextEditorShortcode(
 			$I,
-			'ConvertKit Form',
 			'convertkit-form',
 			[
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],

--- a/tests/acceptance/integrations/WooCommerceProductFormCest.php
+++ b/tests/acceptance/integrations/WooCommerceProductFormCest.php
@@ -2,470 +2,496 @@
 /**
  * Tests for ConvertKit Forms on WooCommerce Products.
  * 
- * @since 	1.9.6
+ * @since 1.9.6
  */
 class WooCommerceProductFormCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		$I->activateConvertKitPlugin($I);
-		$I->activateThirdPartyPlugin($I, 'woocommerce');
-		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
-	}
-
-	/**
-	 * Test that the 'Default' option for the Default Form setting in the Plugin Settings works when
-	 * creating and viewing a new WooCommerce Product, and there is no Default Form specified in the Plugin
-	 * settings.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewProductUsingDefaultFormWithNoDefaultFormSpecifiedInPlugin(AcceptanceTester $I)
-	{
-		// Navigate to Products > Add New.
-		$I->amOnAdminPage('post-new.php?post_type=product');
-
-		// Define a Product Title.
-		$I->fillField('#title', 'ConvertKit: Product: Form: Default: None');
-
-		// Wait, otherwise publishing will fail in WooCommerce.
-		$I->wait(1);
-
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage($I);
-
-		// Confirm that a ConvertKit Form is not displayed.
-		$I->dontSeeElementInDOM('form[data-sv-form]');
-	}
-
-	/**
-	 * Test that the Default Form specified in the Plugin Settings works when
-	 * creating and viewing a new WooCommerce Product.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewProductUsingDefaultForm(AcceptanceTester $I)
-	{
-		// Specify the Default Form in the Plugin Settings.
-		$defaultFormID = $I->setupConvertKitPluginDefaultFormForWooCommerceProducts($I);
-
-		// Navigate to Products > Add New.
-		$I->amOnAdminPage('post-new.php?post_type=product');
-
-		// Define a Product Title.
-		$I->fillField('#title', 'ConvertKit: Product: Form: Default');
-
-		// Wait, otherwise publishing will fail in WooCommerce.
-		$I->wait(1);
-
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage($I);
-
-		// Confirm that the ConvertKit Default Form displays.
-		$I->seeElementInDOM('form[data-sv-form="' . $defaultFormID . '"]');
-	}
-
-	/**
-	 * Test that 'None' Form specified in the Product Settings works when
-	 * creating and viewing a new WooCommerce Product.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewProductUsingNoForm(AcceptanceTester $I)
-	{
-		// Navigate to Products > Add New.
-		$I->amOnAdminPage('post-new.php?post_type=product');
-
-		// Change Form to None.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None', 'aria-owns');
-
-		// Define a Product Title.
-		$I->fillField('#title', 'ConvertKit: Product: Form: None');
-
-		// Wait, otherwise publishing will fail in WooCommerce.
-		$I->wait(1);
-
-		// Publish and view the Product.
-		$I->publishAndViewClassicEditorPage($I);
-
-		// Confirm that no ConvertKit Form is displayed.
-		$I->dontSeeElementInDOM('form[data-sv-form]');
-	}
-
-	/**
-	 * Test that the Form specified in the Product Settings works when
-	 * creating and viewing a new WooCommerce Product.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewProductUsingDefinedForm(AcceptanceTester $I)
-	{
-		// Navigate to Products > Add New.
-		$I->amOnAdminPage('post-new.php?post_type=product');
-
-		// Change Form to Form setting in .env file.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME'], 'aria-owns');
-
-		// Define a Product Title.
-		$I->fillField('#title', 'ConvertKit: Product: Form: Defined');
-
-		// Wait, otherwise publishing will fail in WooCommerce.
-		$I->wait(1);
-
-		// Publish and view the Product.
-		$I->publishAndViewClassicEditorPage($I);
-
-		// Confirm that the ConvertKit Form displays.
-		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-	}
-
-	/**
-	 * Test the [convertkit_form] shortcode is inserted into the applicable Content or Excerpt Visual Editor
-	 * instances when adding a WooCommerce Product.
-	 * 
-	 * @since 	1.9.8.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewProductUsingFormShortcodeInVisualEditor(AcceptanceTester $I)
-	{
-		// Add a Product using the Classic Editor.
-		$I->addClassicEditorPage($I, 'product', 'ConvertKit: Product: Form: Shortcode: Visual Editor');
-
-		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None', 'aria-owns');
-
-		// Add shortcode to Excerpt (Product short description), setting the Form setting to the value specified in the .env file,
-		// and confirming that the expected shortcode is displayed in the Excerpt field.
-		$I->addVisualEditorShortcode(
-			$I,
-			'ConvertKit Form',
-			'convertkit-form',
-			[
-				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
-			],
-			'[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]',
-			'excerpt' // The ID of the Product short description field.
-		);
-
-		// Add shortcode to Content, setting the Form setting to the value specified in the .env file,
-		// and confirming that the expected shortcode is displayed in the Excerpt field.
-		$I->addVisualEditorShortcode(
-			$I,
-			'ConvertKit Form',
-			'convertkit-form',
-			[
-				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
-			],
-			'[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]',
-			'content' // The ID of the Content field.
-		);
-
-		// Publish and view the Product on the frontend site.
-		$I->publishAndViewClassicEditorPage($I);
-
-		// Confirm that the ConvertKit Form is displayed.
-		$I->seeElementInDOM('form[data-sv-form]');
-	}
-
-	/**
-	 * Test the [convertkit_form] shortcode is inserted into the applicable Content or Excerpt Text Editor
-	 * instances when adding a WooCommerce Product.
-	 * 
-	 * @since 	1.9.8.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewProductUsingFormShortcodeInTextEditor(AcceptanceTester $I)
-	{
-		// Add a Product using the Classic Editor.
-		$I->addClassicEditorPage($I, 'product', 'ConvertKit: Product: Form: Shortcode: Text Editor');
-
-		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None', 'aria-owns');
-
-		// Add shortcode to Excerpt (Product short description), setting the Form setting to the value specified in the .env file,
-		// and confirming that the expected shortcode is displayed in the Excerpt field.		
-		$I->addTextEditorShortcode(
-			$I,
-			'ConvertKit Form',
-			'convertkit-form',
-			[
-				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
-			],
-			'[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]',
-			'excerpt' // The ID of the Product short description field.
-		);
-
-		// Add shortcode to Content, setting the Form setting to the value specified in the .env file,
-		// and confirming that the expected shortcode is displayed in the Excerpt field.
-		$I->addTextEditorShortcode(
-			$I,
-			'ConvertKit Form',
-			'convertkit-form',
-			[
-				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
-			],
-			'[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]',
-			'content' // The ID of the Content field.
-		);
-
-		// Publish and view the Product on the frontend site.
-		$I->publishAndViewClassicEditorPage($I);
-
-		// Confirm that the ConvertKit Form is displayed.
-		$I->seeElementInDOM('form[data-sv-form]');
-	}
-
-	/**
-	 * Test that the Default Form for Products displays when the Default option is chosen via
-	 * WordPress' Quick Edit functionality.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testQuickEditUsingDefaultForm(AcceptanceTester $I)
-	{
-		// Specify the Default Form in the Plugin Settings.
-		$I->setupConvertKitPluginDefaultFormForWooCommerceProducts($I);
-
-		// Programmatically create a Product.
-		$productID = $I->havePostInDatabase([
-			'post_type' 	=> 'product',
-			'post_title' 	=> 'ConvertKit: Product: Form: Default: Quick Edit',
-		]);
-
-		// Quick Edit the Product in the Products WP_List_Table.
-		$I->quickEdit($I, 'product', $productID, [
-			'form' => [ 'select', 'Default' ],
-		]);
-
-		// Load the Product on the frontend site.
-		$I->amOnPage('/?p='.$productID);
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm that the ConvertKit Default Form displays.
-		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-	}
-
-	/**
-	 * Test that the defined form displays when chosen via
-	 * WordPress' Quick Edit functionality.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testQuickEditUsingDefinedForm(AcceptanceTester $I)
-	{
-		// Programmatically create a Product.
-		$productID = $I->havePostInDatabase([
-			'post_type' 	=> 'product',
-			'post_title' 	=> 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
-		]);
-
-		// Quick Edit the Product in the Products WP_List_Table.
-		$I->quickEdit($I, 'product', $productID, [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-		]);
-
-		// Load the Product on the frontend site.
-		$I->amOnPage('/?p='.$productID);
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm that the ConvertKit Default Form displays.
-		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-	}
-
-	/**
-	 * Test that the Default Form for Products displays when the Default option is chosen via
-	 * WordPress' Bulk Edit functionality.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBulkEditUsingDefaultForm(AcceptanceTester $I)
-	{
-		// Specify the Default Form in the Plugin Settings.
-		$I->setupConvertKitPluginDefaultFormForWooCommerceProducts($I);
-
-		// Programmatically create two Products.
-		$productIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'product',
-				'post_title' 	=> 'ConvertKit: Product: Form: Default: Bulk Edit #1',
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'product',
-				'post_title' 	=> 'ConvertKit: Product: Form: Default: Bulk Edit #2',
-			])
-		);
-
-		// Bulk Edit the Products in the Products WP_List_Table.
-		$I->bulkEdit($I, 'product', $productIDs, [
-			'form' => [ 'select', 'Default' ],
-		]);
-
-		// Iterate through Products to run frontend tests.
-		foreach($productIDs as $productID) {
-			// Load Product on the frontend site.
-			$I->amOnPage('/?p='.$productID);
-
-			// Check that no PHP warnings or notices were output.
-			$I->checkNoWarningsAndNoticesOnScreen($I);
-
-			// Confirm that the ConvertKit Default Form displays.
-			$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-		}
-	}
-
-	/**
-	 * Test that the defined form displays when chosen via
-	 * WordPress' Bulk Edit functionality.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBulkEditUsingDefinedForm(AcceptanceTester $I)
-	{
-		// Programmatically create two Products.
-		$productIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'product',
-				'post_title' 	=> 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'product',
-				'post_title' 	=> 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
-			])
-		);
-
-		// Bulk Edit the Products in the Products WP_List_Table.
-		$I->bulkEdit($I, 'product', $productIDs, [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-		]);
-
-		// Iterate through Products to run frontend tests.
-		foreach($productIDs as $productID) {
-			// Load Product on the frontend site.
-			$I->amOnPage('/?p='.$productID);
-
-			// Check that no PHP warnings or notices were output.
-			$I->checkNoWarningsAndNoticesOnScreen($I);
-
-			// Confirm that the ConvertKit Default Form displays.
-			$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-		}
-	}
-
-	/**
-	 * Test that the existing settings are honored and not changed
-	 * when the Bulk Edit options are set to 'No Change'.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBulkEditWithNoChanges(AcceptanceTester $I)
-	{
-		// Programmatically create two Products with a defined form.
-		$productIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'product',
-				'post_title' 	=> 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #1',
-				'meta_input'	=> [
-					'_wp_convertkit_post_meta' => [
-						'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
-						'landing_page' => '',
-						'tag'          => '',
-					]
-				],
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'product',
-				'post_title' 	=> 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
-				'meta_input'	=> [
-					'_wp_convertkit_post_meta' => [
-						'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
-						'landing_page' => '',
-						'tag'          => '',
-					]
-				],
-			])
-		);
-
-		// Bulk Edit the Products in the Products WP_List_Table.
-		$I->bulkEdit($I, 'product', $productIDs, [
-			'form' => [ 'select', '— No Change —' ],
-		]);
-
-		// Iterate through Products to run frontend tests.
-		foreach($productIDs as $productID) {
-			// Load Page on the frontend site.
-			$I->amOnPage('/?p='.$productID);
-
-			// Check that no PHP warnings or notices were output.
-			$I->checkNoWarningsAndNoticesOnScreen($I);
-
-			// Confirm that the ConvertKit Form displays.
-			$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-		}
-	}
-
-	/**
-	 * Test that the Bulk Edit fields do not display when a search on a WP_List_Table
-	 * returns no results.
-	 * 
-	 * @since 	1.9.8.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBulkEditFieldsHiddenWhenNoProductsFound(AcceptanceTester $I)
-	{
-		// Emulate the user searching for Products with a query string that yields no results.
-		$I->amOnAdminPage('edit.php?post_type=product&s=nothing');
-
-		// Confirm that the Bulk Edit fields do not display.
-		$I->dontSeeElement('#convertkit-bulk-edit');
-	}
-
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateConvertKitPlugin($I);
-		$I->deactivateThirdPartyPlugin($I, 'classic-editor');
-		$I->deactivateThirdPartyPlugin($I, 'woocommerce');
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        $I->activateConvertKitPlugin($I);
+        $I->activateThirdPartyPlugin($I, 'woocommerce');
+        $I->setupConvertKitPlugin($I);
+        $I->enableDebugLog($I);
+    }
+
+    /**
+     * Test that the 'Default' option for the Default Form setting in the Plugin Settings works when
+     * creating and viewing a new WooCommerce Product, and there is no Default Form specified in the Plugin
+     * settings.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewProductUsingDefaultFormWithNoDefaultFormSpecifiedInPlugin(AcceptanceTester $I)
+    {
+        // Navigate to Products > Add New.
+        $I->amOnAdminPage('post-new.php?post_type=product');
+
+        // Define a Product Title.
+        $I->fillField('#title', 'ConvertKit: Product: Form: Default: None');
+
+        // Wait, otherwise publishing will fail in WooCommerce.
+        $I->wait(1);
+
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewClassicEditorPage($I);
+
+        // Confirm that a ConvertKit Form is not displayed.
+        $I->dontSeeElementInDOM('form[data-sv-form]');
+    }
+
+    /**
+     * Test that the Default Form specified in the Plugin Settings works when
+     * creating and viewing a new WooCommerce Product.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewProductUsingDefaultForm(AcceptanceTester $I)
+    {
+        // Specify the Default Form in the Plugin Settings.
+        $defaultFormID = $I->setupConvertKitPluginDefaultFormForWooCommerceProducts($I);
+
+        // Navigate to Products > Add New.
+        $I->amOnAdminPage('post-new.php?post_type=product');
+
+        // Define a Product Title.
+        $I->fillField('#title', 'ConvertKit: Product: Form: Default');
+
+        // Wait, otherwise publishing will fail in WooCommerce.
+        $I->wait(1);
+
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewClassicEditorPage($I);
+
+        // Confirm that the ConvertKit Default Form displays.
+        $I->seeElementInDOM('form[data-sv-form="' . $defaultFormID . '"]');
+    }
+
+    /**
+     * Test that 'None' Form specified in the Product Settings works when
+     * creating and viewing a new WooCommerce Product.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewProductUsingNoForm(AcceptanceTester $I)
+    {
+        // Navigate to Products > Add New.
+        $I->amOnAdminPage('post-new.php?post_type=product');
+
+        // Change Form to None.
+        $I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None', 'aria-owns');
+
+        // Define a Product Title.
+        $I->fillField('#title', 'ConvertKit: Product: Form: None');
+
+        // Wait, otherwise publishing will fail in WooCommerce.
+        $I->wait(1);
+
+        // Publish and view the Product.
+        $I->publishAndViewClassicEditorPage($I);
+
+        // Confirm that no ConvertKit Form is displayed.
+        $I->dontSeeElementInDOM('form[data-sv-form]');
+    }
+
+    /**
+     * Test that the Form specified in the Product Settings works when
+     * creating and viewing a new WooCommerce Product.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewProductUsingDefinedForm(AcceptanceTester $I)
+    {
+        // Navigate to Products > Add New.
+        $I->amOnAdminPage('post-new.php?post_type=product');
+
+        // Change Form to Form setting in .env file.
+        $I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME'], 'aria-owns');
+
+        // Define a Product Title.
+        $I->fillField('#title', 'ConvertKit: Product: Form: Defined');
+
+        // Wait, otherwise publishing will fail in WooCommerce.
+        $I->wait(1);
+
+        // Publish and view the Product.
+        $I->publishAndViewClassicEditorPage($I);
+
+        // Confirm that the ConvertKit Form displays.
+        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+    }
+
+    /**
+     * Test the [convertkit_form] shortcode is inserted into the applicable Content or Excerpt Visual Editor
+     * instances when adding a WooCommerce Product.
+     * 
+     * @since 1.9.8.3
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewProductUsingFormShortcodeInVisualEditor(AcceptanceTester $I)
+    {
+        // Add a Product using the Classic Editor.
+        $I->addClassicEditorPage($I, 'product', 'ConvertKit: Product: Form: Shortcode: Visual Editor');
+
+        // Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
+        $I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None', 'aria-owns');
+
+        // Add shortcode to Excerpt (Product short description), setting the Form setting to the value specified in the .env file,
+        // and confirming that the expected shortcode is displayed in the Excerpt field.
+        $I->addVisualEditorShortcode(
+            $I,
+            'ConvertKit Form',
+            'convertkit-form',
+            [
+            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+            ],
+            '[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]',
+            'excerpt' // The ID of the Product short description field.
+        );
+
+        // Add shortcode to Content, setting the Form setting to the value specified in the .env file,
+        // and confirming that the expected shortcode is displayed in the Excerpt field.
+        $I->addVisualEditorShortcode(
+            $I,
+            'ConvertKit Form',
+            'convertkit-form',
+            [
+            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+            ],
+            '[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]',
+            'content' // The ID of the Content field.
+        );
+
+        // Publish and view the Product on the frontend site.
+        $I->publishAndViewClassicEditorPage($I);
+
+        // Confirm that the ConvertKit Form is displayed.
+        $I->seeElementInDOM('form[data-sv-form]');
+    }
+
+    /**
+     * Test the [convertkit_form] shortcode is inserted into the applicable Content or Excerpt Text Editor
+     * instances when adding a WooCommerce Product.
+     * 
+     * @since 1.9.8.3
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewProductUsingFormShortcodeInTextEditor(AcceptanceTester $I)
+    {
+        // Add a Product using the Classic Editor.
+        $I->addClassicEditorPage($I, 'product', 'ConvertKit: Product: Form: Shortcode: Text Editor');
+
+        // Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
+        $I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None', 'aria-owns');
+
+        // Add shortcode to Excerpt (Product short description), setting the Form setting to the value specified in the .env file,
+        // and confirming that the expected shortcode is displayed in the Excerpt field.        
+        $I->addTextEditorShortcode(
+            $I,
+            'ConvertKit Form',
+            'convertkit-form',
+            [
+            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+            ],
+            '[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]',
+            'excerpt' // The ID of the Product short description field.
+        );
+
+        // Add shortcode to Content, setting the Form setting to the value specified in the .env file,
+        // and confirming that the expected shortcode is displayed in the Excerpt field.
+        $I->addTextEditorShortcode(
+            $I,
+            'ConvertKit Form',
+            'convertkit-form',
+            [
+            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+            ],
+            '[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]',
+            'content' // The ID of the Content field.
+        );
+
+        // Publish and view the Product on the frontend site.
+        $I->publishAndViewClassicEditorPage($I);
+
+        // Confirm that the ConvertKit Form is displayed.
+        $I->seeElementInDOM('form[data-sv-form]');
+    }
+
+    /**
+     * Test that the Default Form for Products displays when the Default option is chosen via
+     * WordPress' Quick Edit functionality.
+     * 
+     * @since 1.9.8.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testQuickEditUsingDefaultForm(AcceptanceTester $I)
+    {
+        // Specify the Default Form in the Plugin Settings.
+        $I->setupConvertKitPluginDefaultFormForWooCommerceProducts($I);
+
+        // Programmatically create a Product.
+        $productID = $I->havePostInDatabase(
+            [
+            'post_type'     => 'product',
+            'post_title'     => 'ConvertKit: Product: Form: Default: Quick Edit',
+            ]
+        );
+
+        // Quick Edit the Product in the Products WP_List_Table.
+        $I->quickEdit(
+            $I, 'product', $productID, [
+            'form' => [ 'select', 'Default' ],
+            ]
+        );
+
+        // Load the Product on the frontend site.
+        $I->amOnPage('/?p='.$productID);
+
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
+
+        // Confirm that the ConvertKit Default Form displays.
+        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+    }
+
+    /**
+     * Test that the defined form displays when chosen via
+     * WordPress' Quick Edit functionality.
+     * 
+     * @since 1.9.8.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testQuickEditUsingDefinedForm(AcceptanceTester $I)
+    {
+        // Programmatically create a Product.
+        $productID = $I->havePostInDatabase(
+            [
+            'post_type'     => 'product',
+            'post_title'     => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
+            ]
+        );
+
+        // Quick Edit the Product in the Products WP_List_Table.
+        $I->quickEdit(
+            $I, 'product', $productID, [
+            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+            ]
+        );
+
+        // Load the Product on the frontend site.
+        $I->amOnPage('/?p='.$productID);
+
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
+
+        // Confirm that the ConvertKit Default Form displays.
+        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+    }
+
+    /**
+     * Test that the Default Form for Products displays when the Default option is chosen via
+     * WordPress' Bulk Edit functionality.
+     * 
+     * @since 1.9.8.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBulkEditUsingDefaultForm(AcceptanceTester $I)
+    {
+        // Specify the Default Form in the Plugin Settings.
+        $I->setupConvertKitPluginDefaultFormForWooCommerceProducts($I);
+
+        // Programmatically create two Products.
+        $productIDs = array(
+        $I->havePostInDatabase(
+            [
+            'post_type'     => 'product',
+            'post_title'     => 'ConvertKit: Product: Form: Default: Bulk Edit #1',
+            ]
+        ),
+        $I->havePostInDatabase(
+            [
+            'post_type'     => 'product',
+            'post_title'     => 'ConvertKit: Product: Form: Default: Bulk Edit #2',
+            ]
+        )
+        );
+
+        // Bulk Edit the Products in the Products WP_List_Table.
+        $I->bulkEdit(
+            $I, 'product', $productIDs, [
+            'form' => [ 'select', 'Default' ],
+            ]
+        );
+
+        // Iterate through Products to run frontend tests.
+        foreach($productIDs as $productID) {
+            // Load Product on the frontend site.
+            $I->amOnPage('/?p='.$productID);
+
+            // Check that no PHP warnings or notices were output.
+            $I->checkNoWarningsAndNoticesOnScreen($I);
+
+            // Confirm that the ConvertKit Default Form displays.
+            $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+        }
+    }
+
+    /**
+     * Test that the defined form displays when chosen via
+     * WordPress' Bulk Edit functionality.
+     * 
+     * @since 1.9.8.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBulkEditUsingDefinedForm(AcceptanceTester $I)
+    {
+        // Programmatically create two Products.
+        $productIDs = array(
+        $I->havePostInDatabase(
+            [
+            'post_type'     => 'product',
+            'post_title'     => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
+            ]
+        ),
+        $I->havePostInDatabase(
+            [
+            'post_type'     => 'product',
+            'post_title'     => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
+            ]
+        )
+        );
+
+        // Bulk Edit the Products in the Products WP_List_Table.
+        $I->bulkEdit(
+            $I, 'product', $productIDs, [
+            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+            ]
+        );
+
+        // Iterate through Products to run frontend tests.
+        foreach($productIDs as $productID) {
+            // Load Product on the frontend site.
+            $I->amOnPage('/?p='.$productID);
+
+            // Check that no PHP warnings or notices were output.
+            $I->checkNoWarningsAndNoticesOnScreen($I);
+
+            // Confirm that the ConvertKit Default Form displays.
+            $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+        }
+    }
+
+    /**
+     * Test that the existing settings are honored and not changed
+     * when the Bulk Edit options are set to 'No Change'.
+     * 
+     * @since 1.9.8.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBulkEditWithNoChanges(AcceptanceTester $I)
+    {
+        // Programmatically create two Products with a defined form.
+        $productIDs = array(
+        $I->havePostInDatabase(
+            [
+            'post_type'     => 'product',
+            'post_title'     => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #1',
+            'meta_input'    => [
+            '_wp_convertkit_post_meta' => [
+            'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
+            'landing_page' => '',
+            'tag'          => '',
+            ]
+            ],
+            ]
+        ),
+        $I->havePostInDatabase(
+            [
+            'post_type'     => 'product',
+            'post_title'     => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
+            'meta_input'    => [
+            '_wp_convertkit_post_meta' => [
+            'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
+            'landing_page' => '',
+            'tag'          => '',
+            ]
+            ],
+            ]
+        )
+        );
+
+        // Bulk Edit the Products in the Products WP_List_Table.
+        $I->bulkEdit(
+            $I, 'product', $productIDs, [
+            'form' => [ 'select', '— No Change —' ],
+            ]
+        );
+
+        // Iterate through Products to run frontend tests.
+        foreach($productIDs as $productID) {
+            // Load Page on the frontend site.
+            $I->amOnPage('/?p='.$productID);
+
+            // Check that no PHP warnings or notices were output.
+            $I->checkNoWarningsAndNoticesOnScreen($I);
+
+            // Confirm that the ConvertKit Form displays.
+            $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+        }
+    }
+
+    /**
+     * Test that the Bulk Edit fields do not display when a search on a WP_List_Table
+     * returns no results.
+     * 
+     * @since 1.9.8.1
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBulkEditFieldsHiddenWhenNoProductsFound(AcceptanceTester $I)
+    {
+        // Emulate the user searching for Products with a query string that yields no results.
+        $I->amOnAdminPage('edit.php?post_type=product&s=nothing');
+
+        // Confirm that the Bulk Edit fields do not display.
+        $I->dontSeeElement('#convertkit-bulk-edit');
+    }
+
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateConvertKitPlugin($I);
+        $I->deactivateThirdPartyPlugin($I, 'classic-editor');
+        $I->deactivateThirdPartyPlugin($I, 'woocommerce');
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/integrations/WooCommerceProductFormCest.php
+++ b/tests/acceptance/integrations/WooCommerceProductFormCest.php
@@ -1,17 +1,17 @@
 <?php
 /**
  * Tests for ConvertKit Forms on WooCommerce Products.
- * 
- * @since 	1.9.6
+ *
+ * @since   1.9.6
  */
 class WooCommerceProductFormCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -25,10 +25,10 @@ class WooCommerceProductFormCest
 	 * Test that the 'Default' option for the Default Form setting in the Plugin Settings works when
 	 * creating and viewing a new WooCommerce Product, and there is no Default Form specified in the Plugin
 	 * settings.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewProductUsingDefaultFormWithNoDefaultFormSpecifiedInPlugin(AcceptanceTester $I)
 	{
@@ -51,10 +51,10 @@ class WooCommerceProductFormCest
 	/**
 	 * Test that the Default Form specified in the Plugin Settings works when
 	 * creating and viewing a new WooCommerce Product.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewProductUsingDefaultForm(AcceptanceTester $I)
 	{
@@ -80,10 +80,10 @@ class WooCommerceProductFormCest
 	/**
 	 * Test that 'None' Form specified in the Product Settings works when
 	 * creating and viewing a new WooCommerce Product.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewProductUsingNoForm(AcceptanceTester $I)
 	{
@@ -109,10 +109,10 @@ class WooCommerceProductFormCest
 	/**
 	 * Test that the Form specified in the Product Settings works when
 	 * creating and viewing a new WooCommerce Product.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewProductUsingDefinedForm(AcceptanceTester $I)
 	{
@@ -138,10 +138,10 @@ class WooCommerceProductFormCest
 	/**
 	 * Test the [convertkit_form] shortcode is inserted into the applicable Content or Excerpt Visual Editor
 	 * instances when adding a WooCommerce Product.
-	 * 
-	 * @since 	1.9.8.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewProductUsingFormShortcodeInVisualEditor(AcceptanceTester $I)
 	{
@@ -158,9 +158,9 @@ class WooCommerceProductFormCest
 			'ConvertKit Form',
 			'convertkit-form',
 			[
-				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			],
-			'[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]',
+			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]',
 			'excerpt' // The ID of the Product short description field.
 		);
 
@@ -171,9 +171,9 @@ class WooCommerceProductFormCest
 			'ConvertKit Form',
 			'convertkit-form',
 			[
-				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			],
-			'[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]',
+			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]',
 			'content' // The ID of the Content field.
 		);
 
@@ -187,10 +187,10 @@ class WooCommerceProductFormCest
 	/**
 	 * Test the [convertkit_form] shortcode is inserted into the applicable Content or Excerpt Text Editor
 	 * instances when adding a WooCommerce Product.
-	 * 
-	 * @since 	1.9.8.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewProductUsingFormShortcodeInTextEditor(AcceptanceTester $I)
 	{
@@ -201,15 +201,15 @@ class WooCommerceProductFormCest
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None', 'aria-owns');
 
 		// Add shortcode to Excerpt (Product short description), setting the Form setting to the value specified in the .env file,
-		// and confirming that the expected shortcode is displayed in the Excerpt field.		
+		// and confirming that the expected shortcode is displayed in the Excerpt field.
 		$I->addTextEditorShortcode(
 			$I,
 			'ConvertKit Form',
 			'convertkit-form',
 			[
-				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			],
-			'[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]',
+			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]',
 			'excerpt' // The ID of the Product short description field.
 		);
 
@@ -220,9 +220,9 @@ class WooCommerceProductFormCest
 			'ConvertKit Form',
 			'convertkit-form',
 			[
-				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			],
-			'[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]',
+			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]',
 			'content' // The ID of the Content field.
 		);
 
@@ -236,10 +236,10 @@ class WooCommerceProductFormCest
 	/**
 	 * Test that the Default Form for Products displays when the Default option is chosen via
 	 * WordPress' Quick Edit functionality.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testQuickEditUsingDefaultForm(AcceptanceTester $I)
 	{
@@ -247,18 +247,25 @@ class WooCommerceProductFormCest
 		$I->setupConvertKitPluginDefaultFormForWooCommerceProducts($I);
 
 		// Programmatically create a Product.
-		$productID = $I->havePostInDatabase([
-			'post_type' 	=> 'product',
-			'post_title' 	=> 'ConvertKit: Product: Form: Default: Quick Edit',
-		]);
+		$productID = $I->havePostInDatabase(
+			[
+				'post_type'  => 'product',
+				'post_title' => 'ConvertKit: Product: Form: Default: Quick Edit',
+			]
+		);
 
 		// Quick Edit the Product in the Products WP_List_Table.
-		$I->quickEdit($I, 'product', $productID, [
-			'form' => [ 'select', 'Default' ],
-		]);
+		$I->quickEdit(
+			$I,
+			'product',
+			$productID,
+			[
+				'form' => [ 'select', 'Default' ],
+			]
+		);
 
 		// Load the Product on the frontend site.
-		$I->amOnPage('/?p='.$productID);
+		$I->amOnPage('/?p=' . $productID);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -270,26 +277,33 @@ class WooCommerceProductFormCest
 	/**
 	 * Test that the defined form displays when chosen via
 	 * WordPress' Quick Edit functionality.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testQuickEditUsingDefinedForm(AcceptanceTester $I)
 	{
 		// Programmatically create a Product.
-		$productID = $I->havePostInDatabase([
-			'post_type' 	=> 'product',
-			'post_title' 	=> 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
-		]);
+		$productID = $I->havePostInDatabase(
+			[
+				'post_type'  => 'product',
+				'post_title' => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
+			]
+		);
 
 		// Quick Edit the Product in the Products WP_List_Table.
-		$I->quickEdit($I, 'product', $productID, [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-		]);
+		$I->quickEdit(
+			$I,
+			'product',
+			$productID,
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+			]
+		);
 
 		// Load the Product on the frontend site.
-		$I->amOnPage('/?p='.$productID);
+		$I->amOnPage('/?p=' . $productID);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -301,10 +315,10 @@ class WooCommerceProductFormCest
 	/**
 	 * Test that the Default Form for Products displays when the Default option is chosen via
 	 * WordPress' Bulk Edit functionality.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBulkEditUsingDefaultForm(AcceptanceTester $I)
 	{
@@ -313,25 +327,34 @@ class WooCommerceProductFormCest
 
 		// Programmatically create two Products.
 		$productIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'product',
-				'post_title' 	=> 'ConvertKit: Product: Form: Default: Bulk Edit #1',
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'product',
-				'post_title' 	=> 'ConvertKit: Product: Form: Default: Bulk Edit #2',
-			])
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'product',
+					'post_title' => 'ConvertKit: Product: Form: Default: Bulk Edit #1',
+				]
+			),
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'product',
+					'post_title' => 'ConvertKit: Product: Form: Default: Bulk Edit #2',
+				]
+			),
 		);
 
 		// Bulk Edit the Products in the Products WP_List_Table.
-		$I->bulkEdit($I, 'product', $productIDs, [
-			'form' => [ 'select', 'Default' ],
-		]);
+		$I->bulkEdit(
+			$I,
+			'product',
+			$productIDs,
+			[
+				'form' => [ 'select', 'Default' ],
+			]
+		);
 
 		// Iterate through Products to run frontend tests.
-		foreach($productIDs as $productID) {
+		foreach ($productIDs as $productID) {
 			// Load Product on the frontend site.
-			$I->amOnPage('/?p='.$productID);
+			$I->amOnPage('/?p=' . $productID);
 
 			// Check that no PHP warnings or notices were output.
 			$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -344,34 +367,43 @@ class WooCommerceProductFormCest
 	/**
 	 * Test that the defined form displays when chosen via
 	 * WordPress' Bulk Edit functionality.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBulkEditUsingDefinedForm(AcceptanceTester $I)
 	{
 		// Programmatically create two Products.
 		$productIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'product',
-				'post_title' 	=> 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'product',
-				'post_title' 	=> 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
-			])
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'product',
+					'post_title' => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
+				]
+			),
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'product',
+					'post_title' => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
+				]
+			),
 		);
 
 		// Bulk Edit the Products in the Products WP_List_Table.
-		$I->bulkEdit($I, 'product', $productIDs, [
-			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-		]);
+		$I->bulkEdit(
+			$I,
+			'product',
+			$productIDs,
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+			]
+		);
 
 		// Iterate through Products to run frontend tests.
-		foreach($productIDs as $productID) {
+		foreach ($productIDs as $productID) {
 			// Load Product on the frontend site.
-			$I->amOnPage('/?p='.$productID);
+			$I->amOnPage('/?p=' . $productID);
 
 			// Check that no PHP warnings or notices were output.
 			$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -384,48 +416,57 @@ class WooCommerceProductFormCest
 	/**
 	 * Test that the existing settings are honored and not changed
 	 * when the Bulk Edit options are set to 'No Change'.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBulkEditWithNoChanges(AcceptanceTester $I)
 	{
 		// Programmatically create two Products with a defined form.
 		$productIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'product',
-				'post_title' 	=> 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #1',
-				'meta_input'	=> [
-					'_wp_convertkit_post_meta' => [
-						'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
-						'landing_page' => '',
-						'tag'          => '',
-					]
-				],
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'product',
-				'post_title' 	=> 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
-				'meta_input'	=> [
-					'_wp_convertkit_post_meta' => [
-						'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
-						'landing_page' => '',
-						'tag'          => '',
-					]
-				],
-			])
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'product',
+					'post_title' => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #1',
+					'meta_input' => [
+						'_wp_convertkit_post_meta' => [
+							'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
+							'landing_page' => '',
+							'tag'          => '',
+						],
+					],
+				]
+			),
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'product',
+					'post_title' => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
+					'meta_input' => [
+						'_wp_convertkit_post_meta' => [
+							'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
+							'landing_page' => '',
+							'tag'          => '',
+						],
+					],
+				]
+			),
 		);
 
 		// Bulk Edit the Products in the Products WP_List_Table.
-		$I->bulkEdit($I, 'product', $productIDs, [
-			'form' => [ 'select', '— No Change —' ],
-		]);
+		$I->bulkEdit(
+			$I,
+			'product',
+			$productIDs,
+			[
+				'form' => [ 'select', '— No Change —' ],
+			]
+		);
 
 		// Iterate through Products to run frontend tests.
-		foreach($productIDs as $productID) {
+		foreach ($productIDs as $productID) {
 			// Load Page on the frontend site.
-			$I->amOnPage('/?p='.$productID);
+			$I->amOnPage('/?p=' . $productID);
 
 			// Check that no PHP warnings or notices were output.
 			$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -438,10 +479,10 @@ class WooCommerceProductFormCest
 	/**
 	 * Test that the Bulk Edit fields do not display when a search on a WP_List_Table
 	 * returns no results.
-	 * 
-	 * @since 	1.9.8.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBulkEditFieldsHiddenWhenNoProductsFound(AcceptanceTester $I)
 	{
@@ -456,10 +497,10 @@ class WooCommerceProductFormCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/integrations/WooCommerceProductFormCest.php
+++ b/tests/acceptance/integrations/WooCommerceProductFormCest.php
@@ -343,7 +343,7 @@ class WooCommerceProductFormCest
         );
 
         // Iterate through Products to run frontend tests.
-        foreach($productIDs as $productID) {
+        foreach ($productIDs as $productID) {
             // Load Product on the frontend site.
             $I->amOnPage('/?p='.$productID);
 
@@ -389,7 +389,7 @@ class WooCommerceProductFormCest
         );
 
         // Iterate through Products to run frontend tests.
-        foreach($productIDs as $productID) {
+        foreach ($productIDs as $productID) {
             // Load Product on the frontend site.
             $I->amOnPage('/?p='.$productID);
 
@@ -449,7 +449,7 @@ class WooCommerceProductFormCest
         );
 
         // Iterate through Products to run frontend tests.
-        foreach($productIDs as $productID) {
+        foreach ($productIDs as $productID) {
             // Load Page on the frontend site.
             $I->amOnPage('/?p='.$productID);
 

--- a/tests/acceptance/integrations/WooCommerceProductFormCest.php
+++ b/tests/acceptance/integrations/WooCommerceProductFormCest.php
@@ -1,497 +1,498 @@
 <?php
 /**
  * Tests for ConvertKit Forms on WooCommerce Products.
- * 
+ *
  * @since 1.9.6
  */
-class WooCommerceProductFormCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        $I->activateConvertKitPlugin($I);
-        $I->activateThirdPartyPlugin($I, 'woocommerce');
-        $I->setupConvertKitPlugin($I);
-        $I->enableDebugLog($I);
-    }
-
-    /**
-     * Test that the 'Default' option for the Default Form setting in the Plugin Settings works when
-     * creating and viewing a new WooCommerce Product, and there is no Default Form specified in the Plugin
-     * settings.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewProductUsingDefaultFormWithNoDefaultFormSpecifiedInPlugin(AcceptanceTester $I)
-    {
-        // Navigate to Products > Add New.
-        $I->amOnAdminPage('post-new.php?post_type=product');
-
-        // Define a Product Title.
-        $I->fillField('#title', 'ConvertKit: Product: Form: Default: None');
-
-        // Wait, otherwise publishing will fail in WooCommerce.
-        $I->wait(1);
-
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewClassicEditorPage($I);
-
-        // Confirm that a ConvertKit Form is not displayed.
-        $I->dontSeeElementInDOM('form[data-sv-form]');
-    }
-
-    /**
-     * Test that the Default Form specified in the Plugin Settings works when
-     * creating and viewing a new WooCommerce Product.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewProductUsingDefaultForm(AcceptanceTester $I)
-    {
-        // Specify the Default Form in the Plugin Settings.
-        $defaultFormID = $I->setupConvertKitPluginDefaultFormForWooCommerceProducts($I);
-
-        // Navigate to Products > Add New.
-        $I->amOnAdminPage('post-new.php?post_type=product');
-
-        // Define a Product Title.
-        $I->fillField('#title', 'ConvertKit: Product: Form: Default');
-
-        // Wait, otherwise publishing will fail in WooCommerce.
-        $I->wait(1);
-
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewClassicEditorPage($I);
-
-        // Confirm that the ConvertKit Default Form displays.
-        $I->seeElementInDOM('form[data-sv-form="' . $defaultFormID . '"]');
-    }
-
-    /**
-     * Test that 'None' Form specified in the Product Settings works when
-     * creating and viewing a new WooCommerce Product.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewProductUsingNoForm(AcceptanceTester $I)
-    {
-        // Navigate to Products > Add New.
-        $I->amOnAdminPage('post-new.php?post_type=product');
-
-        // Change Form to None.
-        $I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None', 'aria-owns');
-
-        // Define a Product Title.
-        $I->fillField('#title', 'ConvertKit: Product: Form: None');
-
-        // Wait, otherwise publishing will fail in WooCommerce.
-        $I->wait(1);
-
-        // Publish and view the Product.
-        $I->publishAndViewClassicEditorPage($I);
-
-        // Confirm that no ConvertKit Form is displayed.
-        $I->dontSeeElementInDOM('form[data-sv-form]');
-    }
-
-    /**
-     * Test that the Form specified in the Product Settings works when
-     * creating and viewing a new WooCommerce Product.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewProductUsingDefinedForm(AcceptanceTester $I)
-    {
-        // Navigate to Products > Add New.
-        $I->amOnAdminPage('post-new.php?post_type=product');
-
-        // Change Form to Form setting in .env file.
-        $I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME'], 'aria-owns');
-
-        // Define a Product Title.
-        $I->fillField('#title', 'ConvertKit: Product: Form: Defined');
-
-        // Wait, otherwise publishing will fail in WooCommerce.
-        $I->wait(1);
-
-        // Publish and view the Product.
-        $I->publishAndViewClassicEditorPage($I);
-
-        // Confirm that the ConvertKit Form displays.
-        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-    }
-
-    /**
-     * Test the [convertkit_form] shortcode is inserted into the applicable Content or Excerpt Visual Editor
-     * instances when adding a WooCommerce Product.
-     * 
-     * @since 1.9.8.3
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewProductUsingFormShortcodeInVisualEditor(AcceptanceTester $I)
-    {
-        // Add a Product using the Classic Editor.
-        $I->addClassicEditorPage($I, 'product', 'ConvertKit: Product: Form: Shortcode: Visual Editor');
-
-        // Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
-        $I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None', 'aria-owns');
-
-        // Add shortcode to Excerpt (Product short description), setting the Form setting to the value specified in the .env file,
-        // and confirming that the expected shortcode is displayed in the Excerpt field.
-        $I->addVisualEditorShortcode(
-            $I,
-            'ConvertKit Form',
-            'convertkit-form',
-            [
-            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
-            ],
-            '[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]',
-            'excerpt' // The ID of the Product short description field.
-        );
-
-        // Add shortcode to Content, setting the Form setting to the value specified in the .env file,
-        // and confirming that the expected shortcode is displayed in the Excerpt field.
-        $I->addVisualEditorShortcode(
-            $I,
-            'ConvertKit Form',
-            'convertkit-form',
-            [
-            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
-            ],
-            '[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]',
-            'content' // The ID of the Content field.
-        );
-
-        // Publish and view the Product on the frontend site.
-        $I->publishAndViewClassicEditorPage($I);
-
-        // Confirm that the ConvertKit Form is displayed.
-        $I->seeElementInDOM('form[data-sv-form]');
-    }
-
-    /**
-     * Test the [convertkit_form] shortcode is inserted into the applicable Content or Excerpt Text Editor
-     * instances when adding a WooCommerce Product.
-     * 
-     * @since 1.9.8.3
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewProductUsingFormShortcodeInTextEditor(AcceptanceTester $I)
-    {
-        // Add a Product using the Classic Editor.
-        $I->addClassicEditorPage($I, 'product', 'ConvertKit: Product: Form: Shortcode: Text Editor');
-
-        // Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
-        $I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None', 'aria-owns');
-
-        // Add shortcode to Excerpt (Product short description), setting the Form setting to the value specified in the .env file,
-        // and confirming that the expected shortcode is displayed in the Excerpt field.        
-        $I->addTextEditorShortcode(
-            $I,
-            'ConvertKit Form',
-            'convertkit-form',
-            [
-            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
-            ],
-            '[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]',
-            'excerpt' // The ID of the Product short description field.
-        );
-
-        // Add shortcode to Content, setting the Form setting to the value specified in the .env file,
-        // and confirming that the expected shortcode is displayed in the Excerpt field.
-        $I->addTextEditorShortcode(
-            $I,
-            'ConvertKit Form',
-            'convertkit-form',
-            [
-            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
-            ],
-            '[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]',
-            'content' // The ID of the Content field.
-        );
-
-        // Publish and view the Product on the frontend site.
-        $I->publishAndViewClassicEditorPage($I);
-
-        // Confirm that the ConvertKit Form is displayed.
-        $I->seeElementInDOM('form[data-sv-form]');
-    }
-
-    /**
-     * Test that the Default Form for Products displays when the Default option is chosen via
-     * WordPress' Quick Edit functionality.
-     * 
-     * @since 1.9.8.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testQuickEditUsingDefaultForm(AcceptanceTester $I)
-    {
-        // Specify the Default Form in the Plugin Settings.
-        $I->setupConvertKitPluginDefaultFormForWooCommerceProducts($I);
-
-        // Programmatically create a Product.
-        $productID = $I->havePostInDatabase(
-            [
-            'post_type'     => 'product',
-            'post_title'     => 'ConvertKit: Product: Form: Default: Quick Edit',
-            ]
-        );
-
-        // Quick Edit the Product in the Products WP_List_Table.
-        $I->quickEdit(
-            $I, 'product', $productID, [
-            'form' => [ 'select', 'Default' ],
-            ]
-        );
-
-        // Load the Product on the frontend site.
-        $I->amOnPage('/?p='.$productID);
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Confirm that the ConvertKit Default Form displays.
-        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-    }
-
-    /**
-     * Test that the defined form displays when chosen via
-     * WordPress' Quick Edit functionality.
-     * 
-     * @since 1.9.8.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testQuickEditUsingDefinedForm(AcceptanceTester $I)
-    {
-        // Programmatically create a Product.
-        $productID = $I->havePostInDatabase(
-            [
-            'post_type'     => 'product',
-            'post_title'     => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
-            ]
-        );
-
-        // Quick Edit the Product in the Products WP_List_Table.
-        $I->quickEdit(
-            $I, 'product', $productID, [
-            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-            ]
-        );
-
-        // Load the Product on the frontend site.
-        $I->amOnPage('/?p='.$productID);
-
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-
-        // Confirm that the ConvertKit Default Form displays.
-        $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-    }
-
-    /**
-     * Test that the Default Form for Products displays when the Default option is chosen via
-     * WordPress' Bulk Edit functionality.
-     * 
-     * @since 1.9.8.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBulkEditUsingDefaultForm(AcceptanceTester $I)
-    {
-        // Specify the Default Form in the Plugin Settings.
-        $I->setupConvertKitPluginDefaultFormForWooCommerceProducts($I);
-
-        // Programmatically create two Products.
-        $productIDs = array(
-        $I->havePostInDatabase(
-            [
-            'post_type'     => 'product',
-            'post_title'     => 'ConvertKit: Product: Form: Default: Bulk Edit #1',
-            ]
-        ),
-        $I->havePostInDatabase(
-            [
-            'post_type'     => 'product',
-            'post_title'     => 'ConvertKit: Product: Form: Default: Bulk Edit #2',
-            ]
-        )
-        );
-
-        // Bulk Edit the Products in the Products WP_List_Table.
-        $I->bulkEdit(
-            $I, 'product', $productIDs, [
-            'form' => [ 'select', 'Default' ],
-            ]
-        );
-
-        // Iterate through Products to run frontend tests.
-        foreach ($productIDs as $productID) {
-            // Load Product on the frontend site.
-            $I->amOnPage('/?p='.$productID);
-
-            // Check that no PHP warnings or notices were output.
-            $I->checkNoWarningsAndNoticesOnScreen($I);
-
-            // Confirm that the ConvertKit Default Form displays.
-            $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-        }
-    }
-
-    /**
-     * Test that the defined form displays when chosen via
-     * WordPress' Bulk Edit functionality.
-     * 
-     * @since 1.9.8.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBulkEditUsingDefinedForm(AcceptanceTester $I)
-    {
-        // Programmatically create two Products.
-        $productIDs = array(
-        $I->havePostInDatabase(
-            [
-            'post_type'     => 'product',
-            'post_title'     => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
-            ]
-        ),
-        $I->havePostInDatabase(
-            [
-            'post_type'     => 'product',
-            'post_title'     => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
-            ]
-        )
-        );
-
-        // Bulk Edit the Products in the Products WP_List_Table.
-        $I->bulkEdit(
-            $I, 'product', $productIDs, [
-            'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-            ]
-        );
-
-        // Iterate through Products to run frontend tests.
-        foreach ($productIDs as $productID) {
-            // Load Product on the frontend site.
-            $I->amOnPage('/?p='.$productID);
-
-            // Check that no PHP warnings or notices were output.
-            $I->checkNoWarningsAndNoticesOnScreen($I);
-
-            // Confirm that the ConvertKit Default Form displays.
-            $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-        }
-    }
-
-    /**
-     * Test that the existing settings are honored and not changed
-     * when the Bulk Edit options are set to 'No Change'.
-     * 
-     * @since 1.9.8.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBulkEditWithNoChanges(AcceptanceTester $I)
-    {
-        // Programmatically create two Products with a defined form.
-        $productIDs = array(
-        $I->havePostInDatabase(
-            [
-            'post_type'     => 'product',
-            'post_title'     => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #1',
-            'meta_input'    => [
-            '_wp_convertkit_post_meta' => [
-            'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
-            'landing_page' => '',
-            'tag'          => '',
-            ]
-            ],
-            ]
-        ),
-        $I->havePostInDatabase(
-            [
-            'post_type'     => 'product',
-            'post_title'     => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
-            'meta_input'    => [
-            '_wp_convertkit_post_meta' => [
-            'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
-            'landing_page' => '',
-            'tag'          => '',
-            ]
-            ],
-            ]
-        )
-        );
-
-        // Bulk Edit the Products in the Products WP_List_Table.
-        $I->bulkEdit(
-            $I, 'product', $productIDs, [
-            'form' => [ 'select', '— No Change —' ],
-            ]
-        );
-
-        // Iterate through Products to run frontend tests.
-        foreach ($productIDs as $productID) {
-            // Load Page on the frontend site.
-            $I->amOnPage('/?p='.$productID);
-
-            // Check that no PHP warnings or notices were output.
-            $I->checkNoWarningsAndNoticesOnScreen($I);
-
-            // Confirm that the ConvertKit Form displays.
-            $I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
-        }
-    }
-
-    /**
-     * Test that the Bulk Edit fields do not display when a search on a WP_List_Table
-     * returns no results.
-     * 
-     * @since 1.9.8.1
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBulkEditFieldsHiddenWhenNoProductsFound(AcceptanceTester $I)
-    {
-        // Emulate the user searching for Products with a query string that yields no results.
-        $I->amOnAdminPage('edit.php?post_type=product&s=nothing');
-
-        // Confirm that the Bulk Edit fields do not display.
-        $I->dontSeeElement('#convertkit-bulk-edit');
-    }
-
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateConvertKitPlugin($I);
-        $I->deactivateThirdPartyPlugin($I, 'classic-editor');
-        $I->deactivateThirdPartyPlugin($I, 'woocommerce');
-        $I->resetConvertKitPlugin($I);
-    }
+class WooCommerceProductFormCest {
+
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		$I->activateConvertKitPlugin( $I );
+		$I->activateThirdPartyPlugin( $I, 'woocommerce' );
+		$I->setupConvertKitPlugin( $I );
+		$I->enableDebugLog( $I );
+	}
+
+	/**
+	 * Test that the 'Default' option for the Default Form setting in the Plugin Settings works when
+	 * creating and viewing a new WooCommerce Product, and there is no Default Form specified in the Plugin
+	 * settings.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewProductUsingDefaultFormWithNoDefaultFormSpecifiedInPlugin( AcceptanceTester $I ) {
+		// Navigate to Products > Add New.
+		$I->amOnAdminPage( 'post-new.php?post_type=product' );
+
+		// Define a Product Title.
+		$I->fillField( '#title', 'ConvertKit: Product: Form: Default: None' );
+
+		// Wait, otherwise publishing will fail in WooCommerce.
+		$I->wait( 1 );
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage( $I );
+
+		// Confirm that a ConvertKit Form is not displayed.
+		$I->dontSeeElementInDOM( 'form[data-sv-form]' );
+	}
+
+	/**
+	 * Test that the Default Form specified in the Plugin Settings works when
+	 * creating and viewing a new WooCommerce Product.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewProductUsingDefaultForm( AcceptanceTester $I ) {
+		// Specify the Default Form in the Plugin Settings.
+		$defaultFormID = $I->setupConvertKitPluginDefaultFormForWooCommerceProducts( $I );
+
+		// Navigate to Products > Add New.
+		$I->amOnAdminPage( 'post-new.php?post_type=product' );
+
+		// Define a Product Title.
+		$I->fillField( '#title', 'ConvertKit: Product: Form: Default' );
+
+		// Wait, otherwise publishing will fail in WooCommerce.
+		$I->wait( 1 );
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage( $I );
+
+		// Confirm that the ConvertKit Default Form displays.
+		$I->seeElementInDOM( 'form[data-sv-form="' . $defaultFormID . '"]' );
+	}
+
+	/**
+	 * Test that 'None' Form specified in the Product Settings works when
+	 * creating and viewing a new WooCommerce Product.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewProductUsingNoForm( AcceptanceTester $I ) {
+		// Navigate to Products > Add New.
+		$I->amOnAdminPage( 'post-new.php?post_type=product' );
+
+		// Change Form to None.
+		$I->fillSelect2Field( $I, '#select2-wp-convertkit-form-container', 'None', 'aria-owns' );
+
+		// Define a Product Title.
+		$I->fillField( '#title', 'ConvertKit: Product: Form: None' );
+
+		// Wait, otherwise publishing will fail in WooCommerce.
+		$I->wait( 1 );
+
+		// Publish and view the Product.
+		$I->publishAndViewClassicEditorPage( $I );
+
+		// Confirm that no ConvertKit Form is displayed.
+		$I->dontSeeElementInDOM( 'form[data-sv-form]' );
+	}
+
+	/**
+	 * Test that the Form specified in the Product Settings works when
+	 * creating and viewing a new WooCommerce Product.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewProductUsingDefinedForm( AcceptanceTester $I ) {
+		// Navigate to Products > Add New.
+		$I->amOnAdminPage( 'post-new.php?post_type=product' );
+
+		// Change Form to Form setting in .env file.
+		$I->fillSelect2Field( $I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME'], 'aria-owns' );
+
+		// Define a Product Title.
+		$I->fillField( '#title', 'ConvertKit: Product: Form: Defined' );
+
+		// Wait, otherwise publishing will fail in WooCommerce.
+		$I->wait( 1 );
+
+		// Publish and view the Product.
+		$I->publishAndViewClassicEditorPage( $I );
+
+		// Confirm that the ConvertKit Form displays.
+		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+	}
+
+	/**
+	 * Test the [convertkit_form] shortcode is inserted into the applicable Content or Excerpt Visual Editor
+	 * instances when adding a WooCommerce Product.
+	 *
+	 * @since 1.9.8.3
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewProductUsingFormShortcodeInVisualEditor( AcceptanceTester $I ) {
+		// Add a Product using the Classic Editor.
+		$I->addClassicEditorPage( $I, 'product', 'ConvertKit: Product: Form: Shortcode: Visual Editor' );
+
+		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
+		$I->fillSelect2Field( $I, '#select2-wp-convertkit-form-container', 'None', 'aria-owns' );
+
+		// Add shortcode to Excerpt (Product short description), setting the Form setting to the value specified in the .env file,
+		// and confirming that the expected shortcode is displayed in the Excerpt field.
+		$I->addVisualEditorShortcode(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			array(
+				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
+			),
+			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]',
+			'excerpt' // The ID of the Product short description field.
+		);
+
+		// Add shortcode to Content, setting the Form setting to the value specified in the .env file,
+		// and confirming that the expected shortcode is displayed in the Excerpt field.
+		$I->addVisualEditorShortcode(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			array(
+				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
+			),
+			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]',
+			'content' // The ID of the Content field.
+		);
+
+		// Publish and view the Product on the frontend site.
+		$I->publishAndViewClassicEditorPage( $I );
+
+		// Confirm that the ConvertKit Form is displayed.
+		$I->seeElementInDOM( 'form[data-sv-form]' );
+	}
+
+	/**
+	 * Test the [convertkit_form] shortcode is inserted into the applicable Content or Excerpt Text Editor
+	 * instances when adding a WooCommerce Product.
+	 *
+	 * @since 1.9.8.3
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewProductUsingFormShortcodeInTextEditor( AcceptanceTester $I ) {
+		// Add a Product using the Classic Editor.
+		$I->addClassicEditorPage( $I, 'product', 'ConvertKit: Product: Form: Shortcode: Text Editor' );
+
+		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
+		$I->fillSelect2Field( $I, '#select2-wp-convertkit-form-container', 'None', 'aria-owns' );
+
+		// Add shortcode to Excerpt (Product short description), setting the Form setting to the value specified in the .env file,
+		// and confirming that the expected shortcode is displayed in the Excerpt field.
+		$I->addTextEditorShortcode(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			array(
+				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
+			),
+			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]',
+			'excerpt' // The ID of the Product short description field.
+		);
+
+		// Add shortcode to Content, setting the Form setting to the value specified in the .env file,
+		// and confirming that the expected shortcode is displayed in the Excerpt field.
+		$I->addTextEditorShortcode(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			array(
+				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
+			),
+			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]',
+			'content' // The ID of the Content field.
+		);
+
+		// Publish and view the Product on the frontend site.
+		$I->publishAndViewClassicEditorPage( $I );
+
+		// Confirm that the ConvertKit Form is displayed.
+		$I->seeElementInDOM( 'form[data-sv-form]' );
+	}
+
+	/**
+	 * Test that the Default Form for Products displays when the Default option is chosen via
+	 * WordPress' Quick Edit functionality.
+	 *
+	 * @since 1.9.8.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testQuickEditUsingDefaultForm( AcceptanceTester $I ) {
+		// Specify the Default Form in the Plugin Settings.
+		$I->setupConvertKitPluginDefaultFormForWooCommerceProducts( $I );
+
+		// Programmatically create a Product.
+		$productID = $I->havePostInDatabase(
+			array(
+				'post_type'  => 'product',
+				'post_title' => 'ConvertKit: Product: Form: Default: Quick Edit',
+			)
+		);
+
+		// Quick Edit the Product in the Products WP_List_Table.
+		$I->quickEdit(
+			$I,
+			'product',
+			$productID,
+			array(
+				'form' => array( 'select', 'Default' ),
+			)
+		);
+
+		// Load the Product on the frontend site.
+		$I->amOnPage( '/?p=' . $productID );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Confirm that the ConvertKit Default Form displays.
+		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+	}
+
+	/**
+	 * Test that the defined form displays when chosen via
+	 * WordPress' Quick Edit functionality.
+	 *
+	 * @since 1.9.8.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testQuickEditUsingDefinedForm( AcceptanceTester $I ) {
+		// Programmatically create a Product.
+		$productID = $I->havePostInDatabase(
+			array(
+				'post_type'  => 'product',
+				'post_title' => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
+			)
+		);
+
+		// Quick Edit the Product in the Products WP_List_Table.
+		$I->quickEdit(
+			$I,
+			'product',
+			$productID,
+			array(
+				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
+			)
+		);
+
+		// Load the Product on the frontend site.
+		$I->amOnPage( '/?p=' . $productID );
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+		// Confirm that the ConvertKit Default Form displays.
+		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+	}
+
+	/**
+	 * Test that the Default Form for Products displays when the Default option is chosen via
+	 * WordPress' Bulk Edit functionality.
+	 *
+	 * @since 1.9.8.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBulkEditUsingDefaultForm( AcceptanceTester $I ) {
+		// Specify the Default Form in the Plugin Settings.
+		$I->setupConvertKitPluginDefaultFormForWooCommerceProducts( $I );
+
+		// Programmatically create two Products.
+		$productIDs = array(
+			$I->havePostInDatabase(
+				array(
+					'post_type'  => 'product',
+					'post_title' => 'ConvertKit: Product: Form: Default: Bulk Edit #1',
+				)
+			),
+			$I->havePostInDatabase(
+				array(
+					'post_type'  => 'product',
+					'post_title' => 'ConvertKit: Product: Form: Default: Bulk Edit #2',
+				)
+			),
+		);
+
+		// Bulk Edit the Products in the Products WP_List_Table.
+		$I->bulkEdit(
+			$I,
+			'product',
+			$productIDs,
+			array(
+				'form' => array( 'select', 'Default' ),
+			)
+		);
+
+		// Iterate through Products to run frontend tests.
+		foreach ( $productIDs as $productID ) {
+			// Load Product on the frontend site.
+			$I->amOnPage( '/?p=' . $productID );
+
+			// Check that no PHP warnings or notices were output.
+			$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+			// Confirm that the ConvertKit Default Form displays.
+			$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		}
+	}
+
+	/**
+	 * Test that the defined form displays when chosen via
+	 * WordPress' Bulk Edit functionality.
+	 *
+	 * @since 1.9.8.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBulkEditUsingDefinedForm( AcceptanceTester $I ) {
+		// Programmatically create two Products.
+		$productIDs = array(
+			$I->havePostInDatabase(
+				array(
+					'post_type'  => 'product',
+					'post_title' => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
+				)
+			),
+			$I->havePostInDatabase(
+				array(
+					'post_type'  => 'product',
+					'post_title' => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
+				)
+			),
+		);
+
+		// Bulk Edit the Products in the Products WP_List_Table.
+		$I->bulkEdit(
+			$I,
+			'product',
+			$productIDs,
+			array(
+				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
+			)
+		);
+
+		// Iterate through Products to run frontend tests.
+		foreach ( $productIDs as $productID ) {
+			// Load Product on the frontend site.
+			$I->amOnPage( '/?p=' . $productID );
+
+			// Check that no PHP warnings or notices were output.
+			$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+			// Confirm that the ConvertKit Default Form displays.
+			$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		}
+	}
+
+	/**
+	 * Test that the existing settings are honored and not changed
+	 * when the Bulk Edit options are set to 'No Change'.
+	 *
+	 * @since 1.9.8.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBulkEditWithNoChanges( AcceptanceTester $I ) {
+		// Programmatically create two Products with a defined form.
+		$productIDs = array(
+			$I->havePostInDatabase(
+				array(
+					'post_type'  => 'product',
+					'post_title' => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #1',
+					'meta_input' => array(
+						'_wp_convertkit_post_meta' => array(
+							'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
+							'landing_page' => '',
+							'tag'          => '',
+						),
+					),
+				)
+			),
+			$I->havePostInDatabase(
+				array(
+					'post_type'  => 'product',
+					'post_title' => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
+					'meta_input' => array(
+						'_wp_convertkit_post_meta' => array(
+							'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
+							'landing_page' => '',
+							'tag'          => '',
+						),
+					),
+				)
+			),
+		);
+
+		// Bulk Edit the Products in the Products WP_List_Table.
+		$I->bulkEdit(
+			$I,
+			'product',
+			$productIDs,
+			array(
+				'form' => array( 'select', '— No Change —' ),
+			)
+		);
+
+		// Iterate through Products to run frontend tests.
+		foreach ( $productIDs as $productID ) {
+			// Load Page on the frontend site.
+			$I->amOnPage( '/?p=' . $productID );
+
+			// Check that no PHP warnings or notices were output.
+			$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+			// Confirm that the ConvertKit Form displays.
+			$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		}
+	}
+
+	/**
+	 * Test that the Bulk Edit fields do not display when a search on a WP_List_Table
+	 * returns no results.
+	 *
+	 * @since 1.9.8.1
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBulkEditFieldsHiddenWhenNoProductsFound( AcceptanceTester $I ) {
+		// Emulate the user searching for Products with a query string that yields no results.
+		$I->amOnAdminPage( 'edit.php?post_type=product&s=nothing' );
+
+		// Confirm that the Bulk Edit fields do not display.
+		$I->dontSeeElement( '#convertkit-bulk-edit' );
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateConvertKitPlugin( $I );
+		$I->deactivateThirdPartyPlugin( $I, 'classic-editor' );
+		$I->deactivateThirdPartyPlugin( $I, 'woocommerce' );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/integrations/WooCommerceProductFormCest.php
+++ b/tests/acceptance/integrations/WooCommerceProductFormCest.php
@@ -1,149 +1,155 @@
 <?php
 /**
  * Tests for ConvertKit Forms on WooCommerce Products.
- *
- * @since 1.9.6
+ * 
+ * @since 	1.9.6
  */
-class WooCommerceProductFormCest {
-
+class WooCommerceProductFormCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
-		$I->activateConvertKitPlugin( $I );
-		$I->activateThirdPartyPlugin( $I, 'woocommerce' );
-		$I->setupConvertKitPlugin( $I );
-		$I->enableDebugLog( $I );
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'woocommerce');
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
 	}
 
 	/**
 	 * Test that the 'Default' option for the Default Form setting in the Plugin Settings works when
 	 * creating and viewing a new WooCommerce Product, and there is no Default Form specified in the Plugin
 	 * settings.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewProductUsingDefaultFormWithNoDefaultFormSpecifiedInPlugin( AcceptanceTester $I ) {
+	public function testAddNewProductUsingDefaultFormWithNoDefaultFormSpecifiedInPlugin(AcceptanceTester $I)
+	{
 		// Navigate to Products > Add New.
-		$I->amOnAdminPage( 'post-new.php?post_type=product' );
+		$I->amOnAdminPage('post-new.php?post_type=product');
 
 		// Define a Product Title.
-		$I->fillField( '#title', 'ConvertKit: Product: Form: Default: None' );
+		$I->fillField('#title', 'ConvertKit: Product: Form: Default: None');
 
 		// Wait, otherwise publishing will fail in WooCommerce.
-		$I->wait( 1 );
+		$I->wait(1);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage( $I );
+		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that a ConvertKit Form is not displayed.
-		$I->dontSeeElementInDOM( 'form[data-sv-form]' );
+		$I->dontSeeElementInDOM('form[data-sv-form]');
 	}
 
 	/**
 	 * Test that the Default Form specified in the Plugin Settings works when
 	 * creating and viewing a new WooCommerce Product.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewProductUsingDefaultForm( AcceptanceTester $I ) {
+	public function testAddNewProductUsingDefaultForm(AcceptanceTester $I)
+	{
 		// Specify the Default Form in the Plugin Settings.
-		$defaultFormID = $I->setupConvertKitPluginDefaultFormForWooCommerceProducts( $I );
+		$defaultFormID = $I->setupConvertKitPluginDefaultFormForWooCommerceProducts($I);
 
 		// Navigate to Products > Add New.
-		$I->amOnAdminPage( 'post-new.php?post_type=product' );
+		$I->amOnAdminPage('post-new.php?post_type=product');
 
 		// Define a Product Title.
-		$I->fillField( '#title', 'ConvertKit: Product: Form: Default' );
+		$I->fillField('#title', 'ConvertKit: Product: Form: Default');
 
 		// Wait, otherwise publishing will fail in WooCommerce.
-		$I->wait( 1 );
+		$I->wait(1);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage( $I );
+		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the ConvertKit Default Form displays.
-		$I->seeElementInDOM( 'form[data-sv-form="' . $defaultFormID . '"]' );
+		$I->seeElementInDOM('form[data-sv-form="' . $defaultFormID . '"]');
 	}
 
 	/**
 	 * Test that 'None' Form specified in the Product Settings works when
 	 * creating and viewing a new WooCommerce Product.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewProductUsingNoForm( AcceptanceTester $I ) {
+	public function testAddNewProductUsingNoForm(AcceptanceTester $I)
+	{
 		// Navigate to Products > Add New.
-		$I->amOnAdminPage( 'post-new.php?post_type=product' );
+		$I->amOnAdminPage('post-new.php?post_type=product');
 
 		// Change Form to None.
-		$I->fillSelect2Field( $I, '#select2-wp-convertkit-form-container', 'None', 'aria-owns' );
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None', 'aria-owns');
 
 		// Define a Product Title.
-		$I->fillField( '#title', 'ConvertKit: Product: Form: None' );
+		$I->fillField('#title', 'ConvertKit: Product: Form: None');
 
 		// Wait, otherwise publishing will fail in WooCommerce.
-		$I->wait( 1 );
+		$I->wait(1);
 
 		// Publish and view the Product.
-		$I->publishAndViewClassicEditorPage( $I );
+		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that no ConvertKit Form is displayed.
-		$I->dontSeeElementInDOM( 'form[data-sv-form]' );
+		$I->dontSeeElementInDOM('form[data-sv-form]');
 	}
 
 	/**
 	 * Test that the Form specified in the Product Settings works when
 	 * creating and viewing a new WooCommerce Product.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewProductUsingDefinedForm( AcceptanceTester $I ) {
+	public function testAddNewProductUsingDefinedForm(AcceptanceTester $I)
+	{
 		// Navigate to Products > Add New.
-		$I->amOnAdminPage( 'post-new.php?post_type=product' );
+		$I->amOnAdminPage('post-new.php?post_type=product');
 
 		// Change Form to Form setting in .env file.
-		$I->fillSelect2Field( $I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME'], 'aria-owns' );
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME'], 'aria-owns');
 
 		// Define a Product Title.
-		$I->fillField( '#title', 'ConvertKit: Product: Form: Defined' );
+		$I->fillField('#title', 'ConvertKit: Product: Form: Defined');
 
 		// Wait, otherwise publishing will fail in WooCommerce.
-		$I->wait( 1 );
+		$I->wait(1);
 
 		// Publish and view the Product.
-		$I->publishAndViewClassicEditorPage( $I );
+		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the ConvertKit Form displays.
-		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 	}
 
 	/**
 	 * Test the [convertkit_form] shortcode is inserted into the applicable Content or Excerpt Visual Editor
 	 * instances when adding a WooCommerce Product.
-	 *
-	 * @since 1.9.8.3
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewProductUsingFormShortcodeInVisualEditor( AcceptanceTester $I ) {
+	public function testAddNewProductUsingFormShortcodeInVisualEditor(AcceptanceTester $I)
+	{
 		// Add a Product using the Classic Editor.
-		$I->addClassicEditorPage( $I, 'product', 'ConvertKit: Product: Form: Shortcode: Visual Editor' );
+		$I->addClassicEditorPage($I, 'product', 'ConvertKit: Product: Form: Shortcode: Visual Editor');
 
 		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
-		$I->fillSelect2Field( $I, '#select2-wp-convertkit-form-container', 'None', 'aria-owns' );
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None', 'aria-owns');
 
 		// Add shortcode to Excerpt (Product short description), setting the Form setting to the value specified in the .env file,
 		// and confirming that the expected shortcode is displayed in the Excerpt field.
@@ -151,10 +157,10 @@ class WooCommerceProductFormCest {
 			$I,
 			'ConvertKit Form',
 			'convertkit-form',
-			array(
-				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
-			),
-			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]',
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+			],
+			'[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]',
 			'excerpt' // The ID of the Product short description field.
 		);
 
@@ -164,45 +170,46 @@ class WooCommerceProductFormCest {
 			$I,
 			'ConvertKit Form',
 			'convertkit-form',
-			array(
-				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
-			),
-			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]',
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+			],
+			'[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]',
 			'content' // The ID of the Content field.
 		);
 
 		// Publish and view the Product on the frontend site.
-		$I->publishAndViewClassicEditorPage( $I );
+		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the ConvertKit Form is displayed.
-		$I->seeElementInDOM( 'form[data-sv-form]' );
+		$I->seeElementInDOM('form[data-sv-form]');
 	}
 
 	/**
 	 * Test the [convertkit_form] shortcode is inserted into the applicable Content or Excerpt Text Editor
 	 * instances when adding a WooCommerce Product.
-	 *
-	 * @since 1.9.8.3
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewProductUsingFormShortcodeInTextEditor( AcceptanceTester $I ) {
+	public function testAddNewProductUsingFormShortcodeInTextEditor(AcceptanceTester $I)
+	{
 		// Add a Product using the Classic Editor.
-		$I->addClassicEditorPage( $I, 'product', 'ConvertKit: Product: Form: Shortcode: Text Editor' );
+		$I->addClassicEditorPage($I, 'product', 'ConvertKit: Product: Form: Shortcode: Text Editor');
 
 		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
-		$I->fillSelect2Field( $I, '#select2-wp-convertkit-form-container', 'None', 'aria-owns' );
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None', 'aria-owns');
 
 		// Add shortcode to Excerpt (Product short description), setting the Form setting to the value specified in the .env file,
-		// and confirming that the expected shortcode is displayed in the Excerpt field.
+		// and confirming that the expected shortcode is displayed in the Excerpt field.		
 		$I->addTextEditorShortcode(
 			$I,
 			'ConvertKit Form',
 			'convertkit-form',
-			array(
-				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
-			),
-			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]',
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+			],
+			'[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]',
 			'excerpt' // The ID of the Product short description field.
 		);
 
@@ -212,287 +219,253 @@ class WooCommerceProductFormCest {
 			$I,
 			'ConvertKit Form',
 			'convertkit-form',
-			array(
-				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
-			),
-			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]',
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ]
+			],
+			'[convertkit_form form="'.$_ENV['CONVERTKIT_API_FORM_ID'].'"]',
 			'content' // The ID of the Content field.
 		);
 
 		// Publish and view the Product on the frontend site.
-		$I->publishAndViewClassicEditorPage( $I );
+		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the ConvertKit Form is displayed.
-		$I->seeElementInDOM( 'form[data-sv-form]' );
+		$I->seeElementInDOM('form[data-sv-form]');
 	}
 
 	/**
 	 * Test that the Default Form for Products displays when the Default option is chosen via
 	 * WordPress' Quick Edit functionality.
-	 *
-	 * @since 1.9.8.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testQuickEditUsingDefaultForm( AcceptanceTester $I ) {
+	public function testQuickEditUsingDefaultForm(AcceptanceTester $I)
+	{
 		// Specify the Default Form in the Plugin Settings.
-		$I->setupConvertKitPluginDefaultFormForWooCommerceProducts( $I );
+		$I->setupConvertKitPluginDefaultFormForWooCommerceProducts($I);
 
 		// Programmatically create a Product.
-		$productID = $I->havePostInDatabase(
-			array(
-				'post_type'  => 'product',
-				'post_title' => 'ConvertKit: Product: Form: Default: Quick Edit',
-			)
-		);
+		$productID = $I->havePostInDatabase([
+			'post_type' 	=> 'product',
+			'post_title' 	=> 'ConvertKit: Product: Form: Default: Quick Edit',
+		]);
 
 		// Quick Edit the Product in the Products WP_List_Table.
-		$I->quickEdit(
-			$I,
-			'product',
-			$productID,
-			array(
-				'form' => array( 'select', 'Default' ),
-			)
-		);
+		$I->quickEdit($I, 'product', $productID, [
+			'form' => [ 'select', 'Default' ],
+		]);
 
 		// Load the Product on the frontend site.
-		$I->amOnPage( '/?p=' . $productID );
+		$I->amOnPage('/?p='.$productID);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the ConvertKit Default Form displays.
-		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 	}
 
 	/**
 	 * Test that the defined form displays when chosen via
 	 * WordPress' Quick Edit functionality.
-	 *
-	 * @since 1.9.8.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testQuickEditUsingDefinedForm( AcceptanceTester $I ) {
+	public function testQuickEditUsingDefinedForm(AcceptanceTester $I)
+	{
 		// Programmatically create a Product.
-		$productID = $I->havePostInDatabase(
-			array(
-				'post_type'  => 'product',
-				'post_title' => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
-			)
-		);
+		$productID = $I->havePostInDatabase([
+			'post_type' 	=> 'product',
+			'post_title' 	=> 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
+		]);
 
 		// Quick Edit the Product in the Products WP_List_Table.
-		$I->quickEdit(
-			$I,
-			'product',
-			$productID,
-			array(
-				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
-			)
-		);
+		$I->quickEdit($I, 'product', $productID, [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+		]);
 
 		// Load the Product on the frontend site.
-		$I->amOnPage( '/?p=' . $productID );
+		$I->amOnPage('/?p='.$productID);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the ConvertKit Default Form displays.
-		$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 	}
 
 	/**
 	 * Test that the Default Form for Products displays when the Default option is chosen via
 	 * WordPress' Bulk Edit functionality.
-	 *
-	 * @since 1.9.8.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBulkEditUsingDefaultForm( AcceptanceTester $I ) {
+	public function testBulkEditUsingDefaultForm(AcceptanceTester $I)
+	{
 		// Specify the Default Form in the Plugin Settings.
-		$I->setupConvertKitPluginDefaultFormForWooCommerceProducts( $I );
+		$I->setupConvertKitPluginDefaultFormForWooCommerceProducts($I);
 
 		// Programmatically create two Products.
 		$productIDs = array(
-			$I->havePostInDatabase(
-				array(
-					'post_type'  => 'product',
-					'post_title' => 'ConvertKit: Product: Form: Default: Bulk Edit #1',
-				)
-			),
-			$I->havePostInDatabase(
-				array(
-					'post_type'  => 'product',
-					'post_title' => 'ConvertKit: Product: Form: Default: Bulk Edit #2',
-				)
-			),
+			$I->havePostInDatabase([
+				'post_type' 	=> 'product',
+				'post_title' 	=> 'ConvertKit: Product: Form: Default: Bulk Edit #1',
+			]),
+			$I->havePostInDatabase([
+				'post_type' 	=> 'product',
+				'post_title' 	=> 'ConvertKit: Product: Form: Default: Bulk Edit #2',
+			])
 		);
 
 		// Bulk Edit the Products in the Products WP_List_Table.
-		$I->bulkEdit(
-			$I,
-			'product',
-			$productIDs,
-			array(
-				'form' => array( 'select', 'Default' ),
-			)
-		);
+		$I->bulkEdit($I, 'product', $productIDs, [
+			'form' => [ 'select', 'Default' ],
+		]);
 
 		// Iterate through Products to run frontend tests.
-		foreach ( $productIDs as $productID ) {
+		foreach($productIDs as $productID) {
 			// Load Product on the frontend site.
-			$I->amOnPage( '/?p=' . $productID );
+			$I->amOnPage('/?p='.$productID);
 
 			// Check that no PHP warnings or notices were output.
-			$I->checkNoWarningsAndNoticesOnScreen( $I );
+			$I->checkNoWarningsAndNoticesOnScreen($I);
 
 			// Confirm that the ConvertKit Default Form displays.
-			$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+			$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 		}
 	}
 
 	/**
 	 * Test that the defined form displays when chosen via
 	 * WordPress' Bulk Edit functionality.
-	 *
-	 * @since 1.9.8.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBulkEditUsingDefinedForm( AcceptanceTester $I ) {
+	public function testBulkEditUsingDefinedForm(AcceptanceTester $I)
+	{
 		// Programmatically create two Products.
 		$productIDs = array(
-			$I->havePostInDatabase(
-				array(
-					'post_type'  => 'product',
-					'post_title' => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
-				)
-			),
-			$I->havePostInDatabase(
-				array(
-					'post_type'  => 'product',
-					'post_title' => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
-				)
-			),
+			$I->havePostInDatabase([
+				'post_type' 	=> 'product',
+				'post_title' 	=> 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
+			]),
+			$I->havePostInDatabase([
+				'post_type' 	=> 'product',
+				'post_title' 	=> 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
+			])
 		);
 
 		// Bulk Edit the Products in the Products WP_List_Table.
-		$I->bulkEdit(
-			$I,
-			'product',
-			$productIDs,
-			array(
-				'form' => array( 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ),
-			)
-		);
+		$I->bulkEdit($I, 'product', $productIDs, [
+			'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+		]);
 
 		// Iterate through Products to run frontend tests.
-		foreach ( $productIDs as $productID ) {
+		foreach($productIDs as $productID) {
 			// Load Product on the frontend site.
-			$I->amOnPage( '/?p=' . $productID );
+			$I->amOnPage('/?p='.$productID);
 
 			// Check that no PHP warnings or notices were output.
-			$I->checkNoWarningsAndNoticesOnScreen( $I );
+			$I->checkNoWarningsAndNoticesOnScreen($I);
 
 			// Confirm that the ConvertKit Default Form displays.
-			$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+			$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 		}
 	}
 
 	/**
 	 * Test that the existing settings are honored and not changed
 	 * when the Bulk Edit options are set to 'No Change'.
-	 *
-	 * @since 1.9.8.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBulkEditWithNoChanges( AcceptanceTester $I ) {
+	public function testBulkEditWithNoChanges(AcceptanceTester $I)
+	{
 		// Programmatically create two Products with a defined form.
 		$productIDs = array(
-			$I->havePostInDatabase(
-				array(
-					'post_type'  => 'product',
-					'post_title' => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #1',
-					'meta_input' => array(
-						'_wp_convertkit_post_meta' => array(
-							'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
-							'landing_page' => '',
-							'tag'          => '',
-						),
-					),
-				)
-			),
-			$I->havePostInDatabase(
-				array(
-					'post_type'  => 'product',
-					'post_title' => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
-					'meta_input' => array(
-						'_wp_convertkit_post_meta' => array(
-							'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
-							'landing_page' => '',
-							'tag'          => '',
-						),
-					),
-				)
-			),
+			$I->havePostInDatabase([
+				'post_type' 	=> 'product',
+				'post_title' 	=> 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #1',
+				'meta_input'	=> [
+					'_wp_convertkit_post_meta' => [
+						'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
+						'landing_page' => '',
+						'tag'          => '',
+					]
+				],
+			]),
+			$I->havePostInDatabase([
+				'post_type' 	=> 'product',
+				'post_title' 	=> 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
+				'meta_input'	=> [
+					'_wp_convertkit_post_meta' => [
+						'form'         => $_ENV['CONVERTKIT_API_FORM_ID'],
+						'landing_page' => '',
+						'tag'          => '',
+					]
+				],
+			])
 		);
 
 		// Bulk Edit the Products in the Products WP_List_Table.
-		$I->bulkEdit(
-			$I,
-			'product',
-			$productIDs,
-			array(
-				'form' => array( 'select', '— No Change —' ),
-			)
-		);
+		$I->bulkEdit($I, 'product', $productIDs, [
+			'form' => [ 'select', '— No Change —' ],
+		]);
 
 		// Iterate through Products to run frontend tests.
-		foreach ( $productIDs as $productID ) {
+		foreach($productIDs as $productID) {
 			// Load Page on the frontend site.
-			$I->amOnPage( '/?p=' . $productID );
+			$I->amOnPage('/?p='.$productID);
 
 			// Check that no PHP warnings or notices were output.
-			$I->checkNoWarningsAndNoticesOnScreen( $I );
+			$I->checkNoWarningsAndNoticesOnScreen($I);
 
 			// Confirm that the ConvertKit Form displays.
-			$I->seeElementInDOM( 'form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]' );
+			$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 		}
 	}
 
 	/**
 	 * Test that the Bulk Edit fields do not display when a search on a WP_List_Table
 	 * returns no results.
-	 *
-	 * @since 1.9.8.1
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.1
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBulkEditFieldsHiddenWhenNoProductsFound( AcceptanceTester $I ) {
+	public function testBulkEditFieldsHiddenWhenNoProductsFound(AcceptanceTester $I)
+	{
 		// Emulate the user searching for Products with a query string that yields no results.
-		$I->amOnAdminPage( 'edit.php?post_type=product&s=nothing' );
+		$I->amOnAdminPage('edit.php?post_type=product&s=nothing');
 
 		// Confirm that the Bulk Edit fields do not display.
-		$I->dontSeeElement( '#convertkit-bulk-edit' );
+		$I->dontSeeElement('#convertkit-bulk-edit');
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateConvertKitPlugin( $I );
-		$I->deactivateThirdPartyPlugin( $I, 'classic-editor' );
-		$I->deactivateThirdPartyPlugin( $I, 'woocommerce' );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->deactivateThirdPartyPlugin($I, 'classic-editor');
+		$I->deactivateThirdPartyPlugin($I, 'woocommerce');
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/landing-pages/PageLandingPageCest.php
+++ b/tests/acceptance/landing-pages/PageLandingPageCest.php
@@ -1,226 +1,214 @@
 <?php
 /**
  * Tests for ConvertKit Landing Pages on WordPress Pages.
- *
- * @since 1.9.6
+ * 
+ * @since 	1.9.6
  */
-class PageLandingPageCest {
-
+class PageLandingPageCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
+	public function _before(AcceptanceTester $I)
+	{
 		// Activate and Setup ConvertKit plugin
-		$I->activateConvertKitPlugin( $I );
-		$I->setupConvertKitPlugin( $I );
-		$I->enableDebugLog( $I );
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
 	}
 
 	/**
 	 * Test that 'None' Landing Page specified in the Page Settings works when
 	 * creating and viewing a new WordPress Page.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewPageUsingNoLandingPage( AcceptanceTester $I ) {
+	public function testAddNewPageUsingNoLandingPage(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Landing Page: None' );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Landing Page: None');
 
 		// Configure metabox's Landing Page setting = None.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'landing_page' => array( 'select2', 'None' ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'landing_page' => [ 'select2', 'None' ],
+		]);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that no ConvertKit Landing Page is displayed.
-		$I->dontSeeElementInDOM( 'form[data-sv-form]' );
+		$I->dontSeeElementInDOM('form[data-sv-form]');
 	}
 
 	/**
 	 * Test that the Landing Page specified in the Page Settings works when
 	 * creating and viewing a new WordPress Page.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewPageUsingDefinedLandingPage( AcceptanceTester $I ) {
+	public function testAddNewPageUsingDefinedLandingPage(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME'] );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME']);
 
 		// Configure metabox's Landing Page setting to value specified in the .env file.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'landing_page' => array( 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME'] ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME'] ],
+		]);
 
 		// Get Landing Page ID.
-		$landingPageID = $I->grabValueFrom( '#wp-convertkit-landing_page' );
+		$landingPageID = $I->grabValueFrom('#wp-convertkit-landing_page');
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the basic HTML structure is correct.
-		$this->_seeBasicHTMLStructure( $I );
-
+		$this->_seeBasicHTMLStructure($I);
+		
 		// Confirm that the ConvertKit Landing Page displays.
-		$I->dontSeeElementInDOM( 'body.page' ); // WordPress didn't load its template, which is correct.
-		$I->seeElementInDOM( 'form[data-sv-form="' . $landingPageID . '"]' ); // ConvertKit injected its Landing Page Form, which is correct.
+		$I->dontSeeElementInDOM('body.page'); // WordPress didn't load its template, which is correct.
+		$I->seeElementInDOM('form[data-sv-form="' . $landingPageID . '"]'); // ConvertKit injected its Landing Page Form, which is correct.		
 	}
 
 	/**
 	 * Test that character encoding is correct when a Landing Page is output.
-	 *
-	 * @since 1.9.6.1
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.1
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testLandingPageCharacterEncoding( AcceptanceTester $I ) {
+	public function testLandingPageCharacterEncoding(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LANDING_PAGE_CHARACTER_ENCODING_NAME'] );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LANDING_PAGE_CHARACTER_ENCODING_NAME']);
 
 		// Configure metabox's Landing Page setting to value specified in the .env file.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'landing_page' => array( 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_CHARACTER_ENCODING_NAME'] ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_CHARACTER_ENCODING_NAME'] ],
+		]);
 
 		// Get Landing Page ID.
-		$landingPageID = $I->grabValueFrom( '#wp-convertkit-landing_page' );
+		$landingPageID = $I->grabValueFrom('#wp-convertkit-landing_page');
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the basic HTML structure is correct.
-		$this->_seeBasicHTMLStructure( $I );
+		$this->_seeBasicHTMLStructure($I);
 
 		// Confirm that the Landing Page title is the same as defined on ConvertKit i.e. that character encoding is correct.
-		$I->seeInSource( 'Vantar þinn ungling sjálfstraust í stærðfræði?' );
+		$I->seeInSource('Vantar þinn ungling sjálfstraust í stærðfræði?');
 	}
 
 	/**
 	 * Test that the Legacy Landing Page specified in the Page Settings works when
 	 * creating and viewing a new WordPress Page.
-	 *
-	 * @since 1.9.6.3
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewPageUsingDefinedLegacyLandingPage( AcceptanceTester $I ) {
+	public function testAddNewPageUsingDefinedLegacyLandingPage(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME'] );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME']);
 
 		// Configure metabox's Landing Page setting to value specified in the .env file.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'landing_page' => array( 'select2', $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME'] ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME'] ],
+		]);
 
 		// Get Landing Page ID.
-		$landingPageID = $I->grabValueFrom( '#wp-convertkit-landing_page' );
+		$landingPageID = $I->grabValueFrom('#wp-convertkit-landing_page');
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the basic HTML structure is correct.
-		$this->_seeBasicHTMLStructure( $I );
+		$this->_seeBasicHTMLStructure($I);
 
 		// Confirm that the ConvertKit Landing Page displays.
-		$I->dontSeeElementInDOM( 'body.page' ); // WordPress didn't load its template, which is correct.
-		$I->seeInSource( '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://app.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_ID'] . '/subscribe" data-remote="true">' ); // ConvertKit injected its Landing Page Form, which is correct.
+		$I->dontSeeElementInDOM('body.page'); // WordPress didn't load its template, which is correct.
+		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://app.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_ID'] . '/subscribe" data-remote="true">'); // ConvertKit injected its Landing Page Form, which is correct.
 	}
 
 	/**
 	 * Test that the Legacy Landing Page specified in the Page Settings works when
 	 * the Landing Page was defined by the ConvertKit Plugin < 1.9.6, which used a URL
 	 * instead of an ID.
-	 *
-	 * @since 1.9.6.3
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewPageUsingDefinedLegacyLandingPageURL( AcceptanceTester $I ) {
+	public function testAddNewPageUsingDefinedLegacyLandingPageURL(AcceptanceTester $I)
+	{
 		// Create a Page with Plugin settings that contain a Legacy Landing Page URL,
 		// mirroring how < 1.9.6 of the Plugin worked.
-		$pageID = $I->havePageInDatabase(
-			array(
-				'post_type'   => 'page',
-				'post_status' => 'publish',
-				'post_title'  => 'ConvertKit: Landing Page: Legacy URL',
-				'post_name'   => 'convertkit-landing-page-legacy-url',
-				'meta_input'  => array(
-					'_wp_convertkit_post_meta' => array(
-						'form'         => '-1',
-						// Emulates how Legacy Landing Pages were stored in < 1.9.6 as a URL, instead of an ID.
-						'landing_page' => $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_URL'],
-						'tag'          => '',
-					),
-				),
-			)
-		);
+		$pageID = $I->havePageInDatabase([
+			'post_type' => 'page',
+			'post_status' => 'publish',
+			'post_title' => 'ConvertKit: Landing Page: Legacy URL',
+			'post_name' => 'convertkit-landing-page-legacy-url',
+			'meta_input' => [
+				'_wp_convertkit_post_meta' => [
+					'form'         => '-1',
+					// Emulates how Legacy Landing Pages were stored in < 1.9.6 as a URL, instead of an ID.
+					'landing_page' => $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_URL'],
+					'tag'          => '',
+				],
+			],
+		]);
 
 		// Load the Page on the frontend site
-		$I->amOnPage( '/convertkit-landing-page-legacy-url' );
+		$I->amOnPage('/convertkit-landing-page-legacy-url');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the basic HTML structure is correct.
-		$this->_seeBasicHTMLStructure( $I );
+		$this->_seeBasicHTMLStructure($I);
 
 		// Confirm that the ConvertKit Landing Page displays.
-		$I->dontSeeElementInDOM( 'body.page' ); // WordPress didn't load its template, which is correct.
-		$I->seeInSource( '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://app.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_ID'] . '/subscribe" data-remote="true">' ); // ConvertKit injected its Landing Page Form, which is correct.
+		$I->dontSeeElementInDOM('body.page'); // WordPress didn't load its template, which is correct.
+		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://app.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_ID'] . '/subscribe" data-remote="true">'); // ConvertKit injected its Landing Page Form, which is correct.
 	}
 
 	/**
 	 * Helper method to assert that the expected landing page HTML is output.
-	 *
-	 * @since 1.9.7.5
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.5
 	 */
-	private function _seeBasicHTMLStructure( $I ) {
-		$I->seeInSource( '<html>' );
-		$I->seeInSource( '<head>' );
-		$I->seeInSource( '</head>' );
-		$I->seeInSource( '<body' );
-		$I->seeInSource( '</body>' );
-		$I->seeInSource( '</html>' );
+	private function _seeBasicHTMLStructure($I)
+	{
+		$I->seeInSource('<html>');
+		$I->seeInSource('<head>');
+		$I->seeInSource('</head>');
+		$I->seeInSource('<body');
+		$I->seeInSource('</body>');
+		$I->seeInSource('</html>');
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/landing-pages/PageLandingPageCest.php
+++ b/tests/acceptance/landing-pages/PageLandingPageCest.php
@@ -2,213 +2,223 @@
 /**
  * Tests for ConvertKit Landing Pages on WordPress Pages.
  * 
- * @since 	1.9.6
+ * @since 1.9.6
  */
 class PageLandingPageCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		// Activate and Setup ConvertKit plugin
-		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
-	}
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        // Activate and Setup ConvertKit plugin
+        $I->activateConvertKitPlugin($I);
+        $I->setupConvertKitPlugin($I);
+        $I->enableDebugLog($I);
+    }
 
-	/**
-	 * Test that 'None' Landing Page specified in the Page Settings works when
-	 * creating and viewing a new WordPress Page.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewPageUsingNoLandingPage(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Landing Page: None');
+    /**
+     * Test that 'None' Landing Page specified in the Page Settings works when
+     * creating and viewing a new WordPress Page.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewPageUsingNoLandingPage(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Landing Page: None');
 
-		// Configure metabox's Landing Page setting = None.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'landing_page' => [ 'select2', 'None' ],
-		]);
+        // Configure metabox's Landing Page setting = None.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'landing_page' => [ 'select2', 'None' ],
+            ]
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Confirm that no ConvertKit Landing Page is displayed.
-		$I->dontSeeElementInDOM('form[data-sv-form]');
-	}
+        // Confirm that no ConvertKit Landing Page is displayed.
+        $I->dontSeeElementInDOM('form[data-sv-form]');
+    }
 
-	/**
-	 * Test that the Landing Page specified in the Page Settings works when
-	 * creating and viewing a new WordPress Page.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewPageUsingDefinedLandingPage(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME']);
+    /**
+     * Test that the Landing Page specified in the Page Settings works when
+     * creating and viewing a new WordPress Page.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewPageUsingDefinedLandingPage(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME']);
 
-		// Configure metabox's Landing Page setting to value specified in the .env file.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME'] ],
-		]);
+        // Configure metabox's Landing Page setting to value specified in the .env file.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME'] ],
+            ]
+        );
 
-		// Get Landing Page ID.
-		$landingPageID = $I->grabValueFrom('#wp-convertkit-landing_page');
+        // Get Landing Page ID.
+        $landingPageID = $I->grabValueFrom('#wp-convertkit-landing_page');
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Confirm that the basic HTML structure is correct.
-		$this->_seeBasicHTMLStructure($I);
+        // Confirm that the basic HTML structure is correct.
+        $this->_seeBasicHTMLStructure($I);
 		
-		// Confirm that the ConvertKit Landing Page displays.
-		$I->dontSeeElementInDOM('body.page'); // WordPress didn't load its template, which is correct.
-		$I->seeElementInDOM('form[data-sv-form="' . $landingPageID . '"]'); // ConvertKit injected its Landing Page Form, which is correct.		
-	}
+        // Confirm that the ConvertKit Landing Page displays.
+        $I->dontSeeElementInDOM('body.page'); // WordPress didn't load its template, which is correct.
+        $I->seeElementInDOM('form[data-sv-form="' . $landingPageID . '"]'); // ConvertKit injected its Landing Page Form, which is correct.        
+    }
 
-	/**
-	 * Test that character encoding is correct when a Landing Page is output.
-	 * 
-	 * @since 	1.9.6.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testLandingPageCharacterEncoding(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LANDING_PAGE_CHARACTER_ENCODING_NAME']);
+    /**
+     * Test that character encoding is correct when a Landing Page is output.
+     * 
+     * @since 1.9.6.1
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testLandingPageCharacterEncoding(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LANDING_PAGE_CHARACTER_ENCODING_NAME']);
 
-		// Configure metabox's Landing Page setting to value specified in the .env file.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_CHARACTER_ENCODING_NAME'] ],
-		]);
+        // Configure metabox's Landing Page setting to value specified in the .env file.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_CHARACTER_ENCODING_NAME'] ],
+            ]
+        );
 
-		// Get Landing Page ID.
-		$landingPageID = $I->grabValueFrom('#wp-convertkit-landing_page');
+        // Get Landing Page ID.
+        $landingPageID = $I->grabValueFrom('#wp-convertkit-landing_page');
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Confirm that the basic HTML structure is correct.
-		$this->_seeBasicHTMLStructure($I);
+        // Confirm that the basic HTML structure is correct.
+        $this->_seeBasicHTMLStructure($I);
 
-		// Confirm that the Landing Page title is the same as defined on ConvertKit i.e. that character encoding is correct.
-		$I->seeInSource('Vantar þinn ungling sjálfstraust í stærðfræði?');
-	}
+        // Confirm that the Landing Page title is the same as defined on ConvertKit i.e. that character encoding is correct.
+        $I->seeInSource('Vantar þinn ungling sjálfstraust í stærðfræði?');
+    }
 
-	/**
-	 * Test that the Legacy Landing Page specified in the Page Settings works when
-	 * creating and viewing a new WordPress Page.
-	 * 
-	 * @since 	1.9.6.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewPageUsingDefinedLegacyLandingPage(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME']);
+    /**
+     * Test that the Legacy Landing Page specified in the Page Settings works when
+     * creating and viewing a new WordPress Page.
+     * 
+     * @since 1.9.6.3
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewPageUsingDefinedLegacyLandingPage(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME']);
 
-		// Configure metabox's Landing Page setting to value specified in the .env file.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME'] ],
-		]);
+        // Configure metabox's Landing Page setting to value specified in the .env file.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME'] ],
+            ]
+        );
 
-		// Get Landing Page ID.
-		$landingPageID = $I->grabValueFrom('#wp-convertkit-landing_page');
+        // Get Landing Page ID.
+        $landingPageID = $I->grabValueFrom('#wp-convertkit-landing_page');
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Confirm that the basic HTML structure is correct.
-		$this->_seeBasicHTMLStructure($I);
+        // Confirm that the basic HTML structure is correct.
+        $this->_seeBasicHTMLStructure($I);
 
-		// Confirm that the ConvertKit Landing Page displays.
-		$I->dontSeeElementInDOM('body.page'); // WordPress didn't load its template, which is correct.
-		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://app.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_ID'] . '/subscribe" data-remote="true">'); // ConvertKit injected its Landing Page Form, which is correct.
-	}
+        // Confirm that the ConvertKit Landing Page displays.
+        $I->dontSeeElementInDOM('body.page'); // WordPress didn't load its template, which is correct.
+        $I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://app.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_ID'] . '/subscribe" data-remote="true">'); // ConvertKit injected its Landing Page Form, which is correct.
+    }
 
-	/**
-	 * Test that the Legacy Landing Page specified in the Page Settings works when
-	 * the Landing Page was defined by the ConvertKit Plugin < 1.9.6, which used a URL
-	 * instead of an ID.
-	 * 
-	 * @since 	1.9.6.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewPageUsingDefinedLegacyLandingPageURL(AcceptanceTester $I)
-	{
-		// Create a Page with Plugin settings that contain a Legacy Landing Page URL,
-		// mirroring how < 1.9.6 of the Plugin worked.
-		$pageID = $I->havePageInDatabase([
-			'post_type' => 'page',
-			'post_status' => 'publish',
-			'post_title' => 'ConvertKit: Landing Page: Legacy URL',
-			'post_name' => 'convertkit-landing-page-legacy-url',
-			'meta_input' => [
-				'_wp_convertkit_post_meta' => [
-					'form'         => '-1',
-					// Emulates how Legacy Landing Pages were stored in < 1.9.6 as a URL, instead of an ID.
-					'landing_page' => $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_URL'],
-					'tag'          => '',
-				],
-			],
-		]);
+    /**
+     * Test that the Legacy Landing Page specified in the Page Settings works when
+     * the Landing Page was defined by the ConvertKit Plugin < 1.9.6, which used a URL
+     * instead of an ID.
+     * 
+     * @since 1.9.6.3
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewPageUsingDefinedLegacyLandingPageURL(AcceptanceTester $I)
+    {
+        // Create a Page with Plugin settings that contain a Legacy Landing Page URL,
+        // mirroring how < 1.9.6 of the Plugin worked.
+        $pageID = $I->havePageInDatabase(
+            [
+            'post_type' => 'page',
+            'post_status' => 'publish',
+            'post_title' => 'ConvertKit: Landing Page: Legacy URL',
+            'post_name' => 'convertkit-landing-page-legacy-url',
+            'meta_input' => [
+            '_wp_convertkit_post_meta' => [
+            'form'         => '-1',
+            // Emulates how Legacy Landing Pages were stored in < 1.9.6 as a URL, instead of an ID.
+            'landing_page' => $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_URL'],
+            'tag'          => '',
+            ],
+            ],
+            ]
+        );
 
-		// Load the Page on the frontend site
-		$I->amOnPage('/convertkit-landing-page-legacy-url');
+        // Load the Page on the frontend site
+        $I->amOnPage('/convertkit-landing-page-legacy-url');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the basic HTML structure is correct.
-		$this->_seeBasicHTMLStructure($I);
+        // Confirm that the basic HTML structure is correct.
+        $this->_seeBasicHTMLStructure($I);
 
-		// Confirm that the ConvertKit Landing Page displays.
-		$I->dontSeeElementInDOM('body.page'); // WordPress didn't load its template, which is correct.
-		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://app.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_ID'] . '/subscribe" data-remote="true">'); // ConvertKit injected its Landing Page Form, which is correct.
-	}
+        // Confirm that the ConvertKit Landing Page displays.
+        $I->dontSeeElementInDOM('body.page'); // WordPress didn't load its template, which is correct.
+        $I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://app.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_ID'] . '/subscribe" data-remote="true">'); // ConvertKit injected its Landing Page Form, which is correct.
+    }
 
-	/**
-	 * Helper method to assert that the expected landing page HTML is output.
-	 * 
-	 * @since 	1.9.7.5
-	 */
-	private function _seeBasicHTMLStructure($I)
-	{
-		$I->seeInSource('<html>');
-		$I->seeInSource('<head>');
-		$I->seeInSource('</head>');
-		$I->seeInSource('<body');
-		$I->seeInSource('</body>');
-		$I->seeInSource('</html>');
-	}
+    /**
+     * Helper method to assert that the expected landing page HTML is output.
+     * 
+     * @since 1.9.7.5
+     */
+    private function _seeBasicHTMLStructure($I)
+    {
+        $I->seeInSource('<html>');
+        $I->seeInSource('<head>');
+        $I->seeInSource('</head>');
+        $I->seeInSource('<body');
+        $I->seeInSource('</body>');
+        $I->seeInSource('</html>');
+    }
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/landing-pages/PageLandingPageCest.php
+++ b/tests/acceptance/landing-pages/PageLandingPageCest.php
@@ -196,6 +196,8 @@ class PageLandingPageCest
      * Helper method to assert that the expected landing page HTML is output.
      * 
      * @since 1.9.7.5
+     * 
+     * @param AcceptanceTester $I Tester
      */
     private function _seeBasicHTMLStructure($I)
     {

--- a/tests/acceptance/landing-pages/PageLandingPageCest.php
+++ b/tests/acceptance/landing-pages/PageLandingPageCest.php
@@ -1,21 +1,21 @@
 <?php
 /**
  * Tests for ConvertKit Landing Pages on WordPress Pages.
- * 
- * @since 	1.9.6
+ *
+ * @since   1.9.6
  */
 class PageLandingPageCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
-		// Activate and Setup ConvertKit plugin
+		// Activate and Setup ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
 		$I->enableDebugLog($I);
@@ -24,10 +24,10 @@ class PageLandingPageCest
 	/**
 	 * Test that 'None' Landing Page specified in the Page Settings works when
 	 * creating and viewing a new WordPress Page.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewPageUsingNoLandingPage(AcceptanceTester $I)
 	{
@@ -35,9 +35,13 @@ class PageLandingPageCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Landing Page: None');
 
 		// Configure metabox's Landing Page setting = None.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'landing_page' => [ 'select2', 'None' ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'landing_page' => [ 'select2', 'None' ],
+			]
+		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -49,10 +53,10 @@ class PageLandingPageCest
 	/**
 	 * Test that the Landing Page specified in the Page Settings works when
 	 * creating and viewing a new WordPress Page.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewPageUsingDefinedLandingPage(AcceptanceTester $I)
 	{
@@ -60,9 +64,13 @@ class PageLandingPageCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME']);
 
 		// Configure metabox's Landing Page setting to value specified in the .env file.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME'] ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME'] ],
+			]
+		);
 
 		// Get Landing Page ID.
 		$landingPageID = $I->grabValueFrom('#wp-convertkit-landing_page');
@@ -72,18 +80,18 @@ class PageLandingPageCest
 
 		// Confirm that the basic HTML structure is correct.
 		$this->_seeBasicHTMLStructure($I);
-		
+
 		// Confirm that the ConvertKit Landing Page displays.
 		$I->dontSeeElementInDOM('body.page'); // WordPress didn't load its template, which is correct.
-		$I->seeElementInDOM('form[data-sv-form="' . $landingPageID . '"]'); // ConvertKit injected its Landing Page Form, which is correct.		
+		$I->seeElementInDOM('form[data-sv-form="' . $landingPageID . '"]'); // ConvertKit injected its Landing Page Form, which is correct.
 	}
 
 	/**
 	 * Test that character encoding is correct when a Landing Page is output.
-	 * 
-	 * @since 	1.9.6.1
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testLandingPageCharacterEncoding(AcceptanceTester $I)
 	{
@@ -91,9 +99,13 @@ class PageLandingPageCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LANDING_PAGE_CHARACTER_ENCODING_NAME']);
 
 		// Configure metabox's Landing Page setting to value specified in the .env file.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_CHARACTER_ENCODING_NAME'] ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_CHARACTER_ENCODING_NAME'] ],
+			]
+		);
 
 		// Get Landing Page ID.
 		$landingPageID = $I->grabValueFrom('#wp-convertkit-landing_page');
@@ -111,10 +123,10 @@ class PageLandingPageCest
 	/**
 	 * Test that the Legacy Landing Page specified in the Page Settings works when
 	 * creating and viewing a new WordPress Page.
-	 * 
-	 * @since 	1.9.6.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewPageUsingDefinedLegacyLandingPage(AcceptanceTester $I)
 	{
@@ -122,9 +134,13 @@ class PageLandingPageCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME']);
 
 		// Configure metabox's Landing Page setting to value specified in the .env file.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME'] ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME'] ],
+			]
+		);
 
 		// Get Landing Page ID.
 		$landingPageID = $I->grabValueFrom('#wp-convertkit-landing_page');
@@ -144,31 +160,33 @@ class PageLandingPageCest
 	 * Test that the Legacy Landing Page specified in the Page Settings works when
 	 * the Landing Page was defined by the ConvertKit Plugin < 1.9.6, which used a URL
 	 * instead of an ID.
-	 * 
-	 * @since 	1.9.6.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewPageUsingDefinedLegacyLandingPageURL(AcceptanceTester $I)
 	{
 		// Create a Page with Plugin settings that contain a Legacy Landing Page URL,
 		// mirroring how < 1.9.6 of the Plugin worked.
-		$pageID = $I->havePageInDatabase([
-			'post_type' => 'page',
-			'post_status' => 'publish',
-			'post_title' => 'ConvertKit: Landing Page: Legacy URL',
-			'post_name' => 'convertkit-landing-page-legacy-url',
-			'meta_input' => [
-				'_wp_convertkit_post_meta' => [
-					'form'         => '-1',
-					// Emulates how Legacy Landing Pages were stored in < 1.9.6 as a URL, instead of an ID.
-					'landing_page' => $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_URL'],
-					'tag'          => '',
+		$pageID = $I->havePageInDatabase(
+			[
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'ConvertKit: Landing Page: Legacy URL',
+				'post_name'   => 'convertkit-landing-page-legacy-url',
+				'meta_input'  => [
+					'_wp_convertkit_post_meta' => [
+						'form'         => '-1',
+						// Emulates how Legacy Landing Pages were stored in < 1.9.6 as a URL, instead of an ID.
+						'landing_page' => $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_URL'],
+						'tag'          => '',
+					],
 				],
-			],
-		]);
+			]
+		);
 
-		// Load the Page on the frontend site
+		// Load the Page on the frontend site.
 		$I->amOnPage('/convertkit-landing-page-legacy-url');
 
 		// Check that no PHP warnings or notices were output.
@@ -184,8 +202,10 @@ class PageLandingPageCest
 
 	/**
 	 * Helper method to assert that the expected landing page HTML is output.
-	 * 
-	 * @since 	1.9.7.5
+	 *
+	 * @since   1.9.7.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	private function _seeBasicHTMLStructure($I)
 	{
@@ -201,10 +221,10 @@ class PageLandingPageCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/landing-pages/PageLandingPageCest.php
+++ b/tests/acceptance/landing-pages/PageLandingPageCest.php
@@ -1,226 +1,226 @@
 <?php
 /**
  * Tests for ConvertKit Landing Pages on WordPress Pages.
- * 
+ *
  * @since 1.9.6
  */
-class PageLandingPageCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        // Activate and Setup ConvertKit plugin
-        $I->activateConvertKitPlugin($I);
-        $I->setupConvertKitPlugin($I);
-        $I->enableDebugLog($I);
-    }
+class PageLandingPageCest {
 
-    /**
-     * Test that 'None' Landing Page specified in the Page Settings works when
-     * creating and viewing a new WordPress Page.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewPageUsingNoLandingPage(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Landing Page: None');
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		// Activate and Setup ConvertKit plugin
+		$I->activateConvertKitPlugin( $I );
+		$I->setupConvertKitPlugin( $I );
+		$I->enableDebugLog( $I );
+	}
 
-        // Configure metabox's Landing Page setting = None.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'landing_page' => [ 'select2', 'None' ],
-            ]
-        );
+	/**
+	 * Test that 'None' Landing Page specified in the Page Settings works when
+	 * creating and viewing a new WordPress Page.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewPageUsingNoLandingPage( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Landing Page: None' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
+		// Configure metabox's Landing Page setting = None.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'landing_page' => array( 'select2', 'None' ),
+			)
+		);
 
-        // Confirm that no ConvertKit Landing Page is displayed.
-        $I->dontSeeElementInDOM('form[data-sv-form]');
-    }
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
 
-    /**
-     * Test that the Landing Page specified in the Page Settings works when
-     * creating and viewing a new WordPress Page.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewPageUsingDefinedLandingPage(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME']);
+		// Confirm that no ConvertKit Landing Page is displayed.
+		$I->dontSeeElementInDOM( 'form[data-sv-form]' );
+	}
 
-        // Configure metabox's Landing Page setting to value specified in the .env file.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME'] ],
-            ]
-        );
+	/**
+	 * Test that the Landing Page specified in the Page Settings works when
+	 * creating and viewing a new WordPress Page.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewPageUsingDefinedLandingPage( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME'] );
 
-        // Get Landing Page ID.
-        $landingPageID = $I->grabValueFrom('#wp-convertkit-landing_page');
+		// Configure metabox's Landing Page setting to value specified in the .env file.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'landing_page' => array( 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME'] ),
+			)
+		);
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
+		// Get Landing Page ID.
+		$landingPageID = $I->grabValueFrom( '#wp-convertkit-landing_page' );
 
-        // Confirm that the basic HTML structure is correct.
-        $this->_seeBasicHTMLStructure($I);
-		
-        // Confirm that the ConvertKit Landing Page displays.
-        $I->dontSeeElementInDOM('body.page'); // WordPress didn't load its template, which is correct.
-        $I->seeElementInDOM('form[data-sv-form="' . $landingPageID . '"]'); // ConvertKit injected its Landing Page Form, which is correct.        
-    }
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
 
-    /**
-     * Test that character encoding is correct when a Landing Page is output.
-     * 
-     * @since 1.9.6.1
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testLandingPageCharacterEncoding(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LANDING_PAGE_CHARACTER_ENCODING_NAME']);
+		// Confirm that the basic HTML structure is correct.
+		$this->_seeBasicHTMLStructure( $I );
 
-        // Configure metabox's Landing Page setting to value specified in the .env file.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_CHARACTER_ENCODING_NAME'] ],
-            ]
-        );
+		// Confirm that the ConvertKit Landing Page displays.
+		$I->dontSeeElementInDOM( 'body.page' ); // WordPress didn't load its template, which is correct.
+		$I->seeElementInDOM( 'form[data-sv-form="' . $landingPageID . '"]' ); // ConvertKit injected its Landing Page Form, which is correct.
+	}
 
-        // Get Landing Page ID.
-        $landingPageID = $I->grabValueFrom('#wp-convertkit-landing_page');
+	/**
+	 * Test that character encoding is correct when a Landing Page is output.
+	 *
+	 * @since 1.9.6.1
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testLandingPageCharacterEncoding( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LANDING_PAGE_CHARACTER_ENCODING_NAME'] );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
+		// Configure metabox's Landing Page setting to value specified in the .env file.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'landing_page' => array( 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_CHARACTER_ENCODING_NAME'] ),
+			)
+		);
 
-        // Confirm that the basic HTML structure is correct.
-        $this->_seeBasicHTMLStructure($I);
+		// Get Landing Page ID.
+		$landingPageID = $I->grabValueFrom( '#wp-convertkit-landing_page' );
 
-        // Confirm that the Landing Page title is the same as defined on ConvertKit i.e. that character encoding is correct.
-        $I->seeInSource('Vantar þinn ungling sjálfstraust í stærðfræði?');
-    }
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
 
-    /**
-     * Test that the Legacy Landing Page specified in the Page Settings works when
-     * creating and viewing a new WordPress Page.
-     * 
-     * @since 1.9.6.3
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewPageUsingDefinedLegacyLandingPage(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME']);
+		// Confirm that the basic HTML structure is correct.
+		$this->_seeBasicHTMLStructure( $I );
 
-        // Configure metabox's Landing Page setting to value specified in the .env file.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME'] ],
-            ]
-        );
+		// Confirm that the Landing Page title is the same as defined on ConvertKit i.e. that character encoding is correct.
+		$I->seeInSource( 'Vantar þinn ungling sjálfstraust í stærðfræði?' );
+	}
 
-        // Get Landing Page ID.
-        $landingPageID = $I->grabValueFrom('#wp-convertkit-landing_page');
+	/**
+	 * Test that the Legacy Landing Page specified in the Page Settings works when
+	 * creating and viewing a new WordPress Page.
+	 *
+	 * @since 1.9.6.3
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewPageUsingDefinedLegacyLandingPage( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Landing Page: ' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME'] );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
+		// Configure metabox's Landing Page setting to value specified in the .env file.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'landing_page' => array( 'select2', $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME'] ),
+			)
+		);
 
-        // Confirm that the basic HTML structure is correct.
-        $this->_seeBasicHTMLStructure($I);
+		// Get Landing Page ID.
+		$landingPageID = $I->grabValueFrom( '#wp-convertkit-landing_page' );
 
-        // Confirm that the ConvertKit Landing Page displays.
-        $I->dontSeeElementInDOM('body.page'); // WordPress didn't load its template, which is correct.
-        $I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://app.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_ID'] . '/subscribe" data-remote="true">'); // ConvertKit injected its Landing Page Form, which is correct.
-    }
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
 
-    /**
-     * Test that the Legacy Landing Page specified in the Page Settings works when
-     * the Landing Page was defined by the ConvertKit Plugin < 1.9.6, which used a URL
-     * instead of an ID.
-     * 
-     * @since 1.9.6.3
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewPageUsingDefinedLegacyLandingPageURL(AcceptanceTester $I)
-    {
-        // Create a Page with Plugin settings that contain a Legacy Landing Page URL,
-        // mirroring how < 1.9.6 of the Plugin worked.
-        $pageID = $I->havePageInDatabase(
-            [
-            'post_type' => 'page',
-            'post_status' => 'publish',
-            'post_title' => 'ConvertKit: Landing Page: Legacy URL',
-            'post_name' => 'convertkit-landing-page-legacy-url',
-            'meta_input' => [
-            '_wp_convertkit_post_meta' => [
-            'form'         => '-1',
-            // Emulates how Legacy Landing Pages were stored in < 1.9.6 as a URL, instead of an ID.
-            'landing_page' => $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_URL'],
-            'tag'          => '',
-            ],
-            ],
-            ]
-        );
+		// Confirm that the basic HTML structure is correct.
+		$this->_seeBasicHTMLStructure( $I );
 
-        // Load the Page on the frontend site
-        $I->amOnPage('/convertkit-landing-page-legacy-url');
+		// Confirm that the ConvertKit Landing Page displays.
+		$I->dontSeeElementInDOM( 'body.page' ); // WordPress didn't load its template, which is correct.
+		$I->seeInSource( '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://app.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_ID'] . '/subscribe" data-remote="true">' ); // ConvertKit injected its Landing Page Form, which is correct.
+	}
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+	/**
+	 * Test that the Legacy Landing Page specified in the Page Settings works when
+	 * the Landing Page was defined by the ConvertKit Plugin < 1.9.6, which used a URL
+	 * instead of an ID.
+	 *
+	 * @since 1.9.6.3
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewPageUsingDefinedLegacyLandingPageURL( AcceptanceTester $I ) {
+		// Create a Page with Plugin settings that contain a Legacy Landing Page URL,
+		// mirroring how < 1.9.6 of the Plugin worked.
+		$pageID = $I->havePageInDatabase(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'ConvertKit: Landing Page: Legacy URL',
+				'post_name'   => 'convertkit-landing-page-legacy-url',
+				'meta_input'  => array(
+					'_wp_convertkit_post_meta' => array(
+						'form'         => '-1',
+						// Emulates how Legacy Landing Pages were stored in < 1.9.6 as a URL, instead of an ID.
+						'landing_page' => $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_URL'],
+						'tag'          => '',
+					),
+				),
+			)
+		);
 
-        // Confirm that the basic HTML structure is correct.
-        $this->_seeBasicHTMLStructure($I);
+		// Load the Page on the frontend site
+		$I->amOnPage( '/convertkit-landing-page-legacy-url' );
 
-        // Confirm that the ConvertKit Landing Page displays.
-        $I->dontSeeElementInDOM('body.page'); // WordPress didn't load its template, which is correct.
-        $I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://app.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_ID'] . '/subscribe" data-remote="true">'); // ConvertKit injected its Landing Page Form, which is correct.
-    }
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-    /**
-     * Helper method to assert that the expected landing page HTML is output.
-     * 
-     * @since 1.9.7.5
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    private function _seeBasicHTMLStructure($I)
-    {
-        $I->seeInSource('<html>');
-        $I->seeInSource('<head>');
-        $I->seeInSource('</head>');
-        $I->seeInSource('<body');
-        $I->seeInSource('</body>');
-        $I->seeInSource('</html>');
-    }
+		// Confirm that the basic HTML structure is correct.
+		$this->_seeBasicHTMLStructure( $I );
 
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+		// Confirm that the ConvertKit Landing Page displays.
+		$I->dontSeeElementInDOM( 'body.page' ); // WordPress didn't load its template, which is correct.
+		$I->seeInSource( '<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://app.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_ID'] . '/subscribe" data-remote="true">' ); // ConvertKit injected its Landing Page Form, which is correct.
+	}
+
+	/**
+	 * Helper method to assert that the expected landing page HTML is output.
+	 *
+	 * @since 1.9.7.5
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	private function _seeBasicHTMLStructure( $I ) {
+		$I->seeInSource( '<html>' );
+		$I->seeInSource( '<head>' );
+		$I->seeInSource( '</head>' );
+		$I->seeInSource( '<body' );
+		$I->seeInSource( '</body>' );
+		$I->seeInSource( '</html>' );
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/landing-pages/PostLandingPageCest.php
+++ b/tests/acceptance/landing-pages/PostLandingPageCest.php
@@ -1,21 +1,21 @@
 <?php
 /**
  * Tests for ConvertKit Landing Pages on WordPress Posts.
- * 
- * @since 	1.9.6.4
+ *
+ * @since   1.9.6.4
  */
 class PostLandingPageCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
-		// Activate and Setup ConvertKit plugin
+		// Activate and Setup ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
 		$I->enableDebugLog($I);
@@ -25,10 +25,10 @@ class PostLandingPageCest
 	 * Test that no Landing Page option is displayedin the Plugin Settings when
 	 * creating and viewing a new WordPress Post, and that no attempt to check
 	 * for a Landing Page is made when viewing a Post.
-	 * 
-	 * @since 	1.9.6.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewPostDoesNotDisplayLandingPageOption(AcceptanceTester $I)
 	{
@@ -42,9 +42,13 @@ class PostLandingPageCest
 		$I->dontSeeElementInDOM('#wp-convertkit-landing_page');
 
 		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'Default' ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'Default' ],
+			]
+		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -57,10 +61,10 @@ class PostLandingPageCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/landing-pages/PostLandingPageCest.php
+++ b/tests/acceptance/landing-pages/PostLandingPageCest.php
@@ -1,72 +1,71 @@
 <?php
 /**
  * Tests for ConvertKit Landing Pages on WordPress Posts.
- * 
+ *
  * @since 1.9.6.4
  */
-class PostLandingPageCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.6.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        // Activate and Setup ConvertKit plugin
-        $I->activateConvertKitPlugin($I);
-        $I->setupConvertKitPlugin($I);
-        $I->enableDebugLog($I);
-    }
+class PostLandingPageCest {
 
-    /**
-     * Test that no Landing Page option is displayedin the Plugin Settings when
-     * creating and viewing a new WordPress Post, and that no attempt to check
-     * for a Landing Page is made when viewing a Post.
-     * 
-     * @since 1.9.6.4
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewPostDoesNotDisplayLandingPageOption(AcceptanceTester $I)
-    {
-        // Add a Post using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Landing Page');
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.6.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		// Activate and Setup ConvertKit plugin
+		$I->activateConvertKitPlugin( $I );
+		$I->setupConvertKitPlugin( $I );
+		$I->enableDebugLog( $I );
+	}
 
-        // Check that the metabox is displayed.
-        $I->seeElementInDOM('#wp-convertkit-meta-box');
+	/**
+	 * Test that no Landing Page option is displayedin the Plugin Settings when
+	 * creating and viewing a new WordPress Post, and that no attempt to check
+	 * for a Landing Page is made when viewing a Post.
+	 *
+	 * @since 1.9.6.4
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewPostDoesNotDisplayLandingPageOption( AcceptanceTester $I ) {
+		// Add a Post using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'post', 'ConvertKit: Post: Landing Page' );
 
-        // Check that no Landing Page option is displayed.
-        $I->dontSeeElementInDOM('#wp-convertkit-landing_page');
+		// Check that the metabox is displayed.
+		$I->seeElementInDOM( '#wp-convertkit-meta-box' );
 
-        // Configure metabox's Form setting = Default.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'form' => [ 'select2', 'Default' ],
-            ]
-        );
+		// Check that no Landing Page option is displayed.
+		$I->dontSeeElementInDOM( '#wp-convertkit-landing_page' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
+		// Configure metabox's Form setting = Default.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'form' => array( 'select2', 'Default' ),
+			)
+		);
 
-        // Confirm that no ConvertKit Form is displayed.
-        $I->dontSeeElementInDOM('form[data-sv-form]');
-    }
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
 
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+		// Confirm that no ConvertKit Form is displayed.
+		$I->dontSeeElementInDOM( 'form[data-sv-form]' );
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/landing-pages/PostLandingPageCest.php
+++ b/tests/acceptance/landing-pages/PostLandingPageCest.php
@@ -1,71 +1,70 @@
 <?php
 /**
  * Tests for ConvertKit Landing Pages on WordPress Posts.
- *
- * @since 1.9.6.4
+ * 
+ * @since 	1.9.6.4
  */
-class PostLandingPageCest {
-
+class PostLandingPageCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.6.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
+	public function _before(AcceptanceTester $I)
+	{
 		// Activate and Setup ConvertKit plugin
-		$I->activateConvertKitPlugin( $I );
-		$I->setupConvertKitPlugin( $I );
-		$I->enableDebugLog( $I );
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
 	}
 
 	/**
 	 * Test that no Landing Page option is displayedin the Plugin Settings when
 	 * creating and viewing a new WordPress Post, and that no attempt to check
 	 * for a Landing Page is made when viewing a Post.
-	 *
-	 * @since 1.9.6.4
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.4
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewPostDoesNotDisplayLandingPageOption( AcceptanceTester $I ) {
+	public function testAddNewPostDoesNotDisplayLandingPageOption(AcceptanceTester $I)
+	{
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'post', 'ConvertKit: Post: Landing Page' );
+		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Landing Page');
 
 		// Check that the metabox is displayed.
-		$I->seeElementInDOM( '#wp-convertkit-meta-box' );
+		$I->seeElementInDOM('#wp-convertkit-meta-box');
 
 		// Check that no Landing Page option is displayed.
-		$I->dontSeeElementInDOM( '#wp-convertkit-landing_page' );
+		$I->dontSeeElementInDOM('#wp-convertkit-landing_page');
 
 		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'form' => array( 'select2', 'Default' ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'Default' ],
+		]);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that no ConvertKit Form is displayed.
-		$I->dontSeeElementInDOM( 'form[data-sv-form]' );
+		$I->dontSeeElementInDOM('form[data-sv-form]');
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/landing-pages/PostLandingPageCest.php
+++ b/tests/acceptance/landing-pages/PostLandingPageCest.php
@@ -2,69 +2,71 @@
 /**
  * Tests for ConvertKit Landing Pages on WordPress Posts.
  * 
- * @since 	1.9.6.4
+ * @since 1.9.6.4
  */
 class PostLandingPageCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		// Activate and Setup ConvertKit plugin
-		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
-	}
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.6.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        // Activate and Setup ConvertKit plugin
+        $I->activateConvertKitPlugin($I);
+        $I->setupConvertKitPlugin($I);
+        $I->enableDebugLog($I);
+    }
 
-	/**
-	 * Test that no Landing Page option is displayedin the Plugin Settings when
-	 * creating and viewing a new WordPress Post, and that no attempt to check
-	 * for a Landing Page is made when viewing a Post.
-	 * 
-	 * @since 	1.9.6.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewPostDoesNotDisplayLandingPageOption(AcceptanceTester $I)
-	{
-		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Landing Page');
+    /**
+     * Test that no Landing Page option is displayedin the Plugin Settings when
+     * creating and viewing a new WordPress Post, and that no attempt to check
+     * for a Landing Page is made when viewing a Post.
+     * 
+     * @since 1.9.6.4
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewPostDoesNotDisplayLandingPageOption(AcceptanceTester $I)
+    {
+        // Add a Post using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Landing Page');
 
-		// Check that the metabox is displayed.
-		$I->seeElementInDOM('#wp-convertkit-meta-box');
+        // Check that the metabox is displayed.
+        $I->seeElementInDOM('#wp-convertkit-meta-box');
 
-		// Check that no Landing Page option is displayed.
-		$I->dontSeeElementInDOM('#wp-convertkit-landing_page');
+        // Check that no Landing Page option is displayed.
+        $I->dontSeeElementInDOM('#wp-convertkit-landing_page');
 
-		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'Default' ],
-		]);
+        // Configure metabox's Form setting = Default.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'form' => [ 'select2', 'Default' ],
+            ]
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Confirm that no ConvertKit Form is displayed.
-		$I->dontSeeElementInDOM('form[data-sv-form]');
-	}
+        // Confirm that no ConvertKit Form is displayed.
+        $I->dontSeeElementInDOM('form[data-sv-form]');
+    }
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/products/PageBlockProductCest.php
+++ b/tests/acceptance/products/PageBlockProductCest.php
@@ -1,17 +1,17 @@
 <?php
 /**
  * Tests for the ConvertKit Product Gutenberg Block.
- * 
- * @since 	1.9.8.5
+ *
+ * @since   1.9.8.5
  */
 class PageBlockProductCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -22,10 +22,10 @@ class PageBlockProductCest
 
 	/**
 	 * Test the Product block works when using a valid Product parameter.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testProductBlockWithValidProductParameter(AcceptanceTester $I)
 	{
@@ -33,14 +33,23 @@ class PageBlockProductCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Valid Product Param');
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'None' ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
 
 		// Add block to Page, setting the Product setting to the value specified in the .env file.
-		$I->addGutenbergBlock($I, 'ConvertKit Product', 'convertkit-product', [
-			'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
-		]);
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Product',
+			'convertkit-product',
+			[
+				'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+			]
+		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -51,10 +60,10 @@ class PageBlockProductCest
 
 	/**
 	 * Test the Product block works when not defining a Product parameter.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testProductBlockWithNoProductParameter(AcceptanceTester $I)
 	{
@@ -62,17 +71,24 @@ class PageBlockProductCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: No Product Param');
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'None' ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
 
 		// Add block to Page.
 		$I->addGutenbergBlock($I, 'ConvertKit Product', 'convertkit-product');
 
 		// Confirm that the Product block displays instructions to the user on how to select a Product.
-		$I->see('Select a Product using the Product option in the Gutenberg sidebar.', [
-			'css' => '.convertkit-no-content',
-		]);
+		$I->see(
+			'Select a Product using the Product option in the Gutenberg sidebar.',
+			[
+				'css' => '.convertkit-no-content',
+			]
+		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -83,10 +99,10 @@ class PageBlockProductCest
 
 	/**
 	 * Test the Product block's text parameter works.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testProductBlockWithTextParameter(AcceptanceTester $I)
 	{
@@ -94,10 +110,15 @@ class PageBlockProductCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Text Param');
 
 		// Add block to Page, setting the date format.
-		$I->addGutenbergBlock($I, 'ConvertKit Product', 'convertkit-product', [
-			'product' 	=> [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
-			'text' 		=> [ 'text', 'Buy Now' ],
-		]);
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Product',
+			'convertkit-product',
+			[
+				'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+				'text'    => [ 'text', 'Buy Now' ],
+			]
+		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -108,25 +129,27 @@ class PageBlockProductCest
 
 	/**
 	 * Test the Product block's theme color parameters works.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testProductBlockWithThemeColorParameters(AcceptanceTester $I)
 	{
 		// Define colors.
 		$backgroundColor = 'white';
-		$textColor = 'purple';
+		$textColor       = 'purple';
 
 		// It's tricky to interact with Gutenberg's color picker, so we programmatically create the Page
 		// instead to then confirm the color settings apply on the output.
 		// We don't need to test the color picker itself, as it's a Gutenberg supplied component, and our
 		// other Acceptance tests confirm that the block can be added in Gutenberg etc.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-page-product-block-theme-color-params',
-			'post_content' 	=> '<!-- wp:convertkit/product {"product":"36377","backgroundColor":"'.$backgroundColor.'","textColor":"'.$textColor.'"} /-->',
-		]);
+		$I->havePageInDatabase(
+			[
+				'post_name'    => 'convertkit-page-product-block-theme-color-params',
+				'post_content' => '<!-- wp:convertkit/product {"product":"36377","backgroundColor":"' . $backgroundColor . '","textColor":"' . $textColor . '"} /-->',
+			]
+		);
 
 		// Load the Page on the frontend site.
 		$I->amOnPage('/convertkit-page-product-block-theme-color-params');
@@ -141,30 +164,32 @@ class PageBlockProductCest
 		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL']);
 
 		// Confirm that the chosen colors are applied as CSS styles.
-		$I->seeInSource('class="wp-block-button__link convertkit-product has-text-color has-'.$textColor.'-color has-background has-'.$backgroundColor.'-background-color');
+		$I->seeInSource('class="wp-block-button__link convertkit-product has-text-color has-' . $textColor . '-color has-background has-' . $backgroundColor . '-background-color');
 	}
 
 	/**
 	 * Test the Product block's hex color parameters works.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testProductBlockWithHexColorParameters(AcceptanceTester $I)
 	{
 		// Define colors.
 		$backgroundColor = '#ee1616';
-		$textColor = '#1212c0';
+		$textColor       = '#1212c0';
 
 		// It's tricky to interact with Gutenberg's color picker, so we programmatically create the Page
 		// instead to then confirm the color settings apply on the output.
 		// We don't need to test the color picker itself, as it's a Gutenberg supplied component, and our
 		// other Acceptance tests confirm that the block can be added in Gutenberg etc.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-page-product-block-hex-color-params',
-			'post_content' 	=> '<!-- wp:convertkit/product {"product":"36377","style":{"color":{"text":"'.$textColor.'","background":"'.$backgroundColor.'"}}} /-->',
-		]);
+		$I->havePageInDatabase(
+			[
+				'post_name'    => 'convertkit-page-product-block-hex-color-params',
+				'post_content' => '<!-- wp:convertkit/product {"product":"36377","style":{"color":{"text":"' . $textColor . '","background":"' . $backgroundColor . '"}}} /-->',
+			]
+		);
 
 		// Load the Page on the frontend site.
 		$I->amOnPage('/convertkit-page-product-block-hex-color-params');
@@ -183,10 +208,10 @@ class PageBlockProductCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/products/PageBlockProductCest.php
+++ b/tests/acceptance/products/PageBlockProductCest.php
@@ -2,195 +2,209 @@
 /**
  * Tests for the ConvertKit Product Gutenberg Block.
  * 
- * @since 	1.9.8.5
+ * @since 1.9.8.5
  */
 class PageBlockProductCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
-	}
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.8.5
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        $I->activateConvertKitPlugin($I);
+        $I->setupConvertKitPlugin($I);
+        $I->enableDebugLog($I);
+    }
 
-	/**
-	 * Test the Product block works when using a valid Product parameter.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testProductBlockWithValidProductParameter(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Valid Product Param');
+    /**
+     * Test the Product block works when using a valid Product parameter.
+     * 
+     * @since 1.9.8.5
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testProductBlockWithValidProductParameter(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Valid Product Param');
 
-		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'None' ],
-		]);
+        // Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'form' => [ 'select2', 'None' ],
+            ]
+        );
 
-		// Add block to Page, setting the Product setting to the value specified in the .env file.
-		$I->addGutenbergBlock($I, 'ConvertKit Product', 'convertkit-product', [
-			'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
-		]);
+        // Add block to Page, setting the Product setting to the value specified in the .env file.
+        $I->addGutenbergBlock(
+            $I, 'ConvertKit Product', 'convertkit-product', [
+            'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+            ]
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Confirm that the block displays.
-		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
-	}
+        // Confirm that the block displays.
+        $I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
+    }
 
-	/**
-	 * Test the Product block works when not defining a Product parameter.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testProductBlockWithNoProductParameter(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: No Product Param');
+    /**
+     * Test the Product block works when not defining a Product parameter.
+     * 
+     * @since 1.9.8.5
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testProductBlockWithNoProductParameter(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: No Product Param');
 
-		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'None' ],
-		]);
+        // Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'form' => [ 'select2', 'None' ],
+            ]
+        );
 
-		// Add block to Page.
-		$I->addGutenbergBlock($I, 'ConvertKit Product', 'convertkit-product');
+        // Add block to Page.
+        $I->addGutenbergBlock($I, 'ConvertKit Product', 'convertkit-product');
 
-		// Confirm that the Product block displays instructions to the user on how to select a Product.
-		$I->see('Select a Product using the Product option in the Gutenberg sidebar.', [
-			'css' => '.convertkit-no-content',
-		]);
+        // Confirm that the Product block displays instructions to the user on how to select a Product.
+        $I->see(
+            'Select a Product using the Product option in the Gutenberg sidebar.', [
+            'css' => '.convertkit-no-content',
+            ]
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Confirm that no ConvertKit Product button is displayed.
-		$I->dontSeeProductOutput($I);
-	}
+        // Confirm that no ConvertKit Product button is displayed.
+        $I->dontSeeProductOutput($I);
+    }
 
-	/**
-	 * Test the Product block's text parameter works.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testProductBlockWithTextParameter(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Text Param');
+    /**
+     * Test the Product block's text parameter works.
+     * 
+     * @since 1.9.8.5
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testProductBlockWithTextParameter(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Text Param');
 
-		// Add block to Page, setting the date format.
-		$I->addGutenbergBlock($I, 'ConvertKit Product', 'convertkit-product', [
-			'product' 	=> [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
-			'text' 		=> [ 'text', 'Buy Now' ],
-		]);
+        // Add block to Page, setting the date format.
+        $I->addGutenbergBlock(
+            $I, 'ConvertKit Product', 'convertkit-product', [
+            'product'     => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+            'text'         => [ 'text', 'Buy Now' ],
+            ]
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Confirm that the block displays.
-		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy Now');
-	}
+        // Confirm that the block displays.
+        $I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy Now');
+    }
 
-	/**
-	 * Test the Product block's theme color parameters works.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testProductBlockWithThemeColorParameters(AcceptanceTester $I)
-	{
-		// Define colors.
-		$backgroundColor = 'white';
-		$textColor = 'purple';
+    /**
+     * Test the Product block's theme color parameters works.
+     * 
+     * @since 1.9.8.5
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testProductBlockWithThemeColorParameters(AcceptanceTester $I)
+    {
+        // Define colors.
+        $backgroundColor = 'white';
+        $textColor = 'purple';
 
-		// It's tricky to interact with Gutenberg's color picker, so we programmatically create the Page
-		// instead to then confirm the color settings apply on the output.
-		// We don't need to test the color picker itself, as it's a Gutenberg supplied component, and our
-		// other Acceptance tests confirm that the block can be added in Gutenberg etc.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-page-product-block-theme-color-params',
-			'post_content' 	=> '<!-- wp:convertkit/product {"product":"36377","backgroundColor":"'.$backgroundColor.'","textColor":"'.$textColor.'"} /-->',
-		]);
+        // It's tricky to interact with Gutenberg's color picker, so we programmatically create the Page
+        // instead to then confirm the color settings apply on the output.
+        // We don't need to test the color picker itself, as it's a Gutenberg supplied component, and our
+        // other Acceptance tests confirm that the block can be added in Gutenberg etc.
+        $I->havePageInDatabase(
+            [
+            'post_name'     => 'convertkit-page-product-block-theme-color-params',
+            'post_content'     => '<!-- wp:convertkit/product {"product":"36377","backgroundColor":"'.$backgroundColor.'","textColor":"'.$textColor.'"} /-->',
+            ]
+        );
 
-		// Load the Page on the frontend site.
-		$I->amOnPage('/convertkit-page-product-block-theme-color-params');
+        // Load the Page on the frontend site.
+        $I->amOnPage('/convertkit-page-product-block-theme-color-params');
 
-		// Wait for frontend web site to load.
-		$I->waitForElementVisible('body.page-template-default');
+        // Wait for frontend web site to load.
+        $I->waitForElementVisible('body.page-template-default');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the block displays.
-		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL']);
+        // Confirm that the block displays.
+        $I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL']);
 
-		// Confirm that the chosen colors are applied as CSS styles.
-		$I->seeInSource('class="wp-block-button__link convertkit-product has-text-color has-'.$textColor.'-color has-background has-'.$backgroundColor.'-background-color');
-	}
+        // Confirm that the chosen colors are applied as CSS styles.
+        $I->seeInSource('class="wp-block-button__link convertkit-product has-text-color has-'.$textColor.'-color has-background has-'.$backgroundColor.'-background-color');
+    }
 
-	/**
-	 * Test the Product block's hex color parameters works.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testProductBlockWithHexColorParameters(AcceptanceTester $I)
-	{
-		// Define colors.
-		$backgroundColor = '#ee1616';
-		$textColor = '#1212c0';
+    /**
+     * Test the Product block's hex color parameters works.
+     * 
+     * @since 1.9.8.5
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testProductBlockWithHexColorParameters(AcceptanceTester $I)
+    {
+        // Define colors.
+        $backgroundColor = '#ee1616';
+        $textColor = '#1212c0';
 
-		// It's tricky to interact with Gutenberg's color picker, so we programmatically create the Page
-		// instead to then confirm the color settings apply on the output.
-		// We don't need to test the color picker itself, as it's a Gutenberg supplied component, and our
-		// other Acceptance tests confirm that the block can be added in Gutenberg etc.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-page-product-block-hex-color-params',
-			'post_content' 	=> '<!-- wp:convertkit/product {"product":"36377","style":{"color":{"text":"'.$textColor.'","background":"'.$backgroundColor.'"}}} /-->',
-		]);
+        // It's tricky to interact with Gutenberg's color picker, so we programmatically create the Page
+        // instead to then confirm the color settings apply on the output.
+        // We don't need to test the color picker itself, as it's a Gutenberg supplied component, and our
+        // other Acceptance tests confirm that the block can be added in Gutenberg etc.
+        $I->havePageInDatabase(
+            [
+            'post_name'     => 'convertkit-page-product-block-hex-color-params',
+            'post_content'     => '<!-- wp:convertkit/product {"product":"36377","style":{"color":{"text":"'.$textColor.'","background":"'.$backgroundColor.'"}}} /-->',
+            ]
+        );
 
-		// Load the Page on the frontend site.
-		$I->amOnPage('/convertkit-page-product-block-hex-color-params');
+        // Load the Page on the frontend site.
+        $I->amOnPage('/convertkit-page-product-block-hex-color-params');
 
-		// Wait for frontend web site to load.
-		$I->waitForElementVisible('body.page-template-default');
+        // Wait for frontend web site to load.
+        $I->waitForElementVisible('body.page-template-default');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the block displays.
-		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product', $textColor, $backgroundColor);
-	}
+        // Confirm that the block displays.
+        $I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product', $textColor, $backgroundColor);
+    }
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.8.5
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/products/PageBlockProductCest.php
+++ b/tests/acceptance/products/PageBlockProductCest.php
@@ -1,214 +1,196 @@
 <?php
 /**
  * Tests for the ConvertKit Product Gutenberg Block.
- *
- * @since 1.9.8.5
+ * 
+ * @since 	1.9.8.5
  */
-class PageBlockProductCest {
-
+class PageBlockProductCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.8.5
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
-		$I->activateConvertKitPlugin( $I );
-		$I->setupConvertKitPlugin( $I );
-		$I->enableDebugLog( $I );
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
 	}
 
 	/**
 	 * Test the Product block works when using a valid Product parameter.
-	 *
-	 * @since 1.9.8.5
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testProductBlockWithValidProductParameter( AcceptanceTester $I ) {
+	public function testProductBlockWithValidProductParameter(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Product: Valid Product Param' );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Valid Product Param');
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'form' => array( 'select2', 'None' ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'None' ],
+		]);
 
 		// Add block to Page, setting the Product setting to the value specified in the .env file.
-		$I->addGutenbergBlock(
-			$I,
-			'ConvertKit Product',
-			'convertkit-product',
-			array(
-				'product' => array( 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ),
-			)
-		);
+		$I->addGutenbergBlock($I, 'ConvertKit Product', 'convertkit-product', [
+			'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+		]);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the block displays.
-		$I->seeProductOutput( $I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product' );
+		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
 	}
 
 	/**
 	 * Test the Product block works when not defining a Product parameter.
-	 *
-	 * @since 1.9.8.5
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testProductBlockWithNoProductParameter( AcceptanceTester $I ) {
+	public function testProductBlockWithNoProductParameter(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Product: No Product Param' );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: No Product Param');
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'form' => array( 'select2', 'None' ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'None' ],
+		]);
 
 		// Add block to Page.
-		$I->addGutenbergBlock( $I, 'ConvertKit Product', 'convertkit-product' );
+		$I->addGutenbergBlock($I, 'ConvertKit Product', 'convertkit-product');
 
 		// Confirm that the Product block displays instructions to the user on how to select a Product.
-		$I->see(
-			'Select a Product using the Product option in the Gutenberg sidebar.',
-			array(
-				'css' => '.convertkit-no-content',
-			)
-		);
+		$I->see('Select a Product using the Product option in the Gutenberg sidebar.', [
+			'css' => '.convertkit-no-content',
+		]);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that no ConvertKit Product button is displayed.
-		$I->dontSeeProductOutput( $I );
+		$I->dontSeeProductOutput($I);
 	}
 
 	/**
 	 * Test the Product block's text parameter works.
-	 *
-	 * @since 1.9.8.5
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testProductBlockWithTextParameter( AcceptanceTester $I ) {
+	public function testProductBlockWithTextParameter(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Product: Text Param' );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Text Param');
 
 		// Add block to Page, setting the date format.
-		$I->addGutenbergBlock(
-			$I,
-			'ConvertKit Product',
-			'convertkit-product',
-			array(
-				'product' => array( 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ),
-				'text'    => array( 'text', 'Buy Now' ),
-			)
-		);
+		$I->addGutenbergBlock($I, 'ConvertKit Product', 'convertkit-product', [
+			'product' 	=> [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+			'text' 		=> [ 'text', 'Buy Now' ],
+		]);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the block displays.
-		$I->seeProductOutput( $I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy Now' );
+		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy Now');
 	}
 
 	/**
 	 * Test the Product block's theme color parameters works.
-	 *
-	 * @since 1.9.8.5
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testProductBlockWithThemeColorParameters( AcceptanceTester $I ) {
+	public function testProductBlockWithThemeColorParameters(AcceptanceTester $I)
+	{
 		// Define colors.
 		$backgroundColor = 'white';
-		$textColor       = 'purple';
+		$textColor = 'purple';
 
 		// It's tricky to interact with Gutenberg's color picker, so we programmatically create the Page
 		// instead to then confirm the color settings apply on the output.
 		// We don't need to test the color picker itself, as it's a Gutenberg supplied component, and our
 		// other Acceptance tests confirm that the block can be added in Gutenberg etc.
-		$I->havePageInDatabase(
-			array(
-				'post_name'    => 'convertkit-page-product-block-theme-color-params',
-				'post_content' => '<!-- wp:convertkit/product {"product":"36377","backgroundColor":"' . $backgroundColor . '","textColor":"' . $textColor . '"} /-->',
-			)
-		);
+		$I->havePageInDatabase([
+			'post_name' 	=> 'convertkit-page-product-block-theme-color-params',
+			'post_content' 	=> '<!-- wp:convertkit/product {"product":"36377","backgroundColor":"'.$backgroundColor.'","textColor":"'.$textColor.'"} /-->',
+		]);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage( '/convertkit-page-product-block-theme-color-params' );
+		$I->amOnPage('/convertkit-page-product-block-theme-color-params');
 
 		// Wait for frontend web site to load.
-		$I->waitForElementVisible( 'body.page-template-default' );
+		$I->waitForElementVisible('body.page-template-default');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the block displays.
-		$I->seeProductOutput( $I, $_ENV['CONVERTKIT_API_PRODUCT_URL'] );
+		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL']);
 
 		// Confirm that the chosen colors are applied as CSS styles.
-		$I->seeInSource( 'class="wp-block-button__link convertkit-product has-text-color has-' . $textColor . '-color has-background has-' . $backgroundColor . '-background-color' );
+		$I->seeInSource('class="wp-block-button__link convertkit-product has-text-color has-'.$textColor.'-color has-background has-'.$backgroundColor.'-background-color');
 	}
 
 	/**
 	 * Test the Product block's hex color parameters works.
-	 *
-	 * @since 1.9.8.5
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testProductBlockWithHexColorParameters( AcceptanceTester $I ) {
+	public function testProductBlockWithHexColorParameters(AcceptanceTester $I)
+	{
 		// Define colors.
 		$backgroundColor = '#ee1616';
-		$textColor       = '#1212c0';
+		$textColor = '#1212c0';
 
 		// It's tricky to interact with Gutenberg's color picker, so we programmatically create the Page
 		// instead to then confirm the color settings apply on the output.
 		// We don't need to test the color picker itself, as it's a Gutenberg supplied component, and our
 		// other Acceptance tests confirm that the block can be added in Gutenberg etc.
-		$I->havePageInDatabase(
-			array(
-				'post_name'    => 'convertkit-page-product-block-hex-color-params',
-				'post_content' => '<!-- wp:convertkit/product {"product":"36377","style":{"color":{"text":"' . $textColor . '","background":"' . $backgroundColor . '"}}} /-->',
-			)
-		);
+		$I->havePageInDatabase([
+			'post_name' 	=> 'convertkit-page-product-block-hex-color-params',
+			'post_content' 	=> '<!-- wp:convertkit/product {"product":"36377","style":{"color":{"text":"'.$textColor.'","background":"'.$backgroundColor.'"}}} /-->',
+		]);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage( '/convertkit-page-product-block-hex-color-params' );
+		$I->amOnPage('/convertkit-page-product-block-hex-color-params');
 
 		// Wait for frontend web site to load.
-		$I->waitForElementVisible( 'body.page-template-default' );
+		$I->waitForElementVisible('body.page-template-default');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the block displays.
-		$I->seeProductOutput( $I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product', $textColor, $backgroundColor );
+		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product', $textColor, $backgroundColor);
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.8.5
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/products/PageBlockProductCest.php
+++ b/tests/acceptance/products/PageBlockProductCest.php
@@ -1,210 +1,214 @@
 <?php
 /**
  * Tests for the ConvertKit Product Gutenberg Block.
- * 
+ *
  * @since 1.9.8.5
  */
-class PageBlockProductCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.8.5
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        $I->activateConvertKitPlugin($I);
-        $I->setupConvertKitPlugin($I);
-        $I->enableDebugLog($I);
-    }
+class PageBlockProductCest {
 
-    /**
-     * Test the Product block works when using a valid Product parameter.
-     * 
-     * @since 1.9.8.5
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testProductBlockWithValidProductParameter(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Valid Product Param');
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.8.5
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		$I->activateConvertKitPlugin( $I );
+		$I->setupConvertKitPlugin( $I );
+		$I->enableDebugLog( $I );
+	}
 
-        // Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'form' => [ 'select2', 'None' ],
-            ]
-        );
+	/**
+	 * Test the Product block works when using a valid Product parameter.
+	 *
+	 * @since 1.9.8.5
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testProductBlockWithValidProductParameter( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Product: Valid Product Param' );
 
-        // Add block to Page, setting the Product setting to the value specified in the .env file.
-        $I->addGutenbergBlock(
-            $I, 'ConvertKit Product', 'convertkit-product', [
-            'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
-            ]
-        );
+		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'form' => array( 'select2', 'None' ),
+			)
+		);
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
+		// Add block to Page, setting the Product setting to the value specified in the .env file.
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Product',
+			'convertkit-product',
+			array(
+				'product' => array( 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ),
+			)
+		);
 
-        // Confirm that the block displays.
-        $I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
-    }
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
 
-    /**
-     * Test the Product block works when not defining a Product parameter.
-     * 
-     * @since 1.9.8.5
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testProductBlockWithNoProductParameter(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: No Product Param');
+		// Confirm that the block displays.
+		$I->seeProductOutput( $I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product' );
+	}
 
-        // Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'form' => [ 'select2', 'None' ],
-            ]
-        );
+	/**
+	 * Test the Product block works when not defining a Product parameter.
+	 *
+	 * @since 1.9.8.5
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testProductBlockWithNoProductParameter( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Product: No Product Param' );
 
-        // Add block to Page.
-        $I->addGutenbergBlock($I, 'ConvertKit Product', 'convertkit-product');
+		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'form' => array( 'select2', 'None' ),
+			)
+		);
 
-        // Confirm that the Product block displays instructions to the user on how to select a Product.
-        $I->see(
-            'Select a Product using the Product option in the Gutenberg sidebar.', [
-            'css' => '.convertkit-no-content',
-            ]
-        );
+		// Add block to Page.
+		$I->addGutenbergBlock( $I, 'ConvertKit Product', 'convertkit-product' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
+		// Confirm that the Product block displays instructions to the user on how to select a Product.
+		$I->see(
+			'Select a Product using the Product option in the Gutenberg sidebar.',
+			array(
+				'css' => '.convertkit-no-content',
+			)
+		);
 
-        // Confirm that no ConvertKit Product button is displayed.
-        $I->dontSeeProductOutput($I);
-    }
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
 
-    /**
-     * Test the Product block's text parameter works.
-     * 
-     * @since 1.9.8.5
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testProductBlockWithTextParameter(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Text Param');
+		// Confirm that no ConvertKit Product button is displayed.
+		$I->dontSeeProductOutput( $I );
+	}
 
-        // Add block to Page, setting the date format.
-        $I->addGutenbergBlock(
-            $I, 'ConvertKit Product', 'convertkit-product', [
-            'product'     => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
-            'text'         => [ 'text', 'Buy Now' ],
-            ]
-        );
+	/**
+	 * Test the Product block's text parameter works.
+	 *
+	 * @since 1.9.8.5
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testProductBlockWithTextParameter( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Product: Text Param' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
+		// Add block to Page, setting the date format.
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Product',
+			'convertkit-product',
+			array(
+				'product' => array( 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ),
+				'text'    => array( 'text', 'Buy Now' ),
+			)
+		);
 
-        // Confirm that the block displays.
-        $I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy Now');
-    }
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
 
-    /**
-     * Test the Product block's theme color parameters works.
-     * 
-     * @since 1.9.8.5
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testProductBlockWithThemeColorParameters(AcceptanceTester $I)
-    {
-        // Define colors.
-        $backgroundColor = 'white';
-        $textColor = 'purple';
+		// Confirm that the block displays.
+		$I->seeProductOutput( $I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy Now' );
+	}
 
-        // It's tricky to interact with Gutenberg's color picker, so we programmatically create the Page
-        // instead to then confirm the color settings apply on the output.
-        // We don't need to test the color picker itself, as it's a Gutenberg supplied component, and our
-        // other Acceptance tests confirm that the block can be added in Gutenberg etc.
-        $I->havePageInDatabase(
-            [
-            'post_name'     => 'convertkit-page-product-block-theme-color-params',
-            'post_content'     => '<!-- wp:convertkit/product {"product":"36377","backgroundColor":"'.$backgroundColor.'","textColor":"'.$textColor.'"} /-->',
-            ]
-        );
+	/**
+	 * Test the Product block's theme color parameters works.
+	 *
+	 * @since 1.9.8.5
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testProductBlockWithThemeColorParameters( AcceptanceTester $I ) {
+		// Define colors.
+		$backgroundColor = 'white';
+		$textColor       = 'purple';
 
-        // Load the Page on the frontend site.
-        $I->amOnPage('/convertkit-page-product-block-theme-color-params');
+		// It's tricky to interact with Gutenberg's color picker, so we programmatically create the Page
+		// instead to then confirm the color settings apply on the output.
+		// We don't need to test the color picker itself, as it's a Gutenberg supplied component, and our
+		// other Acceptance tests confirm that the block can be added in Gutenberg etc.
+		$I->havePageInDatabase(
+			array(
+				'post_name'    => 'convertkit-page-product-block-theme-color-params',
+				'post_content' => '<!-- wp:convertkit/product {"product":"36377","backgroundColor":"' . $backgroundColor . '","textColor":"' . $textColor . '"} /-->',
+			)
+		);
 
-        // Wait for frontend web site to load.
-        $I->waitForElementVisible('body.page-template-default');
+		// Load the Page on the frontend site.
+		$I->amOnPage( '/convertkit-page-product-block-theme-color-params' );
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible( 'body.page-template-default' );
 
-        // Confirm that the block displays.
-        $I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL']);
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-        // Confirm that the chosen colors are applied as CSS styles.
-        $I->seeInSource('class="wp-block-button__link convertkit-product has-text-color has-'.$textColor.'-color has-background has-'.$backgroundColor.'-background-color');
-    }
+		// Confirm that the block displays.
+		$I->seeProductOutput( $I, $_ENV['CONVERTKIT_API_PRODUCT_URL'] );
 
-    /**
-     * Test the Product block's hex color parameters works.
-     * 
-     * @since 1.9.8.5
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testProductBlockWithHexColorParameters(AcceptanceTester $I)
-    {
-        // Define colors.
-        $backgroundColor = '#ee1616';
-        $textColor = '#1212c0';
+		// Confirm that the chosen colors are applied as CSS styles.
+		$I->seeInSource( 'class="wp-block-button__link convertkit-product has-text-color has-' . $textColor . '-color has-background has-' . $backgroundColor . '-background-color' );
+	}
 
-        // It's tricky to interact with Gutenberg's color picker, so we programmatically create the Page
-        // instead to then confirm the color settings apply on the output.
-        // We don't need to test the color picker itself, as it's a Gutenberg supplied component, and our
-        // other Acceptance tests confirm that the block can be added in Gutenberg etc.
-        $I->havePageInDatabase(
-            [
-            'post_name'     => 'convertkit-page-product-block-hex-color-params',
-            'post_content'     => '<!-- wp:convertkit/product {"product":"36377","style":{"color":{"text":"'.$textColor.'","background":"'.$backgroundColor.'"}}} /-->',
-            ]
-        );
+	/**
+	 * Test the Product block's hex color parameters works.
+	 *
+	 * @since 1.9.8.5
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testProductBlockWithHexColorParameters( AcceptanceTester $I ) {
+		// Define colors.
+		$backgroundColor = '#ee1616';
+		$textColor       = '#1212c0';
 
-        // Load the Page on the frontend site.
-        $I->amOnPage('/convertkit-page-product-block-hex-color-params');
+		// It's tricky to interact with Gutenberg's color picker, so we programmatically create the Page
+		// instead to then confirm the color settings apply on the output.
+		// We don't need to test the color picker itself, as it's a Gutenberg supplied component, and our
+		// other Acceptance tests confirm that the block can be added in Gutenberg etc.
+		$I->havePageInDatabase(
+			array(
+				'post_name'    => 'convertkit-page-product-block-hex-color-params',
+				'post_content' => '<!-- wp:convertkit/product {"product":"36377","style":{"color":{"text":"' . $textColor . '","background":"' . $backgroundColor . '"}}} /-->',
+			)
+		);
 
-        // Wait for frontend web site to load.
-        $I->waitForElementVisible('body.page-template-default');
+		// Load the Page on the frontend site.
+		$I->amOnPage( '/convertkit-page-product-block-hex-color-params' );
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible( 'body.page-template-default' );
 
-        // Confirm that the block displays.
-        $I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product', $textColor, $backgroundColor);
-    }
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.8.5
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+		// Confirm that the block displays.
+		$I->seeProductOutput( $I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product', $textColor, $backgroundColor );
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.8.5
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/products/PageLinkProductCest.php
+++ b/tests/acceptance/products/PageLinkProductCest.php
@@ -2,17 +2,17 @@
 /**
  * Tests that the Gutenberg LinkControl and Classic Editor Link button correctly
  * link to ConvertKit Products when selected.
- * 
- * @since 	2.0.0
+ *
+ * @since   2.0.0
  */
 class PageLinkProductCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	2.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   2.0.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -23,10 +23,10 @@ class PageLinkProductCest
 
 	/**
 	 * Test that linking text in a paragraph to a ConvertKit Product works.
-	 * 
-	 * @since 	2.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   2.0.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testLinkParagraphTextToProduct(AcceptanceTester $I)
 	{
@@ -34,9 +34,13 @@ class PageLinkProductCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Link Text');
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'None' ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
 
 		// Add paragraph to Page.
 		$I->addGutenbergParagraphBlock($I, 'This is some text. ');
@@ -53,10 +57,10 @@ class PageLinkProductCest
 
 	/**
 	 * Test that linking text in a button to a ConvertKit Product works.
-	 * 
-	 * @since 	2.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   2.0.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testLinkButtonTextToProduct(AcceptanceTester $I)
 	{
@@ -64,9 +68,13 @@ class PageLinkProductCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Button Link');
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'None' ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
 
 		// Add button to Page.
 		$I->addGutenbergBlock($I, 'Buttons', 'buttons');
@@ -84,10 +92,10 @@ class PageLinkProductCest
 	/**
 	 * Test that linking text in a paragraph to a ConvertKit Product works
 	 * in the Classic Editor.
-	 * 
-	 * @since 	2.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   2.0.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testLinkParagraphTextToProductInClassicEditor(AcceptanceTester $I)
 	{
@@ -108,10 +116,10 @@ class PageLinkProductCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	2.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   2.0.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/products/PageLinkProductCest.php
+++ b/tests/acceptance/products/PageLinkProductCest.php
@@ -2,123 +2,120 @@
 /**
  * Tests that the Gutenberg LinkControl and Classic Editor Link button correctly
  * link to ConvertKit Products when selected.
- *
- * @since 2.0.0
+ * 
+ * @since 	2.0.0
  */
-class PageLinkProductCest {
-
+class PageLinkProductCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	2.0.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
-		$I->activateConvertKitPlugin( $I );
-		$I->setupConvertKitPlugin( $I );
-		$I->enableDebugLog( $I );
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
 	}
 
 	/**
 	 * Test that linking text in a paragraph to a ConvertKit Product works.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	2.0.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testLinkParagraphTextToProduct( AcceptanceTester $I ) {
+	public function testLinkParagraphTextToProduct(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Product: Link Text' );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Link Text');
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'form' => array( 'select2', 'None' ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'None' ],
+		]);
 
 		// Add paragraph to Page.
-		$I->addGutenbergParagraphBlock( $I, 'This is some text. ' );
+		$I->addGutenbergParagraphBlock($I, 'This is some text. ');
 
 		// Add link to end of paragraph.
-		$I->addGutenbergLinkToParagraph( $I, $_ENV['CONVERTKIT_API_PRODUCT_NAME'] );
+		$I->addGutenbergLinkToParagraph($I, $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the link displays, links to the expected URL and the ConvertKit Product Modal works.
-		$I->seeProductLink( $I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], $_ENV['CONVERTKIT_API_PRODUCT_NAME'] );
+		$I->seeProductLink($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
 	}
 
 	/**
 	 * Test that linking text in a button to a ConvertKit Product works.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	2.0.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testLinkButtonTextToProduct( AcceptanceTester $I ) {
+	public function testLinkButtonTextToProduct(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Product: Button Link' );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Button Link');
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'form' => array( 'select2', 'None' ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'form' => [ 'select2', 'None' ],
+		]);
 
 		// Add button to Page.
-		$I->addGutenbergBlock( $I, 'Buttons', 'buttons' );
+		$I->addGutenbergBlock($I, 'Buttons', 'buttons');
 
 		// Add link to button.
-		$I->addGutenbergLinkToButton( $I, $_ENV['CONVERTKIT_API_PRODUCT_NAME'] );
+		$I->addGutenbergLinkToButton($I, $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the link displays, links to the expected URL and the ConvertKit Product Modal works.
-		$I->seeProductLink( $I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], $_ENV['CONVERTKIT_API_PRODUCT_NAME'] );
+		$I->seeProductLink($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
 	}
 
 	/**
 	 * Test that linking text in a paragraph to a ConvertKit Product works
 	 * in the Classic Editor.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	2.0.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testLinkParagraphTextToProductInClassicEditor( AcceptanceTester $I ) {
+	public function testLinkParagraphTextToProductInClassicEditor(AcceptanceTester $I)
+	{
 		// Add a Page using the Classic editor.
-		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Product: Classic Editor: Link Text' );
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Product: Classic Editor: Link Text');
 
 		// Add link to Product in Classic Editor.
-		$I->addClassicEditorLink( $I, $_ENV['CONVERTKIT_API_PRODUCT_NAME'] );
+		$I->addClassicEditorLink($I, $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage( $I );
+		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the link displays, links to the expected URL and the ConvertKit Product Modal works.
-		$I->seeProductLink( $I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], $_ENV['CONVERTKIT_API_PRODUCT_NAME'] );
+		$I->seeProductLink($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	2.0.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/products/PageLinkProductCest.php
+++ b/tests/acceptance/products/PageLinkProductCest.php
@@ -2,124 +2,123 @@
 /**
  * Tests that the Gutenberg LinkControl and Classic Editor Link button correctly
  * link to ConvertKit Products when selected.
- * 
+ *
  * @since 2.0.0
  */
-class PageLinkProductCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 2.0.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        $I->activateConvertKitPlugin($I);
-        $I->setupConvertKitPlugin($I);
-        $I->enableDebugLog($I);
-    }
+class PageLinkProductCest {
 
-    /**
-     * Test that linking text in a paragraph to a ConvertKit Product works.
-     * 
-     * @since 2.0.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testLinkParagraphTextToProduct(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Link Text');
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		$I->activateConvertKitPlugin( $I );
+		$I->setupConvertKitPlugin( $I );
+		$I->enableDebugLog( $I );
+	}
 
-        // Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'form' => [ 'select2', 'None' ],
-            ]
-        );
+	/**
+	 * Test that linking text in a paragraph to a ConvertKit Product works.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testLinkParagraphTextToProduct( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Product: Link Text' );
 
-        // Add paragraph to Page.
-        $I->addGutenbergParagraphBlock($I, 'This is some text. ');
+		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'form' => array( 'select2', 'None' ),
+			)
+		);
 
-        // Add link to end of paragraph.
-        $I->addGutenbergLinkToParagraph($I, $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
+		// Add paragraph to Page.
+		$I->addGutenbergParagraphBlock( $I, 'This is some text. ' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
+		// Add link to end of paragraph.
+		$I->addGutenbergLinkToParagraph( $I, $_ENV['CONVERTKIT_API_PRODUCT_NAME'] );
 
-        // Confirm that the link displays, links to the expected URL and the ConvertKit Product Modal works.
-        $I->seeProductLink($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
-    }
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
 
-    /**
-     * Test that linking text in a button to a ConvertKit Product works.
-     * 
-     * @since 2.0.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testLinkButtonTextToProduct(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Button Link');
+		// Confirm that the link displays, links to the expected URL and the ConvertKit Product Modal works.
+		$I->seeProductLink( $I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], $_ENV['CONVERTKIT_API_PRODUCT_NAME'] );
+	}
 
-        // Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'form' => [ 'select2', 'None' ],
-            ]
-        );
+	/**
+	 * Test that linking text in a button to a ConvertKit Product works.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testLinkButtonTextToProduct( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Product: Button Link' );
 
-        // Add button to Page.
-        $I->addGutenbergBlock($I, 'Buttons', 'buttons');
+		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'form' => array( 'select2', 'None' ),
+			)
+		);
 
-        // Add link to button.
-        $I->addGutenbergLinkToButton($I, $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
+		// Add button to Page.
+		$I->addGutenbergBlock( $I, 'Buttons', 'buttons' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
+		// Add link to button.
+		$I->addGutenbergLinkToButton( $I, $_ENV['CONVERTKIT_API_PRODUCT_NAME'] );
 
-        // Confirm that the link displays, links to the expected URL and the ConvertKit Product Modal works.
-        $I->seeProductLink($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
-    }
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
 
-    /**
-     * Test that linking text in a paragraph to a ConvertKit Product works
-     * in the Classic Editor.
-     * 
-     * @since 2.0.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testLinkParagraphTextToProductInClassicEditor(AcceptanceTester $I)
-    {
-        // Add a Page using the Classic editor.
-        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Product: Classic Editor: Link Text');
+		// Confirm that the link displays, links to the expected URL and the ConvertKit Product Modal works.
+		$I->seeProductLink( $I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], $_ENV['CONVERTKIT_API_PRODUCT_NAME'] );
+	}
 
-        // Add link to Product in Classic Editor.
-        $I->addClassicEditorLink($I, $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
+	/**
+	 * Test that linking text in a paragraph to a ConvertKit Product works
+	 * in the Classic Editor.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testLinkParagraphTextToProductInClassicEditor( AcceptanceTester $I ) {
+		// Add a Page using the Classic editor.
+		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Product: Classic Editor: Link Text' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewClassicEditorPage($I);
+		// Add link to Product in Classic Editor.
+		$I->addClassicEditorLink( $I, $_ENV['CONVERTKIT_API_PRODUCT_NAME'] );
 
-        // Confirm that the link displays, links to the expected URL and the ConvertKit Product Modal works.
-        $I->seeProductLink($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
-    }
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage( $I );
 
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 2.0.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+		// Confirm that the link displays, links to the expected URL and the ConvertKit Product Modal works.
+		$I->seeProductLink( $I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], $_ENV['CONVERTKIT_API_PRODUCT_NAME'] );
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/products/PageLinkProductCest.php
+++ b/tests/acceptance/products/PageLinkProductCest.php
@@ -3,119 +3,123 @@
  * Tests that the Gutenberg LinkControl and Classic Editor Link button correctly
  * link to ConvertKit Products when selected.
  * 
- * @since 	2.0.0
+ * @since 2.0.0
  */
 class PageLinkProductCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	2.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
-	}
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 2.0.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        $I->activateConvertKitPlugin($I);
+        $I->setupConvertKitPlugin($I);
+        $I->enableDebugLog($I);
+    }
 
-	/**
-	 * Test that linking text in a paragraph to a ConvertKit Product works.
-	 * 
-	 * @since 	2.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testLinkParagraphTextToProduct(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Link Text');
+    /**
+     * Test that linking text in a paragraph to a ConvertKit Product works.
+     * 
+     * @since 2.0.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testLinkParagraphTextToProduct(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Link Text');
 
-		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'None' ],
-		]);
+        // Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'form' => [ 'select2', 'None' ],
+            ]
+        );
 
-		// Add paragraph to Page.
-		$I->addGutenbergParagraphBlock($I, 'This is some text. ');
+        // Add paragraph to Page.
+        $I->addGutenbergParagraphBlock($I, 'This is some text. ');
 
-		// Add link to end of paragraph.
-		$I->addGutenbergLinkToParagraph($I, $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
+        // Add link to end of paragraph.
+        $I->addGutenbergLinkToParagraph($I, $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Confirm that the link displays, links to the expected URL and the ConvertKit Product Modal works.
-		$I->seeProductLink($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
-	}
+        // Confirm that the link displays, links to the expected URL and the ConvertKit Product Modal works.
+        $I->seeProductLink($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
+    }
 
-	/**
-	 * Test that linking text in a button to a ConvertKit Product works.
-	 * 
-	 * @since 	2.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testLinkButtonTextToProduct(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Button Link');
+    /**
+     * Test that linking text in a button to a ConvertKit Product works.
+     * 
+     * @since 2.0.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testLinkButtonTextToProduct(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Button Link');
 
-		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'form' => [ 'select2', 'None' ],
-		]);
+        // Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'form' => [ 'select2', 'None' ],
+            ]
+        );
 
-		// Add button to Page.
-		$I->addGutenbergBlock($I, 'Buttons', 'buttons');
+        // Add button to Page.
+        $I->addGutenbergBlock($I, 'Buttons', 'buttons');
 
-		// Add link to button.
-		$I->addGutenbergLinkToButton($I, $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
+        // Add link to button.
+        $I->addGutenbergLinkToButton($I, $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Confirm that the link displays, links to the expected URL and the ConvertKit Product Modal works.
-		$I->seeProductLink($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
-	}
+        // Confirm that the link displays, links to the expected URL and the ConvertKit Product Modal works.
+        $I->seeProductLink($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
+    }
 
-	/**
-	 * Test that linking text in a paragraph to a ConvertKit Product works
-	 * in the Classic Editor.
-	 * 
-	 * @since 	2.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testLinkParagraphTextToProductInClassicEditor(AcceptanceTester $I)
-	{
-		// Add a Page using the Classic editor.
-		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Product: Classic Editor: Link Text');
+    /**
+     * Test that linking text in a paragraph to a ConvertKit Product works
+     * in the Classic Editor.
+     * 
+     * @since 2.0.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testLinkParagraphTextToProductInClassicEditor(AcceptanceTester $I)
+    {
+        // Add a Page using the Classic editor.
+        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Product: Classic Editor: Link Text');
 
-		// Add link to Product in Classic Editor.
-		$I->addClassicEditorLink($I, $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
+        // Add link to Product in Classic Editor.
+        $I->addClassicEditorLink($I, $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewClassicEditorPage($I);
 
-		// Confirm that the link displays, links to the expected URL and the ConvertKit Product Modal works.
-		$I->seeProductLink($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
-	}
+        // Confirm that the link displays, links to the expected URL and the ConvertKit Product Modal works.
+        $I->seeProductLink($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
+    }
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	2.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 2.0.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/products/PageShortcodeProductCest.php
+++ b/tests/acceptance/products/PageShortcodeProductCest.php
@@ -1,158 +1,160 @@
 <?php
 /**
  * Tests for the ConvertKit Product shortcode.
- *
- * @since 1.9.8.5
+ * 
+ * @since 	1.9.8.5
  */
-class PageShortcodeProductCest {
-
+class PageShortcodeFormCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.8.5
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
-		$I->activateConvertKitPlugin( $I );
-		$I->setupConvertKitPlugin( $I );
-		$I->enableDebugLog( $I );
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
 	}
 
 	/**
 	 * Test the [convertkit_product] shortcode works when a valid Product ID is specified,
 	 * using the Classic Editor (TinyMCE / Visual).
-	 *
-	 * @since 1.9.7.5
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testProductShortcodeInVisualEditorWithValidProductParameter( AcceptanceTester $I ) {
+	public function testProductShortcodeInVisualEditorWithValidProductParameter(AcceptanceTester $I)
+	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Product: Shortcode: Visual Editor' );
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Product: Shortcode: Visual Editor');
 
 		// Add shortcode to Page, setting the Product setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
 			'ConvertKit Product',
 			'convertkit-product',
-			array(
-				'product' => array( 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ),
-			),
-			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product"]'
+			[
+				'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ]
+			],
+			'[convertkit_product product="'.$_ENV['CONVERTKIT_API_PRODUCT_ID'].'" text="Buy my product"]'
 		);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage( $I );
+		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the ConvertKit Product is displayed.
-		$I->seeProductOutput( $I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product' );
+		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
 	}
 
 	/**
 	 * Test the [convertkit_product] shortcode works when a valid Product ID is specified,
 	 * using the Text Editor.
-	 *
-	 * @since 1.9.7.5
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testProductShortcodeInTextEditorWithValidProductParameter( AcceptanceTester $I ) {
+	public function testProductShortcodeInTextEditorWithValidProductParameter(AcceptanceTester $I)
+	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Product: Shortcode: Text Editor' );
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Product: Shortcode: Text Editor');
 
 		// Add shortcode to Page, setting the Product setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
 			'ConvertKit Product',
 			'convertkit-product',
-			array(
-				'product' => array( 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ),
-			),
-			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product"]'
+			[
+				'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ]
+			],
+			'[convertkit_product product="'.$_ENV['CONVERTKIT_API_PRODUCT_ID'].'" text="Buy my product"]'
 		);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage( $I );
+		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the ConvertKit Product is displayed.
-		$I->seeProductOutput( $I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product' );
+		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
 	}
 
 	/**
 	 * Test the [convertkit_product] shortcode does not output errors when an invalid Product ID is specified.
-	 *
-	 * @since 1.9.8.5
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testProductShortcodeWithInvalidProductParameter( AcceptanceTester $I ) {
+	public function testProductShortcodeWithInvalidProductParameter(AcceptanceTester $I)
+	{
 		// Create Page with Shortcode.
-		$I->havePageInDatabase(
-			array(
-				'post_name'    => 'convertkit-product-shortcode-invalid-product-param',
-				'post_content' => '[convertkit_product=1]',
-			)
-		);
+		$I->havePageInDatabase([
+			'post_name' 	=> 'convertkit-product-shortcode-invalid-product-param',
+			'post_content' 	=> '[convertkit_product=1]',
+		]);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage( '/convertkit-product-shortcode-invalid-product-param' );
+		$I->amOnPage('/convertkit-product-shortcode-invalid-product-param');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that no ConvertKit Product button is displayed.
-		$I->dontSeeProductOutput( $I );
+		$I->dontSeeProductOutput($I);
 	}
 
 	/**
 	 * Test the [convertkit_product] shortcode hex colors works when defined.
-	 *
-	 * @since 1.9.8.5
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testProductShortcodeWithHexColorParameters( AcceptanceTester $I ) {
+	public function testProductShortcodeWithHexColorParameters(AcceptanceTester $I)
+	{
 		// Define colors.
 		$backgroundColor = '#ee1616';
-		$textColor       = '#1212c0';
+		$textColor = '#1212c0';
 
 		// It's tricky to interact with WordPress's color picker, so we programmatically create the Page
 		// instead to then confirm the color settings apply on the output.
 		// We don't need to test the color picker itself, as it's a WordPress supplied component, and our
 		// other Acceptance tests confirm that the shortcode can be added in the Classic Editor.
-		$I->havePageInDatabase(
-			array(
-				'post_name'    => 'convertkit-page-product-shortcode-hex-color-params',
-				'post_content' => '[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" background_color="' . $backgroundColor . '" text_color="' . $textColor . '"]',
-			)
-		);
+		$I->havePageInDatabase([
+			'post_name' 	=> 'convertkit-page-product-shortcode-hex-color-params',
+			'post_content' 	=> '[convertkit_product product="'.$_ENV['CONVERTKIT_API_PRODUCT_ID'].'" text="Buy my product" background_color="'.$backgroundColor.'" text_color="'.$textColor.'"]'
+		]);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage( '/convertkit-page-product-shortcode-hex-color-params' );
+		$I->amOnPage('/convertkit-page-product-shortcode-hex-color-params');
 
 		// Wait for frontend web site to load.
-		$I->waitForElementVisible( 'body.page-template-default' );
+		$I->waitForElementVisible('body.page-template-default');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the ConvertKit Product is displayed.
-		$I->seeProductOutput( $I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product', $textColor, $backgroundColor );
+		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product', $textColor, $backgroundColor);
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.8.5.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.5.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateThirdPartyPlugin( $I, 'classic-editor' );
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateThirdPartyPlugin($I, 'classic-editor');
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/products/PageShortcodeProductCest.php
+++ b/tests/acceptance/products/PageShortcodeProductCest.php
@@ -2,159 +2,163 @@
 /**
  * Tests for the ConvertKit Product shortcode.
  * 
- * @since 	1.9.8.5
+ * @since 1.9.8.5
  */
 class PageShortcodeFormCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
-	}
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.8.5
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        $I->activateConvertKitPlugin($I);
+        $I->setupConvertKitPlugin($I);
+        $I->enableDebugLog($I);
+    }
 
-	/**
-	 * Test the [convertkit_product] shortcode works when a valid Product ID is specified,
-	 * using the Classic Editor (TinyMCE / Visual).
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testProductShortcodeInVisualEditorWithValidProductParameter(AcceptanceTester $I)
-	{
-		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Product: Shortcode: Visual Editor');
+    /**
+     * Test the [convertkit_product] shortcode works when a valid Product ID is specified,
+     * using the Classic Editor (TinyMCE / Visual).
+     * 
+     * @since 1.9.7.5
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testProductShortcodeInVisualEditorWithValidProductParameter(AcceptanceTester $I)
+    {
+        // Add a Page using the Classic Editor.
+        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Product: Shortcode: Visual Editor');
 
-		// Add shortcode to Page, setting the Product setting to the value specified in the .env file.
-		$I->addVisualEditorShortcode(
-			$I,
-			'ConvertKit Product',
-			'convertkit-product',
-			[
-				'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ]
-			],
-			'[convertkit_product product="'.$_ENV['CONVERTKIT_API_PRODUCT_ID'].'" text="Buy my product"]'
-		);
+        // Add shortcode to Page, setting the Product setting to the value specified in the .env file.
+        $I->addVisualEditorShortcode(
+            $I,
+            'ConvertKit Product',
+            'convertkit-product',
+            [
+            'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ]
+            ],
+            '[convertkit_product product="'.$_ENV['CONVERTKIT_API_PRODUCT_ID'].'" text="Buy my product"]'
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewClassicEditorPage($I);
 
-		// Confirm that the ConvertKit Product is displayed.
-		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
-	}
+        // Confirm that the ConvertKit Product is displayed.
+        $I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
+    }
 
-	/**
-	 * Test the [convertkit_product] shortcode works when a valid Product ID is specified,
-	 * using the Text Editor.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testProductShortcodeInTextEditorWithValidProductParameter(AcceptanceTester $I)
-	{
-		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Product: Shortcode: Text Editor');
+    /**
+     * Test the [convertkit_product] shortcode works when a valid Product ID is specified,
+     * using the Text Editor.
+     * 
+     * @since 1.9.7.5
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testProductShortcodeInTextEditorWithValidProductParameter(AcceptanceTester $I)
+    {
+        // Add a Page using the Classic Editor.
+        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Product: Shortcode: Text Editor');
 
-		// Add shortcode to Page, setting the Product setting to the value specified in the .env file.
-		$I->addTextEditorShortcode(
-			$I,
-			'ConvertKit Product',
-			'convertkit-product',
-			[
-				'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ]
-			],
-			'[convertkit_product product="'.$_ENV['CONVERTKIT_API_PRODUCT_ID'].'" text="Buy my product"]'
-		);
+        // Add shortcode to Page, setting the Product setting to the value specified in the .env file.
+        $I->addTextEditorShortcode(
+            $I,
+            'ConvertKit Product',
+            'convertkit-product',
+            [
+            'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ]
+            ],
+            '[convertkit_product product="'.$_ENV['CONVERTKIT_API_PRODUCT_ID'].'" text="Buy my product"]'
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewClassicEditorPage($I);
 
-		// Confirm that the ConvertKit Product is displayed.
-		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
-	}
+        // Confirm that the ConvertKit Product is displayed.
+        $I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
+    }
 
-	/**
-	 * Test the [convertkit_product] shortcode does not output errors when an invalid Product ID is specified.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testProductShortcodeWithInvalidProductParameter(AcceptanceTester $I)
-	{
-		// Create Page with Shortcode.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-product-shortcode-invalid-product-param',
-			'post_content' 	=> '[convertkit_product=1]',
-		]);
+    /**
+     * Test the [convertkit_product] shortcode does not output errors when an invalid Product ID is specified.
+     * 
+     * @since 1.9.8.5
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testProductShortcodeWithInvalidProductParameter(AcceptanceTester $I)
+    {
+        // Create Page with Shortcode.
+        $I->havePageInDatabase(
+            [
+            'post_name'     => 'convertkit-product-shortcode-invalid-product-param',
+            'post_content'     => '[convertkit_product=1]',
+            ]
+        );
 
-		// Load the Page on the frontend site.
-		$I->amOnPage('/convertkit-product-shortcode-invalid-product-param');
+        // Load the Page on the frontend site.
+        $I->amOnPage('/convertkit-product-shortcode-invalid-product-param');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that no ConvertKit Product button is displayed.
-		$I->dontSeeProductOutput($I);
-	}
+        // Confirm that no ConvertKit Product button is displayed.
+        $I->dontSeeProductOutput($I);
+    }
 
-	/**
-	 * Test the [convertkit_product] shortcode hex colors works when defined.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testProductShortcodeWithHexColorParameters(AcceptanceTester $I)
-	{
-		// Define colors.
-		$backgroundColor = '#ee1616';
-		$textColor = '#1212c0';
+    /**
+     * Test the [convertkit_product] shortcode hex colors works when defined.
+     * 
+     * @since 1.9.8.5
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testProductShortcodeWithHexColorParameters(AcceptanceTester $I)
+    {
+        // Define colors.
+        $backgroundColor = '#ee1616';
+        $textColor = '#1212c0';
 
-		// It's tricky to interact with WordPress's color picker, so we programmatically create the Page
-		// instead to then confirm the color settings apply on the output.
-		// We don't need to test the color picker itself, as it's a WordPress supplied component, and our
-		// other Acceptance tests confirm that the shortcode can be added in the Classic Editor.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-page-product-shortcode-hex-color-params',
-			'post_content' 	=> '[convertkit_product product="'.$_ENV['CONVERTKIT_API_PRODUCT_ID'].'" text="Buy my product" background_color="'.$backgroundColor.'" text_color="'.$textColor.'"]'
-		]);
+        // It's tricky to interact with WordPress's color picker, so we programmatically create the Page
+        // instead to then confirm the color settings apply on the output.
+        // We don't need to test the color picker itself, as it's a WordPress supplied component, and our
+        // other Acceptance tests confirm that the shortcode can be added in the Classic Editor.
+        $I->havePageInDatabase(
+            [
+            'post_name'     => 'convertkit-page-product-shortcode-hex-color-params',
+            'post_content'     => '[convertkit_product product="'.$_ENV['CONVERTKIT_API_PRODUCT_ID'].'" text="Buy my product" background_color="'.$backgroundColor.'" text_color="'.$textColor.'"]'
+            ]
+        );
 
-		// Load the Page on the frontend site.
-		$I->amOnPage('/convertkit-page-product-shortcode-hex-color-params');
+        // Load the Page on the frontend site.
+        $I->amOnPage('/convertkit-page-product-shortcode-hex-color-params');
 
-		// Wait for frontend web site to load.
-		$I->waitForElementVisible('body.page-template-default');
+        // Wait for frontend web site to load.
+        $I->waitForElementVisible('body.page-template-default');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the ConvertKit Product is displayed.
-		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product', $textColor, $backgroundColor);
-	}
+        // Confirm that the ConvertKit Product is displayed.
+        $I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product', $textColor, $backgroundColor);
+    }
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.8.5.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateThirdPartyPlugin($I, 'classic-editor');
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.8.5.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateThirdPartyPlugin($I, 'classic-editor');
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/products/PageShortcodeProductCest.php
+++ b/tests/acceptance/products/PageShortcodeProductCest.php
@@ -37,7 +37,6 @@ class PageShortcodeProductCest
 		$I->addVisualEditorShortcode(
 			$I,
 			'ConvertKit Product',
-			'convertkit-product',
 			[
 				'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			],
@@ -67,7 +66,6 @@ class PageShortcodeProductCest
 		// Add shortcode to Page, setting the Product setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
-			'ConvertKit Product',
 			'convertkit-product',
 			[
 				'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],

--- a/tests/acceptance/products/PageShortcodeProductCest.php
+++ b/tests/acceptance/products/PageShortcodeProductCest.php
@@ -1,164 +1,158 @@
 <?php
 /**
  * Tests for the ConvertKit Product shortcode.
- * 
+ *
  * @since 1.9.8.5
  */
-class PageShortcodeFormCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.8.5
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        $I->activateConvertKitPlugin($I);
-        $I->setupConvertKitPlugin($I);
-        $I->enableDebugLog($I);
-    }
+class PageShortcodeProductCest {
 
-    /**
-     * Test the [convertkit_product] shortcode works when a valid Product ID is specified,
-     * using the Classic Editor (TinyMCE / Visual).
-     * 
-     * @since 1.9.7.5
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testProductShortcodeInVisualEditorWithValidProductParameter(AcceptanceTester $I)
-    {
-        // Add a Page using the Classic Editor.
-        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Product: Shortcode: Visual Editor');
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.8.5
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		$I->activateConvertKitPlugin( $I );
+		$I->setupConvertKitPlugin( $I );
+		$I->enableDebugLog( $I );
+	}
 
-        // Add shortcode to Page, setting the Product setting to the value specified in the .env file.
-        $I->addVisualEditorShortcode(
-            $I,
-            'ConvertKit Product',
-            'convertkit-product',
-            [
-            'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ]
-            ],
-            '[convertkit_product product="'.$_ENV['CONVERTKIT_API_PRODUCT_ID'].'" text="Buy my product"]'
-        );
+	/**
+	 * Test the [convertkit_product] shortcode works when a valid Product ID is specified,
+	 * using the Classic Editor (TinyMCE / Visual).
+	 *
+	 * @since 1.9.7.5
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testProductShortcodeInVisualEditorWithValidProductParameter( AcceptanceTester $I ) {
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Product: Shortcode: Visual Editor' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewClassicEditorPage($I);
+		// Add shortcode to Page, setting the Product setting to the value specified in the .env file.
+		$I->addVisualEditorShortcode(
+			$I,
+			'ConvertKit Product',
+			'convertkit-product',
+			array(
+				'product' => array( 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ),
+			),
+			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product"]'
+		);
 
-        // Confirm that the ConvertKit Product is displayed.
-        $I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
-    }
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage( $I );
 
-    /**
-     * Test the [convertkit_product] shortcode works when a valid Product ID is specified,
-     * using the Text Editor.
-     * 
-     * @since 1.9.7.5
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testProductShortcodeInTextEditorWithValidProductParameter(AcceptanceTester $I)
-    {
-        // Add a Page using the Classic Editor.
-        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Product: Shortcode: Text Editor');
+		// Confirm that the ConvertKit Product is displayed.
+		$I->seeProductOutput( $I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product' );
+	}
 
-        // Add shortcode to Page, setting the Product setting to the value specified in the .env file.
-        $I->addTextEditorShortcode(
-            $I,
-            'ConvertKit Product',
-            'convertkit-product',
-            [
-            'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ]
-            ],
-            '[convertkit_product product="'.$_ENV['CONVERTKIT_API_PRODUCT_ID'].'" text="Buy my product"]'
-        );
+	/**
+	 * Test the [convertkit_product] shortcode works when a valid Product ID is specified,
+	 * using the Text Editor.
+	 *
+	 * @since 1.9.7.5
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testProductShortcodeInTextEditorWithValidProductParameter( AcceptanceTester $I ) {
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Product: Shortcode: Text Editor' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewClassicEditorPage($I);
+		// Add shortcode to Page, setting the Product setting to the value specified in the .env file.
+		$I->addTextEditorShortcode(
+			$I,
+			'ConvertKit Product',
+			'convertkit-product',
+			array(
+				'product' => array( 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ),
+			),
+			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product"]'
+		);
 
-        // Confirm that the ConvertKit Product is displayed.
-        $I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
-    }
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage( $I );
 
-    /**
-     * Test the [convertkit_product] shortcode does not output errors when an invalid Product ID is specified.
-     * 
-     * @since 1.9.8.5
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testProductShortcodeWithInvalidProductParameter(AcceptanceTester $I)
-    {
-        // Create Page with Shortcode.
-        $I->havePageInDatabase(
-            [
-            'post_name'     => 'convertkit-product-shortcode-invalid-product-param',
-            'post_content'     => '[convertkit_product=1]',
-            ]
-        );
+		// Confirm that the ConvertKit Product is displayed.
+		$I->seeProductOutput( $I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product' );
+	}
 
-        // Load the Page on the frontend site.
-        $I->amOnPage('/convertkit-product-shortcode-invalid-product-param');
+	/**
+	 * Test the [convertkit_product] shortcode does not output errors when an invalid Product ID is specified.
+	 *
+	 * @since 1.9.8.5
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testProductShortcodeWithInvalidProductParameter( AcceptanceTester $I ) {
+		// Create Page with Shortcode.
+		$I->havePageInDatabase(
+			array(
+				'post_name'    => 'convertkit-product-shortcode-invalid-product-param',
+				'post_content' => '[convertkit_product=1]',
+			)
+		);
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Load the Page on the frontend site.
+		$I->amOnPage( '/convertkit-product-shortcode-invalid-product-param' );
 
-        // Confirm that no ConvertKit Product button is displayed.
-        $I->dontSeeProductOutput($I);
-    }
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-    /**
-     * Test the [convertkit_product] shortcode hex colors works when defined.
-     * 
-     * @since 1.9.8.5
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testProductShortcodeWithHexColorParameters(AcceptanceTester $I)
-    {
-        // Define colors.
-        $backgroundColor = '#ee1616';
-        $textColor = '#1212c0';
+		// Confirm that no ConvertKit Product button is displayed.
+		$I->dontSeeProductOutput( $I );
+	}
 
-        // It's tricky to interact with WordPress's color picker, so we programmatically create the Page
-        // instead to then confirm the color settings apply on the output.
-        // We don't need to test the color picker itself, as it's a WordPress supplied component, and our
-        // other Acceptance tests confirm that the shortcode can be added in the Classic Editor.
-        $I->havePageInDatabase(
-            [
-            'post_name'     => 'convertkit-page-product-shortcode-hex-color-params',
-            'post_content'     => '[convertkit_product product="'.$_ENV['CONVERTKIT_API_PRODUCT_ID'].'" text="Buy my product" background_color="'.$backgroundColor.'" text_color="'.$textColor.'"]'
-            ]
-        );
+	/**
+	 * Test the [convertkit_product] shortcode hex colors works when defined.
+	 *
+	 * @since 1.9.8.5
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testProductShortcodeWithHexColorParameters( AcceptanceTester $I ) {
+		// Define colors.
+		$backgroundColor = '#ee1616';
+		$textColor       = '#1212c0';
 
-        // Load the Page on the frontend site.
-        $I->amOnPage('/convertkit-page-product-shortcode-hex-color-params');
+		// It's tricky to interact with WordPress's color picker, so we programmatically create the Page
+		// instead to then confirm the color settings apply on the output.
+		// We don't need to test the color picker itself, as it's a WordPress supplied component, and our
+		// other Acceptance tests confirm that the shortcode can be added in the Classic Editor.
+		$I->havePageInDatabase(
+			array(
+				'post_name'    => 'convertkit-page-product-shortcode-hex-color-params',
+				'post_content' => '[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" background_color="' . $backgroundColor . '" text_color="' . $textColor . '"]',
+			)
+		);
 
-        // Wait for frontend web site to load.
-        $I->waitForElementVisible('body.page-template-default');
+		// Load the Page on the frontend site.
+		$I->amOnPage( '/convertkit-page-product-shortcode-hex-color-params' );
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible( 'body.page-template-default' );
 
-        // Confirm that the ConvertKit Product is displayed.
-        $I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product', $textColor, $backgroundColor);
-    }
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.8.5.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateThirdPartyPlugin($I, 'classic-editor');
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+		// Confirm that the ConvertKit Product is displayed.
+		$I->seeProductOutput( $I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product', $textColor, $backgroundColor );
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.8.5.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateThirdPartyPlugin( $I, 'classic-editor' );
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/products/PageShortcodeProductCest.php
+++ b/tests/acceptance/products/PageShortcodeProductCest.php
@@ -1,17 +1,17 @@
 <?php
 /**
  * Tests for the ConvertKit Product shortcode.
- * 
- * @since 	1.9.8.5
+ *
+ * @since   1.9.8.5
  */
-class PageShortcodeFormCest
+class PageShortcodeProductCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -23,10 +23,10 @@ class PageShortcodeFormCest
 	/**
 	 * Test the [convertkit_product] shortcode works when a valid Product ID is specified,
 	 * using the Classic Editor (TinyMCE / Visual).
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testProductShortcodeInVisualEditorWithValidProductParameter(AcceptanceTester $I)
 	{
@@ -39,9 +39,9 @@ class PageShortcodeFormCest
 			'ConvertKit Product',
 			'convertkit-product',
 			[
-				'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ]
+				'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			],
-			'[convertkit_product product="'.$_ENV['CONVERTKIT_API_PRODUCT_ID'].'" text="Buy my product"]'
+			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -54,10 +54,10 @@ class PageShortcodeFormCest
 	/**
 	 * Test the [convertkit_product] shortcode works when a valid Product ID is specified,
 	 * using the Text Editor.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testProductShortcodeInTextEditorWithValidProductParameter(AcceptanceTester $I)
 	{
@@ -70,9 +70,9 @@ class PageShortcodeFormCest
 			'ConvertKit Product',
 			'convertkit-product',
 			[
-				'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ]
+				'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			],
-			'[convertkit_product product="'.$_ENV['CONVERTKIT_API_PRODUCT_ID'].'" text="Buy my product"]'
+			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -84,18 +84,20 @@ class PageShortcodeFormCest
 
 	/**
 	 * Test the [convertkit_product] shortcode does not output errors when an invalid Product ID is specified.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testProductShortcodeWithInvalidProductParameter(AcceptanceTester $I)
 	{
 		// Create Page with Shortcode.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-product-shortcode-invalid-product-param',
-			'post_content' 	=> '[convertkit_product=1]',
-		]);
+		$I->havePageInDatabase(
+			[
+				'post_name'    => 'convertkit-product-shortcode-invalid-product-param',
+				'post_content' => '[convertkit_product=1]',
+			]
+		);
 
 		// Load the Page on the frontend site.
 		$I->amOnPage('/convertkit-product-shortcode-invalid-product-param');
@@ -109,25 +111,27 @@ class PageShortcodeFormCest
 
 	/**
 	 * Test the [convertkit_product] shortcode hex colors works when defined.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testProductShortcodeWithHexColorParameters(AcceptanceTester $I)
 	{
 		// Define colors.
 		$backgroundColor = '#ee1616';
-		$textColor = '#1212c0';
+		$textColor       = '#1212c0';
 
 		// It's tricky to interact with WordPress's color picker, so we programmatically create the Page
 		// instead to then confirm the color settings apply on the output.
 		// We don't need to test the color picker itself, as it's a WordPress supplied component, and our
 		// other Acceptance tests confirm that the shortcode can be added in the Classic Editor.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-page-product-shortcode-hex-color-params',
-			'post_content' 	=> '[convertkit_product product="'.$_ENV['CONVERTKIT_API_PRODUCT_ID'].'" text="Buy my product" background_color="'.$backgroundColor.'" text_color="'.$textColor.'"]'
-		]);
+		$I->havePageInDatabase(
+			[
+				'post_name'    => 'convertkit-page-product-shortcode-hex-color-params',
+				'post_content' => '[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" background_color="' . $backgroundColor . '" text_color="' . $textColor . '"]',
+			]
+		);
 
 		// Load the Page on the frontend site.
 		$I->amOnPage('/convertkit-page-product-shortcode-hex-color-params');
@@ -146,10 +150,10 @@ class PageShortcodeFormCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.8.5.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.5.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/tags/PageShortcodeCustomContentCest.php
+++ b/tests/acceptance/tags/PageShortcodeCustomContentCest.php
@@ -1,172 +1,166 @@
 <?php
 /**
  * Tests for the ConvertKit Custom Content shortcode.
- * 
+ *
  * @since 1.9.6
  */
-class PageShortcodeCustomContentCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        $I->activateConvertKitPlugin($I);
-        $I->setupConvertKitPlugin($I);
-        $I->enableDebugLog($I);
-    }
+class PageShortcodeCustomContentCest {
 
-    /**
-     * Test the [convertkit_content] shortcode works using the Classic Editor (TinyMCE / Visual).
-     * 
-     * @since 1.9.7.5
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testCustomContentShortcodeInVisualEditor(AcceptanceTester $I)
-    {
-        // Add a Page using the Classic Editor.
-        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Custom Content: Shortcode: Visual Editor');
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		$I->activateConvertKitPlugin( $I );
+		$I->setupConvertKitPlugin( $I );
+		$I->enableDebugLog( $I );
+	}
 
-        // Add shortcode to Page, setting the Tag setting to the value specified in the .env file.
-        $I->addVisualEditorShortcode(
-            $I,
-            'ConvertKit Custom Content',
-            'convertkit-content',
-            [
-            'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ]
-            ],
-            '[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"][/convertkit_content]'
-        );
+	/**
+	 * Test the [convertkit_content] shortcode works using the Classic Editor (TinyMCE / Visual).
+	 *
+	 * @since 1.9.7.5
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testCustomContentShortcodeInVisualEditor( AcceptanceTester $I ) {
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Custom Content: Shortcode: Visual Editor' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewClassicEditorPage($I);
-    }
+		// Add shortcode to Page, setting the Tag setting to the value specified in the .env file.
+		$I->addVisualEditorShortcode(
+			$I,
+			'ConvertKit Custom Content',
+			'convertkit-content',
+			array(
+				'tag' => array( 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ),
+			),
+			'[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"][/convertkit_content]'
+		);
 
-    /**
-     * Test the [convertkit_content] shortcode works using the Text Editor.
-     * 
-     * @since 1.9.7.5
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testCustomContentShortcodeInTextEditor(AcceptanceTester $I)
-    {
-        // Add a Page using the Classic Editor.
-        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Custom Content: Shortcode: Text Editor');
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage( $I );
+	}
 
-        // Add shortcode to Page, setting the Tag setting to the value specified in the .env file.
-        $I->addTextEditorShortcode(
-            $I,
-            'ConvertKit Custom Content',
-            'convertkit-content',
-            [
-            'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ]
-            ],
-            '[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"][/convertkit_content]'
-        );
+	/**
+	 * Test the [convertkit_content] shortcode works using the Text Editor.
+	 *
+	 * @since 1.9.7.5
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testCustomContentShortcodeInTextEditor( AcceptanceTester $I ) {
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Custom Content: Shortcode: Text Editor' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewClassicEditorPage($I);
-    }
+		// Add shortcode to Page, setting the Tag setting to the value specified in the .env file.
+		$I->addTextEditorShortcode(
+			$I,
+			'ConvertKit Custom Content',
+			'convertkit-content',
+			array(
+				'tag' => array( 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ),
+			),
+			'[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"][/convertkit_content]'
+		);
 
-    /**
-     * Test the [convertkit_content] shortcode works when a valid Tag ID is specified,
-     * and an invalid Subscriber ID is used.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testCustomContentShortcodeWithValidTagParameterAndInvalidSubscriberID(AcceptanceTester $I)
-    {
-        // Create Page with Shortcode.
-        $I->havePageInDatabase(
-            [
-            'post_name'     => 'convertkit-custom-content-shortcode-valid-tag-param-and-invalid-subscriber-id',
-            'post_content'    => '[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]ConvertKitCustomContent[/convertkit_content]',
-            ]
-        );
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage( $I );
+	}
 
-        // Prevent API rate limit from being hit in parallel tests.
-        $I->wait(2);
+	/**
+	 * Test the [convertkit_content] shortcode works when a valid Tag ID is specified,
+	 * and an invalid Subscriber ID is used.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testCustomContentShortcodeWithValidTagParameterAndInvalidSubscriberID( AcceptanceTester $I ) {
+		// Create Page with Shortcode.
+		$I->havePageInDatabase(
+			array(
+				'post_name'    => 'convertkit-custom-content-shortcode-valid-tag-param-and-invalid-subscriber-id',
+				'post_content' => '[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]ConvertKitCustomContent[/convertkit_content]',
+			)
+		);
 
-        // Load the Page on the frontend site.
-        $I->amOnPage('/convertkit-custom-content-shortcode-valid-tag-param-and-invalid-subscriber-id');
+		// Prevent API rate limit from being hit in parallel tests.
+		$I->wait( 2 );
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Load the Page on the frontend site.
+		$I->amOnPage( '/convertkit-custom-content-shortcode-valid-tag-param-and-invalid-subscriber-id' );
 
-        // Confirm that the Custom Content is not yet displayed.
-        $I->dontSeeInSource('ConvertKitCustomContent');
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-        // Reload the page, this time with an invalid subscriber ID .
-        $I->amOnPage('/convertkit-custom-content-shortcode-valid-tag-param-and-invalid-subscriber-id?ck_subscriber_id=1');
+		// Confirm that the Custom Content is not yet displayed.
+		$I->dontSeeInSource( 'ConvertKitCustomContent' );
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Reload the page, this time with an invalid subscriber ID .
+		$I->amOnPage( '/convertkit-custom-content-shortcode-valid-tag-param-and-invalid-subscriber-id?ck_subscriber_id=1' );
 
-        // Confirm that the Custom Content is not yet displayed.
-        $I->dontSeeInSource('ConvertKitCustomContent');
-    }
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-    /**
-     * Test the [convertkit_content] shortcode works when a valid Tag ID is specified,
-     * and a valid Subscriber ID is used who is subscribed to the tag.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testCustomContentShortcodeWithValidTagParameterAndValidSubscriberID(AcceptanceTester $I)
-    {
-        // Create Page with Shortcode.
-        $I->havePageInDatabase(
-            [
-            'post_name'     => 'convertkit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id',
-            'post_content'    => '[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]ConvertKitCustomContent[/convertkit_content]',
-            ]
-        );
+		// Confirm that the Custom Content is not yet displayed.
+		$I->dontSeeInSource( 'ConvertKitCustomContent' );
+	}
 
-        // Prevent API rate limit from being hit in parallel tests.
-        $I->wait(2);
+	/**
+	 * Test the [convertkit_content] shortcode works when a valid Tag ID is specified,
+	 * and a valid Subscriber ID is used who is subscribed to the tag.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testCustomContentShortcodeWithValidTagParameterAndValidSubscriberID( AcceptanceTester $I ) {
+		// Create Page with Shortcode.
+		$I->havePageInDatabase(
+			array(
+				'post_name'    => 'convertkit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id',
+				'post_content' => '[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]ConvertKitCustomContent[/convertkit_content]',
+			)
+		);
 
-        // Load the Page on the frontend site.
-        $I->amOnPage('/convertkit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id');
+		// Prevent API rate limit from being hit in parallel tests.
+		$I->wait( 2 );
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Load the Page on the frontend site.
+		$I->amOnPage( '/convertkit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id' );
 
-        // Confirm that the Custom Content is not yet displayed.
-        $I->dontSeeInSource('ConvertKitCustomContent');
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-        // Reload the page, this time with a subscriber ID who is already subscribed to the tag.
-        $I->amOnPage('/convertkit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id?ck_subscriber_id=' . $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']);
+		// Confirm that the Custom Content is not yet displayed.
+		$I->dontSeeInSource( 'ConvertKitCustomContent' );
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
+		// Reload the page, this time with a subscriber ID who is already subscribed to the tag.
+		$I->amOnPage( '/convertkit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id?ck_subscriber_id=' . $_ENV['CONVERTKIT_API_SUBSCRIBER_ID'] );
 
-        // Confirm that the Custom Content is now displayed.
-        $I->seeInSource('ConvertKitCustomContent');
-    }
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateThirdPartyPlugin($I, 'classic-editor');
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+		// Confirm that the Custom Content is now displayed.
+		$I->seeInSource( 'ConvertKitCustomContent' );
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateThirdPartyPlugin( $I, 'classic-editor' );
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/tags/PageShortcodeCustomContentCest.php
+++ b/tests/acceptance/tags/PageShortcodeCustomContentCest.php
@@ -2,161 +2,165 @@
 /**
  * Tests for the ConvertKit Custom Content shortcode.
  * 
- * @since 	1.9.6
+ * @since 1.9.6
  */
 class PageShortcodeCustomContentCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
-	}
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        $I->activateConvertKitPlugin($I);
+        $I->setupConvertKitPlugin($I);
+        $I->enableDebugLog($I);
+    }
 
-	/**
-	 * Test the [convertkit_content] shortcode works using the Classic Editor (TinyMCE / Visual).
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testCustomContentShortcodeInVisualEditor(AcceptanceTester $I)
-	{
-		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Custom Content: Shortcode: Visual Editor');
+    /**
+     * Test the [convertkit_content] shortcode works using the Classic Editor (TinyMCE / Visual).
+     * 
+     * @since 1.9.7.5
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testCustomContentShortcodeInVisualEditor(AcceptanceTester $I)
+    {
+        // Add a Page using the Classic Editor.
+        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Custom Content: Shortcode: Visual Editor');
 
-		// Add shortcode to Page, setting the Tag setting to the value specified in the .env file.
-		$I->addVisualEditorShortcode(
-			$I,
-			'ConvertKit Custom Content',
-			'convertkit-content',
-			[
-				'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ]
-			],
-			'[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"][/convertkit_content]'
-		);
+        // Add shortcode to Page, setting the Tag setting to the value specified in the .env file.
+        $I->addVisualEditorShortcode(
+            $I,
+            'ConvertKit Custom Content',
+            'convertkit-content',
+            [
+            'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ]
+            ],
+            '[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"][/convertkit_content]'
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage($I);
-	}
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewClassicEditorPage($I);
+    }
 
-	/**
-	 * Test the [convertkit_content] shortcode works using the Text Editor.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testCustomContentShortcodeInTextEditor(AcceptanceTester $I)
-	{
-		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Custom Content: Shortcode: Text Editor');
+    /**
+     * Test the [convertkit_content] shortcode works using the Text Editor.
+     * 
+     * @since 1.9.7.5
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testCustomContentShortcodeInTextEditor(AcceptanceTester $I)
+    {
+        // Add a Page using the Classic Editor.
+        $I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Custom Content: Shortcode: Text Editor');
 
-		// Add shortcode to Page, setting the Tag setting to the value specified in the .env file.
-		$I->addTextEditorShortcode(
-			$I,
-			'ConvertKit Custom Content',
-			'convertkit-content',
-			[
-				'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ]
-			],
-			'[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"][/convertkit_content]'
-		);
+        // Add shortcode to Page, setting the Tag setting to the value specified in the .env file.
+        $I->addTextEditorShortcode(
+            $I,
+            'ConvertKit Custom Content',
+            'convertkit-content',
+            [
+            'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ]
+            ],
+            '[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"][/convertkit_content]'
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage($I);
-	}
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewClassicEditorPage($I);
+    }
 
-	/**
-	 * Test the [convertkit_content] shortcode works when a valid Tag ID is specified,
-	 * and an invalid Subscriber ID is used.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testCustomContentShortcodeWithValidTagParameterAndInvalidSubscriberID(AcceptanceTester $I)
-	{
-		// Create Page with Shortcode.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-custom-content-shortcode-valid-tag-param-and-invalid-subscriber-id',
-			'post_content'	=> '[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]ConvertKitCustomContent[/convertkit_content]',
-		]);
+    /**
+     * Test the [convertkit_content] shortcode works when a valid Tag ID is specified,
+     * and an invalid Subscriber ID is used.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testCustomContentShortcodeWithValidTagParameterAndInvalidSubscriberID(AcceptanceTester $I)
+    {
+        // Create Page with Shortcode.
+        $I->havePageInDatabase(
+            [
+            'post_name'     => 'convertkit-custom-content-shortcode-valid-tag-param-and-invalid-subscriber-id',
+            'post_content'    => '[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]ConvertKitCustomContent[/convertkit_content]',
+            ]
+        );
 
-		// Load the Page on the frontend site.
-		$I->amOnPage('/convertkit-custom-content-shortcode-valid-tag-param-and-invalid-subscriber-id');
+        // Load the Page on the frontend site.
+        $I->amOnPage('/convertkit-custom-content-shortcode-valid-tag-param-and-invalid-subscriber-id');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the Custom Content is not yet displayed.
-		$I->dontSeeInSource('ConvertKitCustomContent');
+        // Confirm that the Custom Content is not yet displayed.
+        $I->dontSeeInSource('ConvertKitCustomContent');
 
-		// Reload the page, this time with an invalid subscriber ID .
-		$I->amOnPage('/convertkit-custom-content-shortcode-valid-tag-param-and-invalid-subscriber-id?ck_subscriber_id=1');
+        // Reload the page, this time with an invalid subscriber ID .
+        $I->amOnPage('/convertkit-custom-content-shortcode-valid-tag-param-and-invalid-subscriber-id?ck_subscriber_id=1');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the Custom Content is not yet displayed.
-		$I->dontSeeInSource('ConvertKitCustomContent');
-	}
+        // Confirm that the Custom Content is not yet displayed.
+        $I->dontSeeInSource('ConvertKitCustomContent');
+    }
 
-	/**
-	 * Test the [convertkit_content] shortcode works when a valid Tag ID is specified,
-	 * and a valid Subscriber ID is used who is subscribed to the tag.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testCustomContentShortcodeWithValidTagParameterAndValidSubscriberID(AcceptanceTester $I)
-	{
-		// Create Page with Shortcode.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id',
-			'post_content'	=> '[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]ConvertKitCustomContent[/convertkit_content]',
-		]);
+    /**
+     * Test the [convertkit_content] shortcode works when a valid Tag ID is specified,
+     * and a valid Subscriber ID is used who is subscribed to the tag.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testCustomContentShortcodeWithValidTagParameterAndValidSubscriberID(AcceptanceTester $I)
+    {
+        // Create Page with Shortcode.
+        $I->havePageInDatabase(
+            [
+            'post_name'     => 'convertkit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id',
+            'post_content'    => '[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]ConvertKitCustomContent[/convertkit_content]',
+            ]
+        );
 
-		// Load the Page on the frontend site.
-		$I->amOnPage('/convertkit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id');
+        // Load the Page on the frontend site.
+        $I->amOnPage('/convertkit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id');
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the Custom Content is not yet displayed.
-		$I->dontSeeInSource('ConvertKitCustomContent');
+        // Confirm that the Custom Content is not yet displayed.
+        $I->dontSeeInSource('ConvertKitCustomContent');
 
-		// Reload the page, this time with a subscriber ID who is already subscribed to the tag.
-		$I->amOnPage('/convertkit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id?ck_subscriber_id=' . $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']);
+        // Reload the page, this time with a subscriber ID who is already subscribed to the tag.
+        $I->amOnPage('/convertkit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id?ck_subscriber_id=' . $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the Custom Content is now displayed.
-		$I->seeInSource('ConvertKitCustomContent');
-	}
+        // Confirm that the Custom Content is now displayed.
+        $I->seeInSource('ConvertKitCustomContent');
+    }
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateThirdPartyPlugin($I, 'classic-editor');
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateThirdPartyPlugin($I, 'classic-editor');
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/acceptance/tags/PageShortcodeCustomContentCest.php
+++ b/tests/acceptance/tags/PageShortcodeCustomContentCest.php
@@ -36,7 +36,6 @@ class PageShortcodeCustomContentCest
 		$I->addVisualEditorShortcode(
 			$I,
 			'ConvertKit Custom Content',
-			'convertkit-content',
 			[
 				'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
 			],
@@ -62,7 +61,6 @@ class PageShortcodeCustomContentCest
 		// Add shortcode to Page, setting the Tag setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
-			'ConvertKit Custom Content',
 			'convertkit-content',
 			[
 				'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ],

--- a/tests/acceptance/tags/PageShortcodeCustomContentCest.php
+++ b/tests/acceptance/tags/PageShortcodeCustomContentCest.php
@@ -1,17 +1,17 @@
 <?php
 /**
  * Tests for the ConvertKit Custom Content shortcode.
- * 
- * @since 	1.9.6
+ *
+ * @since   1.9.6
  */
 class PageShortcodeCustomContentCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -22,10 +22,10 @@ class PageShortcodeCustomContentCest
 
 	/**
 	 * Test the [convertkit_content] shortcode works using the Classic Editor (TinyMCE / Visual).
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testCustomContentShortcodeInVisualEditor(AcceptanceTester $I)
 	{
@@ -38,7 +38,7 @@ class PageShortcodeCustomContentCest
 			'ConvertKit Custom Content',
 			'convertkit-content',
 			[
-				'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ]
+				'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
 			],
 			'[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"][/convertkit_content]'
 		);
@@ -49,10 +49,10 @@ class PageShortcodeCustomContentCest
 
 	/**
 	 * Test the [convertkit_content] shortcode works using the Text Editor.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.7.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testCustomContentShortcodeInTextEditor(AcceptanceTester $I)
 	{
@@ -65,7 +65,7 @@ class PageShortcodeCustomContentCest
 			'ConvertKit Custom Content',
 			'convertkit-content',
 			[
-				'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ]
+				'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
 			],
 			'[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"][/convertkit_content]'
 		);
@@ -77,18 +77,20 @@ class PageShortcodeCustomContentCest
 	/**
 	 * Test the [convertkit_content] shortcode works when a valid Tag ID is specified,
 	 * and an invalid Subscriber ID is used.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testCustomContentShortcodeWithValidTagParameterAndInvalidSubscriberID(AcceptanceTester $I)
 	{
 		// Create Page with Shortcode.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-custom-content-shortcode-valid-tag-param-and-invalid-subscriber-id',
-			'post_content'	=> '[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]ConvertKitCustomContent[/convertkit_content]',
-		]);
+		$I->havePageInDatabase(
+			[
+				'post_name'    => 'convertkit-custom-content-shortcode-valid-tag-param-and-invalid-subscriber-id',
+				'post_content' => '[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]ConvertKitCustomContent[/convertkit_content]',
+			]
+		);
 
 		// Prevent API rate limit from being hit in parallel tests.
 		$I->wait(2);
@@ -115,18 +117,20 @@ class PageShortcodeCustomContentCest
 	/**
 	 * Test the [convertkit_content] shortcode works when a valid Tag ID is specified,
 	 * and a valid Subscriber ID is used who is subscribed to the tag.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testCustomContentShortcodeWithValidTagParameterAndValidSubscriberID(AcceptanceTester $I)
 	{
 		// Create Page with Shortcode.
-		$I->havePageInDatabase([
-			'post_name' 	=> 'convertkit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id',
-			'post_content'	=> '[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]ConvertKitCustomContent[/convertkit_content]',
-		]);
+		$I->havePageInDatabase(
+			[
+				'post_name'    => 'convertkit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id',
+				'post_content' => '[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]ConvertKitCustomContent[/convertkit_content]',
+			]
+		);
 
 		// Prevent API rate limit from being hit in parallel tests.
 		$I->wait(2);
@@ -154,10 +158,10 @@ class PageShortcodeCustomContentCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/tags/PageShortcodeCustomContentCest.php
+++ b/tests/acceptance/tags/PageShortcodeCustomContentCest.php
@@ -1,166 +1,168 @@
 <?php
 /**
  * Tests for the ConvertKit Custom Content shortcode.
- *
- * @since 1.9.6
+ * 
+ * @since 	1.9.6
  */
-class PageShortcodeCustomContentCest {
-
+class PageShortcodeCustomContentCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
-		$I->activateConvertKitPlugin( $I );
-		$I->setupConvertKitPlugin( $I );
-		$I->enableDebugLog( $I );
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
 	}
 
 	/**
 	 * Test the [convertkit_content] shortcode works using the Classic Editor (TinyMCE / Visual).
-	 *
-	 * @since 1.9.7.5
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testCustomContentShortcodeInVisualEditor( AcceptanceTester $I ) {
+	public function testCustomContentShortcodeInVisualEditor(AcceptanceTester $I)
+	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Custom Content: Shortcode: Visual Editor' );
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Custom Content: Shortcode: Visual Editor');
 
 		// Add shortcode to Page, setting the Tag setting to the value specified in the .env file.
 		$I->addVisualEditorShortcode(
 			$I,
 			'ConvertKit Custom Content',
 			'convertkit-content',
-			array(
-				'tag' => array( 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ),
-			),
+			[
+				'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ]
+			],
 			'[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"][/convertkit_content]'
 		);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage( $I );
+		$I->publishAndViewClassicEditorPage($I);
 	}
 
 	/**
 	 * Test the [convertkit_content] shortcode works using the Text Editor.
-	 *
-	 * @since 1.9.7.5
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.7.5
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testCustomContentShortcodeInTextEditor( AcceptanceTester $I ) {
+	public function testCustomContentShortcodeInTextEditor(AcceptanceTester $I)
+	{
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage( $I, 'page', 'ConvertKit: Page: Custom Content: Shortcode: Text Editor' );
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Custom Content: Shortcode: Text Editor');
 
 		// Add shortcode to Page, setting the Tag setting to the value specified in the .env file.
 		$I->addTextEditorShortcode(
 			$I,
 			'ConvertKit Custom Content',
 			'convertkit-content',
-			array(
-				'tag' => array( 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ),
-			),
+			[
+				'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ]
+			],
 			'[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"][/convertkit_content]'
 		);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewClassicEditorPage( $I );
+		$I->publishAndViewClassicEditorPage($I);
 	}
 
 	/**
 	 * Test the [convertkit_content] shortcode works when a valid Tag ID is specified,
 	 * and an invalid Subscriber ID is used.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testCustomContentShortcodeWithValidTagParameterAndInvalidSubscriberID( AcceptanceTester $I ) {
+	public function testCustomContentShortcodeWithValidTagParameterAndInvalidSubscriberID(AcceptanceTester $I)
+	{
 		// Create Page with Shortcode.
-		$I->havePageInDatabase(
-			array(
-				'post_name'    => 'convertkit-custom-content-shortcode-valid-tag-param-and-invalid-subscriber-id',
-				'post_content' => '[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]ConvertKitCustomContent[/convertkit_content]',
-			)
-		);
+		$I->havePageInDatabase([
+			'post_name' 	=> 'convertkit-custom-content-shortcode-valid-tag-param-and-invalid-subscriber-id',
+			'post_content'	=> '[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]ConvertKitCustomContent[/convertkit_content]',
+		]);
 
 		// Prevent API rate limit from being hit in parallel tests.
-		$I->wait( 2 );
+		$I->wait(2);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage( '/convertkit-custom-content-shortcode-valid-tag-param-and-invalid-subscriber-id' );
+		$I->amOnPage('/convertkit-custom-content-shortcode-valid-tag-param-and-invalid-subscriber-id');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the Custom Content is not yet displayed.
-		$I->dontSeeInSource( 'ConvertKitCustomContent' );
+		$I->dontSeeInSource('ConvertKitCustomContent');
 
 		// Reload the page, this time with an invalid subscriber ID .
-		$I->amOnPage( '/convertkit-custom-content-shortcode-valid-tag-param-and-invalid-subscriber-id?ck_subscriber_id=1' );
+		$I->amOnPage('/convertkit-custom-content-shortcode-valid-tag-param-and-invalid-subscriber-id?ck_subscriber_id=1');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the Custom Content is not yet displayed.
-		$I->dontSeeInSource( 'ConvertKitCustomContent' );
+		$I->dontSeeInSource('ConvertKitCustomContent');
 	}
 
 	/**
 	 * Test the [convertkit_content] shortcode works when a valid Tag ID is specified,
 	 * and a valid Subscriber ID is used who is subscribed to the tag.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testCustomContentShortcodeWithValidTagParameterAndValidSubscriberID( AcceptanceTester $I ) {
+	public function testCustomContentShortcodeWithValidTagParameterAndValidSubscriberID(AcceptanceTester $I)
+	{
 		// Create Page with Shortcode.
-		$I->havePageInDatabase(
-			array(
-				'post_name'    => 'convertkit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id',
-				'post_content' => '[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]ConvertKitCustomContent[/convertkit_content]',
-			)
-		);
+		$I->havePageInDatabase([
+			'post_name' 	=> 'convertkit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id',
+			'post_content'	=> '[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]ConvertKitCustomContent[/convertkit_content]',
+		]);
 
 		// Prevent API rate limit from being hit in parallel tests.
-		$I->wait( 2 );
+		$I->wait(2);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage( '/convertkit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id' );
+		$I->amOnPage('/convertkit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id');
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the Custom Content is not yet displayed.
-		$I->dontSeeInSource( 'ConvertKitCustomContent' );
+		$I->dontSeeInSource('ConvertKitCustomContent');
 
 		// Reload the page, this time with a subscriber ID who is already subscribed to the tag.
-		$I->amOnPage( '/convertkit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id?ck_subscriber_id=' . $_ENV['CONVERTKIT_API_SUBSCRIBER_ID'] );
+		$I->amOnPage('/convertkit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id?ck_subscriber_id=' . $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the Custom Content is now displayed.
-		$I->seeInSource( 'ConvertKitCustomContent' );
+		$I->seeInSource('ConvertKitCustomContent');
 	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateThirdPartyPlugin( $I, 'classic-editor' );
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateThirdPartyPlugin($I, 'classic-editor');
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/tags/PageTagCest.php
+++ b/tests/acceptance/tags/PageTagCest.php
@@ -1,239 +1,245 @@
 <?php
 /**
  * Tests for ConvertKit Tags on WordPress Pages.
- * 
+ *
  * @since 1.9.6
  */
-class PageTagCest
-{
-    /**
-     * Run common actions before running the test functions in this class.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _before(AcceptanceTester $I)
-    {
-        // Activate and Setup ConvertKit plugin
-        $I->activateConvertKitPlugin($I);
-        $I->setupConvertKitPlugin($I);
-        $I->enableDebugLog($I);
-    }
+class PageTagCest {
 
-    /**
-     * Test that 'None' Tag specified in the Page Settings works when
-     * creating and viewing a new WordPress Page.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewPageUsingNoTag(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Tag: None');
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _before( AcceptanceTester $I ) {
+		// Activate and Setup ConvertKit plugin
+		$I->activateConvertKitPlugin( $I );
+		$I->setupConvertKitPlugin( $I );
+		$I->enableDebugLog( $I );
+	}
 
-        // Configure metabox's Tag setting = None.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'tag' => [ 'select2', 'None' ],
-            ]
-        );
+	/**
+	 * Test that 'None' Tag specified in the Page Settings works when
+	 * creating and viewing a new WordPress Page.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewPageUsingNoTag( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Tag: None' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
+		// Configure metabox's Tag setting = None.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'tag' => array( 'select2', 'None' ),
+			)
+		);
 
-        // Confirm that the tag parameter is not set to the Tag ID.
-        $I->dontSeeInSource('"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"');
-    }
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
 
-    /**
-     * Test that the Tag specified in the Page Settings works when
-     * creating and viewing a new WordPress Page.
-     * 
-     * @since 1.9.6
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testAddNewPageUsingDefinedTag(AcceptanceTester $I)
-    {
-        // Add a Page using the Gutenberg editor.
-        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME']);
+		// Confirm that the tag parameter is not set to the Tag ID.
+		$I->dontSeeInSource( '"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"' );
+	}
 
-        // Configure metabox's Tag setting to the value specified in the .env file.
-        $I->configureMetaboxSettings(
-            $I, 'wp-convertkit-meta-box', [
-            'tag' => [ 'select2', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
-            ]
-        );
+	/**
+	 * Test that the Tag specified in the Page Settings works when
+	 * creating and viewing a new WordPress Page.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testAddNewPageUsingDefinedTag( AcceptanceTester $I ) {
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] );
 
-        // Get Tag ID.
-        $tagID = $I->grabValueFrom('#wp-convertkit-tag');
+		// Configure metabox's Tag setting to the value specified in the .env file.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			array(
+				'tag' => array( 'select2', $_ENV['CONVERTKIT_API_TAG_NAME'] ),
+			)
+		);
 
-        // Confirm it matches the Tag ID in the .env file.
-        $I->assertEquals($tagID, $_ENV['CONVERTKIT_API_TAG_ID']);
+		// Get Tag ID.
+		$tagID = $I->grabValueFrom( '#wp-convertkit-tag' );
 
-        // Publish and view the Page on the frontend site.
-        $I->publishAndViewGutenbergPage($I);
+		// Confirm it matches the Tag ID in the .env file.
+		$I->assertEquals( $tagID, $_ENV['CONVERTKIT_API_TAG_ID'] );
 
-        // Confirm that the post_has_tag parameter is set to true in the source code.
-        $I->seeInSource('"tag":"' . $tagID . '"');
-    }
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage( $I );
 
-    /**
-     * Test that the defined tag is honored when chosen via
-     * WordPress' Quick Edit functionality.
-     * 
-     * @since 1.9.8.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testQuickEditUsingDefinedTag(AcceptanceTester $I)
-    {
-        // Programmatically create a Page.
-        $pageID = $I->havePostInDatabase(
-            [
-            'post_type'     => 'page',
-            'post_title'     => 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Quick Edit',
-            ]
-        );
+		// Confirm that the post_has_tag parameter is set to true in the source code.
+		$I->seeInSource( '"tag":"' . $tagID . '"' );
+	}
 
-        // Quick Edit the Page in the Pages WP_List_Table.
-        $I->quickEdit(
-            $I, 'page', $pageID, [
-            'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
-            ]
-        );
+	/**
+	 * Test that the defined tag is honored when chosen via
+	 * WordPress' Quick Edit functionality.
+	 *
+	 * @since 1.9.8.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testQuickEditUsingDefinedTag( AcceptanceTester $I ) {
+		// Programmatically create a Page.
+		$pageID = $I->havePostInDatabase(
+			array(
+				'post_type'  => 'page',
+				'post_title' => 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Quick Edit',
+			)
+		);
 
-        // Load the Page on the frontend site.
-        $I->amOnPage('/?p='.$pageID);
+		// Quick Edit the Page in the Pages WP_List_Table.
+		$I->quickEdit(
+			$I,
+			'page',
+			$pageID,
+			array(
+				'tag' => array( 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ),
+			)
+		);
 
-        // Check that no PHP warnings or notices were output.
-        $I->checkNoWarningsAndNoticesOnScreen($I);
-		
-        // Confirm that the post_has_tag parameter is set to true in the source code.
-        $I->seeInSource('"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"');
-    }
+		// Load the Page on the frontend site.
+		$I->amOnPage( '/?p=' . $pageID );
 
-    /**
-     * Test that the defined tag displays when chosen via
-     * WordPress' Bulk Edit functionality.
-     * 
-     * @since 1.9.8.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBulkEditUsingDefinedTag(AcceptanceTester $I)
-    {
-        // Programmatically create two Pages.
-        $pageIDs = array(
-        $I->havePostInDatabase(
-            [
-            'post_type'     => 'page',
-            'post_title'     => 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit #1',
-            ]
-        ),
-        $I->havePostInDatabase(
-            [
-            'post_type'     => 'page',
-            'post_title'     => 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit #2',
-            ]
-        )
-        );
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-        // Bulk Edit the Pages in the Pages WP_List_Table.
-        $I->bulkEdit(
-            $I, 'page', $pageIDs, [
-            'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
-            ]
-        );
+		// Confirm that the post_has_tag parameter is set to true in the source code.
+		$I->seeInSource( '"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"' );
+	}
 
-        // Iterate through Pages to run frontend tests.
-        foreach ($pageIDs as $pageID) {
-            // Load the Page on the frontend site.
-            $I->amOnPage('/?p='.$pageID);
+	/**
+	 * Test that the defined tag displays when chosen via
+	 * WordPress' Bulk Edit functionality.
+	 *
+	 * @since 1.9.8.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBulkEditUsingDefinedTag( AcceptanceTester $I ) {
+		// Programmatically create two Pages.
+		$pageIDs = array(
+			$I->havePostInDatabase(
+				array(
+					'post_type'  => 'page',
+					'post_title' => 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit #1',
+				)
+			),
+			$I->havePostInDatabase(
+				array(
+					'post_type'  => 'page',
+					'post_title' => 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit #2',
+				)
+			),
+		);
 
-            // Check that no PHP warnings or notices were output.
-            $I->checkNoWarningsAndNoticesOnScreen($I);
-			
-            // Confirm that the post_has_tag parameter is set to true in the source code.
-            $I->seeInSource('"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"');
-        }
-    }
+		// Bulk Edit the Pages in the Pages WP_List_Table.
+		$I->bulkEdit(
+			$I,
+			'page',
+			$pageIDs,
+			array(
+				'tag' => array( 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ),
+			)
+		);
 
-    /**
-     * Test that the existing settings are honored and not changed
-     * when the Bulk Edit options are set to 'No Change'.
-     * 
-     * @since 1.9.8.0
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function testBulkEditWithNoChanges(AcceptanceTester $I)
-    {
-        // Programmatically create two Pages with a defined tag.
-        $pageIDs = array(
-        $I->havePostInDatabase(
-            [
-            'post_type'     => 'page',
-            'post_title'     => 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit with No Change #1',
-            'meta_input'    => [
-            '_wp_convertkit_post_meta' => [
-            'form'         => '',
-            'landing_page' => '',
-            'tag'          => $_ENV['CONVERTKIT_API_TAG_ID'],
-            ]
-            ],
-            ]
-        ),
-        $I->havePostInDatabase(
-            [
-            'post_type'     => 'page',
-            'post_title'     => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
-            'meta_input'    => [
-            '_wp_convertkit_post_meta' => [
-            'form'         => '',
-            'landing_page' => '',
-            'tag'          => $_ENV['CONVERTKIT_API_TAG_ID'],
-            ]
-            ],
-            ]
-        )
-        );
+		// Iterate through Pages to run frontend tests.
+		foreach ( $pageIDs as $pageID ) {
+			// Load the Page on the frontend site.
+			$I->amOnPage( '/?p=' . $pageID );
 
-        // Bulk Edit the Pages in the Pages WP_List_Table.
-        $I->bulkEdit(
-            $I, 'page', $pageIDs, [
-            'tag' => [ 'select', '— No Change —' ],
-            ]
-        );
+			// Check that no PHP warnings or notices were output.
+			$I->checkNoWarningsAndNoticesOnScreen( $I );
 
-        // Iterate through Pages to run frontend tests.
-        foreach ($pageIDs as $pageID) {
-            // Load the Page on the frontend site.
-            $I->amOnPage('/?p='.$pageID);
+			// Confirm that the post_has_tag parameter is set to true in the source code.
+			$I->seeInSource( '"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"' );
+		}
+	}
 
-            // Check that no PHP warnings or notices were output.
-            $I->checkNoWarningsAndNoticesOnScreen($I);
-			
-            // Confirm that the post_has_tag parameter is set to true in the source code.
-            $I->seeInSource('"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"');
-        }
-    }
+	/**
+	 * Test that the existing settings are honored and not changed
+	 * when the Bulk Edit options are set to 'No Change'.
+	 *
+	 * @since 1.9.8.0
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testBulkEditWithNoChanges( AcceptanceTester $I ) {
+		// Programmatically create two Pages with a defined tag.
+		$pageIDs = array(
+			$I->havePostInDatabase(
+				array(
+					'post_type'  => 'page',
+					'post_title' => 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit with No Change #1',
+					'meta_input' => array(
+						'_wp_convertkit_post_meta' => array(
+							'form'         => '',
+							'landing_page' => '',
+							'tag'          => $_ENV['CONVERTKIT_API_TAG_ID'],
+						),
+					),
+				)
+			),
+			$I->havePostInDatabase(
+				array(
+					'post_type'  => 'page',
+					'post_title' => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
+					'meta_input' => array(
+						'_wp_convertkit_post_meta' => array(
+							'form'         => '',
+							'landing_page' => '',
+							'tag'          => $_ENV['CONVERTKIT_API_TAG_ID'],
+						),
+					),
+				)
+			),
+		);
 
-    /**
-     * Deactivate and reset Plugin(s) after each test, if the test passes.
-     * We don't use _after, as this would provide a screenshot of the Plugin
-     * deactivation and not the true test error.
-     * 
-     * @since 1.9.6.7
-     * 
-     * @param AcceptanceTester $I Tester
-     */
-    public function _passed(AcceptanceTester $I)
-    {
-        $I->deactivateConvertKitPlugin($I);
-        $I->resetConvertKitPlugin($I);
-    }
+		// Bulk Edit the Pages in the Pages WP_List_Table.
+		$I->bulkEdit(
+			$I,
+			'page',
+			$pageIDs,
+			array(
+				'tag' => array( 'select', '— No Change —' ),
+			)
+		);
+
+		// Iterate through Pages to run frontend tests.
+		foreach ( $pageIDs as $pageID ) {
+			// Load the Page on the frontend site.
+			$I->amOnPage( '/?p=' . $pageID );
+
+			// Check that no PHP warnings or notices were output.
+			$I->checkNoWarningsAndNoticesOnScreen( $I );
+
+			// Confirm that the post_has_tag parameter is set to true in the source code.
+			$I->seeInSource( '"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"' );
+		}
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since 1.9.6.7
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function _passed( AcceptanceTester $I ) {
+		$I->deactivateConvertKitPlugin( $I );
+		$I->resetConvertKitPlugin( $I );
+	}
 }

--- a/tests/acceptance/tags/PageTagCest.php
+++ b/tests/acceptance/tags/PageTagCest.php
@@ -1,231 +1,204 @@
 <?php
 /**
  * Tests for ConvertKit Tags on WordPress Pages.
- *
- * @since 1.9.6
+ * 
+ * @since 	1.9.6
  */
-class PageTagCest {
-
+class PageTagCest
+{
 	/**
 	 * Run common actions before running the test functions in this class.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _before( AcceptanceTester $I ) {
+	public function _before(AcceptanceTester $I)
+	{
 		// Activate and Setup ConvertKit plugin
-		$I->activateConvertKitPlugin( $I );
-		$I->setupConvertKitPlugin( $I );
-		$I->enableDebugLog( $I );
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
 	}
 
 	/**
 	 * Test that 'None' Tag specified in the Page Settings works when
 	 * creating and viewing a new WordPress Page.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewPageUsingNoTag( AcceptanceTester $I ) {
+	public function testAddNewPageUsingNoTag(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Tag: None' );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Tag: None');
 
 		// Configure metabox's Tag setting = None.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'tag' => array( 'select2', 'None' ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'tag' => [ 'select2', 'None' ],
+		]);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the tag parameter is not set to the Tag ID.
-		$I->dontSeeInSource( '"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"' );
+		$I->dontSeeInSource('"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"');
 	}
 
 	/**
 	 * Test that the Tag specified in the Page Settings works when
 	 * creating and viewing a new WordPress Page.
-	 *
-	 * @since 1.9.6
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testAddNewPageUsingDefinedTag( AcceptanceTester $I ) {
+	public function testAddNewPageUsingDefinedTag(AcceptanceTester $I)
+	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage( $I, 'page', 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] );
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] );
 
 		// Configure metabox's Tag setting to the value specified in the .env file.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			array(
-				'tag' => array( 'select2', $_ENV['CONVERTKIT_API_TAG_NAME'] ),
-			)
-		);
+		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
+			'tag' => [ 'select2', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
+		]);
 
 		// Get Tag ID.
-		$tagID = $I->grabValueFrom( '#wp-convertkit-tag' );
+		$tagID = $I->grabValueFrom('#wp-convertkit-tag');
 
 		// Confirm it matches the Tag ID in the .env file.
-		$I->assertEquals( $tagID, $_ENV['CONVERTKIT_API_TAG_ID'] );
+		$I->assertEquals($tagID, $_ENV['CONVERTKIT_API_TAG_ID']);
 
 		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage( $I );
+		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the post_has_tag parameter is set to true in the source code.
-		$I->seeInSource( '"tag":"' . $tagID . '"' );
+		$I->seeInSource('"tag":"' . $tagID . '"');
 	}
 
 	/**
 	 * Test that the defined tag is honored when chosen via
 	 * WordPress' Quick Edit functionality.
-	 *
-	 * @since 1.9.8.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testQuickEditUsingDefinedTag( AcceptanceTester $I ) {
+	public function testQuickEditUsingDefinedTag(AcceptanceTester $I)
+	{
 		// Programmatically create a Page.
-		$pageID = $I->havePostInDatabase(
-			array(
-				'post_type'  => 'page',
-				'post_title' => 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Quick Edit',
-			)
-		);
+		$pageID = $I->havePostInDatabase([
+			'post_type' 	=> 'page',
+			'post_title' 	=> 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Quick Edit',
+		]);
 
 		// Quick Edit the Page in the Pages WP_List_Table.
-		$I->quickEdit(
-			$I,
-			'page',
-			$pageID,
-			array(
-				'tag' => array( 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ),
-			)
-		);
+		$I->quickEdit($I, 'page', $pageID, [
+			'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
+		]);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage( '/?p=' . $pageID );
+		$I->amOnPage('/?p='.$pageID);
 
 		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen( $I );
-
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+		
 		// Confirm that the post_has_tag parameter is set to true in the source code.
-		$I->seeInSource( '"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"' );
+		$I->seeInSource('"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"');
 	}
 
 	/**
 	 * Test that the defined tag displays when chosen via
 	 * WordPress' Bulk Edit functionality.
-	 *
-	 * @since 1.9.8.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBulkEditUsingDefinedTag( AcceptanceTester $I ) {
+	public function testBulkEditUsingDefinedTag(AcceptanceTester $I)
+	{
 		// Programmatically create two Pages.
 		$pageIDs = array(
-			$I->havePostInDatabase(
-				array(
-					'post_type'  => 'page',
-					'post_title' => 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit #1',
-				)
-			),
-			$I->havePostInDatabase(
-				array(
-					'post_type'  => 'page',
-					'post_title' => 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit #2',
-				)
-			),
+			$I->havePostInDatabase([
+				'post_type' 	=> 'page',
+				'post_title' 	=> 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit #1',
+			]),
+			$I->havePostInDatabase([
+				'post_type' 	=> 'page',
+				'post_title' 	=> 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit #2',
+			])
 		);
 
 		// Bulk Edit the Pages in the Pages WP_List_Table.
-		$I->bulkEdit(
-			$I,
-			'page',
-			$pageIDs,
-			array(
-				'tag' => array( 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ),
-			)
-		);
+		$I->bulkEdit($I, 'page', $pageIDs, [
+			'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
+		]);
 
 		// Iterate through Pages to run frontend tests.
-		foreach ( $pageIDs as $pageID ) {
+		foreach($pageIDs as $pageID) {
 			// Load the Page on the frontend site.
-			$I->amOnPage( '/?p=' . $pageID );
+			$I->amOnPage('/?p='.$pageID);
 
 			// Check that no PHP warnings or notices were output.
-			$I->checkNoWarningsAndNoticesOnScreen( $I );
-
+			$I->checkNoWarningsAndNoticesOnScreen($I);
+			
 			// Confirm that the post_has_tag parameter is set to true in the source code.
-			$I->seeInSource( '"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"' );
+			$I->seeInSource('"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"');
 		}
 	}
 
 	/**
 	 * Test that the existing settings are honored and not changed
 	 * when the Bulk Edit options are set to 'No Change'.
-	 *
-	 * @since 1.9.8.0
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testBulkEditWithNoChanges( AcceptanceTester $I ) {
+	public function testBulkEditWithNoChanges(AcceptanceTester $I)
+	{
 		// Programmatically create two Pages with a defined tag.
 		$pageIDs = array(
-			$I->havePostInDatabase(
-				array(
-					'post_type'  => 'page',
-					'post_title' => 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit with No Change #1',
-					'meta_input' => array(
-						'_wp_convertkit_post_meta' => array(
-							'form'         => '',
-							'landing_page' => '',
-							'tag'          => $_ENV['CONVERTKIT_API_TAG_ID'],
-						),
-					),
-				)
-			),
-			$I->havePostInDatabase(
-				array(
-					'post_type'  => 'page',
-					'post_title' => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
-					'meta_input' => array(
-						'_wp_convertkit_post_meta' => array(
-							'form'         => '',
-							'landing_page' => '',
-							'tag'          => $_ENV['CONVERTKIT_API_TAG_ID'],
-						),
-					),
-				)
-			),
+			$I->havePostInDatabase([
+				'post_type' 	=> 'page',
+				'post_title' 	=> 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit with No Change #1',
+				'meta_input'	=> [
+					'_wp_convertkit_post_meta' => [
+						'form'         => '',
+						'landing_page' => '',
+						'tag'          => $_ENV['CONVERTKIT_API_TAG_ID'],
+					]
+				],
+			]),
+			$I->havePostInDatabase([
+				'post_type' 	=> 'page',
+				'post_title' 	=> 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
+				'meta_input'	=> [
+					'_wp_convertkit_post_meta' => [
+						'form'         => '',
+						'landing_page' => '',
+						'tag'          => $_ENV['CONVERTKIT_API_TAG_ID'],
+					]
+				],
+			])
 		);
 
 		// Bulk Edit the Pages in the Pages WP_List_Table.
-		$I->bulkEdit(
-			$I,
-			'page',
-			$pageIDs,
-			array(
-				'tag' => array( 'select', '— No Change —' ),
-			)
-		);
+		$I->bulkEdit($I, 'page', $pageIDs, [
+			'tag' => [ 'select', '— No Change —' ],
+		]);
 
 		// Iterate through Pages to run frontend tests.
-		foreach ( $pageIDs as $pageID ) {
+		foreach($pageIDs as $pageID) {
 			// Load the Page on the frontend site.
-			$I->amOnPage( '/?p=' . $pageID );
+			$I->amOnPage('/?p='.$pageID);
 
 			// Check that no PHP warnings or notices were output.
-			$I->checkNoWarningsAndNoticesOnScreen( $I );
-
+			$I->checkNoWarningsAndNoticesOnScreen($I);
+			
 			// Confirm that the post_has_tag parameter is set to true in the source code.
-			$I->seeInSource( '"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"' );
+			$I->seeInSource('"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"');
 		}
 	}
 
@@ -233,13 +206,14 @@ class PageTagCest {
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 *
-	 * @since 1.9.6.7
-	 *
-	 * @param AcceptanceTester $I Tester
+	 * 
+	 * @since 	1.9.6.7
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function _passed( AcceptanceTester $I ) {
-		$I->deactivateConvertKitPlugin( $I );
-		$I->resetConvertKitPlugin( $I );
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
 	}
 }

--- a/tests/acceptance/tags/PageTagCest.php
+++ b/tests/acceptance/tags/PageTagCest.php
@@ -150,7 +150,7 @@ class PageTagCest
         );
 
         // Iterate through Pages to run frontend tests.
-        foreach($pageIDs as $pageID) {
+        foreach ($pageIDs as $pageID) {
             // Load the Page on the frontend site.
             $I->amOnPage('/?p='.$pageID);
 
@@ -210,7 +210,7 @@ class PageTagCest
         );
 
         // Iterate through Pages to run frontend tests.
-        foreach($pageIDs as $pageID) {
+        foreach ($pageIDs as $pageID) {
             // Load the Page on the frontend site.
             $I->amOnPage('/?p='.$pageID);
 

--- a/tests/acceptance/tags/PageTagCest.php
+++ b/tests/acceptance/tags/PageTagCest.php
@@ -1,21 +1,21 @@
 <?php
 /**
  * Tests for ConvertKit Tags on WordPress Pages.
- * 
- * @since 	1.9.6
+ *
+ * @since   1.9.6
  */
 class PageTagCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _before(AcceptanceTester $I)
 	{
-		// Activate and Setup ConvertKit plugin
+		// Activate and Setup ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
 		$I->enableDebugLog($I);
@@ -24,10 +24,10 @@ class PageTagCest
 	/**
 	 * Test that 'None' Tag specified in the Page Settings works when
 	 * creating and viewing a new WordPress Page.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewPageUsingNoTag(AcceptanceTester $I)
 	{
@@ -35,9 +35,13 @@ class PageTagCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Tag: None');
 
 		// Configure metabox's Tag setting = None.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'tag' => [ 'select2', 'None' ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'tag' => [ 'select2', 'None' ],
+			]
+		);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -49,10 +53,10 @@ class PageTagCest
 	/**
 	 * Test that the Tag specified in the Page Settings works when
 	 * creating and viewing a new WordPress Page.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testAddNewPageUsingDefinedTag(AcceptanceTester $I)
 	{
@@ -60,9 +64,13 @@ class PageTagCest
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] );
 
 		// Configure metabox's Tag setting to the value specified in the .env file.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'tag' => [ 'select2', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
-		]);
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'tag' => [ 'select2', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
+			]
+		);
 
 		// Get Tag ID.
 		$tagID = $I->grabValueFrom('#wp-convertkit-tag');
@@ -80,30 +88,37 @@ class PageTagCest
 	/**
 	 * Test that the defined tag is honored when chosen via
 	 * WordPress' Quick Edit functionality.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testQuickEditUsingDefinedTag(AcceptanceTester $I)
 	{
 		// Programmatically create a Page.
-		$pageID = $I->havePostInDatabase([
-			'post_type' 	=> 'page',
-			'post_title' 	=> 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Quick Edit',
-		]);
+		$pageID = $I->havePostInDatabase(
+			[
+				'post_type'  => 'page',
+				'post_title' => 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Quick Edit',
+			]
+		);
 
 		// Quick Edit the Page in the Pages WP_List_Table.
-		$I->quickEdit($I, 'page', $pageID, [
-			'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
-		]);
+		$I->quickEdit(
+			$I,
+			'page',
+			$pageID,
+			[
+				'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
+			]
+		);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage('/?p='.$pageID);
+		$I->amOnPage('/?p=' . $pageID);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
-		
+
 		// Confirm that the post_has_tag parameter is set to true in the source code.
 		$I->seeInSource('"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"');
 	}
@@ -111,38 +126,47 @@ class PageTagCest
 	/**
 	 * Test that the defined tag displays when chosen via
 	 * WordPress' Bulk Edit functionality.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBulkEditUsingDefinedTag(AcceptanceTester $I)
 	{
 		// Programmatically create two Pages.
 		$pageIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'page',
-				'post_title' 	=> 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit #1',
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'page',
-				'post_title' 	=> 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit #2',
-			])
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'page',
+					'post_title' => 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit #1',
+				]
+			),
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'page',
+					'post_title' => 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit #2',
+				]
+			),
 		);
 
 		// Bulk Edit the Pages in the Pages WP_List_Table.
-		$I->bulkEdit($I, 'page', $pageIDs, [
-			'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
-		]);
+		$I->bulkEdit(
+			$I,
+			'page',
+			$pageIDs,
+			[
+				'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
+			]
+		);
 
 		// Iterate through Pages to run frontend tests.
-		foreach($pageIDs as $pageID) {
+		foreach ($pageIDs as $pageID) {
 			// Load the Page on the frontend site.
-			$I->amOnPage('/?p='.$pageID);
+			$I->amOnPage('/?p=' . $pageID);
 
 			// Check that no PHP warnings or notices were output.
 			$I->checkNoWarningsAndNoticesOnScreen($I);
-			
+
 			// Confirm that the post_has_tag parameter is set to true in the source code.
 			$I->seeInSource('"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"');
 		}
@@ -151,52 +175,61 @@ class PageTagCest
 	/**
 	 * Test that the existing settings are honored and not changed
 	 * when the Bulk Edit options are set to 'No Change'.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.8.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBulkEditWithNoChanges(AcceptanceTester $I)
 	{
 		// Programmatically create two Pages with a defined tag.
 		$pageIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'page',
-				'post_title' 	=> 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit with No Change #1',
-				'meta_input'	=> [
-					'_wp_convertkit_post_meta' => [
-						'form'         => '',
-						'landing_page' => '',
-						'tag'          => $_ENV['CONVERTKIT_API_TAG_ID'],
-					]
-				],
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'page',
-				'post_title' 	=> 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
-				'meta_input'	=> [
-					'_wp_convertkit_post_meta' => [
-						'form'         => '',
-						'landing_page' => '',
-						'tag'          => $_ENV['CONVERTKIT_API_TAG_ID'],
-					]
-				],
-			])
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'page',
+					'post_title' => 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit with No Change #1',
+					'meta_input' => [
+						'_wp_convertkit_post_meta' => [
+							'form'         => '',
+							'landing_page' => '',
+							'tag'          => $_ENV['CONVERTKIT_API_TAG_ID'],
+						],
+					],
+				]
+			),
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'page',
+					'post_title' => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
+					'meta_input' => [
+						'_wp_convertkit_post_meta' => [
+							'form'         => '',
+							'landing_page' => '',
+							'tag'          => $_ENV['CONVERTKIT_API_TAG_ID'],
+						],
+					],
+				]
+			),
 		);
 
 		// Bulk Edit the Pages in the Pages WP_List_Table.
-		$I->bulkEdit($I, 'page', $pageIDs, [
-			'tag' => [ 'select', '— No Change —' ],
-		]);
+		$I->bulkEdit(
+			$I,
+			'page',
+			$pageIDs,
+			[
+				'tag' => [ 'select', '— No Change —' ],
+			]
+		);
 
 		// Iterate through Pages to run frontend tests.
-		foreach($pageIDs as $pageID) {
+		foreach ($pageIDs as $pageID) {
 			// Load the Page on the frontend site.
-			$I->amOnPage('/?p='.$pageID);
+			$I->amOnPage('/?p=' . $pageID);
 
 			// Check that no PHP warnings or notices were output.
 			$I->checkNoWarningsAndNoticesOnScreen($I);
-			
+
 			// Confirm that the post_has_tag parameter is set to true in the source code.
 			$I->seeInSource('"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"');
 		}
@@ -206,10 +239,10 @@ class PageTagCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/tags/PageTagCest.php
+++ b/tests/acceptance/tags/PageTagCest.php
@@ -2,218 +2,238 @@
 /**
  * Tests for ConvertKit Tags on WordPress Pages.
  * 
- * @since 	1.9.6
+ * @since 1.9.6
  */
 class PageTagCest
 {
-	/**
-	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _before(AcceptanceTester $I)
-	{
-		// Activate and Setup ConvertKit plugin
-		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
-	}
+    /**
+     * Run common actions before running the test functions in this class.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _before(AcceptanceTester $I)
+    {
+        // Activate and Setup ConvertKit plugin
+        $I->activateConvertKitPlugin($I);
+        $I->setupConvertKitPlugin($I);
+        $I->enableDebugLog($I);
+    }
 
-	/**
-	 * Test that 'None' Tag specified in the Page Settings works when
-	 * creating and viewing a new WordPress Page.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewPageUsingNoTag(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Tag: None');
+    /**
+     * Test that 'None' Tag specified in the Page Settings works when
+     * creating and viewing a new WordPress Page.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewPageUsingNoTag(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Tag: None');
 
-		// Configure metabox's Tag setting = None.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'tag' => [ 'select2', 'None' ],
-		]);
+        // Configure metabox's Tag setting = None.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'tag' => [ 'select2', 'None' ],
+            ]
+        );
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Confirm that the tag parameter is not set to the Tag ID.
-		$I->dontSeeInSource('"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"');
-	}
+        // Confirm that the tag parameter is not set to the Tag ID.
+        $I->dontSeeInSource('"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"');
+    }
 
-	/**
-	 * Test that the Tag specified in the Page Settings works when
-	 * creating and viewing a new WordPress Page.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testAddNewPageUsingDefinedTag(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] );
+    /**
+     * Test that the Tag specified in the Page Settings works when
+     * creating and viewing a new WordPress Page.
+     * 
+     * @since 1.9.6
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testAddNewPageUsingDefinedTag(AcceptanceTester $I)
+    {
+        // Add a Page using the Gutenberg editor.
+        $I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME']);
 
-		// Configure metabox's Tag setting to the value specified in the .env file.
-		$I->configureMetaboxSettings($I, 'wp-convertkit-meta-box', [
-			'tag' => [ 'select2', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
-		]);
+        // Configure metabox's Tag setting to the value specified in the .env file.
+        $I->configureMetaboxSettings(
+            $I, 'wp-convertkit-meta-box', [
+            'tag' => [ 'select2', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
+            ]
+        );
 
-		// Get Tag ID.
-		$tagID = $I->grabValueFrom('#wp-convertkit-tag');
+        // Get Tag ID.
+        $tagID = $I->grabValueFrom('#wp-convertkit-tag');
 
-		// Confirm it matches the Tag ID in the .env file.
-		$I->assertEquals($tagID, $_ENV['CONVERTKIT_API_TAG_ID']);
+        // Confirm it matches the Tag ID in the .env file.
+        $I->assertEquals($tagID, $_ENV['CONVERTKIT_API_TAG_ID']);
 
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+        // Publish and view the Page on the frontend site.
+        $I->publishAndViewGutenbergPage($I);
 
-		// Confirm that the post_has_tag parameter is set to true in the source code.
-		$I->seeInSource('"tag":"' . $tagID . '"');
-	}
+        // Confirm that the post_has_tag parameter is set to true in the source code.
+        $I->seeInSource('"tag":"' . $tagID . '"');
+    }
 
-	/**
-	 * Test that the defined tag is honored when chosen via
-	 * WordPress' Quick Edit functionality.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testQuickEditUsingDefinedTag(AcceptanceTester $I)
-	{
-		// Programmatically create a Page.
-		$pageID = $I->havePostInDatabase([
-			'post_type' 	=> 'page',
-			'post_title' 	=> 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Quick Edit',
-		]);
+    /**
+     * Test that the defined tag is honored when chosen via
+     * WordPress' Quick Edit functionality.
+     * 
+     * @since 1.9.8.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testQuickEditUsingDefinedTag(AcceptanceTester $I)
+    {
+        // Programmatically create a Page.
+        $pageID = $I->havePostInDatabase(
+            [
+            'post_type'     => 'page',
+            'post_title'     => 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Quick Edit',
+            ]
+        );
 
-		// Quick Edit the Page in the Pages WP_List_Table.
-		$I->quickEdit($I, 'page', $pageID, [
-			'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
-		]);
+        // Quick Edit the Page in the Pages WP_List_Table.
+        $I->quickEdit(
+            $I, 'page', $pageID, [
+            'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
+            ]
+        );
 
-		// Load the Page on the frontend site.
-		$I->amOnPage('/?p='.$pageID);
+        // Load the Page on the frontend site.
+        $I->amOnPage('/?p='.$pageID);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+        // Check that no PHP warnings or notices were output.
+        $I->checkNoWarningsAndNoticesOnScreen($I);
 		
-		// Confirm that the post_has_tag parameter is set to true in the source code.
-		$I->seeInSource('"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"');
-	}
+        // Confirm that the post_has_tag parameter is set to true in the source code.
+        $I->seeInSource('"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"');
+    }
 
-	/**
-	 * Test that the defined tag displays when chosen via
-	 * WordPress' Bulk Edit functionality.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBulkEditUsingDefinedTag(AcceptanceTester $I)
-	{
-		// Programmatically create two Pages.
-		$pageIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'page',
-				'post_title' 	=> 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit #1',
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'page',
-				'post_title' 	=> 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit #2',
-			])
-		);
+    /**
+     * Test that the defined tag displays when chosen via
+     * WordPress' Bulk Edit functionality.
+     * 
+     * @since 1.9.8.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBulkEditUsingDefinedTag(AcceptanceTester $I)
+    {
+        // Programmatically create two Pages.
+        $pageIDs = array(
+        $I->havePostInDatabase(
+            [
+            'post_type'     => 'page',
+            'post_title'     => 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit #1',
+            ]
+        ),
+        $I->havePostInDatabase(
+            [
+            'post_type'     => 'page',
+            'post_title'     => 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit #2',
+            ]
+        )
+        );
 
-		// Bulk Edit the Pages in the Pages WP_List_Table.
-		$I->bulkEdit($I, 'page', $pageIDs, [
-			'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
-		]);
+        // Bulk Edit the Pages in the Pages WP_List_Table.
+        $I->bulkEdit(
+            $I, 'page', $pageIDs, [
+            'tag' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
+            ]
+        );
 
-		// Iterate through Pages to run frontend tests.
-		foreach($pageIDs as $pageID) {
-			// Load the Page on the frontend site.
-			$I->amOnPage('/?p='.$pageID);
+        // Iterate through Pages to run frontend tests.
+        foreach($pageIDs as $pageID) {
+            // Load the Page on the frontend site.
+            $I->amOnPage('/?p='.$pageID);
 
-			// Check that no PHP warnings or notices were output.
-			$I->checkNoWarningsAndNoticesOnScreen($I);
+            // Check that no PHP warnings or notices were output.
+            $I->checkNoWarningsAndNoticesOnScreen($I);
 			
-			// Confirm that the post_has_tag parameter is set to true in the source code.
-			$I->seeInSource('"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"');
-		}
-	}
+            // Confirm that the post_has_tag parameter is set to true in the source code.
+            $I->seeInSource('"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"');
+        }
+    }
 
-	/**
-	 * Test that the existing settings are honored and not changed
-	 * when the Bulk Edit options are set to 'No Change'.
-	 * 
-	 * @since 	1.9.8.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testBulkEditWithNoChanges(AcceptanceTester $I)
-	{
-		// Programmatically create two Pages with a defined tag.
-		$pageIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'page',
-				'post_title' 	=> 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit with No Change #1',
-				'meta_input'	=> [
-					'_wp_convertkit_post_meta' => [
-						'form'         => '',
-						'landing_page' => '',
-						'tag'          => $_ENV['CONVERTKIT_API_TAG_ID'],
-					]
-				],
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'page',
-				'post_title' 	=> 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
-				'meta_input'	=> [
-					'_wp_convertkit_post_meta' => [
-						'form'         => '',
-						'landing_page' => '',
-						'tag'          => $_ENV['CONVERTKIT_API_TAG_ID'],
-					]
-				],
-			])
-		);
+    /**
+     * Test that the existing settings are honored and not changed
+     * when the Bulk Edit options are set to 'No Change'.
+     * 
+     * @since 1.9.8.0
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function testBulkEditWithNoChanges(AcceptanceTester $I)
+    {
+        // Programmatically create two Pages with a defined tag.
+        $pageIDs = array(
+        $I->havePostInDatabase(
+            [
+            'post_type'     => 'page',
+            'post_title'     => 'ConvertKit: Page: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit with No Change #1',
+            'meta_input'    => [
+            '_wp_convertkit_post_meta' => [
+            'form'         => '',
+            'landing_page' => '',
+            'tag'          => $_ENV['CONVERTKIT_API_TAG_ID'],
+            ]
+            ],
+            ]
+        ),
+        $I->havePostInDatabase(
+            [
+            'post_type'     => 'page',
+            'post_title'     => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
+            'meta_input'    => [
+            '_wp_convertkit_post_meta' => [
+            'form'         => '',
+            'landing_page' => '',
+            'tag'          => $_ENV['CONVERTKIT_API_TAG_ID'],
+            ]
+            ],
+            ]
+        )
+        );
 
-		// Bulk Edit the Pages in the Pages WP_List_Table.
-		$I->bulkEdit($I, 'page', $pageIDs, [
-			'tag' => [ 'select', '— No Change —' ],
-		]);
+        // Bulk Edit the Pages in the Pages WP_List_Table.
+        $I->bulkEdit(
+            $I, 'page', $pageIDs, [
+            'tag' => [ 'select', '— No Change —' ],
+            ]
+        );
 
-		// Iterate through Pages to run frontend tests.
-		foreach($pageIDs as $pageID) {
-			// Load the Page on the frontend site.
-			$I->amOnPage('/?p='.$pageID);
+        // Iterate through Pages to run frontend tests.
+        foreach($pageIDs as $pageID) {
+            // Load the Page on the frontend site.
+            $I->amOnPage('/?p='.$pageID);
 
-			// Check that no PHP warnings or notices were output.
-			$I->checkNoWarningsAndNoticesOnScreen($I);
+            // Check that no PHP warnings or notices were output.
+            $I->checkNoWarningsAndNoticesOnScreen($I);
 			
-			// Confirm that the post_has_tag parameter is set to true in the source code.
-			$I->seeInSource('"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"');
-		}
-	}
+            // Confirm that the post_has_tag parameter is set to true in the source code.
+            $I->seeInSource('"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"');
+        }
+    }
 
-	/**
-	 * Deactivate and reset Plugin(s) after each test, if the test passes.
-	 * We don't use _after, as this would provide a screenshot of the Plugin
-	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function _passed(AcceptanceTester $I)
-	{
-		$I->deactivateConvertKitPlugin($I);
-		$I->resetConvertKitPlugin($I);
-	}
+    /**
+     * Deactivate and reset Plugin(s) after each test, if the test passes.
+     * We don't use _after, as this would provide a screenshot of the Plugin
+     * deactivation and not the true test error.
+     * 
+     * @since 1.9.6.7
+     * 
+     * @param AcceptanceTester $I Tester
+     */
+    public function _passed(AcceptanceTester $I)
+    {
+        $I->deactivateConvertKitPlugin($I);
+        $I->resetConvertKitPlugin($I);
+    }
 }

--- a/tests/wpunit/ResourceFormsNoDataTest.php
+++ b/tests/wpunit/ResourceFormsNoDataTest.php
@@ -1,38 +1,40 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Forms class when no data is present in the API.
- * 
- * @since 	1.9.7.8
+ *
+ * @since   1.9.7.8
  */
 class ResourceFormsNoDataTest extends \Codeception\TestCase\WPTestCase
 {
 	/**
-	 * @var \WpunitTester
+	 * The testing implementation.
+	 *
+	 * @var \WpunitTester.
 	 */
 	protected $tester;
 
 	/**
 	 * Holds the ConvertKit Settings class.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @var 	ConvertKit_Settings
+	 *
+	 * @since   1.9.7.8
+	 *
+	 * @var     ConvertKit_Settings
 	 */
 	private $settings;
 
 	/**
 	 * Holds the ConvertKit Resource class.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @var 	ConvertKit_Resource_Forms
+	 *
+	 * @since   1.9.7.8
+	 *
+	 * @var     ConvertKit_Resource_Forms
 	 */
 	private $resource;
 
 	/**
 	 * Performs actions before each test.
-	 * 
-	 * @since 	1.9.7.8
+	 *
+	 * @since   1.9.7.8
 	 */
 	public function setUp(): void
 	{
@@ -43,10 +45,13 @@ class ResourceFormsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 		// Store API Key and Secret in Plugin's settings.
 		$this->settings = new ConvertKit_Settings();
-		update_option($this->settings::SETTINGS_NAME, [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
-		]);
+		update_option(
+			$this->settings::SETTINGS_NAME,
+			[
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+			]
+		);
 
 		// Initialize the resource class we want to test.
 		$this->resource = new ConvertKit_Resource_Forms();
@@ -57,8 +62,8 @@ class ResourceFormsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Performs actions after each test.
-	 * 
-	 * @since 	1.9.6.9
+	 *
+	 * @since   1.9.6.9
 	 */
 	public function tearDown(): void
 	{
@@ -72,14 +77,14 @@ class ResourceFormsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 		// Deactivate Plugin.
 		deactivate_plugins('convertkit/wp-convertkit.php');
-		
+
 		parent::tearDown();
 	}
 
 	/**
 	 * Test that the refresh() function performs as expected, storing data in the options table.
-	 * 
-	 * @since 	1.9.7.8
+	 *
+	 * @since   1.9.7.8
 	 */
 	public function testRefresh()
 	{
@@ -92,8 +97,8 @@ class ResourceFormsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the expiry timestamp is set and returns the expected value.
-	 * 
-	 * @since 	1.9.7.8
+	 *
+	 * @since   1.9.7.8
 	 */
 	public function testExpiry()
 	{
@@ -109,8 +114,8 @@ class ResourceFormsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the get() function performs as expected.
-	 * 
-	 * @since 	1.9.7.8
+	 *
+	 * @since   1.9.7.8
 	 */
 	public function testGet()
 	{
@@ -123,8 +128,8 @@ class ResourceFormsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the count() function returns the number of resources.
-	 * 
-	 * @since 	1.9.7.6
+	 *
+	 * @since   1.9.7.6
 	 */
 	public function testCount()
 	{
@@ -134,8 +139,8 @@ class ResourceFormsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the exist() function performs as expected.
-	 * 
-	 * @since 	1.9.7.8
+	 *
+	 * @since   1.9.7.8
 	 */
 	public function testExist()
 	{

--- a/tests/wpunit/ResourceFormsNoDataTest.php
+++ b/tests/wpunit/ResourceFormsNoDataTest.php
@@ -2,145 +2,147 @@
 /**
  * Tests for the ConvertKit_Resource_Forms class when no data is present in the API.
  * 
- * @since 	1.9.7.8
+ * @since 1.9.7.8
  */
 class ResourceFormsNoDataTest extends \Codeception\TestCase\WPTestCase
 {
-	/**
-	 * @var \WpunitTester
-	 */
-	protected $tester;
+    /**
+     * @var \WpunitTester
+     */
+    protected $tester;
 
-	/**
-	 * Holds the ConvertKit Settings class.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @var 	ConvertKit_Settings
-	 */
-	private $settings;
+    /**
+     * Holds the ConvertKit Settings class.
+     * 
+     * @since 1.9.7.8
+     * 
+     * @var ConvertKit_Settings
+     */
+    private $settings;
 
-	/**
-	 * Holds the ConvertKit Resource class.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @var 	ConvertKit_Resource_Forms
-	 */
-	private $resource;
+    /**
+     * Holds the ConvertKit Resource class.
+     * 
+     * @since 1.9.7.8
+     * 
+     * @var ConvertKit_Resource_Forms
+     */
+    private $resource;
 
-	/**
-	 * Performs actions before each test.
-	 * 
-	 * @since 	1.9.7.8
-	 */
-	public function setUp(): void
-	{
-		parent::setUp();
+    /**
+     * Performs actions before each test.
+     * 
+     * @since 1.9.7.8
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
 
-		// Activate Plugin.
-		activate_plugins('convertkit/wp-convertkit.php');
+        // Activate Plugin.
+        activate_plugins('convertkit/wp-convertkit.php');
 
-		// Store API Key and Secret in Plugin's settings.
-		$this->settings = new ConvertKit_Settings();
-		update_option($this->settings::SETTINGS_NAME, [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
-		]);
+        // Store API Key and Secret in Plugin's settings.
+        $this->settings = new ConvertKit_Settings();
+        update_option(
+            $this->settings::SETTINGS_NAME, [
+            'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+            'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+            ]
+        );
 
-		// Initialize the resource class we want to test.
-		$this->resource = new ConvertKit_Resource_Forms();
+        // Initialize the resource class we want to test.
+        $this->resource = new ConvertKit_Resource_Forms();
 
-		// Confirm initialization didn't result in an error.
-		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
-	}
+        // Confirm initialization didn't result in an error.
+        $this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
+    }
 
-	/**
-	 * Performs actions after each test.
-	 * 
-	 * @since 	1.9.6.9
-	 */
-	public function tearDown(): void
-	{
-		// Delete API Key, API Secret and Resources from Plugin's settings.
-		delete_option($this->settings::SETTINGS_NAME);
-		delete_option($this->resource->settings_name);
-		delete_option($this->resource->settings_name . '_last_queried');
+    /**
+     * Performs actions after each test.
+     * 
+     * @since 1.9.6.9
+     */
+    public function tearDown(): void
+    {
+        // Delete API Key, API Secret and Resources from Plugin's settings.
+        delete_option($this->settings::SETTINGS_NAME);
+        delete_option($this->resource->settings_name);
+        delete_option($this->resource->settings_name . '_last_queried');
 
-		// Destroy the resource class we tested.
-		unset($this->resource);
+        // Destroy the resource class we tested.
+        unset($this->resource);
 
-		// Deactivate Plugin.
-		deactivate_plugins('convertkit/wp-convertkit.php');
+        // Deactivate Plugin.
+        deactivate_plugins('convertkit/wp-convertkit.php');
 		
-		parent::tearDown();
-	}
+        parent::tearDown();
+    }
 
-	/**
-	 * Test that the refresh() function performs as expected, storing data in the options table.
-	 * 
-	 * @since 	1.9.7.8
-	 */
-	public function testRefresh()
-	{
-		// Confirm that the data is stored in the options table and includes some expected keys.
-		$result = $this->resource->refresh();
-		$this->assertNotInstanceOf(WP_Error::class, $result);
-		$this->assertIsArray($result);
-		$this->assertCount(0, $result);
-	}
+    /**
+     * Test that the refresh() function performs as expected, storing data in the options table.
+     * 
+     * @since 1.9.7.8
+     */
+    public function testRefresh()
+    {
+        // Confirm that the data is stored in the options table and includes some expected keys.
+        $result = $this->resource->refresh();
+        $this->assertNotInstanceOf(WP_Error::class, $result);
+        $this->assertIsArray($result);
+        $this->assertCount(0, $result);
+    }
 
-	/**
-	 * Test that the expiry timestamp is set and returns the expected value.
-	 * 
-	 * @since 	1.9.7.8
-	 */
-	public function testExpiry()
-	{
-		// Define the expected expiry date based on the resource class' $cache_duration setting.
-		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+    /**
+     * Test that the expiry timestamp is set and returns the expected value.
+     * 
+     * @since 1.9.7.8
+     */
+    public function testExpiry()
+    {
+        // Define the expected expiry date based on the resource class' $cache_duration setting.
+        $expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
 
-		// Fetch the actual expiry date set when the resource class was initialized.
-		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+        // Fetch the actual expiry date set when the resource class was initialized.
+        $expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
 
-		// Confirm both dates match.
-		$this->assertEquals($expectedExpiryDate, $expiryDate);
-	}
+        // Confirm both dates match.
+        $this->assertEquals($expectedExpiryDate, $expiryDate);
+    }
 
-	/**
-	 * Test that the get() function performs as expected.
-	 * 
-	 * @since 	1.9.7.8
-	 */
-	public function testGet()
-	{
-		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
-		$result = $this->resource->get();
-		$this->assertNotInstanceOf(WP_Error::class, $result);
-		$this->assertIsArray($result);
-		$this->assertCount(0, $result);
-	}
+    /**
+     * Test that the get() function performs as expected.
+     * 
+     * @since 1.9.7.8
+     */
+    public function testGet()
+    {
+        // Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+        $result = $this->resource->get();
+        $this->assertNotInstanceOf(WP_Error::class, $result);
+        $this->assertIsArray($result);
+        $this->assertCount(0, $result);
+    }
 
-	/**
-	 * Test that the count() function returns the number of resources.
-	 * 
-	 * @since 	1.9.7.6
-	 */
-	public function testCount()
-	{
-		$result = $this->resource->get();
-		$this->assertEquals($this->resource->count(), count($result));
-	}
+    /**
+     * Test that the count() function returns the number of resources.
+     * 
+     * @since 1.9.7.6
+     */
+    public function testCount()
+    {
+        $result = $this->resource->get();
+        $this->assertEquals($this->resource->count(), count($result));
+    }
 
-	/**
-	 * Test that the exist() function performs as expected.
-	 * 
-	 * @since 	1.9.7.8
-	 */
-	public function testExist()
-	{
-		// Confirm that the function returns true, because resources exist.
-		$result = $this->resource->exist();
-		$this->assertSame($result, false);
-	}
+    /**
+     * Test that the exist() function performs as expected.
+     * 
+     * @since 1.9.7.8
+     */
+    public function testExist()
+    {
+        // Confirm that the function returns true, because resources exist.
+        $result = $this->resource->exist();
+        $this->assertSame($result, false);
+    }
 }

--- a/tests/wpunit/ResourceFormsNoDataTest.php
+++ b/tests/wpunit/ResourceFormsNoDataTest.php
@@ -1,150 +1,144 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Forms class when no data is present in the API.
- * 
+ *
  * @since 1.9.7.8
  */
-class ResourceFormsNoDataTest extends \Codeception\TestCase\WPTestCase
-{
-    /**
-     * The test object.
-     *
-     * @var \WpunitTester
-     */
-    protected $tester;
+class ResourceFormsNoDataTest extends \Codeception\TestCase\WPTestCase {
 
-    /**
-     * Holds the ConvertKit Settings class.
-     * 
-     * @since 1.9.7.8
-     * 
-     * @var ConvertKit_Settings
-     */
-    private $settings;
+	/**
+	 * The test object.
+	 *
+	 * @var \WpunitTester
+	 */
+	protected $tester;
 
-    /**
-     * Holds the ConvertKit Resource class.
-     * 
-     * @since 1.9.7.8
-     * 
-     * @var ConvertKit_Resource_Forms
-     */
-    private $resource;
+	/**
+	 * Holds the ConvertKit Settings class.
+	 *
+	 * @since 1.9.7.8
+	 *
+	 * @var ConvertKit_Settings
+	 */
+	private $settings;
 
-    /**
-     * Performs actions before each test.
-     * 
-     * @since 1.9.7.8
-     */
-    public function setUp(): void
-    {
-        parent::setUp();
+	/**
+	 * Holds the ConvertKit Resource class.
+	 *
+	 * @since 1.9.7.8
+	 *
+	 * @var ConvertKit_Resource_Forms
+	 */
+	private $resource;
 
-        // Activate Plugin.
-        activate_plugins('convertkit/wp-convertkit.php');
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since 1.9.7.8
+	 */
+	public function setUp(): void {
+		parent::setUp();
 
-        // Store API Key and Secret in Plugin's settings.
-        $this->settings = new ConvertKit_Settings();
-        update_option(
-            $this->settings::SETTINGS_NAME, [
-            'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
-            'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
-            ]
-        );
+		// Activate Plugin.
+		activate_plugins( 'convertkit/wp-convertkit.php' );
 
-        // Initialize the resource class we want to test.
-        $this->resource = new ConvertKit_Resource_Forms();
+		// Store API Key and Secret in Plugin's settings.
+		$this->settings = new ConvertKit_Settings();
+		update_option(
+			$this->settings::SETTINGS_NAME,
+			array(
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+			)
+		);
 
-        // Confirm initialization didn't result in an error.
-        $this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
-    }
+		// Initialize the resource class we want to test.
+		$this->resource = new ConvertKit_Resource_Forms();
 
-    /**
-     * Performs actions after each test.
-     * 
-     * @since 1.9.6.9
-     */
-    public function tearDown(): void
-    {
-        // Delete API Key, API Secret and Resources from Plugin's settings.
-        delete_option($this->settings::SETTINGS_NAME);
-        delete_option($this->resource->settings_name);
-        delete_option($this->resource->settings_name . '_last_queried');
+		// Confirm initialization didn't result in an error.
+		$this->assertNotInstanceOf( WP_Error::class, $this->resource->resources );
+	}
 
-        // Destroy the resource class we tested.
-        unset($this->resource);
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since 1.9.6.9
+	 */
+	public function tearDown(): void {
+		// Delete API Key, API Secret and Resources from Plugin's settings.
+		delete_option( $this->settings::SETTINGS_NAME );
+		delete_option( $this->resource->settings_name );
+		delete_option( $this->resource->settings_name . '_last_queried' );
 
-        // Deactivate Plugin.
-        deactivate_plugins('convertkit/wp-convertkit.php');
-		
-        parent::tearDown();
-    }
+		// Destroy the resource class we tested.
+		unset( $this->resource );
 
-    /**
-     * Test that the refresh() function performs as expected, storing data in the options table.
-     * 
-     * @since 1.9.7.8
-     */
-    public function testRefresh()
-    {
-        // Confirm that the data is stored in the options table and includes some expected keys.
-        $result = $this->resource->refresh();
-        $this->assertNotInstanceOf(WP_Error::class, $result);
-        $this->assertIsArray($result);
-        $this->assertCount(0, $result);
-    }
+		// Deactivate Plugin.
+		deactivate_plugins( 'convertkit/wp-convertkit.php' );
 
-    /**
-     * Test that the expiry timestamp is set and returns the expected value.
-     * 
-     * @since 1.9.7.8
-     */
-    public function testExpiry()
-    {
-        // Define the expected expiry date based on the resource class' $cache_duration setting.
-        $expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+		parent::tearDown();
+	}
 
-        // Fetch the actual expiry date set when the resource class was initialized.
-        $expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+	/**
+	 * Test that the refresh() function performs as expected, storing data in the options table.
+	 *
+	 * @since 1.9.7.8
+	 */
+	public function testRefresh() {
+		// Confirm that the data is stored in the options table and includes some expected keys.
+		$result = $this->resource->refresh();
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertIsArray( $result );
+		$this->assertCount( 0, $result );
+	}
 
-        // Confirm both dates match.
-        $this->assertEquals($expectedExpiryDate, $expiryDate);
-    }
+	/**
+	 * Test that the expiry timestamp is set and returns the expected value.
+	 *
+	 * @since 1.9.7.8
+	 */
+	public function testExpiry() {
+		// Define the expected expiry date based on the resource class' $cache_duration setting.
+		$expectedExpiryDate = date( 'Y-m-d', time() + $this->resource->cache_duration );
 
-    /**
-     * Test that the get() function performs as expected.
-     * 
-     * @since 1.9.7.8
-     */
-    public function testGet()
-    {
-        // Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
-        $result = $this->resource->get();
-        $this->assertNotInstanceOf(WP_Error::class, $result);
-        $this->assertIsArray($result);
-        $this->assertCount(0, $result);
-    }
+		// Fetch the actual expiry date set when the resource class was initialized.
+		$expiryDate = date( 'Y-m-d', $this->resource->last_queried + $this->resource->cache_duration );
 
-    /**
-     * Test that the count() function returns the number of resources.
-     * 
-     * @since 1.9.7.6
-     */
-    public function testCount()
-    {
-        $result = $this->resource->get();
-        $this->assertEquals($this->resource->count(), count($result));
-    }
+		// Confirm both dates match.
+		$this->assertEquals( $expectedExpiryDate, $expiryDate );
+	}
 
-    /**
-     * Test that the exist() function performs as expected.
-     * 
-     * @since 1.9.7.8
-     */
-    public function testExist()
-    {
-        // Confirm that the function returns true, because resources exist.
-        $result = $this->resource->exist();
-        $this->assertSame($result, false);
-    }
+	/**
+	 * Test that the get() function performs as expected.
+	 *
+	 * @since 1.9.7.8
+	 */
+	public function testGet() {
+		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+		$result = $this->resource->get();
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertIsArray( $result );
+		$this->assertCount( 0, $result );
+	}
+
+	/**
+	 * Test that the count() function returns the number of resources.
+	 *
+	 * @since 1.9.7.6
+	 */
+	public function testCount() {
+		$result = $this->resource->get();
+		$this->assertEquals( $this->resource->count(), count( $result ) );
+	}
+
+	/**
+	 * Test that the exist() function performs as expected.
+	 *
+	 * @since 1.9.7.8
+	 */
+	public function testExist() {
+		// Confirm that the function returns true, because resources exist.
+		$result = $this->resource->exist();
+		$this->assertSame( $result, false );
+	}
 }

--- a/tests/wpunit/ResourceFormsNoDataTest.php
+++ b/tests/wpunit/ResourceFormsNoDataTest.php
@@ -1,144 +1,146 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Forms class when no data is present in the API.
- *
- * @since 1.9.7.8
+ * 
+ * @since 	1.9.7.8
  */
-class ResourceFormsNoDataTest extends \Codeception\TestCase\WPTestCase {
-
+class ResourceFormsNoDataTest extends \Codeception\TestCase\WPTestCase
+{
 	/**
-	 * The test object.
-	 *
 	 * @var \WpunitTester
 	 */
 	protected $tester;
 
 	/**
 	 * Holds the ConvertKit Settings class.
-	 *
-	 * @since 1.9.7.8
-	 *
-	 * @var ConvertKit_Settings
+	 * 
+	 * @since 	1.9.7.8
+	 * 
+	 * @var 	ConvertKit_Settings
 	 */
 	private $settings;
 
 	/**
 	 * Holds the ConvertKit Resource class.
-	 *
-	 * @since 1.9.7.8
-	 *
-	 * @var ConvertKit_Resource_Forms
+	 * 
+	 * @since 	1.9.7.8
+	 * 
+	 * @var 	ConvertKit_Resource_Forms
 	 */
 	private $resource;
 
 	/**
 	 * Performs actions before each test.
-	 *
-	 * @since 1.9.7.8
+	 * 
+	 * @since 	1.9.7.8
 	 */
-	public function setUp(): void {
+	public function setUp(): void
+	{
 		parent::setUp();
 
 		// Activate Plugin.
-		activate_plugins( 'convertkit/wp-convertkit.php' );
+		activate_plugins('convertkit/wp-convertkit.php');
 
 		// Store API Key and Secret in Plugin's settings.
 		$this->settings = new ConvertKit_Settings();
-		update_option(
-			$this->settings::SETTINGS_NAME,
-			array(
-				'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
-				'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
-			)
-		);
+		update_option($this->settings::SETTINGS_NAME, [
+			'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+			'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+		]);
 
 		// Initialize the resource class we want to test.
 		$this->resource = new ConvertKit_Resource_Forms();
 
 		// Confirm initialization didn't result in an error.
-		$this->assertNotInstanceOf( WP_Error::class, $this->resource->resources );
+		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
 	}
 
 	/**
 	 * Performs actions after each test.
-	 *
-	 * @since 1.9.6.9
+	 * 
+	 * @since 	1.9.6.9
 	 */
-	public function tearDown(): void {
+	public function tearDown(): void
+	{
 		// Delete API Key, API Secret and Resources from Plugin's settings.
-		delete_option( $this->settings::SETTINGS_NAME );
-		delete_option( $this->resource->settings_name );
-		delete_option( $this->resource->settings_name . '_last_queried' );
+		delete_option($this->settings::SETTINGS_NAME);
+		delete_option($this->resource->settings_name);
+		delete_option($this->resource->settings_name . '_last_queried');
 
 		// Destroy the resource class we tested.
-		unset( $this->resource );
+		unset($this->resource);
 
 		// Deactivate Plugin.
-		deactivate_plugins( 'convertkit/wp-convertkit.php' );
-
+		deactivate_plugins('convertkit/wp-convertkit.php');
+		
 		parent::tearDown();
 	}
 
 	/**
 	 * Test that the refresh() function performs as expected, storing data in the options table.
-	 *
-	 * @since 1.9.7.8
+	 * 
+	 * @since 	1.9.7.8
 	 */
-	public function testRefresh() {
+	public function testRefresh()
+	{
 		// Confirm that the data is stored in the options table and includes some expected keys.
 		$result = $this->resource->refresh();
-		$this->assertNotInstanceOf( WP_Error::class, $result );
-		$this->assertIsArray( $result );
-		$this->assertCount( 0, $result );
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
 	}
 
 	/**
 	 * Test that the expiry timestamp is set and returns the expected value.
-	 *
-	 * @since 1.9.7.8
+	 * 
+	 * @since 	1.9.7.8
 	 */
-	public function testExpiry() {
+	public function testExpiry()
+	{
 		// Define the expected expiry date based on the resource class' $cache_duration setting.
-		$expectedExpiryDate = date( 'Y-m-d', time() + $this->resource->cache_duration );
+		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
 
 		// Fetch the actual expiry date set when the resource class was initialized.
-		$expiryDate = date( 'Y-m-d', $this->resource->last_queried + $this->resource->cache_duration );
+		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
 
 		// Confirm both dates match.
-		$this->assertEquals( $expectedExpiryDate, $expiryDate );
+		$this->assertEquals($expectedExpiryDate, $expiryDate);
 	}
 
 	/**
 	 * Test that the get() function performs as expected.
-	 *
-	 * @since 1.9.7.8
+	 * 
+	 * @since 	1.9.7.8
 	 */
-	public function testGet() {
+	public function testGet()
+	{
 		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
 		$result = $this->resource->get();
-		$this->assertNotInstanceOf( WP_Error::class, $result );
-		$this->assertIsArray( $result );
-		$this->assertCount( 0, $result );
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
 	}
 
 	/**
 	 * Test that the count() function returns the number of resources.
-	 *
-	 * @since 1.9.7.6
+	 * 
+	 * @since 	1.9.7.6
 	 */
-	public function testCount() {
+	public function testCount()
+	{
 		$result = $this->resource->get();
-		$this->assertEquals( $this->resource->count(), count( $result ) );
+		$this->assertEquals($this->resource->count(), count($result));
 	}
 
 	/**
 	 * Test that the exist() function performs as expected.
-	 *
-	 * @since 1.9.7.8
+	 * 
+	 * @since 	1.9.7.8
 	 */
-	public function testExist() {
+	public function testExist()
+	{
 		// Confirm that the function returns true, because resources exist.
 		$result = $this->resource->exist();
-		$this->assertSame( $result, false );
+		$this->assertSame($result, false);
 	}
 }

--- a/tests/wpunit/ResourceFormsNoDataTest.php
+++ b/tests/wpunit/ResourceFormsNoDataTest.php
@@ -7,6 +7,8 @@
 class ResourceFormsNoDataTest extends \Codeception\TestCase\WPTestCase
 {
     /**
+     * The test object.
+     *
      * @var \WpunitTester
      */
     protected $tester;

--- a/tests/wpunit/ResourceFormsTest.php
+++ b/tests/wpunit/ResourceFormsTest.php
@@ -1,145 +1,147 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Forms class.
- *
- * @since 1.9.7.4
+ * 
+ * @since 	1.9.7.4
  */
-class ResourceFormsTest extends \Codeception\TestCase\WPTestCase {
-
+class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
+{
 	/**
-	 * The test object.
-	 *
 	 * @var \WpunitTester
 	 */
 	protected $tester;
 
 	/**
 	 * Holds the ConvertKit Settings class.
-	 *
-	 * @since 1.9.7.4
-	 *
-	 * @var ConvertKit_Settings
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @var 	ConvertKit_Settings
 	 */
 	private $settings;
 
 	/**
 	 * Holds the ConvertKit Resource class.
-	 *
-	 * @since 1.9.7.4
-	 *
-	 * @var ConvertKit_Resource_Forms
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @var 	ConvertKit_Resource_Forms
 	 */
 	private $resource;
 
 	/**
 	 * Performs actions before each test.
-	 *
-	 * @since 1.9.7.4
+	 * 
+	 * @since 	1.9.7.4
 	 */
-	public function setUp(): void {
+	public function setUp(): void
+	{
 		parent::setUp();
 
 		// Activate Plugin.
-		activate_plugins( 'convertkit/wp-convertkit.php' );
+		activate_plugins('convertkit/wp-convertkit.php');
 
 		// Store API Key and Secret in Plugin's settings.
 		$this->settings = new ConvertKit_Settings();
-		update_option(
-			$this->settings::SETTINGS_NAME,
-			array(
-				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-			)
-		);
+		update_option($this->settings::SETTINGS_NAME, [
+			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+		]);
 
 		// Initialize the resource class we want to test.
 		$this->resource = new ConvertKit_Resource_Forms();
 
 		// Confirm initialization didn't result in an error.
-		$this->assertNotInstanceOf( WP_Error::class, $this->resource->resources );
+		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
 	}
 
 	/**
 	 * Performs actions after each test.
-	 *
-	 * @since 1.9.6.9
+	 * 
+	 * @since 	1.9.6.9
 	 */
-	public function tearDown(): void {
+	public function tearDown(): void
+	{
 		// Delete API Key, API Secret and Resources from Plugin's settings.
-		delete_option( $this->settings::SETTINGS_NAME );
-		delete_option( $this->resource->settings_name );
-		delete_option( $this->resource->settings_name . '_last_queried' );
+		delete_option($this->settings::SETTINGS_NAME);
+		delete_option($this->resource->settings_name);
+		delete_option($this->resource->settings_name . '_last_queried');
 
 		// Destroy the resource class we tested.
-		unset( $this->resource );
+		unset($this->resource);
 
 		// Deactivate Plugin.
-		deactivate_plugins( 'convertkit/wp-convertkit.php' );
-
+		deactivate_plugins('convertkit/wp-convertkit.php');
+		
 		parent::tearDown();
 	}
 
 	/**
 	 * Test that the refresh() function performs as expected.
-	 *
-	 * @since 1.9.7.4
+	 * 
+	 * @since 	1.9.7.4
 	 */
-	public function testRefresh() {
+	public function testRefresh()
+	{
 		// Confirm that the data is stored in the options table and includes some expected keys.
 		$result = $this->resource->refresh();
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'id', reset( $result ) );
-		$this->assertArrayHasKey( 'name', reset( $result ) );
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
 	}
 
 	/**
 	 * Test that the expiry timestamp is set and returns the expected value.
-	 *
-	 * @since 1.9.7.4
+	 * 
+	 * @since 	1.9.7.4
 	 */
-	public function testExpiry() {
+	public function testExpiry()
+	{
 		// Define the expected expiry date based on the resource class' $cache_duration setting.
-		$expectedExpiryDate = date( 'Y-m-d', time() + $this->resource->cache_duration );
+		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
 
 		// Fetch the actual expiry date set when the resource class was initialized.
-		$expiryDate = date( 'Y-m-d', $this->resource->last_queried + $this->resource->cache_duration );
+		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
 
 		// Confirm both dates match.
-		$this->assertEquals( $expectedExpiryDate, $expiryDate );
+		$this->assertEquals($expectedExpiryDate, $expiryDate);
 	}
 
 	/**
 	 * Test that the get() function performs as expected.
-	 *
-	 * @since 1.9.7.4
+	 * 
+	 * @since 	1.9.7.4
 	 */
-	public function testGet() {
+	public function testGet()
+	{
 		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
 		$result = $this->resource->get();
-		$this->assertNotInstanceOf( WP_Error::class, $result );
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'id', reset( $result ) );
-		$this->assertArrayHasKey( 'name', reset( $result ) );
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
 	}
 
 	/**
 	 * Test that the count() function returns the number of resources.
-	 *
-	 * @since 1.9.7.6
+	 * 
+	 * @since 	1.9.7.6
 	 */
-	public function testCount() {
+	public function testCount()
+	{
 		$result = $this->resource->get();
-		$this->assertEquals( $this->resource->count(), count( $result ) );
+		$this->assertEquals($this->resource->count(), count($result));
 	}
 
 	/**
 	 * Test that the exist() function performs as expected.
-	 *
-	 * @since 1.9.7.4
+	 * 
+	 * @since 	1.9.7.4
 	 */
-	public function testExist() {
+	public function testExist()
+	{
 		// Confirm that the function returns true, because resources exist.
 		$result = $this->resource->exist();
-		$this->assertSame( $result, true );
+		$this->assertSame($result, true);
 	}
 }

--- a/tests/wpunit/ResourceFormsTest.php
+++ b/tests/wpunit/ResourceFormsTest.php
@@ -7,6 +7,8 @@
 class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 {
     /**
+     * The test object.
+     *
      * @var \WpunitTester
      */
     protected $tester;

--- a/tests/wpunit/ResourceFormsTest.php
+++ b/tests/wpunit/ResourceFormsTest.php
@@ -2,146 +2,148 @@
 /**
  * Tests for the ConvertKit_Resource_Forms class.
  * 
- * @since 	1.9.7.4
+ * @since 1.9.7.4
  */
 class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 {
-	/**
-	 * @var \WpunitTester
-	 */
-	protected $tester;
+    /**
+     * @var \WpunitTester
+     */
+    protected $tester;
 
-	/**
-	 * Holds the ConvertKit Settings class.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @var 	ConvertKit_Settings
-	 */
-	private $settings;
+    /**
+     * Holds the ConvertKit Settings class.
+     * 
+     * @since 1.9.7.4
+     * 
+     * @var ConvertKit_Settings
+     */
+    private $settings;
 
-	/**
-	 * Holds the ConvertKit Resource class.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @var 	ConvertKit_Resource_Forms
-	 */
-	private $resource;
+    /**
+     * Holds the ConvertKit Resource class.
+     * 
+     * @since 1.9.7.4
+     * 
+     * @var ConvertKit_Resource_Forms
+     */
+    private $resource;
 
-	/**
-	 * Performs actions before each test.
-	 * 
-	 * @since 	1.9.7.4
-	 */
-	public function setUp(): void
-	{
-		parent::setUp();
+    /**
+     * Performs actions before each test.
+     * 
+     * @since 1.9.7.4
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
 
-		// Activate Plugin.
-		activate_plugins('convertkit/wp-convertkit.php');
+        // Activate Plugin.
+        activate_plugins('convertkit/wp-convertkit.php');
 
-		// Store API Key and Secret in Plugin's settings.
-		$this->settings = new ConvertKit_Settings();
-		update_option($this->settings::SETTINGS_NAME, [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-		]);
+        // Store API Key and Secret in Plugin's settings.
+        $this->settings = new ConvertKit_Settings();
+        update_option(
+            $this->settings::SETTINGS_NAME, [
+            'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+            'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+            ]
+        );
 
-		// Initialize the resource class we want to test.
-		$this->resource = new ConvertKit_Resource_Forms();
+        // Initialize the resource class we want to test.
+        $this->resource = new ConvertKit_Resource_Forms();
 
-		// Confirm initialization didn't result in an error.
-		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
-	}
+        // Confirm initialization didn't result in an error.
+        $this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
+    }
 
-	/**
-	 * Performs actions after each test.
-	 * 
-	 * @since 	1.9.6.9
-	 */
-	public function tearDown(): void
-	{
-		// Delete API Key, API Secret and Resources from Plugin's settings.
-		delete_option($this->settings::SETTINGS_NAME);
-		delete_option($this->resource->settings_name);
-		delete_option($this->resource->settings_name . '_last_queried');
+    /**
+     * Performs actions after each test.
+     * 
+     * @since 1.9.6.9
+     */
+    public function tearDown(): void
+    {
+        // Delete API Key, API Secret and Resources from Plugin's settings.
+        delete_option($this->settings::SETTINGS_NAME);
+        delete_option($this->resource->settings_name);
+        delete_option($this->resource->settings_name . '_last_queried');
 
-		// Destroy the resource class we tested.
-		unset($this->resource);
+        // Destroy the resource class we tested.
+        unset($this->resource);
 
-		// Deactivate Plugin.
-		deactivate_plugins('convertkit/wp-convertkit.php');
+        // Deactivate Plugin.
+        deactivate_plugins('convertkit/wp-convertkit.php');
 		
-		parent::tearDown();
-	}
+        parent::tearDown();
+    }
 
-	/**
-	 * Test that the refresh() function performs as expected.
-	 * 
-	 * @since 	1.9.7.4
-	 */
-	public function testRefresh()
-	{
-		// Confirm that the data is stored in the options table and includes some expected keys.
-		$result = $this->resource->refresh();
-		$this->assertIsArray($result);
-		$this->assertArrayHasKey('id', reset($result));
-		$this->assertArrayHasKey('name', reset($result));
-	}
+    /**
+     * Test that the refresh() function performs as expected.
+     * 
+     * @since 1.9.7.4
+     */
+    public function testRefresh()
+    {
+        // Confirm that the data is stored in the options table and includes some expected keys.
+        $result = $this->resource->refresh();
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('id', reset($result));
+        $this->assertArrayHasKey('name', reset($result));
+    }
 
-	/**
-	 * Test that the expiry timestamp is set and returns the expected value.
-	 * 
-	 * @since 	1.9.7.4
-	 */
-	public function testExpiry()
-	{
-		// Define the expected expiry date based on the resource class' $cache_duration setting.
-		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+    /**
+     * Test that the expiry timestamp is set and returns the expected value.
+     * 
+     * @since 1.9.7.4
+     */
+    public function testExpiry()
+    {
+        // Define the expected expiry date based on the resource class' $cache_duration setting.
+        $expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
 
-		// Fetch the actual expiry date set when the resource class was initialized.
-		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+        // Fetch the actual expiry date set when the resource class was initialized.
+        $expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
 
-		// Confirm both dates match.
-		$this->assertEquals($expectedExpiryDate, $expiryDate);
-	}
+        // Confirm both dates match.
+        $this->assertEquals($expectedExpiryDate, $expiryDate);
+    }
 
-	/**
-	 * Test that the get() function performs as expected.
-	 * 
-	 * @since 	1.9.7.4
-	 */
-	public function testGet()
-	{
-		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
-		$result = $this->resource->get();
-		$this->assertNotInstanceOf(WP_Error::class, $result);
-		$this->assertIsArray($result);
-		$this->assertArrayHasKey('id', reset($result));
-		$this->assertArrayHasKey('name', reset($result));
-	}
+    /**
+     * Test that the get() function performs as expected.
+     * 
+     * @since 1.9.7.4
+     */
+    public function testGet()
+    {
+        // Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+        $result = $this->resource->get();
+        $this->assertNotInstanceOf(WP_Error::class, $result);
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('id', reset($result));
+        $this->assertArrayHasKey('name', reset($result));
+    }
 
-	/**
-	 * Test that the count() function returns the number of resources.
-	 * 
-	 * @since 	1.9.7.6
-	 */
-	public function testCount()
-	{
-		$result = $this->resource->get();
-		$this->assertEquals($this->resource->count(), count($result));
-	}
+    /**
+     * Test that the count() function returns the number of resources.
+     * 
+     * @since 1.9.7.6
+     */
+    public function testCount()
+    {
+        $result = $this->resource->get();
+        $this->assertEquals($this->resource->count(), count($result));
+    }
 
-	/**
-	 * Test that the exist() function performs as expected.
-	 * 
-	 * @since 	1.9.7.4
-	 */
-	public function testExist()
-	{
-		// Confirm that the function returns true, because resources exist.
-		$result = $this->resource->exist();
-		$this->assertSame($result, true);
-	}
+    /**
+     * Test that the exist() function performs as expected.
+     * 
+     * @since 1.9.7.4
+     */
+    public function testExist()
+    {
+        // Confirm that the function returns true, because resources exist.
+        $result = $this->resource->exist();
+        $this->assertSame($result, true);
+    }
 }

--- a/tests/wpunit/ResourceFormsTest.php
+++ b/tests/wpunit/ResourceFormsTest.php
@@ -1,151 +1,145 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Forms class.
- * 
+ *
  * @since 1.9.7.4
  */
-class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
-{
-    /**
-     * The test object.
-     *
-     * @var \WpunitTester
-     */
-    protected $tester;
+class ResourceFormsTest extends \Codeception\TestCase\WPTestCase {
 
-    /**
-     * Holds the ConvertKit Settings class.
-     * 
-     * @since 1.9.7.4
-     * 
-     * @var ConvertKit_Settings
-     */
-    private $settings;
+	/**
+	 * The test object.
+	 *
+	 * @var \WpunitTester
+	 */
+	protected $tester;
 
-    /**
-     * Holds the ConvertKit Resource class.
-     * 
-     * @since 1.9.7.4
-     * 
-     * @var ConvertKit_Resource_Forms
-     */
-    private $resource;
+	/**
+	 * Holds the ConvertKit Settings class.
+	 *
+	 * @since 1.9.7.4
+	 *
+	 * @var ConvertKit_Settings
+	 */
+	private $settings;
 
-    /**
-     * Performs actions before each test.
-     * 
-     * @since 1.9.7.4
-     */
-    public function setUp(): void
-    {
-        parent::setUp();
+	/**
+	 * Holds the ConvertKit Resource class.
+	 *
+	 * @since 1.9.7.4
+	 *
+	 * @var ConvertKit_Resource_Forms
+	 */
+	private $resource;
 
-        // Activate Plugin.
-        activate_plugins('convertkit/wp-convertkit.php');
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since 1.9.7.4
+	 */
+	public function setUp(): void {
+		parent::setUp();
 
-        // Store API Key and Secret in Plugin's settings.
-        $this->settings = new ConvertKit_Settings();
-        update_option(
-            $this->settings::SETTINGS_NAME, [
-            'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-            'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-            ]
-        );
+		// Activate Plugin.
+		activate_plugins( 'convertkit/wp-convertkit.php' );
 
-        // Initialize the resource class we want to test.
-        $this->resource = new ConvertKit_Resource_Forms();
+		// Store API Key and Secret in Plugin's settings.
+		$this->settings = new ConvertKit_Settings();
+		update_option(
+			$this->settings::SETTINGS_NAME,
+			array(
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+			)
+		);
 
-        // Confirm initialization didn't result in an error.
-        $this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
-    }
+		// Initialize the resource class we want to test.
+		$this->resource = new ConvertKit_Resource_Forms();
 
-    /**
-     * Performs actions after each test.
-     * 
-     * @since 1.9.6.9
-     */
-    public function tearDown(): void
-    {
-        // Delete API Key, API Secret and Resources from Plugin's settings.
-        delete_option($this->settings::SETTINGS_NAME);
-        delete_option($this->resource->settings_name);
-        delete_option($this->resource->settings_name . '_last_queried');
+		// Confirm initialization didn't result in an error.
+		$this->assertNotInstanceOf( WP_Error::class, $this->resource->resources );
+	}
 
-        // Destroy the resource class we tested.
-        unset($this->resource);
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since 1.9.6.9
+	 */
+	public function tearDown(): void {
+		// Delete API Key, API Secret and Resources from Plugin's settings.
+		delete_option( $this->settings::SETTINGS_NAME );
+		delete_option( $this->resource->settings_name );
+		delete_option( $this->resource->settings_name . '_last_queried' );
 
-        // Deactivate Plugin.
-        deactivate_plugins('convertkit/wp-convertkit.php');
-		
-        parent::tearDown();
-    }
+		// Destroy the resource class we tested.
+		unset( $this->resource );
 
-    /**
-     * Test that the refresh() function performs as expected.
-     * 
-     * @since 1.9.7.4
-     */
-    public function testRefresh()
-    {
-        // Confirm that the data is stored in the options table and includes some expected keys.
-        $result = $this->resource->refresh();
-        $this->assertIsArray($result);
-        $this->assertArrayHasKey('id', reset($result));
-        $this->assertArrayHasKey('name', reset($result));
-    }
+		// Deactivate Plugin.
+		deactivate_plugins( 'convertkit/wp-convertkit.php' );
 
-    /**
-     * Test that the expiry timestamp is set and returns the expected value.
-     * 
-     * @since 1.9.7.4
-     */
-    public function testExpiry()
-    {
-        // Define the expected expiry date based on the resource class' $cache_duration setting.
-        $expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+		parent::tearDown();
+	}
 
-        // Fetch the actual expiry date set when the resource class was initialized.
-        $expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+	/**
+	 * Test that the refresh() function performs as expected.
+	 *
+	 * @since 1.9.7.4
+	 */
+	public function testRefresh() {
+		// Confirm that the data is stored in the options table and includes some expected keys.
+		$result = $this->resource->refresh();
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'id', reset( $result ) );
+		$this->assertArrayHasKey( 'name', reset( $result ) );
+	}
 
-        // Confirm both dates match.
-        $this->assertEquals($expectedExpiryDate, $expiryDate);
-    }
+	/**
+	 * Test that the expiry timestamp is set and returns the expected value.
+	 *
+	 * @since 1.9.7.4
+	 */
+	public function testExpiry() {
+		// Define the expected expiry date based on the resource class' $cache_duration setting.
+		$expectedExpiryDate = date( 'Y-m-d', time() + $this->resource->cache_duration );
 
-    /**
-     * Test that the get() function performs as expected.
-     * 
-     * @since 1.9.7.4
-     */
-    public function testGet()
-    {
-        // Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
-        $result = $this->resource->get();
-        $this->assertNotInstanceOf(WP_Error::class, $result);
-        $this->assertIsArray($result);
-        $this->assertArrayHasKey('id', reset($result));
-        $this->assertArrayHasKey('name', reset($result));
-    }
+		// Fetch the actual expiry date set when the resource class was initialized.
+		$expiryDate = date( 'Y-m-d', $this->resource->last_queried + $this->resource->cache_duration );
 
-    /**
-     * Test that the count() function returns the number of resources.
-     * 
-     * @since 1.9.7.6
-     */
-    public function testCount()
-    {
-        $result = $this->resource->get();
-        $this->assertEquals($this->resource->count(), count($result));
-    }
+		// Confirm both dates match.
+		$this->assertEquals( $expectedExpiryDate, $expiryDate );
+	}
 
-    /**
-     * Test that the exist() function performs as expected.
-     * 
-     * @since 1.9.7.4
-     */
-    public function testExist()
-    {
-        // Confirm that the function returns true, because resources exist.
-        $result = $this->resource->exist();
-        $this->assertSame($result, true);
-    }
+	/**
+	 * Test that the get() function performs as expected.
+	 *
+	 * @since 1.9.7.4
+	 */
+	public function testGet() {
+		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+		$result = $this->resource->get();
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'id', reset( $result ) );
+		$this->assertArrayHasKey( 'name', reset( $result ) );
+	}
+
+	/**
+	 * Test that the count() function returns the number of resources.
+	 *
+	 * @since 1.9.7.6
+	 */
+	public function testCount() {
+		$result = $this->resource->get();
+		$this->assertEquals( $this->resource->count(), count( $result ) );
+	}
+
+	/**
+	 * Test that the exist() function performs as expected.
+	 *
+	 * @since 1.9.7.4
+	 */
+	public function testExist() {
+		// Confirm that the function returns true, because resources exist.
+		$result = $this->resource->exist();
+		$this->assertSame( $result, true );
+	}
 }

--- a/tests/wpunit/ResourceFormsTest.php
+++ b/tests/wpunit/ResourceFormsTest.php
@@ -1,38 +1,40 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Forms class.
- * 
- * @since 	1.9.7.4
+ *
+ * @since   1.9.7.4
  */
 class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 {
 	/**
-	 * @var \WpunitTester
+	 * The testing implementation.
+	 *
+	 * @var \WpunitTester.
 	 */
 	protected $tester;
 
 	/**
 	 * Holds the ConvertKit Settings class.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @var 	ConvertKit_Settings
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @var     ConvertKit_Settings
 	 */
 	private $settings;
 
 	/**
 	 * Holds the ConvertKit Resource class.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @var 	ConvertKit_Resource_Forms
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @var     ConvertKit_Resource_Forms
 	 */
 	private $resource;
 
 	/**
 	 * Performs actions before each test.
-	 * 
-	 * @since 	1.9.7.4
+	 *
+	 * @since   1.9.7.4
 	 */
 	public function setUp(): void
 	{
@@ -43,10 +45,13 @@ class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 
 		// Store API Key and Secret in Plugin's settings.
 		$this->settings = new ConvertKit_Settings();
-		update_option($this->settings::SETTINGS_NAME, [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-		]);
+		update_option(
+			$this->settings::SETTINGS_NAME,
+			[
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+			]
+		);
 
 		// Initialize the resource class we want to test.
 		$this->resource = new ConvertKit_Resource_Forms();
@@ -57,8 +62,8 @@ class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Performs actions after each test.
-	 * 
-	 * @since 	1.9.6.9
+	 *
+	 * @since   1.9.6.9
 	 */
 	public function tearDown(): void
 	{
@@ -72,14 +77,14 @@ class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 
 		// Deactivate Plugin.
 		deactivate_plugins('convertkit/wp-convertkit.php');
-		
+
 		parent::tearDown();
 	}
 
 	/**
 	 * Test that the refresh() function performs as expected.
-	 * 
-	 * @since 	1.9.7.4
+	 *
+	 * @since   1.9.7.4
 	 */
 	public function testRefresh()
 	{
@@ -92,8 +97,8 @@ class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the expiry timestamp is set and returns the expected value.
-	 * 
-	 * @since 	1.9.7.4
+	 *
+	 * @since   1.9.7.4
 	 */
 	public function testExpiry()
 	{
@@ -109,8 +114,8 @@ class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the get() function performs as expected.
-	 * 
-	 * @since 	1.9.7.4
+	 *
+	 * @since   1.9.7.4
 	 */
 	public function testGet()
 	{
@@ -124,8 +129,8 @@ class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the count() function returns the number of resources.
-	 * 
-	 * @since 	1.9.7.6
+	 *
+	 * @since   1.9.7.6
 	 */
 	public function testCount()
 	{
@@ -135,8 +140,8 @@ class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the exist() function performs as expected.
-	 * 
-	 * @since 	1.9.7.4
+	 *
+	 * @since   1.9.7.4
 	 */
 	public function testExist()
 	{

--- a/tests/wpunit/ResourceLandingPagesNoDataTest.php
+++ b/tests/wpunit/ResourceLandingPagesNoDataTest.php
@@ -1,144 +1,146 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Landing_Pages class when no data is present in the API.
- *
- * @since 1.9.7.8
+ * 
+ * @since 	1.9.7.8
  */
-class ResourceLandingPagesNoDataTest extends \Codeception\TestCase\WPTestCase {
-
+class ResourceLandingPagesNoDataTest extends \Codeception\TestCase\WPTestCase
+{
 	/**
-	 * The test object.
-	 *
 	 * @var \WpunitTester
 	 */
 	protected $tester;
 
 	/**
 	 * Holds the ConvertKit Settings class.
-	 *
-	 * @since 1.9.7.8
-	 *
-	 * @var ConvertKit_Settings
+	 * 
+	 * @since 	1.9.7.8
+	 * 
+	 * @var 	ConvertKit_Settings
 	 */
 	private $settings;
 
 	/**
 	 * Holds the ConvertKit Resource class.
-	 *
-	 * @since 1.9.7.8
-	 *
-	 * @var ConvertKit_Resource_Forms
+	 * 
+	 * @since 	1.9.7.8
+	 * 
+	 * @var 	ConvertKit_Resource_Forms
 	 */
 	private $resource;
 
 	/**
 	 * Performs actions before each test.
-	 *
-	 * @since 1.9.7.8
+	 * 
+	 * @since 	1.9.7.8
 	 */
-	public function setUp(): void {
+	public function setUp(): void
+	{
 		parent::setUp();
 
 		// Activate Plugin.
-		activate_plugins( 'convertkit/wp-convertkit.php' );
+		activate_plugins('convertkit/wp-convertkit.php');
 
 		// Store API Key and Secret in Plugin's settings.
 		$this->settings = new ConvertKit_Settings();
-		update_option(
-			$this->settings::SETTINGS_NAME,
-			array(
-				'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
-				'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
-			)
-		);
+		update_option($this->settings::SETTINGS_NAME, [
+			'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+			'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+		]);
 
 		// Initialize the resource class we want to test.
 		$this->resource = new ConvertKit_Resource_Forms();
 
 		// Confirm initialization didn't result in an error.
-		$this->assertNotInstanceOf( WP_Error::class, $this->resource->resources );
+		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
 	}
 
 	/**
 	 * Performs actions after each test.
-	 *
-	 * @since 1.9.6.9
+	 * 
+	 * @since 	1.9.6.9
 	 */
-	public function tearDown(): void {
+	public function tearDown(): void
+	{
 		// Delete API Key, API Secret and Resources from Plugin's settings.
-		delete_option( $this->settings::SETTINGS_NAME );
-		delete_option( $this->resource->settings_name );
-		delete_option( $this->resource->settings_name . '_last_queried' );
+		delete_option($this->settings::SETTINGS_NAME);
+		delete_option($this->resource->settings_name);
+		delete_option($this->resource->settings_name . '_last_queried');
 
 		// Destroy the resource class we tested.
-		unset( $this->resource );
+		unset($this->resource);
 
 		// Deactivate Plugin.
-		deactivate_plugins( 'convertkit/wp-convertkit.php' );
-
+		deactivate_plugins('convertkit/wp-convertkit.php');
+		
 		parent::tearDown();
 	}
 
 	/**
 	 * Test that the refresh() function performs as expected.
-	 *
-	 * @since 1.9.7.8
+	 * 
+	 * @since 	1.9.7.8
 	 */
-	public function testRefresh() {
+	public function testRefresh()
+	{
 		// Confirm that the data is stored in the options table and includes some expected keys.
 		$result = $this->resource->refresh();
-		$this->assertNotInstanceOf( WP_Error::class, $result );
-		$this->assertIsArray( $result );
-		$this->assertCount( 0, $result );
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
 	}
 
 	/**
 	 * Test that the expiry timestamp is set and returns the expected value.
-	 *
-	 * @since 1.9.7.8
+	 * 
+	 * @since 	1.9.7.8
 	 */
-	public function testExpiry() {
+	public function testExpiry()
+	{
 		// Define the expected expiry date based on the resource class' $cache_duration setting.
-		$expectedExpiryDate = date( 'Y-m-d', time() + $this->resource->cache_duration );
+		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
 
 		// Fetch the actual expiry date set when the resource class was initialized.
-		$expiryDate = date( 'Y-m-d', $this->resource->last_queried + $this->resource->cache_duration );
+		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
 
 		// Confirm both dates match.
-		$this->assertEquals( $expectedExpiryDate, $expiryDate );
+		$this->assertEquals($expectedExpiryDate, $expiryDate);
 	}
 
 	/**
 	 * Test that the get() function performs as expected.
-	 *
-	 * @since 1.9.7.8
+	 * 
+	 * @since 	1.9.7.8
 	 */
-	public function testGet() {
+	public function testGet()
+	{
 		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
 		$result = $this->resource->get();
-		$this->assertNotInstanceOf( WP_Error::class, $result );
-		$this->assertIsArray( $result );
-		$this->assertCount( 0, $result );
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
 	}
 
 	/**
 	 * Test that the count() function returns the number of resources.
-	 *
-	 * @since 1.9.7.6
+	 * 
+	 * @since 	1.9.7.6
 	 */
-	public function testCount() {
+	public function testCount()
+	{
 		$result = $this->resource->get();
-		$this->assertEquals( $this->resource->count(), count( $result ) );
+		$this->assertEquals($this->resource->count(), count($result));
 	}
 
 	/**
 	 * Test that the exist() function performs as expected.
-	 *
-	 * @since 1.9.7.8
+	 * 
+	 * @since 	1.9.7.8
 	 */
-	public function testExist() {
+	public function testExist()
+	{
 		// Confirm that the function returns true, because resources exist.
 		$result = $this->resource->exist();
-		$this->assertSame( $result, false );
+		$this->assertSame($result, false);
 	}
 }

--- a/tests/wpunit/ResourceLandingPagesNoDataTest.php
+++ b/tests/wpunit/ResourceLandingPagesNoDataTest.php
@@ -1,38 +1,40 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Landing_Pages class when no data is present in the API.
- * 
- * @since 	1.9.7.8
+ *
+ * @since   1.9.7.8
  */
 class ResourceLandingPagesNoDataTest extends \Codeception\TestCase\WPTestCase
 {
 	/**
-	 * @var \WpunitTester
+	 * The testing implementation.
+	 *
+	 * @var \WpunitTester.
 	 */
 	protected $tester;
 
 	/**
 	 * Holds the ConvertKit Settings class.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @var 	ConvertKit_Settings
+	 *
+	 * @since   1.9.7.8
+	 *
+	 * @var     ConvertKit_Settings
 	 */
 	private $settings;
 
 	/**
 	 * Holds the ConvertKit Resource class.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @var 	ConvertKit_Resource_Forms
+	 *
+	 * @since   1.9.7.8
+	 *
+	 * @var     ConvertKit_Resource_Forms
 	 */
 	private $resource;
 
 	/**
 	 * Performs actions before each test.
-	 * 
-	 * @since 	1.9.7.8
+	 *
+	 * @since   1.9.7.8
 	 */
 	public function setUp(): void
 	{
@@ -43,10 +45,13 @@ class ResourceLandingPagesNoDataTest extends \Codeception\TestCase\WPTestCase
 
 		// Store API Key and Secret in Plugin's settings.
 		$this->settings = new ConvertKit_Settings();
-		update_option($this->settings::SETTINGS_NAME, [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
-		]);
+		update_option(
+			$this->settings::SETTINGS_NAME,
+			[
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+			]
+		);
 
 		// Initialize the resource class we want to test.
 		$this->resource = new ConvertKit_Resource_Forms();
@@ -57,8 +62,8 @@ class ResourceLandingPagesNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Performs actions after each test.
-	 * 
-	 * @since 	1.9.6.9
+	 *
+	 * @since   1.9.6.9
 	 */
 	public function tearDown(): void
 	{
@@ -72,14 +77,14 @@ class ResourceLandingPagesNoDataTest extends \Codeception\TestCase\WPTestCase
 
 		// Deactivate Plugin.
 		deactivate_plugins('convertkit/wp-convertkit.php');
-		
+
 		parent::tearDown();
 	}
 
 	/**
 	 * Test that the refresh() function performs as expected.
-	 * 
-	 * @since 	1.9.7.8
+	 *
+	 * @since   1.9.7.8
 	 */
 	public function testRefresh()
 	{
@@ -92,8 +97,8 @@ class ResourceLandingPagesNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the expiry timestamp is set and returns the expected value.
-	 * 
-	 * @since 	1.9.7.8
+	 *
+	 * @since   1.9.7.8
 	 */
 	public function testExpiry()
 	{
@@ -109,8 +114,8 @@ class ResourceLandingPagesNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the get() function performs as expected.
-	 * 
-	 * @since 	1.9.7.8
+	 *
+	 * @since   1.9.7.8
 	 */
 	public function testGet()
 	{
@@ -123,8 +128,8 @@ class ResourceLandingPagesNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the count() function returns the number of resources.
-	 * 
-	 * @since 	1.9.7.6
+	 *
+	 * @since   1.9.7.6
 	 */
 	public function testCount()
 	{
@@ -134,8 +139,8 @@ class ResourceLandingPagesNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the exist() function performs as expected.
-	 * 
-	 * @since 	1.9.7.8
+	 *
+	 * @since   1.9.7.8
 	 */
 	public function testExist()
 	{

--- a/tests/wpunit/ResourceLandingPagesNoDataTest.php
+++ b/tests/wpunit/ResourceLandingPagesNoDataTest.php
@@ -2,145 +2,147 @@
 /**
  * Tests for the ConvertKit_Resource_Landing_Pages class when no data is present in the API.
  * 
- * @since 	1.9.7.8
+ * @since 1.9.7.8
  */
 class ResourceLandingPagesNoDataTest extends \Codeception\TestCase\WPTestCase
 {
-	/**
-	 * @var \WpunitTester
-	 */
-	protected $tester;
+    /**
+     * @var \WpunitTester
+     */
+    protected $tester;
 
-	/**
-	 * Holds the ConvertKit Settings class.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @var 	ConvertKit_Settings
-	 */
-	private $settings;
+    /**
+     * Holds the ConvertKit Settings class.
+     * 
+     * @since 1.9.7.8
+     * 
+     * @var ConvertKit_Settings
+     */
+    private $settings;
 
-	/**
-	 * Holds the ConvertKit Resource class.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @var 	ConvertKit_Resource_Forms
-	 */
-	private $resource;
+    /**
+     * Holds the ConvertKit Resource class.
+     * 
+     * @since 1.9.7.8
+     * 
+     * @var ConvertKit_Resource_Forms
+     */
+    private $resource;
 
-	/**
-	 * Performs actions before each test.
-	 * 
-	 * @since 	1.9.7.8
-	 */
-	public function setUp(): void
-	{
-		parent::setUp();
+    /**
+     * Performs actions before each test.
+     * 
+     * @since 1.9.7.8
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
 
-		// Activate Plugin.
-		activate_plugins('convertkit/wp-convertkit.php');
+        // Activate Plugin.
+        activate_plugins('convertkit/wp-convertkit.php');
 
-		// Store API Key and Secret in Plugin's settings.
-		$this->settings = new ConvertKit_Settings();
-		update_option($this->settings::SETTINGS_NAME, [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
-		]);
+        // Store API Key and Secret in Plugin's settings.
+        $this->settings = new ConvertKit_Settings();
+        update_option(
+            $this->settings::SETTINGS_NAME, [
+            'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+            'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+            ]
+        );
 
-		// Initialize the resource class we want to test.
-		$this->resource = new ConvertKit_Resource_Forms();
+        // Initialize the resource class we want to test.
+        $this->resource = new ConvertKit_Resource_Forms();
 
-		// Confirm initialization didn't result in an error.
-		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
-	}
+        // Confirm initialization didn't result in an error.
+        $this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
+    }
 
-	/**
-	 * Performs actions after each test.
-	 * 
-	 * @since 	1.9.6.9
-	 */
-	public function tearDown(): void
-	{
-		// Delete API Key, API Secret and Resources from Plugin's settings.
-		delete_option($this->settings::SETTINGS_NAME);
-		delete_option($this->resource->settings_name);
-		delete_option($this->resource->settings_name . '_last_queried');
+    /**
+     * Performs actions after each test.
+     * 
+     * @since 1.9.6.9
+     */
+    public function tearDown(): void
+    {
+        // Delete API Key, API Secret and Resources from Plugin's settings.
+        delete_option($this->settings::SETTINGS_NAME);
+        delete_option($this->resource->settings_name);
+        delete_option($this->resource->settings_name . '_last_queried');
 
-		// Destroy the resource class we tested.
-		unset($this->resource);
+        // Destroy the resource class we tested.
+        unset($this->resource);
 
-		// Deactivate Plugin.
-		deactivate_plugins('convertkit/wp-convertkit.php');
+        // Deactivate Plugin.
+        deactivate_plugins('convertkit/wp-convertkit.php');
 		
-		parent::tearDown();
-	}
+        parent::tearDown();
+    }
 
-	/**
-	 * Test that the refresh() function performs as expected.
-	 * 
-	 * @since 	1.9.7.8
-	 */
-	public function testRefresh()
-	{
-		// Confirm that the data is stored in the options table and includes some expected keys.
-		$result = $this->resource->refresh();
-		$this->assertNotInstanceOf(WP_Error::class, $result);
-		$this->assertIsArray($result);
-		$this->assertCount(0, $result);
-	}
+    /**
+     * Test that the refresh() function performs as expected.
+     * 
+     * @since 1.9.7.8
+     */
+    public function testRefresh()
+    {
+        // Confirm that the data is stored in the options table and includes some expected keys.
+        $result = $this->resource->refresh();
+        $this->assertNotInstanceOf(WP_Error::class, $result);
+        $this->assertIsArray($result);
+        $this->assertCount(0, $result);
+    }
 
-	/**
-	 * Test that the expiry timestamp is set and returns the expected value.
-	 * 
-	 * @since 	1.9.7.8
-	 */
-	public function testExpiry()
-	{
-		// Define the expected expiry date based on the resource class' $cache_duration setting.
-		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+    /**
+     * Test that the expiry timestamp is set and returns the expected value.
+     * 
+     * @since 1.9.7.8
+     */
+    public function testExpiry()
+    {
+        // Define the expected expiry date based on the resource class' $cache_duration setting.
+        $expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
 
-		// Fetch the actual expiry date set when the resource class was initialized.
-		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+        // Fetch the actual expiry date set when the resource class was initialized.
+        $expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
 
-		// Confirm both dates match.
-		$this->assertEquals($expectedExpiryDate, $expiryDate);
-	}
+        // Confirm both dates match.
+        $this->assertEquals($expectedExpiryDate, $expiryDate);
+    }
 
-	/**
-	 * Test that the get() function performs as expected.
-	 * 
-	 * @since 	1.9.7.8
-	 */
-	public function testGet()
-	{
-		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
-		$result = $this->resource->get();
-		$this->assertNotInstanceOf(WP_Error::class, $result);
-		$this->assertIsArray($result);
-		$this->assertCount(0, $result);
-	}
+    /**
+     * Test that the get() function performs as expected.
+     * 
+     * @since 1.9.7.8
+     */
+    public function testGet()
+    {
+        // Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+        $result = $this->resource->get();
+        $this->assertNotInstanceOf(WP_Error::class, $result);
+        $this->assertIsArray($result);
+        $this->assertCount(0, $result);
+    }
 
-	/**
-	 * Test that the count() function returns the number of resources.
-	 * 
-	 * @since 	1.9.7.6
-	 */
-	public function testCount()
-	{
-		$result = $this->resource->get();
-		$this->assertEquals($this->resource->count(), count($result));
-	}
+    /**
+     * Test that the count() function returns the number of resources.
+     * 
+     * @since 1.9.7.6
+     */
+    public function testCount()
+    {
+        $result = $this->resource->get();
+        $this->assertEquals($this->resource->count(), count($result));
+    }
 
-	/**
-	 * Test that the exist() function performs as expected.
-	 * 
-	 * @since 	1.9.7.8
-	 */
-	public function testExist()
-	{
-		// Confirm that the function returns true, because resources exist.
-		$result = $this->resource->exist();
-		$this->assertSame($result, false);
-	}
+    /**
+     * Test that the exist() function performs as expected.
+     * 
+     * @since 1.9.7.8
+     */
+    public function testExist()
+    {
+        // Confirm that the function returns true, because resources exist.
+        $result = $this->resource->exist();
+        $this->assertSame($result, false);
+    }
 }

--- a/tests/wpunit/ResourceLandingPagesNoDataTest.php
+++ b/tests/wpunit/ResourceLandingPagesNoDataTest.php
@@ -1,150 +1,144 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Landing_Pages class when no data is present in the API.
- * 
+ *
  * @since 1.9.7.8
  */
-class ResourceLandingPagesNoDataTest extends \Codeception\TestCase\WPTestCase
-{
-    /**
-     * The test object.
-     *
-     * @var \WpunitTester
-     */
-    protected $tester;
+class ResourceLandingPagesNoDataTest extends \Codeception\TestCase\WPTestCase {
 
-    /**
-     * Holds the ConvertKit Settings class.
-     * 
-     * @since 1.9.7.8
-     * 
-     * @var ConvertKit_Settings
-     */
-    private $settings;
+	/**
+	 * The test object.
+	 *
+	 * @var \WpunitTester
+	 */
+	protected $tester;
 
-    /**
-     * Holds the ConvertKit Resource class.
-     * 
-     * @since 1.9.7.8
-     * 
-     * @var ConvertKit_Resource_Forms
-     */
-    private $resource;
+	/**
+	 * Holds the ConvertKit Settings class.
+	 *
+	 * @since 1.9.7.8
+	 *
+	 * @var ConvertKit_Settings
+	 */
+	private $settings;
 
-    /**
-     * Performs actions before each test.
-     * 
-     * @since 1.9.7.8
-     */
-    public function setUp(): void
-    {
-        parent::setUp();
+	/**
+	 * Holds the ConvertKit Resource class.
+	 *
+	 * @since 1.9.7.8
+	 *
+	 * @var ConvertKit_Resource_Forms
+	 */
+	private $resource;
 
-        // Activate Plugin.
-        activate_plugins('convertkit/wp-convertkit.php');
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since 1.9.7.8
+	 */
+	public function setUp(): void {
+		parent::setUp();
 
-        // Store API Key and Secret in Plugin's settings.
-        $this->settings = new ConvertKit_Settings();
-        update_option(
-            $this->settings::SETTINGS_NAME, [
-            'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
-            'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
-            ]
-        );
+		// Activate Plugin.
+		activate_plugins( 'convertkit/wp-convertkit.php' );
 
-        // Initialize the resource class we want to test.
-        $this->resource = new ConvertKit_Resource_Forms();
+		// Store API Key and Secret in Plugin's settings.
+		$this->settings = new ConvertKit_Settings();
+		update_option(
+			$this->settings::SETTINGS_NAME,
+			array(
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+			)
+		);
 
-        // Confirm initialization didn't result in an error.
-        $this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
-    }
+		// Initialize the resource class we want to test.
+		$this->resource = new ConvertKit_Resource_Forms();
 
-    /**
-     * Performs actions after each test.
-     * 
-     * @since 1.9.6.9
-     */
-    public function tearDown(): void
-    {
-        // Delete API Key, API Secret and Resources from Plugin's settings.
-        delete_option($this->settings::SETTINGS_NAME);
-        delete_option($this->resource->settings_name);
-        delete_option($this->resource->settings_name . '_last_queried');
+		// Confirm initialization didn't result in an error.
+		$this->assertNotInstanceOf( WP_Error::class, $this->resource->resources );
+	}
 
-        // Destroy the resource class we tested.
-        unset($this->resource);
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since 1.9.6.9
+	 */
+	public function tearDown(): void {
+		// Delete API Key, API Secret and Resources from Plugin's settings.
+		delete_option( $this->settings::SETTINGS_NAME );
+		delete_option( $this->resource->settings_name );
+		delete_option( $this->resource->settings_name . '_last_queried' );
 
-        // Deactivate Plugin.
-        deactivate_plugins('convertkit/wp-convertkit.php');
-		
-        parent::tearDown();
-    }
+		// Destroy the resource class we tested.
+		unset( $this->resource );
 
-    /**
-     * Test that the refresh() function performs as expected.
-     * 
-     * @since 1.9.7.8
-     */
-    public function testRefresh()
-    {
-        // Confirm that the data is stored in the options table and includes some expected keys.
-        $result = $this->resource->refresh();
-        $this->assertNotInstanceOf(WP_Error::class, $result);
-        $this->assertIsArray($result);
-        $this->assertCount(0, $result);
-    }
+		// Deactivate Plugin.
+		deactivate_plugins( 'convertkit/wp-convertkit.php' );
 
-    /**
-     * Test that the expiry timestamp is set and returns the expected value.
-     * 
-     * @since 1.9.7.8
-     */
-    public function testExpiry()
-    {
-        // Define the expected expiry date based on the resource class' $cache_duration setting.
-        $expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+		parent::tearDown();
+	}
 
-        // Fetch the actual expiry date set when the resource class was initialized.
-        $expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+	/**
+	 * Test that the refresh() function performs as expected.
+	 *
+	 * @since 1.9.7.8
+	 */
+	public function testRefresh() {
+		// Confirm that the data is stored in the options table and includes some expected keys.
+		$result = $this->resource->refresh();
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertIsArray( $result );
+		$this->assertCount( 0, $result );
+	}
 
-        // Confirm both dates match.
-        $this->assertEquals($expectedExpiryDate, $expiryDate);
-    }
+	/**
+	 * Test that the expiry timestamp is set and returns the expected value.
+	 *
+	 * @since 1.9.7.8
+	 */
+	public function testExpiry() {
+		// Define the expected expiry date based on the resource class' $cache_duration setting.
+		$expectedExpiryDate = date( 'Y-m-d', time() + $this->resource->cache_duration );
 
-    /**
-     * Test that the get() function performs as expected.
-     * 
-     * @since 1.9.7.8
-     */
-    public function testGet()
-    {
-        // Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
-        $result = $this->resource->get();
-        $this->assertNotInstanceOf(WP_Error::class, $result);
-        $this->assertIsArray($result);
-        $this->assertCount(0, $result);
-    }
+		// Fetch the actual expiry date set when the resource class was initialized.
+		$expiryDate = date( 'Y-m-d', $this->resource->last_queried + $this->resource->cache_duration );
 
-    /**
-     * Test that the count() function returns the number of resources.
-     * 
-     * @since 1.9.7.6
-     */
-    public function testCount()
-    {
-        $result = $this->resource->get();
-        $this->assertEquals($this->resource->count(), count($result));
-    }
+		// Confirm both dates match.
+		$this->assertEquals( $expectedExpiryDate, $expiryDate );
+	}
 
-    /**
-     * Test that the exist() function performs as expected.
-     * 
-     * @since 1.9.7.8
-     */
-    public function testExist()
-    {
-        // Confirm that the function returns true, because resources exist.
-        $result = $this->resource->exist();
-        $this->assertSame($result, false);
-    }
+	/**
+	 * Test that the get() function performs as expected.
+	 *
+	 * @since 1.9.7.8
+	 */
+	public function testGet() {
+		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+		$result = $this->resource->get();
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertIsArray( $result );
+		$this->assertCount( 0, $result );
+	}
+
+	/**
+	 * Test that the count() function returns the number of resources.
+	 *
+	 * @since 1.9.7.6
+	 */
+	public function testCount() {
+		$result = $this->resource->get();
+		$this->assertEquals( $this->resource->count(), count( $result ) );
+	}
+
+	/**
+	 * Test that the exist() function performs as expected.
+	 *
+	 * @since 1.9.7.8
+	 */
+	public function testExist() {
+		// Confirm that the function returns true, because resources exist.
+		$result = $this->resource->exist();
+		$this->assertSame( $result, false );
+	}
 }

--- a/tests/wpunit/ResourceLandingPagesNoDataTest.php
+++ b/tests/wpunit/ResourceLandingPagesNoDataTest.php
@@ -7,6 +7,8 @@
 class ResourceLandingPagesNoDataTest extends \Codeception\TestCase\WPTestCase
 {
     /**
+     * The test object.
+     *
      * @var \WpunitTester
      */
     protected $tester;

--- a/tests/wpunit/ResourceLandingPagesTest.php
+++ b/tests/wpunit/ResourceLandingPagesTest.php
@@ -1,38 +1,40 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Landing_Pages class.
- * 
- * @since 	1.9.7.4
+ *
+ * @since   1.9.7.4
  */
 class ResourceLandingPagesTest extends \Codeception\TestCase\WPTestCase
 {
 	/**
-	 * @var \WpunitTester
+	 * The testing implementation.
+	 *
+	 * @var \WpunitTester.
 	 */
 	protected $tester;
 
 	/**
 	 * Holds the ConvertKit Settings class.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @var 	ConvertKit_Settings
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @var     ConvertKit_Settings
 	 */
 	private $settings;
 
 	/**
 	 * Holds the ConvertKit Resource class.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @var 	ConvertKit_Resource_Landing_Pages
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @var     ConvertKit_Resource_Landing_Pages
 	 */
 	private $resource;
 
 	/**
 	 * Performs actions before each test.
-	 * 
-	 * @since 	1.9.7.4
+	 *
+	 * @since   1.9.7.4
 	 */
 	public function setUp(): void
 	{
@@ -43,10 +45,13 @@ class ResourceLandingPagesTest extends \Codeception\TestCase\WPTestCase
 
 		// Store API Key and Secret in Plugin's settings.
 		$this->settings = new ConvertKit_Settings();
-		update_option($this->settings::SETTINGS_NAME, [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-		]);
+		update_option(
+			$this->settings::SETTINGS_NAME,
+			[
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+			]
+		);
 
 		// Initialize the resource class we want to test.
 		$this->resource = new ConvertKit_Resource_Landing_Pages();
@@ -57,8 +62,8 @@ class ResourceLandingPagesTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Performs actions after each test.
-	 * 
-	 * @since 	1.9.6.9
+	 *
+	 * @since   1.9.6.9
 	 */
 	public function tearDown(): void
 	{
@@ -78,8 +83,8 @@ class ResourceLandingPagesTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the refresh() function performs as expected.
-	 * 
-	 * @since 	1.9.7.4
+	 *
+	 * @since   1.9.7.4
 	 */
 	public function testRefresh()
 	{
@@ -92,8 +97,8 @@ class ResourceLandingPagesTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the expiry timestamp is set and returns the expected value.
-	 * 
-	 * @since 	1.9.7.4
+	 *
+	 * @since   1.9.7.4
 	 */
 	public function testExpiry()
 	{
@@ -109,8 +114,8 @@ class ResourceLandingPagesTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the get() function performs as expected.
-	 * 
-	 * @since 	1.9.7.4
+	 *
+	 * @since   1.9.7.4
 	 */
 	public function testGet()
 	{
@@ -124,8 +129,8 @@ class ResourceLandingPagesTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the count() function returns the number of resources.
-	 * 
-	 * @since 	1.9.7.6
+	 *
+	 * @since   1.9.7.6
 	 */
 	public function testCount()
 	{
@@ -135,8 +140,8 @@ class ResourceLandingPagesTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the exist() function performs as expected.
-	 * 
-	 * @since 	1.9.7.4
+	 *
+	 * @since   1.9.7.4
 	 */
 	public function testExist()
 	{

--- a/tests/wpunit/ResourceLandingPagesTest.php
+++ b/tests/wpunit/ResourceLandingPagesTest.php
@@ -2,146 +2,148 @@
 /**
  * Tests for the ConvertKit_Resource_Landing_Pages class.
  * 
- * @since 	1.9.7.4
+ * @since 1.9.7.4
  */
 class ResourceLandingPagesTest extends \Codeception\TestCase\WPTestCase
 {
-	/**
-	 * @var \WpunitTester
-	 */
-	protected $tester;
+    /**
+     * @var \WpunitTester
+     */
+    protected $tester;
 
-	/**
-	 * Holds the ConvertKit Settings class.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @var 	ConvertKit_Settings
-	 */
-	private $settings;
+    /**
+     * Holds the ConvertKit Settings class.
+     * 
+     * @since 1.9.7.4
+     * 
+     * @var ConvertKit_Settings
+     */
+    private $settings;
 
-	/**
-	 * Holds the ConvertKit Resource class.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @var 	ConvertKit_Resource_Landing_Pages
-	 */
-	private $resource;
+    /**
+     * Holds the ConvertKit Resource class.
+     * 
+     * @since 1.9.7.4
+     * 
+     * @var ConvertKit_Resource_Landing_Pages
+     */
+    private $resource;
 
-	/**
-	 * Performs actions before each test.
-	 * 
-	 * @since 	1.9.7.4
-	 */
-	public function setUp(): void
-	{
-		parent::setUp();
+    /**
+     * Performs actions before each test.
+     * 
+     * @since 1.9.7.4
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
 
-		// Activate Plugin.
-		activate_plugins('convertkit/wp-convertkit.php');
+        // Activate Plugin.
+        activate_plugins('convertkit/wp-convertkit.php');
 
-		// Store API Key and Secret in Plugin's settings.
-		$this->settings = new ConvertKit_Settings();
-		update_option($this->settings::SETTINGS_NAME, [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-		]);
+        // Store API Key and Secret in Plugin's settings.
+        $this->settings = new ConvertKit_Settings();
+        update_option(
+            $this->settings::SETTINGS_NAME, [
+            'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+            'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+            ]
+        );
 
-		// Initialize the resource class we want to test.
-		$this->resource = new ConvertKit_Resource_Landing_Pages();
+        // Initialize the resource class we want to test.
+        $this->resource = new ConvertKit_Resource_Landing_Pages();
 
-		// Confirm initialization didn't result in an error.
-		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
-	}
+        // Confirm initialization didn't result in an error.
+        $this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
+    }
 
-	/**
-	 * Performs actions after each test.
-	 * 
-	 * @since 	1.9.6.9
-	 */
-	public function tearDown(): void
-	{
-		// Delete API Key, API Secret and Resources from Plugin's settings.
-		delete_option($this->settings::SETTINGS_NAME);
-		delete_option($this->resource->settings_name);
-		delete_option($this->resource->settings_name . '_last_queried');
+    /**
+     * Performs actions after each test.
+     * 
+     * @since 1.9.6.9
+     */
+    public function tearDown(): void
+    {
+        // Delete API Key, API Secret and Resources from Plugin's settings.
+        delete_option($this->settings::SETTINGS_NAME);
+        delete_option($this->resource->settings_name);
+        delete_option($this->resource->settings_name . '_last_queried');
 
-		// Destroy the resource class we tested.
-		unset($this->resource);
+        // Destroy the resource class we tested.
+        unset($this->resource);
 
-		// Deactivate Plugin.
-		deactivate_plugins('convertkit/wp-convertkit.php');
+        // Deactivate Plugin.
+        deactivate_plugins('convertkit/wp-convertkit.php');
 
-		parent::tearDown();
-	}
+        parent::tearDown();
+    }
 
-	/**
-	 * Test that the refresh() function performs as expected.
-	 * 
-	 * @since 	1.9.7.4
-	 */
-	public function testRefresh()
-	{
-		// Confirm that the data is stored in the options table and includes some expected keys.
-		$result = $this->resource->refresh();
-		$this->assertIsArray($result);
-		$this->assertArrayHasKey('id', reset($result));
-		$this->assertArrayHasKey('name', reset($result));
-	}
+    /**
+     * Test that the refresh() function performs as expected.
+     * 
+     * @since 1.9.7.4
+     */
+    public function testRefresh()
+    {
+        // Confirm that the data is stored in the options table and includes some expected keys.
+        $result = $this->resource->refresh();
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('id', reset($result));
+        $this->assertArrayHasKey('name', reset($result));
+    }
 
-	/**
-	 * Test that the expiry timestamp is set and returns the expected value.
-	 * 
-	 * @since 	1.9.7.4
-	 */
-	public function testExpiry()
-	{
-		// Define the expected expiry date based on the resource class' $cache_duration setting.
-		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+    /**
+     * Test that the expiry timestamp is set and returns the expected value.
+     * 
+     * @since 1.9.7.4
+     */
+    public function testExpiry()
+    {
+        // Define the expected expiry date based on the resource class' $cache_duration setting.
+        $expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
 
-		// Fetch the actual expiry date set when the resource class was initialized.
-		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+        // Fetch the actual expiry date set when the resource class was initialized.
+        $expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
 
-		// Confirm both dates match.
-		$this->assertEquals($expectedExpiryDate, $expiryDate);
-	}
+        // Confirm both dates match.
+        $this->assertEquals($expectedExpiryDate, $expiryDate);
+    }
 
-	/**
-	 * Test that the get() function performs as expected.
-	 * 
-	 * @since 	1.9.7.4
-	 */
-	public function testGet()
-	{
-		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
-		$result = $this->resource->get();
-		$this->assertNotInstanceOf(WP_Error::class, $result);
-		$this->assertIsArray($result);
-		$this->assertArrayHasKey('id', reset($result));
-		$this->assertArrayHasKey('name', reset($result));
-	}
+    /**
+     * Test that the get() function performs as expected.
+     * 
+     * @since 1.9.7.4
+     */
+    public function testGet()
+    {
+        // Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+        $result = $this->resource->get();
+        $this->assertNotInstanceOf(WP_Error::class, $result);
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('id', reset($result));
+        $this->assertArrayHasKey('name', reset($result));
+    }
 
-	/**
-	 * Test that the count() function returns the number of resources.
-	 * 
-	 * @since 	1.9.7.6
-	 */
-	public function testCount()
-	{
-		$result = $this->resource->get();
-		$this->assertEquals($this->resource->count(), count($result));
-	}
+    /**
+     * Test that the count() function returns the number of resources.
+     * 
+     * @since 1.9.7.6
+     */
+    public function testCount()
+    {
+        $result = $this->resource->get();
+        $this->assertEquals($this->resource->count(), count($result));
+    }
 
-	/**
-	 * Test that the exist() function performs as expected.
-	 * 
-	 * @since 	1.9.7.4
-	 */
-	public function testExist()
-	{
-		// Confirm that the function returns true, because resources exist.
-		$result = $this->resource->exist();
-		$this->assertSame($result, true);
-	}
+    /**
+     * Test that the exist() function performs as expected.
+     * 
+     * @since 1.9.7.4
+     */
+    public function testExist()
+    {
+        // Confirm that the function returns true, because resources exist.
+        $result = $this->resource->exist();
+        $this->assertSame($result, true);
+    }
 }

--- a/tests/wpunit/ResourceLandingPagesTest.php
+++ b/tests/wpunit/ResourceLandingPagesTest.php
@@ -1,151 +1,145 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Landing_Pages class.
- * 
+ *
  * @since 1.9.7.4
  */
-class ResourceLandingPagesTest extends \Codeception\TestCase\WPTestCase
-{
-    /**
-     * The test object.
-     *
-     * @var \WpunitTester
-     */
-    protected $tester;
+class ResourceLandingPagesTest extends \Codeception\TestCase\WPTestCase {
 
-    /**
-     * Holds the ConvertKit Settings class.
-     * 
-     * @since 1.9.7.4
-     * 
-     * @var ConvertKit_Settings
-     */
-    private $settings;
+	/**
+	 * The test object.
+	 *
+	 * @var \WpunitTester
+	 */
+	protected $tester;
 
-    /**
-     * Holds the ConvertKit Resource class.
-     * 
-     * @since 1.9.7.4
-     * 
-     * @var ConvertKit_Resource_Landing_Pages
-     */
-    private $resource;
+	/**
+	 * Holds the ConvertKit Settings class.
+	 *
+	 * @since 1.9.7.4
+	 *
+	 * @var ConvertKit_Settings
+	 */
+	private $settings;
 
-    /**
-     * Performs actions before each test.
-     * 
-     * @since 1.9.7.4
-     */
-    public function setUp(): void
-    {
-        parent::setUp();
+	/**
+	 * Holds the ConvertKit Resource class.
+	 *
+	 * @since 1.9.7.4
+	 *
+	 * @var ConvertKit_Resource_Landing_Pages
+	 */
+	private $resource;
 
-        // Activate Plugin.
-        activate_plugins('convertkit/wp-convertkit.php');
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since 1.9.7.4
+	 */
+	public function setUp(): void {
+		parent::setUp();
 
-        // Store API Key and Secret in Plugin's settings.
-        $this->settings = new ConvertKit_Settings();
-        update_option(
-            $this->settings::SETTINGS_NAME, [
-            'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-            'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-            ]
-        );
+		// Activate Plugin.
+		activate_plugins( 'convertkit/wp-convertkit.php' );
 
-        // Initialize the resource class we want to test.
-        $this->resource = new ConvertKit_Resource_Landing_Pages();
+		// Store API Key and Secret in Plugin's settings.
+		$this->settings = new ConvertKit_Settings();
+		update_option(
+			$this->settings::SETTINGS_NAME,
+			array(
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+			)
+		);
 
-        // Confirm initialization didn't result in an error.
-        $this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
-    }
+		// Initialize the resource class we want to test.
+		$this->resource = new ConvertKit_Resource_Landing_Pages();
 
-    /**
-     * Performs actions after each test.
-     * 
-     * @since 1.9.6.9
-     */
-    public function tearDown(): void
-    {
-        // Delete API Key, API Secret and Resources from Plugin's settings.
-        delete_option($this->settings::SETTINGS_NAME);
-        delete_option($this->resource->settings_name);
-        delete_option($this->resource->settings_name . '_last_queried');
+		// Confirm initialization didn't result in an error.
+		$this->assertNotInstanceOf( WP_Error::class, $this->resource->resources );
+	}
 
-        // Destroy the resource class we tested.
-        unset($this->resource);
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since 1.9.6.9
+	 */
+	public function tearDown(): void {
+		// Delete API Key, API Secret and Resources from Plugin's settings.
+		delete_option( $this->settings::SETTINGS_NAME );
+		delete_option( $this->resource->settings_name );
+		delete_option( $this->resource->settings_name . '_last_queried' );
 
-        // Deactivate Plugin.
-        deactivate_plugins('convertkit/wp-convertkit.php');
+		// Destroy the resource class we tested.
+		unset( $this->resource );
 
-        parent::tearDown();
-    }
+		// Deactivate Plugin.
+		deactivate_plugins( 'convertkit/wp-convertkit.php' );
 
-    /**
-     * Test that the refresh() function performs as expected.
-     * 
-     * @since 1.9.7.4
-     */
-    public function testRefresh()
-    {
-        // Confirm that the data is stored in the options table and includes some expected keys.
-        $result = $this->resource->refresh();
-        $this->assertIsArray($result);
-        $this->assertArrayHasKey('id', reset($result));
-        $this->assertArrayHasKey('name', reset($result));
-    }
+		parent::tearDown();
+	}
 
-    /**
-     * Test that the expiry timestamp is set and returns the expected value.
-     * 
-     * @since 1.9.7.4
-     */
-    public function testExpiry()
-    {
-        // Define the expected expiry date based on the resource class' $cache_duration setting.
-        $expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+	/**
+	 * Test that the refresh() function performs as expected.
+	 *
+	 * @since 1.9.7.4
+	 */
+	public function testRefresh() {
+		// Confirm that the data is stored in the options table and includes some expected keys.
+		$result = $this->resource->refresh();
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'id', reset( $result ) );
+		$this->assertArrayHasKey( 'name', reset( $result ) );
+	}
 
-        // Fetch the actual expiry date set when the resource class was initialized.
-        $expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+	/**
+	 * Test that the expiry timestamp is set and returns the expected value.
+	 *
+	 * @since 1.9.7.4
+	 */
+	public function testExpiry() {
+		// Define the expected expiry date based on the resource class' $cache_duration setting.
+		$expectedExpiryDate = date( 'Y-m-d', time() + $this->resource->cache_duration );
 
-        // Confirm both dates match.
-        $this->assertEquals($expectedExpiryDate, $expiryDate);
-    }
+		// Fetch the actual expiry date set when the resource class was initialized.
+		$expiryDate = date( 'Y-m-d', $this->resource->last_queried + $this->resource->cache_duration );
 
-    /**
-     * Test that the get() function performs as expected.
-     * 
-     * @since 1.9.7.4
-     */
-    public function testGet()
-    {
-        // Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
-        $result = $this->resource->get();
-        $this->assertNotInstanceOf(WP_Error::class, $result);
-        $this->assertIsArray($result);
-        $this->assertArrayHasKey('id', reset($result));
-        $this->assertArrayHasKey('name', reset($result));
-    }
+		// Confirm both dates match.
+		$this->assertEquals( $expectedExpiryDate, $expiryDate );
+	}
 
-    /**
-     * Test that the count() function returns the number of resources.
-     * 
-     * @since 1.9.7.6
-     */
-    public function testCount()
-    {
-        $result = $this->resource->get();
-        $this->assertEquals($this->resource->count(), count($result));
-    }
+	/**
+	 * Test that the get() function performs as expected.
+	 *
+	 * @since 1.9.7.4
+	 */
+	public function testGet() {
+		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+		$result = $this->resource->get();
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'id', reset( $result ) );
+		$this->assertArrayHasKey( 'name', reset( $result ) );
+	}
 
-    /**
-     * Test that the exist() function performs as expected.
-     * 
-     * @since 1.9.7.4
-     */
-    public function testExist()
-    {
-        // Confirm that the function returns true, because resources exist.
-        $result = $this->resource->exist();
-        $this->assertSame($result, true);
-    }
+	/**
+	 * Test that the count() function returns the number of resources.
+	 *
+	 * @since 1.9.7.6
+	 */
+	public function testCount() {
+		$result = $this->resource->get();
+		$this->assertEquals( $this->resource->count(), count( $result ) );
+	}
+
+	/**
+	 * Test that the exist() function performs as expected.
+	 *
+	 * @since 1.9.7.4
+	 */
+	public function testExist() {
+		// Confirm that the function returns true, because resources exist.
+		$result = $this->resource->exist();
+		$this->assertSame( $result, true );
+	}
 }

--- a/tests/wpunit/ResourceLandingPagesTest.php
+++ b/tests/wpunit/ResourceLandingPagesTest.php
@@ -7,6 +7,8 @@
 class ResourceLandingPagesTest extends \Codeception\TestCase\WPTestCase
 {
     /**
+     * The test object.
+     *
      * @var \WpunitTester
      */
     protected $tester;

--- a/tests/wpunit/ResourceLandingPagesTest.php
+++ b/tests/wpunit/ResourceLandingPagesTest.php
@@ -1,145 +1,147 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Landing_Pages class.
- *
- * @since 1.9.7.4
+ * 
+ * @since 	1.9.7.4
  */
-class ResourceLandingPagesTest extends \Codeception\TestCase\WPTestCase {
-
+class ResourceLandingPagesTest extends \Codeception\TestCase\WPTestCase
+{
 	/**
-	 * The test object.
-	 *
 	 * @var \WpunitTester
 	 */
 	protected $tester;
 
 	/**
 	 * Holds the ConvertKit Settings class.
-	 *
-	 * @since 1.9.7.4
-	 *
-	 * @var ConvertKit_Settings
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @var 	ConvertKit_Settings
 	 */
 	private $settings;
 
 	/**
 	 * Holds the ConvertKit Resource class.
-	 *
-	 * @since 1.9.7.4
-	 *
-	 * @var ConvertKit_Resource_Landing_Pages
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @var 	ConvertKit_Resource_Landing_Pages
 	 */
 	private $resource;
 
 	/**
 	 * Performs actions before each test.
-	 *
-	 * @since 1.9.7.4
+	 * 
+	 * @since 	1.9.7.4
 	 */
-	public function setUp(): void {
+	public function setUp(): void
+	{
 		parent::setUp();
 
 		// Activate Plugin.
-		activate_plugins( 'convertkit/wp-convertkit.php' );
+		activate_plugins('convertkit/wp-convertkit.php');
 
 		// Store API Key and Secret in Plugin's settings.
 		$this->settings = new ConvertKit_Settings();
-		update_option(
-			$this->settings::SETTINGS_NAME,
-			array(
-				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-			)
-		);
+		update_option($this->settings::SETTINGS_NAME, [
+			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+		]);
 
 		// Initialize the resource class we want to test.
 		$this->resource = new ConvertKit_Resource_Landing_Pages();
 
 		// Confirm initialization didn't result in an error.
-		$this->assertNotInstanceOf( WP_Error::class, $this->resource->resources );
+		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
 	}
 
 	/**
 	 * Performs actions after each test.
-	 *
-	 * @since 1.9.6.9
+	 * 
+	 * @since 	1.9.6.9
 	 */
-	public function tearDown(): void {
+	public function tearDown(): void
+	{
 		// Delete API Key, API Secret and Resources from Plugin's settings.
-		delete_option( $this->settings::SETTINGS_NAME );
-		delete_option( $this->resource->settings_name );
-		delete_option( $this->resource->settings_name . '_last_queried' );
+		delete_option($this->settings::SETTINGS_NAME);
+		delete_option($this->resource->settings_name);
+		delete_option($this->resource->settings_name . '_last_queried');
 
 		// Destroy the resource class we tested.
-		unset( $this->resource );
+		unset($this->resource);
 
 		// Deactivate Plugin.
-		deactivate_plugins( 'convertkit/wp-convertkit.php' );
+		deactivate_plugins('convertkit/wp-convertkit.php');
 
 		parent::tearDown();
 	}
 
 	/**
 	 * Test that the refresh() function performs as expected.
-	 *
-	 * @since 1.9.7.4
+	 * 
+	 * @since 	1.9.7.4
 	 */
-	public function testRefresh() {
+	public function testRefresh()
+	{
 		// Confirm that the data is stored in the options table and includes some expected keys.
 		$result = $this->resource->refresh();
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'id', reset( $result ) );
-		$this->assertArrayHasKey( 'name', reset( $result ) );
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
 	}
 
 	/**
 	 * Test that the expiry timestamp is set and returns the expected value.
-	 *
-	 * @since 1.9.7.4
+	 * 
+	 * @since 	1.9.7.4
 	 */
-	public function testExpiry() {
+	public function testExpiry()
+	{
 		// Define the expected expiry date based on the resource class' $cache_duration setting.
-		$expectedExpiryDate = date( 'Y-m-d', time() + $this->resource->cache_duration );
+		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
 
 		// Fetch the actual expiry date set when the resource class was initialized.
-		$expiryDate = date( 'Y-m-d', $this->resource->last_queried + $this->resource->cache_duration );
+		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
 
 		// Confirm both dates match.
-		$this->assertEquals( $expectedExpiryDate, $expiryDate );
+		$this->assertEquals($expectedExpiryDate, $expiryDate);
 	}
 
 	/**
 	 * Test that the get() function performs as expected.
-	 *
-	 * @since 1.9.7.4
+	 * 
+	 * @since 	1.9.7.4
 	 */
-	public function testGet() {
+	public function testGet()
+	{
 		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
 		$result = $this->resource->get();
-		$this->assertNotInstanceOf( WP_Error::class, $result );
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'id', reset( $result ) );
-		$this->assertArrayHasKey( 'name', reset( $result ) );
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
 	}
 
 	/**
 	 * Test that the count() function returns the number of resources.
-	 *
-	 * @since 1.9.7.6
+	 * 
+	 * @since 	1.9.7.6
 	 */
-	public function testCount() {
+	public function testCount()
+	{
 		$result = $this->resource->get();
-		$this->assertEquals( $this->resource->count(), count( $result ) );
+		$this->assertEquals($this->resource->count(), count($result));
 	}
 
 	/**
 	 * Test that the exist() function performs as expected.
-	 *
-	 * @since 1.9.7.4
+	 * 
+	 * @since 	1.9.7.4
 	 */
-	public function testExist() {
+	public function testExist()
+	{
 		// Confirm that the function returns true, because resources exist.
 		$result = $this->resource->exist();
-		$this->assertSame( $result, true );
+		$this->assertSame($result, true);
 	}
 }

--- a/tests/wpunit/ResourcePostsNoDataTest.php
+++ b/tests/wpunit/ResourcePostsNoDataTest.php
@@ -2,145 +2,147 @@
 /**
  * Tests for the ConvertKit_Resource_Posts class when no data is present in the API.
  * 
- * @since 	1.9.7.8
+ * @since 1.9.7.8
  */
 class ResourcePostsNoDataTest extends \Codeception\TestCase\WPTestCase
 {
-	/**
-	 * @var \WpunitTester
-	 */
-	protected $tester;
+    /**
+     * @var \WpunitTester
+     */
+    protected $tester;
 
-	/**
-	 * Holds the ConvertKit Settings class.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @var 	ConvertKit_Settings
-	 */
-	private $settings;
+    /**
+     * Holds the ConvertKit Settings class.
+     * 
+     * @since 1.9.7.8
+     * 
+     * @var ConvertKit_Settings
+     */
+    private $settings;
 
-	/**
-	 * Holds the ConvertKit Resource class.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @var 	ConvertKit_Resource_Forms
-	 */
-	private $resource;
+    /**
+     * Holds the ConvertKit Resource class.
+     * 
+     * @since 1.9.7.8
+     * 
+     * @var ConvertKit_Resource_Forms
+     */
+    private $resource;
 
-	/**
-	 * Performs actions before each test.
-	 * 
-	 * @since 	1.9.7.8
-	 */
-	public function setUp(): void
-	{
-		parent::setUp();
+    /**
+     * Performs actions before each test.
+     * 
+     * @since 1.9.7.8
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
 
-		// Activate Plugin.
-		activate_plugins('convertkit/wp-convertkit.php');
+        // Activate Plugin.
+        activate_plugins('convertkit/wp-convertkit.php');
 
-		// Store API Key and Secret in Plugin's settings.
-		$this->settings = new ConvertKit_Settings();
-		update_option($this->settings::SETTINGS_NAME, [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
-		]);
+        // Store API Key and Secret in Plugin's settings.
+        $this->settings = new ConvertKit_Settings();
+        update_option(
+            $this->settings::SETTINGS_NAME, [
+            'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+            'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+            ]
+        );
 
-		// Initialize the resource class we want to test.
-		$this->resource = new ConvertKit_Resource_Forms();
+        // Initialize the resource class we want to test.
+        $this->resource = new ConvertKit_Resource_Forms();
 
-		// Confirm initialization didn't result in an error.
-		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
-	}
+        // Confirm initialization didn't result in an error.
+        $this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
+    }
 
-	/**
-	 * Performs actions after each test.
-	 * 
-	 * @since 	1.9.6.9
-	 */
-	public function tearDown(): void
-	{
-		// Delete API Key, API Secret and Resources from Plugin's settings.
-		delete_option($this->settings::SETTINGS_NAME);
-		delete_option($this->resource->settings_name);
-		delete_option($this->resource->settings_name . '_last_queried');
+    /**
+     * Performs actions after each test.
+     * 
+     * @since 1.9.6.9
+     */
+    public function tearDown(): void
+    {
+        // Delete API Key, API Secret and Resources from Plugin's settings.
+        delete_option($this->settings::SETTINGS_NAME);
+        delete_option($this->resource->settings_name);
+        delete_option($this->resource->settings_name . '_last_queried');
 
-		// Destroy the resource class we tested.
-		unset($this->resource);
+        // Destroy the resource class we tested.
+        unset($this->resource);
 
-		// Deactivate Plugin.
-		deactivate_plugins('convertkit/wp-convertkit.php');
+        // Deactivate Plugin.
+        deactivate_plugins('convertkit/wp-convertkit.php');
 		
-		parent::tearDown();
-	}
+        parent::tearDown();
+    }
 
-	/**
-	 * Test that the refresh() function performs as expected.
-	 * 
-	 * @since 	1.9.7.8
-	 */
-	public function testRefresh()
-	{
-		// Confirm that the data is stored in the options table and includes some expected keys.
-		$result = $this->resource->refresh();
-		$this->assertNotInstanceOf(WP_Error::class, $result);
-		$this->assertIsArray($result);
-		$this->assertCount(0, $result);
-	}
+    /**
+     * Test that the refresh() function performs as expected.
+     * 
+     * @since 1.9.7.8
+     */
+    public function testRefresh()
+    {
+        // Confirm that the data is stored in the options table and includes some expected keys.
+        $result = $this->resource->refresh();
+        $this->assertNotInstanceOf(WP_Error::class, $result);
+        $this->assertIsArray($result);
+        $this->assertCount(0, $result);
+    }
 
-	/**
-	 * Test that the expiry timestamp is set and returns the expected value.
-	 * 
-	 * @since 	1.9.7.8
-	 */
-	public function testExpiry()
-	{
-		// Define the expected expiry date based on the resource class' $cache_duration setting.
-		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+    /**
+     * Test that the expiry timestamp is set and returns the expected value.
+     * 
+     * @since 1.9.7.8
+     */
+    public function testExpiry()
+    {
+        // Define the expected expiry date based on the resource class' $cache_duration setting.
+        $expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
 
-		// Fetch the actual expiry date set when the resource class was initialized.
-		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+        // Fetch the actual expiry date set when the resource class was initialized.
+        $expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
 
-		// Confirm both dates match.
-		$this->assertEquals($expectedExpiryDate, $expiryDate);
-	}
+        // Confirm both dates match.
+        $this->assertEquals($expectedExpiryDate, $expiryDate);
+    }
 
-	/**
-	 * Test that the get() function performs as expected.
-	 * 
-	 * @since 	1.9.7.8
-	 */
-	public function testGet()
-	{
-		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
-		$result = $this->resource->get();
-		$this->assertNotInstanceOf(WP_Error::class, $result);
-		$this->assertIsArray($result);
-		$this->assertCount(0, $result);
-	}
+    /**
+     * Test that the get() function performs as expected.
+     * 
+     * @since 1.9.7.8
+     */
+    public function testGet()
+    {
+        // Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+        $result = $this->resource->get();
+        $this->assertNotInstanceOf(WP_Error::class, $result);
+        $this->assertIsArray($result);
+        $this->assertCount(0, $result);
+    }
 
-	/**
-	 * Test that the count() function returns the number of resources.
-	 * 
-	 * @since 	1.9.7.6
-	 */
-	public function testCount()
-	{
-		$result = $this->resource->get();
-		$this->assertEquals($this->resource->count(), count($result));
-	}
+    /**
+     * Test that the count() function returns the number of resources.
+     * 
+     * @since 1.9.7.6
+     */
+    public function testCount()
+    {
+        $result = $this->resource->get();
+        $this->assertEquals($this->resource->count(), count($result));
+    }
 
-	/**
-	 * Test that the exist() function performs as expected.
-	 * 
-	 * @since 	1.9.7.8
-	 */
-	public function testExist()
-	{
-		// Confirm that the function returns true, because resources exist.
-		$result = $this->resource->exist();
-		$this->assertSame($result, false);
-	}
+    /**
+     * Test that the exist() function performs as expected.
+     * 
+     * @since 1.9.7.8
+     */
+    public function testExist()
+    {
+        // Confirm that the function returns true, because resources exist.
+        $result = $this->resource->exist();
+        $this->assertSame($result, false);
+    }
 }

--- a/tests/wpunit/ResourcePostsNoDataTest.php
+++ b/tests/wpunit/ResourcePostsNoDataTest.php
@@ -1,144 +1,146 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Posts class when no data is present in the API.
- *
- * @since 1.9.7.8
+ * 
+ * @since 	1.9.7.8
  */
-class ResourcePostsNoDataTest extends \Codeception\TestCase\WPTestCase {
-
+class ResourcePostsNoDataTest extends \Codeception\TestCase\WPTestCase
+{
 	/**
-	 * The test object.
-	 *
 	 * @var \WpunitTester
 	 */
 	protected $tester;
 
 	/**
 	 * Holds the ConvertKit Settings class.
-	 *
-	 * @since 1.9.7.8
-	 *
-	 * @var ConvertKit_Settings
+	 * 
+	 * @since 	1.9.7.8
+	 * 
+	 * @var 	ConvertKit_Settings
 	 */
 	private $settings;
 
 	/**
 	 * Holds the ConvertKit Resource class.
-	 *
-	 * @since 1.9.7.8
-	 *
-	 * @var ConvertKit_Resource_Forms
+	 * 
+	 * @since 	1.9.7.8
+	 * 
+	 * @var 	ConvertKit_Resource_Forms
 	 */
 	private $resource;
 
 	/**
 	 * Performs actions before each test.
-	 *
-	 * @since 1.9.7.8
+	 * 
+	 * @since 	1.9.7.8
 	 */
-	public function setUp(): void {
+	public function setUp(): void
+	{
 		parent::setUp();
 
 		// Activate Plugin.
-		activate_plugins( 'convertkit/wp-convertkit.php' );
+		activate_plugins('convertkit/wp-convertkit.php');
 
 		// Store API Key and Secret in Plugin's settings.
 		$this->settings = new ConvertKit_Settings();
-		update_option(
-			$this->settings::SETTINGS_NAME,
-			array(
-				'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
-				'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
-			)
-		);
+		update_option($this->settings::SETTINGS_NAME, [
+			'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+			'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+		]);
 
 		// Initialize the resource class we want to test.
 		$this->resource = new ConvertKit_Resource_Forms();
 
 		// Confirm initialization didn't result in an error.
-		$this->assertNotInstanceOf( WP_Error::class, $this->resource->resources );
+		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
 	}
 
 	/**
 	 * Performs actions after each test.
-	 *
-	 * @since 1.9.6.9
+	 * 
+	 * @since 	1.9.6.9
 	 */
-	public function tearDown(): void {
+	public function tearDown(): void
+	{
 		// Delete API Key, API Secret and Resources from Plugin's settings.
-		delete_option( $this->settings::SETTINGS_NAME );
-		delete_option( $this->resource->settings_name );
-		delete_option( $this->resource->settings_name . '_last_queried' );
+		delete_option($this->settings::SETTINGS_NAME);
+		delete_option($this->resource->settings_name);
+		delete_option($this->resource->settings_name . '_last_queried');
 
 		// Destroy the resource class we tested.
-		unset( $this->resource );
+		unset($this->resource);
 
 		// Deactivate Plugin.
-		deactivate_plugins( 'convertkit/wp-convertkit.php' );
-
+		deactivate_plugins('convertkit/wp-convertkit.php');
+		
 		parent::tearDown();
 	}
 
 	/**
 	 * Test that the refresh() function performs as expected.
-	 *
-	 * @since 1.9.7.8
+	 * 
+	 * @since 	1.9.7.8
 	 */
-	public function testRefresh() {
+	public function testRefresh()
+	{
 		// Confirm that the data is stored in the options table and includes some expected keys.
 		$result = $this->resource->refresh();
-		$this->assertNotInstanceOf( WP_Error::class, $result );
-		$this->assertIsArray( $result );
-		$this->assertCount( 0, $result );
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
 	}
 
 	/**
 	 * Test that the expiry timestamp is set and returns the expected value.
-	 *
-	 * @since 1.9.7.8
+	 * 
+	 * @since 	1.9.7.8
 	 */
-	public function testExpiry() {
+	public function testExpiry()
+	{
 		// Define the expected expiry date based on the resource class' $cache_duration setting.
-		$expectedExpiryDate = date( 'Y-m-d', time() + $this->resource->cache_duration );
+		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
 
 		// Fetch the actual expiry date set when the resource class was initialized.
-		$expiryDate = date( 'Y-m-d', $this->resource->last_queried + $this->resource->cache_duration );
+		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
 
 		// Confirm both dates match.
-		$this->assertEquals( $expectedExpiryDate, $expiryDate );
+		$this->assertEquals($expectedExpiryDate, $expiryDate);
 	}
 
 	/**
 	 * Test that the get() function performs as expected.
-	 *
-	 * @since 1.9.7.8
+	 * 
+	 * @since 	1.9.7.8
 	 */
-	public function testGet() {
+	public function testGet()
+	{
 		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
 		$result = $this->resource->get();
-		$this->assertNotInstanceOf( WP_Error::class, $result );
-		$this->assertIsArray( $result );
-		$this->assertCount( 0, $result );
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
 	}
 
 	/**
 	 * Test that the count() function returns the number of resources.
-	 *
-	 * @since 1.9.7.6
+	 * 
+	 * @since 	1.9.7.6
 	 */
-	public function testCount() {
+	public function testCount()
+	{
 		$result = $this->resource->get();
-		$this->assertEquals( $this->resource->count(), count( $result ) );
+		$this->assertEquals($this->resource->count(), count($result));
 	}
 
 	/**
 	 * Test that the exist() function performs as expected.
-	 *
-	 * @since 1.9.7.8
+	 * 
+	 * @since 	1.9.7.8
 	 */
-	public function testExist() {
+	public function testExist()
+	{
 		// Confirm that the function returns true, because resources exist.
 		$result = $this->resource->exist();
-		$this->assertSame( $result, false );
+		$this->assertSame($result, false);
 	}
 }

--- a/tests/wpunit/ResourcePostsNoDataTest.php
+++ b/tests/wpunit/ResourcePostsNoDataTest.php
@@ -1,150 +1,144 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Posts class when no data is present in the API.
- * 
+ *
  * @since 1.9.7.8
  */
-class ResourcePostsNoDataTest extends \Codeception\TestCase\WPTestCase
-{
-    /**
-     * The test object.
-     *
-     * @var \WpunitTester
-     */
-    protected $tester;
+class ResourcePostsNoDataTest extends \Codeception\TestCase\WPTestCase {
 
-    /**
-     * Holds the ConvertKit Settings class.
-     * 
-     * @since 1.9.7.8
-     * 
-     * @var ConvertKit_Settings
-     */
-    private $settings;
+	/**
+	 * The test object.
+	 *
+	 * @var \WpunitTester
+	 */
+	protected $tester;
 
-    /**
-     * Holds the ConvertKit Resource class.
-     * 
-     * @since 1.9.7.8
-     * 
-     * @var ConvertKit_Resource_Forms
-     */
-    private $resource;
+	/**
+	 * Holds the ConvertKit Settings class.
+	 *
+	 * @since 1.9.7.8
+	 *
+	 * @var ConvertKit_Settings
+	 */
+	private $settings;
 
-    /**
-     * Performs actions before each test.
-     * 
-     * @since 1.9.7.8
-     */
-    public function setUp(): void
-    {
-        parent::setUp();
+	/**
+	 * Holds the ConvertKit Resource class.
+	 *
+	 * @since 1.9.7.8
+	 *
+	 * @var ConvertKit_Resource_Forms
+	 */
+	private $resource;
 
-        // Activate Plugin.
-        activate_plugins('convertkit/wp-convertkit.php');
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since 1.9.7.8
+	 */
+	public function setUp(): void {
+		parent::setUp();
 
-        // Store API Key and Secret in Plugin's settings.
-        $this->settings = new ConvertKit_Settings();
-        update_option(
-            $this->settings::SETTINGS_NAME, [
-            'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
-            'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
-            ]
-        );
+		// Activate Plugin.
+		activate_plugins( 'convertkit/wp-convertkit.php' );
 
-        // Initialize the resource class we want to test.
-        $this->resource = new ConvertKit_Resource_Forms();
+		// Store API Key and Secret in Plugin's settings.
+		$this->settings = new ConvertKit_Settings();
+		update_option(
+			$this->settings::SETTINGS_NAME,
+			array(
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+			)
+		);
 
-        // Confirm initialization didn't result in an error.
-        $this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
-    }
+		// Initialize the resource class we want to test.
+		$this->resource = new ConvertKit_Resource_Forms();
 
-    /**
-     * Performs actions after each test.
-     * 
-     * @since 1.9.6.9
-     */
-    public function tearDown(): void
-    {
-        // Delete API Key, API Secret and Resources from Plugin's settings.
-        delete_option($this->settings::SETTINGS_NAME);
-        delete_option($this->resource->settings_name);
-        delete_option($this->resource->settings_name . '_last_queried');
+		// Confirm initialization didn't result in an error.
+		$this->assertNotInstanceOf( WP_Error::class, $this->resource->resources );
+	}
 
-        // Destroy the resource class we tested.
-        unset($this->resource);
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since 1.9.6.9
+	 */
+	public function tearDown(): void {
+		// Delete API Key, API Secret and Resources from Plugin's settings.
+		delete_option( $this->settings::SETTINGS_NAME );
+		delete_option( $this->resource->settings_name );
+		delete_option( $this->resource->settings_name . '_last_queried' );
 
-        // Deactivate Plugin.
-        deactivate_plugins('convertkit/wp-convertkit.php');
-		
-        parent::tearDown();
-    }
+		// Destroy the resource class we tested.
+		unset( $this->resource );
 
-    /**
-     * Test that the refresh() function performs as expected.
-     * 
-     * @since 1.9.7.8
-     */
-    public function testRefresh()
-    {
-        // Confirm that the data is stored in the options table and includes some expected keys.
-        $result = $this->resource->refresh();
-        $this->assertNotInstanceOf(WP_Error::class, $result);
-        $this->assertIsArray($result);
-        $this->assertCount(0, $result);
-    }
+		// Deactivate Plugin.
+		deactivate_plugins( 'convertkit/wp-convertkit.php' );
 
-    /**
-     * Test that the expiry timestamp is set and returns the expected value.
-     * 
-     * @since 1.9.7.8
-     */
-    public function testExpiry()
-    {
-        // Define the expected expiry date based on the resource class' $cache_duration setting.
-        $expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+		parent::tearDown();
+	}
 
-        // Fetch the actual expiry date set when the resource class was initialized.
-        $expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+	/**
+	 * Test that the refresh() function performs as expected.
+	 *
+	 * @since 1.9.7.8
+	 */
+	public function testRefresh() {
+		// Confirm that the data is stored in the options table and includes some expected keys.
+		$result = $this->resource->refresh();
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertIsArray( $result );
+		$this->assertCount( 0, $result );
+	}
 
-        // Confirm both dates match.
-        $this->assertEquals($expectedExpiryDate, $expiryDate);
-    }
+	/**
+	 * Test that the expiry timestamp is set and returns the expected value.
+	 *
+	 * @since 1.9.7.8
+	 */
+	public function testExpiry() {
+		// Define the expected expiry date based on the resource class' $cache_duration setting.
+		$expectedExpiryDate = date( 'Y-m-d', time() + $this->resource->cache_duration );
 
-    /**
-     * Test that the get() function performs as expected.
-     * 
-     * @since 1.9.7.8
-     */
-    public function testGet()
-    {
-        // Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
-        $result = $this->resource->get();
-        $this->assertNotInstanceOf(WP_Error::class, $result);
-        $this->assertIsArray($result);
-        $this->assertCount(0, $result);
-    }
+		// Fetch the actual expiry date set when the resource class was initialized.
+		$expiryDate = date( 'Y-m-d', $this->resource->last_queried + $this->resource->cache_duration );
 
-    /**
-     * Test that the count() function returns the number of resources.
-     * 
-     * @since 1.9.7.6
-     */
-    public function testCount()
-    {
-        $result = $this->resource->get();
-        $this->assertEquals($this->resource->count(), count($result));
-    }
+		// Confirm both dates match.
+		$this->assertEquals( $expectedExpiryDate, $expiryDate );
+	}
 
-    /**
-     * Test that the exist() function performs as expected.
-     * 
-     * @since 1.9.7.8
-     */
-    public function testExist()
-    {
-        // Confirm that the function returns true, because resources exist.
-        $result = $this->resource->exist();
-        $this->assertSame($result, false);
-    }
+	/**
+	 * Test that the get() function performs as expected.
+	 *
+	 * @since 1.9.7.8
+	 */
+	public function testGet() {
+		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+		$result = $this->resource->get();
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertIsArray( $result );
+		$this->assertCount( 0, $result );
+	}
+
+	/**
+	 * Test that the count() function returns the number of resources.
+	 *
+	 * @since 1.9.7.6
+	 */
+	public function testCount() {
+		$result = $this->resource->get();
+		$this->assertEquals( $this->resource->count(), count( $result ) );
+	}
+
+	/**
+	 * Test that the exist() function performs as expected.
+	 *
+	 * @since 1.9.7.8
+	 */
+	public function testExist() {
+		// Confirm that the function returns true, because resources exist.
+		$result = $this->resource->exist();
+		$this->assertSame( $result, false );
+	}
 }

--- a/tests/wpunit/ResourcePostsNoDataTest.php
+++ b/tests/wpunit/ResourcePostsNoDataTest.php
@@ -7,6 +7,8 @@
 class ResourcePostsNoDataTest extends \Codeception\TestCase\WPTestCase
 {
     /**
+     * The test object.
+     *
      * @var \WpunitTester
      */
     protected $tester;

--- a/tests/wpunit/ResourcePostsNoDataTest.php
+++ b/tests/wpunit/ResourcePostsNoDataTest.php
@@ -1,38 +1,40 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Posts class when no data is present in the API.
- * 
- * @since 	1.9.7.8
+ *
+ * @since   1.9.7.8
  */
 class ResourcePostsNoDataTest extends \Codeception\TestCase\WPTestCase
 {
 	/**
-	 * @var \WpunitTester
+	 * The testing implementation.
+	 *
+	 * @var \WpunitTester.
 	 */
 	protected $tester;
 
 	/**
 	 * Holds the ConvertKit Settings class.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @var 	ConvertKit_Settings
+	 *
+	 * @since   1.9.7.8
+	 *
+	 * @var     ConvertKit_Settings
 	 */
 	private $settings;
 
 	/**
 	 * Holds the ConvertKit Resource class.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @var 	ConvertKit_Resource_Forms
+	 *
+	 * @since   1.9.7.8
+	 *
+	 * @var     ConvertKit_Resource_Forms
 	 */
 	private $resource;
 
 	/**
 	 * Performs actions before each test.
-	 * 
-	 * @since 	1.9.7.8
+	 *
+	 * @since   1.9.7.8
 	 */
 	public function setUp(): void
 	{
@@ -43,10 +45,13 @@ class ResourcePostsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 		// Store API Key and Secret in Plugin's settings.
 		$this->settings = new ConvertKit_Settings();
-		update_option($this->settings::SETTINGS_NAME, [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
-		]);
+		update_option(
+			$this->settings::SETTINGS_NAME,
+			[
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+			]
+		);
 
 		// Initialize the resource class we want to test.
 		$this->resource = new ConvertKit_Resource_Forms();
@@ -57,8 +62,8 @@ class ResourcePostsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Performs actions after each test.
-	 * 
-	 * @since 	1.9.6.9
+	 *
+	 * @since   1.9.6.9
 	 */
 	public function tearDown(): void
 	{
@@ -72,14 +77,14 @@ class ResourcePostsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 		// Deactivate Plugin.
 		deactivate_plugins('convertkit/wp-convertkit.php');
-		
+
 		parent::tearDown();
 	}
 
 	/**
 	 * Test that the refresh() function performs as expected.
-	 * 
-	 * @since 	1.9.7.8
+	 *
+	 * @since   1.9.7.8
 	 */
 	public function testRefresh()
 	{
@@ -92,8 +97,8 @@ class ResourcePostsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the expiry timestamp is set and returns the expected value.
-	 * 
-	 * @since 	1.9.7.8
+	 *
+	 * @since   1.9.7.8
 	 */
 	public function testExpiry()
 	{
@@ -109,8 +114,8 @@ class ResourcePostsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the get() function performs as expected.
-	 * 
-	 * @since 	1.9.7.8
+	 *
+	 * @since   1.9.7.8
 	 */
 	public function testGet()
 	{
@@ -123,8 +128,8 @@ class ResourcePostsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the count() function returns the number of resources.
-	 * 
-	 * @since 	1.9.7.6
+	 *
+	 * @since   1.9.7.6
 	 */
 	public function testCount()
 	{
@@ -134,8 +139,8 @@ class ResourcePostsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the exist() function performs as expected.
-	 * 
-	 * @since 	1.9.7.8
+	 *
+	 * @since   1.9.7.8
 	 */
 	public function testExist()
 	{

--- a/tests/wpunit/ResourcePostsTest.php
+++ b/tests/wpunit/ResourcePostsTest.php
@@ -7,6 +7,8 @@
 class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 {
     /**
+     * The test object.
+     *
      * @var \WpunitTester
      */
     protected $tester;

--- a/tests/wpunit/ResourcePostsTest.php
+++ b/tests/wpunit/ResourcePostsTest.php
@@ -1,351 +1,337 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Posts class.
- * 
+ *
  * @since 1.9.7.4
  */
-class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
-{
-    /**
-     * The test object.
-     *
-     * @var \WpunitTester
-     */
-    protected $tester;
+class ResourcePostsTest extends \Codeception\TestCase\WPTestCase {
 
-    /**
-     * Holds the ConvertKit Settings class.
-     * 
-     * @since 1.9.7.4
-     * 
-     * @var ConvertKit_Settings
-     */
-    private $settings;
+	/**
+	 * The test object.
+	 *
+	 * @var \WpunitTester
+	 */
+	protected $tester;
 
-    /**
-     * Holds the ConvertKit Resource class.
-     * 
-     * @since 1.9.7.4
-     * 
-     * @var ConvertKit_Resource_Posts
-     */
-    private $resource;
+	/**
+	 * Holds the ConvertKit Settings class.
+	 *
+	 * @since 1.9.7.4
+	 *
+	 * @var ConvertKit_Settings
+	 */
+	private $settings;
 
-    /**
-     * Performs actions before each test.
-     * 
-     * @since 1.9.7.4
-     */
-    public function setUp(): void
-    {
-        parent::setUp();
+	/**
+	 * Holds the ConvertKit Resource class.
+	 *
+	 * @since 1.9.7.4
+	 *
+	 * @var ConvertKit_Resource_Posts
+	 */
+	private $resource;
 
-        // Activate Plugin.
-        activate_plugins('convertkit/wp-convertkit.php');
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since 1.9.7.4
+	 */
+	public function setUp(): void {
+		parent::setUp();
 
-        // Store API Key and Secret in Plugin's settings.
-        $this->settings = new ConvertKit_Settings();
-        update_option(
-            $this->settings::SETTINGS_NAME, [
-            'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-            'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-            ]
-        );
+		// Activate Plugin.
+		activate_plugins( 'convertkit/wp-convertkit.php' );
 
-        // Initialize the resource class we want to test.
-        $this->resource = new ConvertKit_Resource_Posts();
+		// Store API Key and Secret in Plugin's settings.
+		$this->settings = new ConvertKit_Settings();
+		update_option(
+			$this->settings::SETTINGS_NAME,
+			array(
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+			)
+		);
 
-        // Confirm initialization didn't result in an error.
-        $this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
-    }
+		// Initialize the resource class we want to test.
+		$this->resource = new ConvertKit_Resource_Posts();
 
-    /**
-     * Performs actions after each test.
-     * 
-     * @since 1.9.6.9
-     */
-    public function tearDown(): void
-    {
-        // Delete API Key, API Secret and Resources from Plugin's settings.
-        delete_option($this->settings::SETTINGS_NAME);
-        delete_option($this->resource->settings_name);
-        delete_option($this->resource->settings_name . '_last_queried');
+		// Confirm initialization didn't result in an error.
+		$this->assertNotInstanceOf( WP_Error::class, $this->resource->resources );
+	}
 
-        // Destroy the resource class we tested.
-        unset($this->resource);
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since 1.9.6.9
+	 */
+	public function tearDown(): void {
+		// Delete API Key, API Secret and Resources from Plugin's settings.
+		delete_option( $this->settings::SETTINGS_NAME );
+		delete_option( $this->resource->settings_name );
+		delete_option( $this->resource->settings_name . '_last_queried' );
 
-        // Deactivate Plugin.
-        deactivate_plugins('convertkit/wp-convertkit.php');
+		// Destroy the resource class we tested.
+		unset( $this->resource );
 
-        parent::tearDown();
-    }
+		// Deactivate Plugin.
+		deactivate_plugins( 'convertkit/wp-convertkit.php' );
 
-    /**
-     * Test that the WordPress Cron event for this resource was created with the expected name,
-     * matching the expected schedule as defined in the Resource's class.
-     * 
-     * @since 1.9.7.4
-     */
-    public function testCronEventCreatedOnPluginActivation()
-    {
-        // Confirm the event was scheduled.
-        $this->assertEquals(
-            wp_get_schedule('convertkit_resource_refresh_' . $this->resource->type),
-            $this->resource->wp_cron_schedule
-        );
-    }
+		parent::tearDown();
+	}
 
-    /**
-     * Test that the WordPress Cron event for this resource was created with the expected name,
-     * matching the expected schedule as defined in the Resource's class, when updating
-     * from an earlier version of the Plugin to 1.9.7.4 or higher.
-     * 
-     * @since 1.9.7.4
-     */
-    public function testCronEventCreatedOnPluginUpdate()
-    {
-        // Delete scheduled event.
-        $this->resource->unschedule_cron_event();
+	/**
+	 * Test that the WordPress Cron event for this resource was created with the expected name,
+	 * matching the expected schedule as defined in the Resource's class.
+	 *
+	 * @since 1.9.7.4
+	 */
+	public function testCronEventCreatedOnPluginActivation() {
+		// Confirm the event was scheduled.
+		$this->assertEquals(
+			wp_get_schedule( 'convertkit_resource_refresh_' . $this->resource->type ),
+			$this->resource->wp_cron_schedule
+		);
+	}
 
-        // Confirm scheduled event does not exist.
-        $this->assertFalse(wp_get_schedule('convertkit_resource_refresh_' . $this->resource->type));
+	/**
+	 * Test that the WordPress Cron event for this resource was created with the expected name,
+	 * matching the expected schedule as defined in the Resource's class, when updating
+	 * from an earlier version of the Plugin to 1.9.7.4 or higher.
+	 *
+	 * @since 1.9.7.4
+	 */
+	public function testCronEventCreatedOnPluginUpdate() {
+		// Delete scheduled event.
+		$this->resource->unschedule_cron_event();
 
-        // Set Plugin version number in options table to < 1.9.7.4.
-        update_option('convertkit_version', '1.9.7.2');
+		// Confirm scheduled event does not exist.
+		$this->assertFalse( wp_get_schedule( 'convertkit_resource_refresh_' . $this->resource->type ) );
 
-        // Run the update action as WordPress would when updating the Plugin to a newer version.
-        $convertkit = WP_ConvertKit();
-        $convertkit->update();
+		// Set Plugin version number in options table to < 1.9.7.4.
+		update_option( 'convertkit_version', '1.9.7.2' );
 
-        // Confirm the Plugin version number matches the current version.
-        $this->assertEquals(get_option('convertkit_version'), CONVERTKIT_PLUGIN_VERSION);
+		// Run the update action as WordPress would when updating the Plugin to a newer version.
+		$convertkit = WP_ConvertKit();
+		$convertkit->update();
 
-        // Confirm the event was scheduled by the update() call.
-        $this->assertEquals(
-            wp_get_schedule('convertkit_resource_refresh_' . $this->resource->type),
-            $this->resource->wp_cron_schedule
-        );
-    }
+		// Confirm the Plugin version number matches the current version.
+		$this->assertEquals( get_option( 'convertkit_version' ), CONVERTKIT_PLUGIN_VERSION );
 
-    /**
-     * Test that the WordPress Cron event for this resource works when valid API credentials
-     * are specified in the Plugin's settings.
-     * 
-     * @since 1.9.7.4
-     */
-    public function testCronEventWithValidAPICredentials()
-    {
-        // Delete Resources from options table.
-        delete_option($this->resource->settings_name);
-        delete_option($this->resource->settings_name . '_last_queried');
+		// Confirm the event was scheduled by the update() call.
+		$this->assertEquals(
+			wp_get_schedule( 'convertkit_resource_refresh_' . $this->resource->type ),
+			$this->resource->wp_cron_schedule
+		);
+	}
 
-        // Run the action as WordPress' Cron would.
-        do_action('convertkit_resource_refresh_' . $this->resource->type);
+	/**
+	 * Test that the WordPress Cron event for this resource works when valid API credentials
+	 * are specified in the Plugin's settings.
+	 *
+	 * @since 1.9.7.4
+	 */
+	public function testCronEventWithValidAPICredentials() {
+		// Delete Resources from options table.
+		delete_option( $this->resource->settings_name );
+		delete_option( $this->resource->settings_name . '_last_queried' );
 
-        // Confirm that Resources now exist in the option table.
-        $result = get_option($this->resource->settings_name);
-        $this->assertIsArray($result);
-        $this->assertArrayHasKey('id', reset($result));
-        $this->assertArrayHasKey('title', reset($result));
-    }
+		// Run the action as WordPress' Cron would.
+		do_action( 'convertkit_resource_refresh_' . $this->resource->type );
 
-    /**
-     * Test that the WordPress Cron event for this resource errors when invalid API credentials
-     * are specified in the Plugin's settings.
-     * 
-     * @since 1.9.7.4
-     */
-    public function testCronEventWithInvalidAPICredentials()
-    {
-        // Define invalid API Credentials.
-        update_option(
-            $this->settings::SETTINGS_NAME, [
-            'api_key'    => 'fakeApiKey',
-            'api_secret' => 'fakeApiSecret',
-            ]
-        );
+		// Confirm that Resources now exist in the option table.
+		$result = get_option( $this->resource->settings_name );
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'id', reset( $result ) );
+		$this->assertArrayHasKey( 'title', reset( $result ) );
+	}
 
-        // Delete Resources from options table.
-        delete_option($this->resource->settings_name);
-        delete_option($this->resource->settings_name . '_last_queried');
+	/**
+	 * Test that the WordPress Cron event for this resource errors when invalid API credentials
+	 * are specified in the Plugin's settings.
+	 *
+	 * @since 1.9.7.4
+	 */
+	public function testCronEventWithInvalidAPICredentials() {
+		// Define invalid API Credentials.
+		update_option(
+			$this->settings::SETTINGS_NAME,
+			array(
+				'api_key'    => 'fakeApiKey',
+				'api_secret' => 'fakeApiSecret',
+			)
+		);
 
-        // Run the action as WordPress' Cron would.
-        do_action('convertkit_resource_refresh_' . $this->resource->type);
+		// Delete Resources from options table.
+		delete_option( $this->resource->settings_name );
+		delete_option( $this->resource->settings_name . '_last_queried' );
 
-        // Confirm that no Resources exist in the option table.
-        $result = get_option($this->resource->settings_name);
-        $this->assertFalse($result);
-    }
+		// Run the action as WordPress' Cron would.
+		do_action( 'convertkit_resource_refresh_' . $this->resource->type );
 
-    /**
-     * Test that the WordPress Cron event for this resource was destroyed when the Plugin
-     * is deactivated.
-     * 
-     * @since 1.9.7.4
-     */
-    public function testCronEventDestroyedOnPluginDeactivation()
-    {
-        // Deactivate Plugin.
-        deactivate_plugins('convertkit/wp-convertkit.php');
+		// Confirm that no Resources exist in the option table.
+		$result = get_option( $this->resource->settings_name );
+		$this->assertFalse( $result );
+	}
 
-        // Confirm scheduled event does not exist.
-        $this->assertFalse(wp_get_schedule('convertkit_resource_refresh_' . $this->resource->type));
-    }
-	
-    /**
-     * Test that the refresh() function performs as expected.
-     * 
-     * @since 1.9.7.4
-     */
-    public function testRefresh()
-    {
-        // Confirm that the data is stored in the options table and includes some expected keys.
-        $result = $this->resource->refresh();
-        $this->assertIsArray($result);
-        $this->assertArrayHasKey('id', reset($result));
-        $this->assertArrayHasKey('title', reset($result));
-    }
+	/**
+	 * Test that the WordPress Cron event for this resource was destroyed when the Plugin
+	 * is deactivated.
+	 *
+	 * @since 1.9.7.4
+	 */
+	public function testCronEventDestroyedOnPluginDeactivation() {
+		// Deactivate Plugin.
+		deactivate_plugins( 'convertkit/wp-convertkit.php' );
 
-    /**
-     * Test that the expiry timestamp is set and returns the expected value.
-     * 
-     * @since 1.9.7.4
-     */
-    public function testExpiry()
-    {
-        // Define the expected expiry date based on the resource class' $cache_duration setting.
-        $expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+		// Confirm scheduled event does not exist.
+		$this->assertFalse( wp_get_schedule( 'convertkit_resource_refresh_' . $this->resource->type ) );
+	}
 
-        // Fetch the actual expiry date set when the resource class was initialized.
-        $expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+	/**
+	 * Test that the refresh() function performs as expected.
+	 *
+	 * @since 1.9.7.4
+	 */
+	public function testRefresh() {
+		// Confirm that the data is stored in the options table and includes some expected keys.
+		$result = $this->resource->refresh();
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'id', reset( $result ) );
+		$this->assertArrayHasKey( 'title', reset( $result ) );
+	}
 
-        // Confirm both dates match.
-        $this->assertEquals($expectedExpiryDate, $expiryDate);
-    }
+	/**
+	 * Test that the expiry timestamp is set and returns the expected value.
+	 *
+	 * @since 1.9.7.4
+	 */
+	public function testExpiry() {
+		// Define the expected expiry date based on the resource class' $cache_duration setting.
+		$expectedExpiryDate = date( 'Y-m-d', time() + $this->resource->cache_duration );
 
-    /**
-     * Test that the get() function performs as expected.
-     * 
-     * @since 1.9.7.4
-     */
-    public function testGet()
-    {
-        // Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
-        $result = $this->resource->get();
-        $this->assertNotInstanceOf(WP_Error::class, $result);
-        $this->assertIsArray($result);
-        $this->assertArrayHasKey('id', reset($result));
-        $this->assertArrayHasKey('title', reset($result));
-    }
+		// Fetch the actual expiry date set when the resource class was initialized.
+		$expiryDate = date( 'Y-m-d', $this->resource->last_queried + $this->resource->cache_duration );
 
-    /**
-     * Test that the get_paginated_subset() function performs as expected when requesting one item from the first page.
-     * 
-     * @since 1.9.7.6
-     */
-    public function testGetPaginatedSubsetFirstPage()
-    {
-        $this->testPagination(
-            $this->resource->get_paginated_subset(1, 1), // Paginated array of resources and metadata.
-            1, // Page.
-            1, // Per Page.
-            true, // Has a next page, as more results in the resultset exist.
-            false // Does not have a previous page, as this is the first page in the resultset.
-        );
-    }
+		// Confirm both dates match.
+		$this->assertEquals( $expectedExpiryDate, $expiryDate );
+	}
 
-    /**
-     * Test that the get_paginated_subset() function performs as expected when requesting one item from a page
-     * that is not the first or last page.
-     * 
-     * @since 1.9.7.6
-     */
-    public function testGetPaginatedSubsetMiddlePage()
-    {
-        $this->testPagination(
-            $this->resource->get_paginated_subset(2, 1), // Paginated array of resources and metadata.
-            2, // Page.
-            1, // Per Page.
-            true, // Has a next page, as more results in the resultset exist.
-            true // Has a previous page, as more results in the resultset exist.
-        );
-    }
+	/**
+	 * Test that the get() function performs as expected.
+	 *
+	 * @since 1.9.7.4
+	 */
+	public function testGet() {
+		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+		$result = $this->resource->get();
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'id', reset( $result ) );
+		$this->assertArrayHasKey( 'title', reset( $result ) );
+	}
 
-    /**
-     * Test that the get_paginated_subset() function performs as expected when requesting one item from the last page.
-     * 
-     * @since 1.9.7.6
-     */
-    public function testGetPaginatedSubsetLastPage()
-    {
-        // Query the API to establish how many resources exist.
-        $result = $this->resource->get();
-        $lastPage = count($result);
+	/**
+	 * Test that the get_paginated_subset() function performs as expected when requesting one item from the first page.
+	 *
+	 * @since 1.9.7.6
+	 */
+	public function testGetPaginatedSubsetFirstPage() {
+		$this->testPagination(
+			$this->resource->get_paginated_subset( 1, 1 ), // Paginated array of resources and metadata.
+			1, // Page.
+			1, // Per Page.
+			true, // Has a next page, as more results in the resultset exist.
+			false // Does not have a previous page, as this is the first page in the resultset.
+		);
+	}
 
-        $this->testPagination(
-            $this->resource->get_paginated_subset($lastPage, 1), // Paginated array of resources and metadata.
-            $lastPage, // Page.
-            1, // Per Page.
-            false, // Does not have a next page, as this is the last page in the resultset.
-            true // Has a previous page, as more results in the resultset exist.
-        );
-    }
+	/**
+	 * Test that the get_paginated_subset() function performs as expected when requesting one item from a page
+	 * that is not the first or last page.
+	 *
+	 * @since 1.9.7.6
+	 */
+	public function testGetPaginatedSubsetMiddlePage() {
+		$this->testPagination(
+			$this->resource->get_paginated_subset( 2, 1 ), // Paginated array of resources and metadata.
+			2, // Page.
+			1, // Per Page.
+			true, // Has a next page, as more results in the resultset exist.
+			true // Has a previous page, as more results in the resultset exist.
+		);
+	}
 
-    /**
-     * Test that the count() function returns the number of resources.
-     * 
-     * @since 1.9.7.6
-     */
-    public function testCount()
-    {
-        $result = $this->resource->get();
-        $this->assertEquals($this->resource->count(), count($result));
-    }
+	/**
+	 * Test that the get_paginated_subset() function performs as expected when requesting one item from the last page.
+	 *
+	 * @since 1.9.7.6
+	 */
+	public function testGetPaginatedSubsetLastPage() {
+		// Query the API to establish how many resources exist.
+		$result   = $this->resource->get();
+		$lastPage = count( $result );
 
-    /**
-     * Shared tests for paginated resources, ensuring the response contains expected values for pagination,
-     * next/previous links etc.
-     * 
-     * @since 1.9.7.6
-     * 
-     * @param array $result      Result.
-     * @param int   $page        Page.
-     * @param int   $perPage     Results per page.
-     * @param bool  $hasNextPage Response should indicate pagination is available for older resources.
-     * @param bool  $hasPrevPage Response should indicate pagination is available for newer resources.
-     */
-    private function testPagination($result, $page, $perPage, $hasNextPage, $hasPrevPage)
-    {
-        $this->assertNotInstanceOf(WP_Error::class, $result);
-        $this->assertIsArray($result);
-        $this->assertArrayHasKey('items', $result);
-        $this->assertArrayHasKey('page', $result);
-        $this->assertArrayHasKey('per_page', $result);
-        $this->assertArrayHasKey('has_next_page', $result);
-        $this->assertArrayHasKey('has_prev_page', $result);
+		$this->testPagination(
+			$this->resource->get_paginated_subset( $lastPage, 1 ), // Paginated array of resources and metadata.
+			$lastPage, // Page.
+			1, // Per Page.
+			false, // Does not have a next page, as this is the last page in the resultset.
+			true // Has a previous page, as more results in the resultset exist.
+		);
+	}
 
-        // Check posts exist.
-        $this->assertIsArray($result);
-        $this->assertCount($perPage, $result['items']);
-        $this->assertArrayHasKey('id', reset($result['items']));
-        $this->assertArrayHasKey('title', reset($result['items']));
+	/**
+	 * Test that the count() function returns the number of resources.
+	 *
+	 * @since 1.9.7.6
+	 */
+	public function testCount() {
+		$result = $this->resource->get();
+		$this->assertEquals( $this->resource->count(), count( $result ) );
+	}
 
-        // Check other array values are as expected.
-        $this->assertEquals($result['page'], $page);
-        $this->assertEquals($result['per_page'], $perPage);
-        $this->assertEquals($result['has_next_page'], $hasNextPage);
-        $this->assertEquals($result['has_prev_page'], $hasPrevPage);
-    }
+	/**
+	 * Shared tests for paginated resources, ensuring the response contains expected values for pagination,
+	 * next/previous links etc.
+	 *
+	 * @since 1.9.7.6
+	 *
+	 * @param array $result      Result.
+	 * @param int   $page        Page.
+	 * @param int   $perPage     Results per page.
+	 * @param bool  $hasNextPage Response should indicate pagination is available for older resources.
+	 * @param bool  $hasPrevPage Response should indicate pagination is available for newer resources.
+	 */
+	private function testPagination( $result, $page, $perPage, $hasNextPage, $hasPrevPage ) {
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'items', $result );
+		$this->assertArrayHasKey( 'page', $result );
+		$this->assertArrayHasKey( 'per_page', $result );
+		$this->assertArrayHasKey( 'has_next_page', $result );
+		$this->assertArrayHasKey( 'has_prev_page', $result );
 
-    /**
-     * Test that the exist() function performs as expected.
-     * 
-     * @since 1.9.7.4
-     */
-    public function testExist()
-    {
-        // Confirm that the function returns true, because resources exist.
-        $result = $this->resource->exist();
-        $this->assertSame($result, true);
-    }
+		// Check posts exist.
+		$this->assertIsArray( $result );
+		$this->assertCount( $perPage, $result['items'] );
+		$this->assertArrayHasKey( 'id', reset( $result['items'] ) );
+		$this->assertArrayHasKey( 'title', reset( $result['items'] ) );
+
+		// Check other array values are as expected.
+		$this->assertEquals( $result['page'], $page );
+		$this->assertEquals( $result['per_page'], $perPage );
+		$this->assertEquals( $result['has_next_page'], $hasNextPage );
+		$this->assertEquals( $result['has_prev_page'], $hasPrevPage );
+	}
+
+	/**
+	 * Test that the exist() function performs as expected.
+	 *
+	 * @since 1.9.7.4
+	 */
+	public function testExist() {
+		// Confirm that the function returns true, because resources exist.
+		$result = $this->resource->exist();
+		$this->assertSame( $result, true );
+	}
 }

--- a/tests/wpunit/ResourcePostsTest.php
+++ b/tests/wpunit/ResourcePostsTest.php
@@ -1,80 +1,77 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Posts class.
- *
- * @since 1.9.7.4
+ * 
+ * @since 	1.9.7.4
  */
-class ResourcePostsTest extends \Codeception\TestCase\WPTestCase {
-
+class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
+{
 	/**
-	 * The test object.
-	 *
 	 * @var \WpunitTester
 	 */
 	protected $tester;
 
 	/**
 	 * Holds the ConvertKit Settings class.
-	 *
-	 * @since 1.9.7.4
-	 *
-	 * @var ConvertKit_Settings
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @var 	ConvertKit_Settings
 	 */
 	private $settings;
 
 	/**
 	 * Holds the ConvertKit Resource class.
-	 *
-	 * @since 1.9.7.4
-	 *
-	 * @var ConvertKit_Resource_Posts
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @var 	ConvertKit_Resource_Posts
 	 */
 	private $resource;
 
 	/**
 	 * Performs actions before each test.
-	 *
-	 * @since 1.9.7.4
+	 * 
+	 * @since 	1.9.7.4
 	 */
-	public function setUp(): void {
+	public function setUp(): void
+	{
 		parent::setUp();
 
 		// Activate Plugin.
-		activate_plugins( 'convertkit/wp-convertkit.php' );
+		activate_plugins('convertkit/wp-convertkit.php');
 
 		// Store API Key and Secret in Plugin's settings.
 		$this->settings = new ConvertKit_Settings();
-		update_option(
-			$this->settings::SETTINGS_NAME,
-			array(
-				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-			)
-		);
+		update_option($this->settings::SETTINGS_NAME, [
+			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+		]);
 
 		// Initialize the resource class we want to test.
 		$this->resource = new ConvertKit_Resource_Posts();
 
 		// Confirm initialization didn't result in an error.
-		$this->assertNotInstanceOf( WP_Error::class, $this->resource->resources );
+		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
 	}
 
 	/**
 	 * Performs actions after each test.
-	 *
-	 * @since 1.9.6.9
+	 * 
+	 * @since 	1.9.6.9
 	 */
-	public function tearDown(): void {
+	public function tearDown(): void
+	{
 		// Delete API Key, API Secret and Resources from Plugin's settings.
-		delete_option( $this->settings::SETTINGS_NAME );
-		delete_option( $this->resource->settings_name );
-		delete_option( $this->resource->settings_name . '_last_queried' );
+		delete_option($this->settings::SETTINGS_NAME);
+		delete_option($this->resource->settings_name);
+		delete_option($this->resource->settings_name . '_last_queried');
 
 		// Destroy the resource class we tested.
-		unset( $this->resource );
+		unset($this->resource);
 
 		// Deactivate Plugin.
-		deactivate_plugins( 'convertkit/wp-convertkit.php' );
+		deactivate_plugins('convertkit/wp-convertkit.php');
 
 		parent::tearDown();
 	}
@@ -82,13 +79,14 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * Test that the WordPress Cron event for this resource was created with the expected name,
 	 * matching the expected schedule as defined in the Resource's class.
-	 *
-	 * @since 1.9.7.4
+	 * 
+	 * @since 	1.9.7.4
 	 */
-	public function testCronEventCreatedOnPluginActivation() {
+	public function testCronEventCreatedOnPluginActivation()
+	{
 		// Confirm the event was scheduled.
 		$this->assertEquals(
-			wp_get_schedule( 'convertkit_resource_refresh_' . $this->resource->type ),
+			wp_get_schedule('convertkit_resource_refresh_' . $this->resource->type),
 			$this->resource->wp_cron_schedule
 		);
 	}
@@ -97,29 +95,30 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase {
 	 * Test that the WordPress Cron event for this resource was created with the expected name,
 	 * matching the expected schedule as defined in the Resource's class, when updating
 	 * from an earlier version of the Plugin to 1.9.7.4 or higher.
-	 *
-	 * @since 1.9.7.4
+	 * 
+	 * @since 	1.9.7.4
 	 */
-	public function testCronEventCreatedOnPluginUpdate() {
+	public function testCronEventCreatedOnPluginUpdate()
+	{
 		// Delete scheduled event.
 		$this->resource->unschedule_cron_event();
 
 		// Confirm scheduled event does not exist.
-		$this->assertFalse( wp_get_schedule( 'convertkit_resource_refresh_' . $this->resource->type ) );
+		$this->assertFalse(wp_get_schedule('convertkit_resource_refresh_' . $this->resource->type));
 
 		// Set Plugin version number in options table to < 1.9.7.4.
-		update_option( 'convertkit_version', '1.9.7.2' );
+		update_option('convertkit_version', '1.9.7.2');
 
 		// Run the update action as WordPress would when updating the Plugin to a newer version.
 		$convertkit = WP_ConvertKit();
 		$convertkit->update();
 
 		// Confirm the Plugin version number matches the current version.
-		$this->assertEquals( get_option( 'convertkit_version' ), CONVERTKIT_PLUGIN_VERSION );
+		$this->assertEquals(get_option('convertkit_version'), CONVERTKIT_PLUGIN_VERSION);
 
 		// Confirm the event was scheduled by the update() call.
 		$this->assertEquals(
-			wp_get_schedule( 'convertkit_resource_refresh_' . $this->resource->type ),
+			wp_get_schedule('convertkit_resource_refresh_' . $this->resource->type),
 			$this->resource->wp_cron_schedule
 		);
 	}
@@ -127,117 +126,121 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * Test that the WordPress Cron event for this resource works when valid API credentials
 	 * are specified in the Plugin's settings.
-	 *
-	 * @since 1.9.7.4
+	 * 
+	 * @since 	1.9.7.4
 	 */
-	public function testCronEventWithValidAPICredentials() {
+	public function testCronEventWithValidAPICredentials()
+	{
 		// Delete Resources from options table.
-		delete_option( $this->resource->settings_name );
-		delete_option( $this->resource->settings_name . '_last_queried' );
+		delete_option($this->resource->settings_name);
+		delete_option($this->resource->settings_name . '_last_queried');
 
 		// Run the action as WordPress' Cron would.
-		do_action( 'convertkit_resource_refresh_' . $this->resource->type );
+		do_action('convertkit_resource_refresh_' . $this->resource->type);
 
 		// Confirm that Resources now exist in the option table.
-		$result = get_option( $this->resource->settings_name );
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'id', reset( $result ) );
-		$this->assertArrayHasKey( 'title', reset( $result ) );
+		$result = get_option($this->resource->settings_name);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('title', reset($result));
 	}
 
 	/**
 	 * Test that the WordPress Cron event for this resource errors when invalid API credentials
 	 * are specified in the Plugin's settings.
-	 *
-	 * @since 1.9.7.4
+	 * 
+	 * @since 	1.9.7.4
 	 */
-	public function testCronEventWithInvalidAPICredentials() {
+	public function testCronEventWithInvalidAPICredentials()
+	{
 		// Define invalid API Credentials.
-		update_option(
-			$this->settings::SETTINGS_NAME,
-			array(
-				'api_key'    => 'fakeApiKey',
-				'api_secret' => 'fakeApiSecret',
-			)
-		);
+		update_option($this->settings::SETTINGS_NAME, [
+			'api_key'    => 'fakeApiKey',
+			'api_secret' => 'fakeApiSecret',
+		]);
 
 		// Delete Resources from options table.
-		delete_option( $this->resource->settings_name );
-		delete_option( $this->resource->settings_name . '_last_queried' );
+		delete_option($this->resource->settings_name);
+		delete_option($this->resource->settings_name . '_last_queried');
 
 		// Run the action as WordPress' Cron would.
-		do_action( 'convertkit_resource_refresh_' . $this->resource->type );
+		do_action('convertkit_resource_refresh_' . $this->resource->type);
 
 		// Confirm that no Resources exist in the option table.
-		$result = get_option( $this->resource->settings_name );
-		$this->assertFalse( $result );
+		$result = get_option($this->resource->settings_name);
+		$this->assertFalse($result);
 	}
 
 	/**
 	 * Test that the WordPress Cron event for this resource was destroyed when the Plugin
 	 * is deactivated.
-	 *
-	 * @since 1.9.7.4
+	 * 
+	 * @since 	1.9.7.4
 	 */
-	public function testCronEventDestroyedOnPluginDeactivation() {
+	public function testCronEventDestroyedOnPluginDeactivation()
+	{
 		// Deactivate Plugin.
-		deactivate_plugins( 'convertkit/wp-convertkit.php' );
+		deactivate_plugins('convertkit/wp-convertkit.php');
 
 		// Confirm scheduled event does not exist.
-		$this->assertFalse( wp_get_schedule( 'convertkit_resource_refresh_' . $this->resource->type ) );
+		$this->assertFalse(wp_get_schedule('convertkit_resource_refresh_' . $this->resource->type));
 	}
-
+	
 	/**
 	 * Test that the refresh() function performs as expected.
-	 *
-	 * @since 1.9.7.4
+	 * 
+	 * @since 	1.9.7.4
 	 */
-	public function testRefresh() {
+	public function testRefresh()
+	{
 		// Confirm that the data is stored in the options table and includes some expected keys.
 		$result = $this->resource->refresh();
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'id', reset( $result ) );
-		$this->assertArrayHasKey( 'title', reset( $result ) );
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('title', reset($result));
 	}
 
 	/**
 	 * Test that the expiry timestamp is set and returns the expected value.
-	 *
-	 * @since 1.9.7.4
+	 * 
+	 * @since 	1.9.7.4
 	 */
-	public function testExpiry() {
+	public function testExpiry()
+	{
 		// Define the expected expiry date based on the resource class' $cache_duration setting.
-		$expectedExpiryDate = date( 'Y-m-d', time() + $this->resource->cache_duration );
+		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
 
 		// Fetch the actual expiry date set when the resource class was initialized.
-		$expiryDate = date( 'Y-m-d', $this->resource->last_queried + $this->resource->cache_duration );
+		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
 
 		// Confirm both dates match.
-		$this->assertEquals( $expectedExpiryDate, $expiryDate );
+		$this->assertEquals($expectedExpiryDate, $expiryDate);
 	}
 
 	/**
 	 * Test that the get() function performs as expected.
-	 *
-	 * @since 1.9.7.4
+	 * 
+	 * @since 	1.9.7.4
 	 */
-	public function testGet() {
+	public function testGet()
+	{
 		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
 		$result = $this->resource->get();
-		$this->assertNotInstanceOf( WP_Error::class, $result );
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'id', reset( $result ) );
-		$this->assertArrayHasKey( 'title', reset( $result ) );
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('title', reset($result));
 	}
 
 	/**
 	 * Test that the get_paginated_subset() function performs as expected when requesting one item from the first page.
-	 *
-	 * @since 1.9.7.6
+	 * 
+	 * @since 	1.9.7.6
 	 */
-	public function testGetPaginatedSubsetFirstPage() {
+	public function testGetPaginatedSubsetFirstPage()
+	{
 		$this->testPagination(
-			$this->resource->get_paginated_subset( 1, 1 ), // Paginated array of resources and metadata.
+			$this->resource->get_paginated_subset(1, 1), // Paginated array of resources and metadata.
 			1, // Page.
 			1, // Per Page.
 			true, // Has a next page, as more results in the resultset exist.
@@ -248,12 +251,13 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * Test that the get_paginated_subset() function performs as expected when requesting one item from a page
 	 * that is not the first or last page.
-	 *
-	 * @since 1.9.7.6
+	 * 
+	 * @since 	1.9.7.6
 	 */
-	public function testGetPaginatedSubsetMiddlePage() {
+	public function testGetPaginatedSubsetMiddlePage()
+	{
 		$this->testPagination(
-			$this->resource->get_paginated_subset( 2, 1 ), // Paginated array of resources and metadata.
+			$this->resource->get_paginated_subset(2, 1), // Paginated array of resources and metadata.
 			2, // Page.
 			1, // Per Page.
 			true, // Has a next page, as more results in the resultset exist.
@@ -263,16 +267,17 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase {
 
 	/**
 	 * Test that the get_paginated_subset() function performs as expected when requesting one item from the last page.
-	 *
-	 * @since 1.9.7.6
+	 * 
+	 * @since 	1.9.7.6
 	 */
-	public function testGetPaginatedSubsetLastPage() {
+	public function testGetPaginatedSubsetLastPage()
+	{
 		// Query the API to establish how many resources exist.
-		$result   = $this->resource->get();
-		$lastPage = count( $result );
+		$result = $this->resource->get();
+		$lastPage = count($result);
 
 		$this->testPagination(
-			$this->resource->get_paginated_subset( $lastPage, 1 ), // Paginated array of resources and metadata.
+			$this->resource->get_paginated_subset($lastPage, 1), // Paginated array of resources and metadata.
 			$lastPage, // Page.
 			1, // Per Page.
 			false, // Does not have a next page, as this is the last page in the resultset.
@@ -282,56 +287,59 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase {
 
 	/**
 	 * Test that the count() function returns the number of resources.
-	 *
-	 * @since 1.9.7.6
+	 * 
+	 * @since 	1.9.7.6
 	 */
-	public function testCount() {
+	public function testCount()
+	{
 		$result = $this->resource->get();
-		$this->assertEquals( $this->resource->count(), count( $result ) );
+		$this->assertEquals($this->resource->count(), count($result));
 	}
 
 	/**
 	 * Shared tests for paginated resources, ensuring the response contains expected values for pagination,
 	 * next/previous links etc.
-	 *
-	 * @since 1.9.7.6
-	 *
-	 * @param array $result      Result.
-	 * @param int   $page        Page.
-	 * @param int   $perPage     Results per page.
-	 * @param bool  $hasNextPage Response should indicate pagination is available for older resources.
-	 * @param bool  $hasPrevPage Response should indicate pagination is available for newer resources.
+	 * 
+	 * @since 	1.9.7.6
+	 * 
+	 * @param 	array 	$result 	Result.
+	 * @param 	int 	$page 		Page.
+	 * @param 	int 	$perPage 	Results per page.
+	 * @param 	bool 	$hasNextPage 	Response should indicate pagination is available for older resources.
+	 * @param 	bool 	$hasPrevPage 	Response should indicate pagination is available for newer resources.
 	 */
-	private function testPagination( $result, $page, $perPage, $hasNextPage, $hasPrevPage ) {
-		$this->assertNotInstanceOf( WP_Error::class, $result );
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'items', $result );
-		$this->assertArrayHasKey( 'page', $result );
-		$this->assertArrayHasKey( 'per_page', $result );
-		$this->assertArrayHasKey( 'has_next_page', $result );
-		$this->assertArrayHasKey( 'has_prev_page', $result );
+	private function testPagination($result, $page, $perPage, $hasNextPage, $hasPrevPage)
+	{
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('items', $result);
+		$this->assertArrayHasKey('page', $result);
+		$this->assertArrayHasKey('per_page', $result);
+		$this->assertArrayHasKey('has_next_page', $result);
+		$this->assertArrayHasKey('has_prev_page', $result);
 
 		// Check posts exist.
-		$this->assertIsArray( $result );
-		$this->assertCount( $perPage, $result['items'] );
-		$this->assertArrayHasKey( 'id', reset( $result['items'] ) );
-		$this->assertArrayHasKey( 'title', reset( $result['items'] ) );
+		$this->assertIsArray($result);
+		$this->assertCount($perPage, $result['items']);
+		$this->assertArrayHasKey('id', reset($result['items']));
+		$this->assertArrayHasKey('title', reset($result['items']));
 
 		// Check other array values are as expected.
-		$this->assertEquals( $result['page'], $page );
-		$this->assertEquals( $result['per_page'], $perPage );
-		$this->assertEquals( $result['has_next_page'], $hasNextPage );
-		$this->assertEquals( $result['has_prev_page'], $hasPrevPage );
+		$this->assertEquals($result['page'], $page);
+		$this->assertEquals($result['per_page'], $perPage);
+		$this->assertEquals($result['has_next_page'], $hasNextPage);
+		$this->assertEquals($result['has_prev_page'], $hasPrevPage);
 	}
 
 	/**
 	 * Test that the exist() function performs as expected.
-	 *
-	 * @since 1.9.7.4
+	 * 
+	 * @since 	1.9.7.4
 	 */
-	public function testExist() {
+	public function testExist()
+	{
 		// Confirm that the function returns true, because resources exist.
 		$result = $this->resource->exist();
-		$this->assertSame( $result, true );
+		$this->assertSame($result, true);
 	}
 }

--- a/tests/wpunit/ResourcePostsTest.php
+++ b/tests/wpunit/ResourcePostsTest.php
@@ -1,38 +1,40 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Posts class.
- * 
- * @since 	1.9.7.4
+ *
+ * @since   1.9.7.4
  */
 class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 {
 	/**
-	 * @var \WpunitTester
+	 * The testing implementation.
+	 *
+	 * @var \WpunitTester.
 	 */
 	protected $tester;
 
 	/**
 	 * Holds the ConvertKit Settings class.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @var 	ConvertKit_Settings
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @var     ConvertKit_Settings
 	 */
 	private $settings;
 
 	/**
 	 * Holds the ConvertKit Resource class.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @var 	ConvertKit_Resource_Posts
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @var     ConvertKit_Resource_Posts
 	 */
 	private $resource;
 
 	/**
 	 * Performs actions before each test.
-	 * 
-	 * @since 	1.9.7.4
+	 *
+	 * @since   1.9.7.4
 	 */
 	public function setUp(): void
 	{
@@ -43,10 +45,13 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 
 		// Store API Key and Secret in Plugin's settings.
 		$this->settings = new ConvertKit_Settings();
-		update_option($this->settings::SETTINGS_NAME, [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-		]);
+		update_option(
+			$this->settings::SETTINGS_NAME,
+			[
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+			]
+		);
 
 		// Initialize the resource class we want to test.
 		$this->resource = new ConvertKit_Resource_Posts();
@@ -57,8 +62,8 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Performs actions after each test.
-	 * 
-	 * @since 	1.9.6.9
+	 *
+	 * @since   1.9.6.9
 	 */
 	public function tearDown(): void
 	{
@@ -79,8 +84,8 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 	/**
 	 * Test that the WordPress Cron event for this resource was created with the expected name,
 	 * matching the expected schedule as defined in the Resource's class.
-	 * 
-	 * @since 	1.9.7.4
+	 *
+	 * @since   1.9.7.4
 	 */
 	public function testCronEventCreatedOnPluginActivation()
 	{
@@ -95,8 +100,8 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 	 * Test that the WordPress Cron event for this resource was created with the expected name,
 	 * matching the expected schedule as defined in the Resource's class, when updating
 	 * from an earlier version of the Plugin to 1.9.7.4 or higher.
-	 * 
-	 * @since 	1.9.7.4
+	 *
+	 * @since   1.9.7.4
 	 */
 	public function testCronEventCreatedOnPluginUpdate()
 	{
@@ -126,8 +131,8 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 	/**
 	 * Test that the WordPress Cron event for this resource works when valid API credentials
 	 * are specified in the Plugin's settings.
-	 * 
-	 * @since 	1.9.7.4
+	 *
+	 * @since   1.9.7.4
 	 */
 	public function testCronEventWithValidAPICredentials()
 	{
@@ -148,16 +153,19 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 	/**
 	 * Test that the WordPress Cron event for this resource errors when invalid API credentials
 	 * are specified in the Plugin's settings.
-	 * 
-	 * @since 	1.9.7.4
+	 *
+	 * @since   1.9.7.4
 	 */
 	public function testCronEventWithInvalidAPICredentials()
 	{
 		// Define invalid API Credentials.
-		update_option($this->settings::SETTINGS_NAME, [
-			'api_key'    => 'fakeApiKey',
-			'api_secret' => 'fakeApiSecret',
-		]);
+		update_option(
+			$this->settings::SETTINGS_NAME,
+			[
+				'api_key'    => 'fakeApiKey',
+				'api_secret' => 'fakeApiSecret',
+			]
+		);
 
 		// Delete Resources from options table.
 		delete_option($this->resource->settings_name);
@@ -174,8 +182,8 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 	/**
 	 * Test that the WordPress Cron event for this resource was destroyed when the Plugin
 	 * is deactivated.
-	 * 
-	 * @since 	1.9.7.4
+	 *
+	 * @since   1.9.7.4
 	 */
 	public function testCronEventDestroyedOnPluginDeactivation()
 	{
@@ -185,11 +193,11 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 		// Confirm scheduled event does not exist.
 		$this->assertFalse(wp_get_schedule('convertkit_resource_refresh_' . $this->resource->type));
 	}
-	
+
 	/**
 	 * Test that the refresh() function performs as expected.
-	 * 
-	 * @since 	1.9.7.4
+	 *
+	 * @since   1.9.7.4
 	 */
 	public function testRefresh()
 	{
@@ -202,8 +210,8 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the expiry timestamp is set and returns the expected value.
-	 * 
-	 * @since 	1.9.7.4
+	 *
+	 * @since   1.9.7.4
 	 */
 	public function testExpiry()
 	{
@@ -219,8 +227,8 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the get() function performs as expected.
-	 * 
-	 * @since 	1.9.7.4
+	 *
+	 * @since   1.9.7.4
 	 */
 	public function testGet()
 	{
@@ -234,8 +242,8 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the get_paginated_subset() function performs as expected when requesting one item from the first page.
-	 * 
-	 * @since 	1.9.7.6
+	 *
+	 * @since   1.9.7.6
 	 */
 	public function testGetPaginatedSubsetFirstPage()
 	{
@@ -251,8 +259,8 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 	/**
 	 * Test that the get_paginated_subset() function performs as expected when requesting one item from a page
 	 * that is not the first or last page.
-	 * 
-	 * @since 	1.9.7.6
+	 *
+	 * @since   1.9.7.6
 	 */
 	public function testGetPaginatedSubsetMiddlePage()
 	{
@@ -267,13 +275,13 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the get_paginated_subset() function performs as expected when requesting one item from the last page.
-	 * 
-	 * @since 	1.9.7.6
+	 *
+	 * @since   1.9.7.6
 	 */
 	public function testGetPaginatedSubsetLastPage()
 	{
 		// Query the API to establish how many resources exist.
-		$result = $this->resource->get();
+		$result   = $this->resource->get();
 		$lastPage = count($result);
 
 		$this->testPagination(
@@ -287,8 +295,8 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the count() function returns the number of resources.
-	 * 
-	 * @since 	1.9.7.6
+	 *
+	 * @since   1.9.7.6
 	 */
 	public function testCount()
 	{
@@ -299,14 +307,14 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 	/**
 	 * Shared tests for paginated resources, ensuring the response contains expected values for pagination,
 	 * next/previous links etc.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	array 	$result 	Result.
-	 * @param 	int 	$page 		Page.
-	 * @param 	int 	$perPage 	Results per page.
-	 * @param 	bool 	$hasNextPage 	Response should indicate pagination is available for older resources.
-	 * @param 	bool 	$hasPrevPage 	Response should indicate pagination is available for newer resources.
+	 *
+	 * @since   1.9.7.6
+	 *
+	 * @param   array $result     Result.
+	 * @param   int   $page       Page.
+	 * @param   int   $perPage    Results per page.
+	 * @param   bool  $hasNextPage    Response should indicate pagination is available for older resources.
+	 * @param   bool  $hasPrevPage    Response should indicate pagination is available for newer resources.
 	 */
 	private function testPagination($result, $page, $perPage, $hasNextPage, $hasPrevPage)
 	{
@@ -333,8 +341,8 @@ class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the exist() function performs as expected.
-	 * 
-	 * @since 	1.9.7.4
+	 *
+	 * @since   1.9.7.4
 	 */
 	public function testExist()
 	{

--- a/tests/wpunit/ResourcePostsTest.php
+++ b/tests/wpunit/ResourcePostsTest.php
@@ -2,344 +2,348 @@
 /**
  * Tests for the ConvertKit_Resource_Posts class.
  * 
- * @since 	1.9.7.4
+ * @since 1.9.7.4
  */
 class ResourcePostsTest extends \Codeception\TestCase\WPTestCase
 {
-	/**
-	 * @var \WpunitTester
-	 */
-	protected $tester;
+    /**
+     * @var \WpunitTester
+     */
+    protected $tester;
 
-	/**
-	 * Holds the ConvertKit Settings class.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @var 	ConvertKit_Settings
-	 */
-	private $settings;
+    /**
+     * Holds the ConvertKit Settings class.
+     * 
+     * @since 1.9.7.4
+     * 
+     * @var ConvertKit_Settings
+     */
+    private $settings;
 
-	/**
-	 * Holds the ConvertKit Resource class.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @var 	ConvertKit_Resource_Posts
-	 */
-	private $resource;
+    /**
+     * Holds the ConvertKit Resource class.
+     * 
+     * @since 1.9.7.4
+     * 
+     * @var ConvertKit_Resource_Posts
+     */
+    private $resource;
 
-	/**
-	 * Performs actions before each test.
-	 * 
-	 * @since 	1.9.7.4
-	 */
-	public function setUp(): void
-	{
-		parent::setUp();
+    /**
+     * Performs actions before each test.
+     * 
+     * @since 1.9.7.4
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
 
-		// Activate Plugin.
-		activate_plugins('convertkit/wp-convertkit.php');
+        // Activate Plugin.
+        activate_plugins('convertkit/wp-convertkit.php');
 
-		// Store API Key and Secret in Plugin's settings.
-		$this->settings = new ConvertKit_Settings();
-		update_option($this->settings::SETTINGS_NAME, [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-		]);
+        // Store API Key and Secret in Plugin's settings.
+        $this->settings = new ConvertKit_Settings();
+        update_option(
+            $this->settings::SETTINGS_NAME, [
+            'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+            'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+            ]
+        );
 
-		// Initialize the resource class we want to test.
-		$this->resource = new ConvertKit_Resource_Posts();
+        // Initialize the resource class we want to test.
+        $this->resource = new ConvertKit_Resource_Posts();
 
-		// Confirm initialization didn't result in an error.
-		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
-	}
+        // Confirm initialization didn't result in an error.
+        $this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
+    }
 
-	/**
-	 * Performs actions after each test.
-	 * 
-	 * @since 	1.9.6.9
-	 */
-	public function tearDown(): void
-	{
-		// Delete API Key, API Secret and Resources from Plugin's settings.
-		delete_option($this->settings::SETTINGS_NAME);
-		delete_option($this->resource->settings_name);
-		delete_option($this->resource->settings_name . '_last_queried');
+    /**
+     * Performs actions after each test.
+     * 
+     * @since 1.9.6.9
+     */
+    public function tearDown(): void
+    {
+        // Delete API Key, API Secret and Resources from Plugin's settings.
+        delete_option($this->settings::SETTINGS_NAME);
+        delete_option($this->resource->settings_name);
+        delete_option($this->resource->settings_name . '_last_queried');
 
-		// Destroy the resource class we tested.
-		unset($this->resource);
+        // Destroy the resource class we tested.
+        unset($this->resource);
 
-		// Deactivate Plugin.
-		deactivate_plugins('convertkit/wp-convertkit.php');
+        // Deactivate Plugin.
+        deactivate_plugins('convertkit/wp-convertkit.php');
 
-		parent::tearDown();
-	}
+        parent::tearDown();
+    }
 
-	/**
-	 * Test that the WordPress Cron event for this resource was created with the expected name,
-	 * matching the expected schedule as defined in the Resource's class.
-	 * 
-	 * @since 	1.9.7.4
-	 */
-	public function testCronEventCreatedOnPluginActivation()
-	{
-		// Confirm the event was scheduled.
-		$this->assertEquals(
-			wp_get_schedule('convertkit_resource_refresh_' . $this->resource->type),
-			$this->resource->wp_cron_schedule
-		);
-	}
+    /**
+     * Test that the WordPress Cron event for this resource was created with the expected name,
+     * matching the expected schedule as defined in the Resource's class.
+     * 
+     * @since 1.9.7.4
+     */
+    public function testCronEventCreatedOnPluginActivation()
+    {
+        // Confirm the event was scheduled.
+        $this->assertEquals(
+            wp_get_schedule('convertkit_resource_refresh_' . $this->resource->type),
+            $this->resource->wp_cron_schedule
+        );
+    }
 
-	/**
-	 * Test that the WordPress Cron event for this resource was created with the expected name,
-	 * matching the expected schedule as defined in the Resource's class, when updating
-	 * from an earlier version of the Plugin to 1.9.7.4 or higher.
-	 * 
-	 * @since 	1.9.7.4
-	 */
-	public function testCronEventCreatedOnPluginUpdate()
-	{
-		// Delete scheduled event.
-		$this->resource->unschedule_cron_event();
+    /**
+     * Test that the WordPress Cron event for this resource was created with the expected name,
+     * matching the expected schedule as defined in the Resource's class, when updating
+     * from an earlier version of the Plugin to 1.9.7.4 or higher.
+     * 
+     * @since 1.9.7.4
+     */
+    public function testCronEventCreatedOnPluginUpdate()
+    {
+        // Delete scheduled event.
+        $this->resource->unschedule_cron_event();
 
-		// Confirm scheduled event does not exist.
-		$this->assertFalse(wp_get_schedule('convertkit_resource_refresh_' . $this->resource->type));
+        // Confirm scheduled event does not exist.
+        $this->assertFalse(wp_get_schedule('convertkit_resource_refresh_' . $this->resource->type));
 
-		// Set Plugin version number in options table to < 1.9.7.4.
-		update_option('convertkit_version', '1.9.7.2');
+        // Set Plugin version number in options table to < 1.9.7.4.
+        update_option('convertkit_version', '1.9.7.2');
 
-		// Run the update action as WordPress would when updating the Plugin to a newer version.
-		$convertkit = WP_ConvertKit();
-		$convertkit->update();
+        // Run the update action as WordPress would when updating the Plugin to a newer version.
+        $convertkit = WP_ConvertKit();
+        $convertkit->update();
 
-		// Confirm the Plugin version number matches the current version.
-		$this->assertEquals(get_option('convertkit_version'), CONVERTKIT_PLUGIN_VERSION);
+        // Confirm the Plugin version number matches the current version.
+        $this->assertEquals(get_option('convertkit_version'), CONVERTKIT_PLUGIN_VERSION);
 
-		// Confirm the event was scheduled by the update() call.
-		$this->assertEquals(
-			wp_get_schedule('convertkit_resource_refresh_' . $this->resource->type),
-			$this->resource->wp_cron_schedule
-		);
-	}
+        // Confirm the event was scheduled by the update() call.
+        $this->assertEquals(
+            wp_get_schedule('convertkit_resource_refresh_' . $this->resource->type),
+            $this->resource->wp_cron_schedule
+        );
+    }
 
-	/**
-	 * Test that the WordPress Cron event for this resource works when valid API credentials
-	 * are specified in the Plugin's settings.
-	 * 
-	 * @since 	1.9.7.4
-	 */
-	public function testCronEventWithValidAPICredentials()
-	{
-		// Delete Resources from options table.
-		delete_option($this->resource->settings_name);
-		delete_option($this->resource->settings_name . '_last_queried');
+    /**
+     * Test that the WordPress Cron event for this resource works when valid API credentials
+     * are specified in the Plugin's settings.
+     * 
+     * @since 1.9.7.4
+     */
+    public function testCronEventWithValidAPICredentials()
+    {
+        // Delete Resources from options table.
+        delete_option($this->resource->settings_name);
+        delete_option($this->resource->settings_name . '_last_queried');
 
-		// Run the action as WordPress' Cron would.
-		do_action('convertkit_resource_refresh_' . $this->resource->type);
+        // Run the action as WordPress' Cron would.
+        do_action('convertkit_resource_refresh_' . $this->resource->type);
 
-		// Confirm that Resources now exist in the option table.
-		$result = get_option($this->resource->settings_name);
-		$this->assertIsArray($result);
-		$this->assertArrayHasKey('id', reset($result));
-		$this->assertArrayHasKey('title', reset($result));
-	}
+        // Confirm that Resources now exist in the option table.
+        $result = get_option($this->resource->settings_name);
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('id', reset($result));
+        $this->assertArrayHasKey('title', reset($result));
+    }
 
-	/**
-	 * Test that the WordPress Cron event for this resource errors when invalid API credentials
-	 * are specified in the Plugin's settings.
-	 * 
-	 * @since 	1.9.7.4
-	 */
-	public function testCronEventWithInvalidAPICredentials()
-	{
-		// Define invalid API Credentials.
-		update_option($this->settings::SETTINGS_NAME, [
-			'api_key'    => 'fakeApiKey',
-			'api_secret' => 'fakeApiSecret',
-		]);
+    /**
+     * Test that the WordPress Cron event for this resource errors when invalid API credentials
+     * are specified in the Plugin's settings.
+     * 
+     * @since 1.9.7.4
+     */
+    public function testCronEventWithInvalidAPICredentials()
+    {
+        // Define invalid API Credentials.
+        update_option(
+            $this->settings::SETTINGS_NAME, [
+            'api_key'    => 'fakeApiKey',
+            'api_secret' => 'fakeApiSecret',
+            ]
+        );
 
-		// Delete Resources from options table.
-		delete_option($this->resource->settings_name);
-		delete_option($this->resource->settings_name . '_last_queried');
+        // Delete Resources from options table.
+        delete_option($this->resource->settings_name);
+        delete_option($this->resource->settings_name . '_last_queried');
 
-		// Run the action as WordPress' Cron would.
-		do_action('convertkit_resource_refresh_' . $this->resource->type);
+        // Run the action as WordPress' Cron would.
+        do_action('convertkit_resource_refresh_' . $this->resource->type);
 
-		// Confirm that no Resources exist in the option table.
-		$result = get_option($this->resource->settings_name);
-		$this->assertFalse($result);
-	}
+        // Confirm that no Resources exist in the option table.
+        $result = get_option($this->resource->settings_name);
+        $this->assertFalse($result);
+    }
 
-	/**
-	 * Test that the WordPress Cron event for this resource was destroyed when the Plugin
-	 * is deactivated.
-	 * 
-	 * @since 	1.9.7.4
-	 */
-	public function testCronEventDestroyedOnPluginDeactivation()
-	{
-		// Deactivate Plugin.
-		deactivate_plugins('convertkit/wp-convertkit.php');
+    /**
+     * Test that the WordPress Cron event for this resource was destroyed when the Plugin
+     * is deactivated.
+     * 
+     * @since 1.9.7.4
+     */
+    public function testCronEventDestroyedOnPluginDeactivation()
+    {
+        // Deactivate Plugin.
+        deactivate_plugins('convertkit/wp-convertkit.php');
 
-		// Confirm scheduled event does not exist.
-		$this->assertFalse(wp_get_schedule('convertkit_resource_refresh_' . $this->resource->type));
-	}
+        // Confirm scheduled event does not exist.
+        $this->assertFalse(wp_get_schedule('convertkit_resource_refresh_' . $this->resource->type));
+    }
 	
-	/**
-	 * Test that the refresh() function performs as expected.
-	 * 
-	 * @since 	1.9.7.4
-	 */
-	public function testRefresh()
-	{
-		// Confirm that the data is stored in the options table and includes some expected keys.
-		$result = $this->resource->refresh();
-		$this->assertIsArray($result);
-		$this->assertArrayHasKey('id', reset($result));
-		$this->assertArrayHasKey('title', reset($result));
-	}
+    /**
+     * Test that the refresh() function performs as expected.
+     * 
+     * @since 1.9.7.4
+     */
+    public function testRefresh()
+    {
+        // Confirm that the data is stored in the options table and includes some expected keys.
+        $result = $this->resource->refresh();
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('id', reset($result));
+        $this->assertArrayHasKey('title', reset($result));
+    }
 
-	/**
-	 * Test that the expiry timestamp is set and returns the expected value.
-	 * 
-	 * @since 	1.9.7.4
-	 */
-	public function testExpiry()
-	{
-		// Define the expected expiry date based on the resource class' $cache_duration setting.
-		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+    /**
+     * Test that the expiry timestamp is set and returns the expected value.
+     * 
+     * @since 1.9.7.4
+     */
+    public function testExpiry()
+    {
+        // Define the expected expiry date based on the resource class' $cache_duration setting.
+        $expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
 
-		// Fetch the actual expiry date set when the resource class was initialized.
-		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+        // Fetch the actual expiry date set when the resource class was initialized.
+        $expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
 
-		// Confirm both dates match.
-		$this->assertEquals($expectedExpiryDate, $expiryDate);
-	}
+        // Confirm both dates match.
+        $this->assertEquals($expectedExpiryDate, $expiryDate);
+    }
 
-	/**
-	 * Test that the get() function performs as expected.
-	 * 
-	 * @since 	1.9.7.4
-	 */
-	public function testGet()
-	{
-		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
-		$result = $this->resource->get();
-		$this->assertNotInstanceOf(WP_Error::class, $result);
-		$this->assertIsArray($result);
-		$this->assertArrayHasKey('id', reset($result));
-		$this->assertArrayHasKey('title', reset($result));
-	}
+    /**
+     * Test that the get() function performs as expected.
+     * 
+     * @since 1.9.7.4
+     */
+    public function testGet()
+    {
+        // Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+        $result = $this->resource->get();
+        $this->assertNotInstanceOf(WP_Error::class, $result);
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('id', reset($result));
+        $this->assertArrayHasKey('title', reset($result));
+    }
 
-	/**
-	 * Test that the get_paginated_subset() function performs as expected when requesting one item from the first page.
-	 * 
-	 * @since 	1.9.7.6
-	 */
-	public function testGetPaginatedSubsetFirstPage()
-	{
-		$this->testPagination(
-			$this->resource->get_paginated_subset(1, 1), // Paginated array of resources and metadata.
-			1, // Page.
-			1, // Per Page.
-			true, // Has a next page, as more results in the resultset exist.
-			false // Does not have a previous page, as this is the first page in the resultset.
-		);
-	}
+    /**
+     * Test that the get_paginated_subset() function performs as expected when requesting one item from the first page.
+     * 
+     * @since 1.9.7.6
+     */
+    public function testGetPaginatedSubsetFirstPage()
+    {
+        $this->testPagination(
+            $this->resource->get_paginated_subset(1, 1), // Paginated array of resources and metadata.
+            1, // Page.
+            1, // Per Page.
+            true, // Has a next page, as more results in the resultset exist.
+            false // Does not have a previous page, as this is the first page in the resultset.
+        );
+    }
 
-	/**
-	 * Test that the get_paginated_subset() function performs as expected when requesting one item from a page
-	 * that is not the first or last page.
-	 * 
-	 * @since 	1.9.7.6
-	 */
-	public function testGetPaginatedSubsetMiddlePage()
-	{
-		$this->testPagination(
-			$this->resource->get_paginated_subset(2, 1), // Paginated array of resources and metadata.
-			2, // Page.
-			1, // Per Page.
-			true, // Has a next page, as more results in the resultset exist.
-			true // Has a previous page, as more results in the resultset exist.
-		);
-	}
+    /**
+     * Test that the get_paginated_subset() function performs as expected when requesting one item from a page
+     * that is not the first or last page.
+     * 
+     * @since 1.9.7.6
+     */
+    public function testGetPaginatedSubsetMiddlePage()
+    {
+        $this->testPagination(
+            $this->resource->get_paginated_subset(2, 1), // Paginated array of resources and metadata.
+            2, // Page.
+            1, // Per Page.
+            true, // Has a next page, as more results in the resultset exist.
+            true // Has a previous page, as more results in the resultset exist.
+        );
+    }
 
-	/**
-	 * Test that the get_paginated_subset() function performs as expected when requesting one item from the last page.
-	 * 
-	 * @since 	1.9.7.6
-	 */
-	public function testGetPaginatedSubsetLastPage()
-	{
-		// Query the API to establish how many resources exist.
-		$result = $this->resource->get();
-		$lastPage = count($result);
+    /**
+     * Test that the get_paginated_subset() function performs as expected when requesting one item from the last page.
+     * 
+     * @since 1.9.7.6
+     */
+    public function testGetPaginatedSubsetLastPage()
+    {
+        // Query the API to establish how many resources exist.
+        $result = $this->resource->get();
+        $lastPage = count($result);
 
-		$this->testPagination(
-			$this->resource->get_paginated_subset($lastPage, 1), // Paginated array of resources and metadata.
-			$lastPage, // Page.
-			1, // Per Page.
-			false, // Does not have a next page, as this is the last page in the resultset.
-			true // Has a previous page, as more results in the resultset exist.
-		);
-	}
+        $this->testPagination(
+            $this->resource->get_paginated_subset($lastPage, 1), // Paginated array of resources and metadata.
+            $lastPage, // Page.
+            1, // Per Page.
+            false, // Does not have a next page, as this is the last page in the resultset.
+            true // Has a previous page, as more results in the resultset exist.
+        );
+    }
 
-	/**
-	 * Test that the count() function returns the number of resources.
-	 * 
-	 * @since 	1.9.7.6
-	 */
-	public function testCount()
-	{
-		$result = $this->resource->get();
-		$this->assertEquals($this->resource->count(), count($result));
-	}
+    /**
+     * Test that the count() function returns the number of resources.
+     * 
+     * @since 1.9.7.6
+     */
+    public function testCount()
+    {
+        $result = $this->resource->get();
+        $this->assertEquals($this->resource->count(), count($result));
+    }
 
-	/**
-	 * Shared tests for paginated resources, ensuring the response contains expected values for pagination,
-	 * next/previous links etc.
-	 * 
-	 * @since 	1.9.7.6
-	 * 
-	 * @param 	array 	$result 	Result.
-	 * @param 	int 	$page 		Page.
-	 * @param 	int 	$perPage 	Results per page.
-	 * @param 	bool 	$hasNextPage 	Response should indicate pagination is available for older resources.
-	 * @param 	bool 	$hasPrevPage 	Response should indicate pagination is available for newer resources.
-	 */
-	private function testPagination($result, $page, $perPage, $hasNextPage, $hasPrevPage)
-	{
-		$this->assertNotInstanceOf(WP_Error::class, $result);
-		$this->assertIsArray($result);
-		$this->assertArrayHasKey('items', $result);
-		$this->assertArrayHasKey('page', $result);
-		$this->assertArrayHasKey('per_page', $result);
-		$this->assertArrayHasKey('has_next_page', $result);
-		$this->assertArrayHasKey('has_prev_page', $result);
+    /**
+     * Shared tests for paginated resources, ensuring the response contains expected values for pagination,
+     * next/previous links etc.
+     * 
+     * @since 1.9.7.6
+     * 
+     * @param array $result      Result.
+     * @param int   $page        Page.
+     * @param int   $perPage     Results per page.
+     * @param bool  $hasNextPage Response should indicate pagination is available for older resources.
+     * @param bool  $hasPrevPage Response should indicate pagination is available for newer resources.
+     */
+    private function testPagination($result, $page, $perPage, $hasNextPage, $hasPrevPage)
+    {
+        $this->assertNotInstanceOf(WP_Error::class, $result);
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('items', $result);
+        $this->assertArrayHasKey('page', $result);
+        $this->assertArrayHasKey('per_page', $result);
+        $this->assertArrayHasKey('has_next_page', $result);
+        $this->assertArrayHasKey('has_prev_page', $result);
 
-		// Check posts exist.
-		$this->assertIsArray($result);
-		$this->assertCount($perPage, $result['items']);
-		$this->assertArrayHasKey('id', reset($result['items']));
-		$this->assertArrayHasKey('title', reset($result['items']));
+        // Check posts exist.
+        $this->assertIsArray($result);
+        $this->assertCount($perPage, $result['items']);
+        $this->assertArrayHasKey('id', reset($result['items']));
+        $this->assertArrayHasKey('title', reset($result['items']));
 
-		// Check other array values are as expected.
-		$this->assertEquals($result['page'], $page);
-		$this->assertEquals($result['per_page'], $perPage);
-		$this->assertEquals($result['has_next_page'], $hasNextPage);
-		$this->assertEquals($result['has_prev_page'], $hasPrevPage);
-	}
+        // Check other array values are as expected.
+        $this->assertEquals($result['page'], $page);
+        $this->assertEquals($result['per_page'], $perPage);
+        $this->assertEquals($result['has_next_page'], $hasNextPage);
+        $this->assertEquals($result['has_prev_page'], $hasPrevPage);
+    }
 
-	/**
-	 * Test that the exist() function performs as expected.
-	 * 
-	 * @since 	1.9.7.4
-	 */
-	public function testExist()
-	{
-		// Confirm that the function returns true, because resources exist.
-		$result = $this->resource->exist();
-		$this->assertSame($result, true);
-	}
+    /**
+     * Test that the exist() function performs as expected.
+     * 
+     * @since 1.9.7.4
+     */
+    public function testExist()
+    {
+        // Confirm that the function returns true, because resources exist.
+        $result = $this->resource->exist();
+        $this->assertSame($result, true);
+    }
 }

--- a/tests/wpunit/ResourceProductsNoDataTest.php
+++ b/tests/wpunit/ResourceProductsNoDataTest.php
@@ -1,144 +1,146 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Products class when no data is present in the API.
- *
- * @since 1.9.8.5
+ * 
+ * @since 	1.9.8.5
  */
-class ResourceProductsNoDataTest extends \Codeception\TestCase\WPTestCase {
-
+class ResourceProductsNoDataTest extends \Codeception\TestCase\WPTestCase
+{
 	/**
-	 * The test object.
-	 *
 	 * @var \WpunitTester
 	 */
 	protected $tester;
 
 	/**
 	 * Holds the ConvertKit Settings class.
-	 *
-	 * @since 1.9.8.5
-	 *
-	 * @var ConvertKit_Settings
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @var 	ConvertKit_Settings
 	 */
 	private $settings;
 
 	/**
 	 * Holds the ConvertKit Resource class.
-	 *
-	 * @since 1.9.8.5
-	 *
-	 * @var ConvertKit_Resource_Products
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @var 	ConvertKit_Resource_Products
 	 */
 	private $resource;
 
 	/**
 	 * Performs actions before each test.
-	 *
-	 * @since 1.9.8.5
+	 * 
+	 * @since 	1.9.8.5
 	 */
-	public function setUp(): void {
+	public function setUp(): void
+	{
 		parent::setUp();
 
 		// Activate Plugin.
-		activate_plugins( 'convertkit/wp-convertkit.php' );
+		activate_plugins('convertkit/wp-convertkit.php');
 
 		// Store API Key and Secret in Plugin's settings.
 		$this->settings = new ConvertKit_Settings();
-		update_option(
-			$this->settings::SETTINGS_NAME,
-			array(
-				'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
-				'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
-			)
-		);
+		update_option($this->settings::SETTINGS_NAME, [
+			'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+			'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+		]);
 
 		// Initialize the resource class we want to test.
 		$this->resource = new ConvertKit_Resource_Products();
 
 		// Confirm initialization didn't result in an error.
-		$this->assertNotInstanceOf( WP_Error::class, $this->resource->resources );
+		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
 	}
 
 	/**
 	 * Performs actions after each test.
-	 *
-	 * @since 1.9.6.9
+	 * 
+	 * @since 	1.9.6.9
 	 */
-	public function tearDown(): void {
+	public function tearDown(): void
+	{
 		// Delete API Key, API Secret and Resources from Plugin's settings.
-		delete_option( $this->settings::SETTINGS_NAME );
-		delete_option( $this->resource->settings_name );
-		delete_option( $this->resource->settings_name . '_last_queried' );
+		delete_option($this->settings::SETTINGS_NAME);
+		delete_option($this->resource->settings_name);
+		delete_option($this->resource->settings_name . '_last_queried');
 
 		// Destroy the resource class we tested.
-		unset( $this->resource );
+		unset($this->resource);
 
 		// Deactivate Plugin.
-		deactivate_plugins( 'convertkit/wp-convertkit.php' );
-
+		deactivate_plugins('convertkit/wp-convertkit.php');
+		
 		parent::tearDown();
 	}
 
 	/**
 	 * Test that the refresh() function performs as expected, storing data in the options table.
-	 *
-	 * @since 1.9.8.5
+	 * 
+	 * @since 	1.9.8.5
 	 */
-	public function testRefresh() {
+	public function testRefresh()
+	{
 		// Confirm that the data is stored in the options table and includes some expected keys.
 		$result = $this->resource->refresh();
-		$this->assertNotInstanceOf( WP_Error::class, $result );
-		$this->assertIsArray( $result );
-		$this->assertCount( 0, $result );
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
 	}
 
 	/**
 	 * Test that the expiry timestamp is set and returns the expected value.
-	 *
-	 * @since 1.9.8.5
+	 * 
+	 * @since 	1.9.8.5
 	 */
-	public function testExpiry() {
+	public function testExpiry()
+	{
 		// Define the expected expiry date based on the resource class' $cache_duration setting.
-		$expectedExpiryDate = date( 'Y-m-d', time() + $this->resource->cache_duration );
+		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
 
 		// Fetch the actual expiry date set when the resource class was initialized.
-		$expiryDate = date( 'Y-m-d', $this->resource->last_queried + $this->resource->cache_duration );
+		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
 
 		// Confirm both dates match.
-		$this->assertEquals( $expectedExpiryDate, $expiryDate );
+		$this->assertEquals($expectedExpiryDate, $expiryDate);
 	}
 
 	/**
 	 * Test that the get() function performs as expected.
-	 *
-	 * @since 1.9.8.5
+	 * 
+	 * @since 	1.9.8.5
 	 */
-	public function testGet() {
+	public function testGet()
+	{
 		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
 		$result = $this->resource->get();
-		$this->assertNotInstanceOf( WP_Error::class, $result );
-		$this->assertIsArray( $result );
-		$this->assertCount( 0, $result );
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
 	}
 
 	/**
 	 * Test that the count() function returns the number of resources.
-	 *
-	 * @since 1.9.7.6
+	 * 
+	 * @since 	1.9.7.6
 	 */
-	public function testCount() {
+	public function testCount()
+	{
 		$result = $this->resource->get();
-		$this->assertEquals( $this->resource->count(), count( $result ) );
+		$this->assertEquals($this->resource->count(), count($result));
 	}
 
 	/**
 	 * Test that the exist() function performs as expected.
-	 *
-	 * @since 1.9.8.5
+	 * 
+	 * @since 	1.9.8.5
 	 */
-	public function testExist() {
+	public function testExist()
+	{
 		// Confirm that the function returns true, because resources exist.
 		$result = $this->resource->exist();
-		$this->assertSame( $result, false );
+		$this->assertSame($result, false);
 	}
 }

--- a/tests/wpunit/ResourceProductsNoDataTest.php
+++ b/tests/wpunit/ResourceProductsNoDataTest.php
@@ -1,150 +1,144 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Products class when no data is present in the API.
- * 
+ *
  * @since 1.9.8.5
  */
-class ResourceProductsNoDataTest extends \Codeception\TestCase\WPTestCase
-{
-    /**
-     * The test object.
-     *
-     * @var \WpunitTester
-     */
-    protected $tester;
+class ResourceProductsNoDataTest extends \Codeception\TestCase\WPTestCase {
 
-    /**
-     * Holds the ConvertKit Settings class.
-     * 
-     * @since 1.9.8.5
-     * 
-     * @var ConvertKit_Settings
-     */
-    private $settings;
+	/**
+	 * The test object.
+	 *
+	 * @var \WpunitTester
+	 */
+	protected $tester;
 
-    /**
-     * Holds the ConvertKit Resource class.
-     * 
-     * @since 1.9.8.5
-     * 
-     * @var ConvertKit_Resource_Products
-     */
-    private $resource;
+	/**
+	 * Holds the ConvertKit Settings class.
+	 *
+	 * @since 1.9.8.5
+	 *
+	 * @var ConvertKit_Settings
+	 */
+	private $settings;
 
-    /**
-     * Performs actions before each test.
-     * 
-     * @since 1.9.8.5
-     */
-    public function setUp(): void
-    {
-        parent::setUp();
+	/**
+	 * Holds the ConvertKit Resource class.
+	 *
+	 * @since 1.9.8.5
+	 *
+	 * @var ConvertKit_Resource_Products
+	 */
+	private $resource;
 
-        // Activate Plugin.
-        activate_plugins('convertkit/wp-convertkit.php');
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since 1.9.8.5
+	 */
+	public function setUp(): void {
+		parent::setUp();
 
-        // Store API Key and Secret in Plugin's settings.
-        $this->settings = new ConvertKit_Settings();
-        update_option(
-            $this->settings::SETTINGS_NAME, [
-            'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
-            'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
-            ]
-        );
+		// Activate Plugin.
+		activate_plugins( 'convertkit/wp-convertkit.php' );
 
-        // Initialize the resource class we want to test.
-        $this->resource = new ConvertKit_Resource_Products();
+		// Store API Key and Secret in Plugin's settings.
+		$this->settings = new ConvertKit_Settings();
+		update_option(
+			$this->settings::SETTINGS_NAME,
+			array(
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+			)
+		);
 
-        // Confirm initialization didn't result in an error.
-        $this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
-    }
+		// Initialize the resource class we want to test.
+		$this->resource = new ConvertKit_Resource_Products();
 
-    /**
-     * Performs actions after each test.
-     * 
-     * @since 1.9.6.9
-     */
-    public function tearDown(): void
-    {
-        // Delete API Key, API Secret and Resources from Plugin's settings.
-        delete_option($this->settings::SETTINGS_NAME);
-        delete_option($this->resource->settings_name);
-        delete_option($this->resource->settings_name . '_last_queried');
+		// Confirm initialization didn't result in an error.
+		$this->assertNotInstanceOf( WP_Error::class, $this->resource->resources );
+	}
 
-        // Destroy the resource class we tested.
-        unset($this->resource);
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since 1.9.6.9
+	 */
+	public function tearDown(): void {
+		// Delete API Key, API Secret and Resources from Plugin's settings.
+		delete_option( $this->settings::SETTINGS_NAME );
+		delete_option( $this->resource->settings_name );
+		delete_option( $this->resource->settings_name . '_last_queried' );
 
-        // Deactivate Plugin.
-        deactivate_plugins('convertkit/wp-convertkit.php');
-		
-        parent::tearDown();
-    }
+		// Destroy the resource class we tested.
+		unset( $this->resource );
 
-    /**
-     * Test that the refresh() function performs as expected, storing data in the options table.
-     * 
-     * @since 1.9.8.5
-     */
-    public function testRefresh()
-    {
-        // Confirm that the data is stored in the options table and includes some expected keys.
-        $result = $this->resource->refresh();
-        $this->assertNotInstanceOf(WP_Error::class, $result);
-        $this->assertIsArray($result);
-        $this->assertCount(0, $result);
-    }
+		// Deactivate Plugin.
+		deactivate_plugins( 'convertkit/wp-convertkit.php' );
 
-    /**
-     * Test that the expiry timestamp is set and returns the expected value.
-     * 
-     * @since 1.9.8.5
-     */
-    public function testExpiry()
-    {
-        // Define the expected expiry date based on the resource class' $cache_duration setting.
-        $expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+		parent::tearDown();
+	}
 
-        // Fetch the actual expiry date set when the resource class was initialized.
-        $expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+	/**
+	 * Test that the refresh() function performs as expected, storing data in the options table.
+	 *
+	 * @since 1.9.8.5
+	 */
+	public function testRefresh() {
+		// Confirm that the data is stored in the options table and includes some expected keys.
+		$result = $this->resource->refresh();
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertIsArray( $result );
+		$this->assertCount( 0, $result );
+	}
 
-        // Confirm both dates match.
-        $this->assertEquals($expectedExpiryDate, $expiryDate);
-    }
+	/**
+	 * Test that the expiry timestamp is set and returns the expected value.
+	 *
+	 * @since 1.9.8.5
+	 */
+	public function testExpiry() {
+		// Define the expected expiry date based on the resource class' $cache_duration setting.
+		$expectedExpiryDate = date( 'Y-m-d', time() + $this->resource->cache_duration );
 
-    /**
-     * Test that the get() function performs as expected.
-     * 
-     * @since 1.9.8.5
-     */
-    public function testGet()
-    {
-        // Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
-        $result = $this->resource->get();
-        $this->assertNotInstanceOf(WP_Error::class, $result);
-        $this->assertIsArray($result);
-        $this->assertCount(0, $result);
-    }
+		// Fetch the actual expiry date set when the resource class was initialized.
+		$expiryDate = date( 'Y-m-d', $this->resource->last_queried + $this->resource->cache_duration );
 
-    /**
-     * Test that the count() function returns the number of resources.
-     * 
-     * @since 1.9.7.6
-     */
-    public function testCount()
-    {
-        $result = $this->resource->get();
-        $this->assertEquals($this->resource->count(), count($result));
-    }
+		// Confirm both dates match.
+		$this->assertEquals( $expectedExpiryDate, $expiryDate );
+	}
 
-    /**
-     * Test that the exist() function performs as expected.
-     * 
-     * @since 1.9.8.5
-     */
-    public function testExist()
-    {
-        // Confirm that the function returns true, because resources exist.
-        $result = $this->resource->exist();
-        $this->assertSame($result, false);
-    }
+	/**
+	 * Test that the get() function performs as expected.
+	 *
+	 * @since 1.9.8.5
+	 */
+	public function testGet() {
+		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+		$result = $this->resource->get();
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertIsArray( $result );
+		$this->assertCount( 0, $result );
+	}
+
+	/**
+	 * Test that the count() function returns the number of resources.
+	 *
+	 * @since 1.9.7.6
+	 */
+	public function testCount() {
+		$result = $this->resource->get();
+		$this->assertEquals( $this->resource->count(), count( $result ) );
+	}
+
+	/**
+	 * Test that the exist() function performs as expected.
+	 *
+	 * @since 1.9.8.5
+	 */
+	public function testExist() {
+		// Confirm that the function returns true, because resources exist.
+		$result = $this->resource->exist();
+		$this->assertSame( $result, false );
+	}
 }

--- a/tests/wpunit/ResourceProductsNoDataTest.php
+++ b/tests/wpunit/ResourceProductsNoDataTest.php
@@ -7,6 +7,8 @@
 class ResourceProductsNoDataTest extends \Codeception\TestCase\WPTestCase
 {
     /**
+     * The test object.
+     *
      * @var \WpunitTester
      */
     protected $tester;

--- a/tests/wpunit/ResourceProductsNoDataTest.php
+++ b/tests/wpunit/ResourceProductsNoDataTest.php
@@ -2,145 +2,147 @@
 /**
  * Tests for the ConvertKit_Resource_Products class when no data is present in the API.
  * 
- * @since 	1.9.8.5
+ * @since 1.9.8.5
  */
 class ResourceProductsNoDataTest extends \Codeception\TestCase\WPTestCase
 {
-	/**
-	 * @var \WpunitTester
-	 */
-	protected $tester;
+    /**
+     * @var \WpunitTester
+     */
+    protected $tester;
 
-	/**
-	 * Holds the ConvertKit Settings class.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @var 	ConvertKit_Settings
-	 */
-	private $settings;
+    /**
+     * Holds the ConvertKit Settings class.
+     * 
+     * @since 1.9.8.5
+     * 
+     * @var ConvertKit_Settings
+     */
+    private $settings;
 
-	/**
-	 * Holds the ConvertKit Resource class.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @var 	ConvertKit_Resource_Products
-	 */
-	private $resource;
+    /**
+     * Holds the ConvertKit Resource class.
+     * 
+     * @since 1.9.8.5
+     * 
+     * @var ConvertKit_Resource_Products
+     */
+    private $resource;
 
-	/**
-	 * Performs actions before each test.
-	 * 
-	 * @since 	1.9.8.5
-	 */
-	public function setUp(): void
-	{
-		parent::setUp();
+    /**
+     * Performs actions before each test.
+     * 
+     * @since 1.9.8.5
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
 
-		// Activate Plugin.
-		activate_plugins('convertkit/wp-convertkit.php');
+        // Activate Plugin.
+        activate_plugins('convertkit/wp-convertkit.php');
 
-		// Store API Key and Secret in Plugin's settings.
-		$this->settings = new ConvertKit_Settings();
-		update_option($this->settings::SETTINGS_NAME, [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
-		]);
+        // Store API Key and Secret in Plugin's settings.
+        $this->settings = new ConvertKit_Settings();
+        update_option(
+            $this->settings::SETTINGS_NAME, [
+            'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+            'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+            ]
+        );
 
-		// Initialize the resource class we want to test.
-		$this->resource = new ConvertKit_Resource_Products();
+        // Initialize the resource class we want to test.
+        $this->resource = new ConvertKit_Resource_Products();
 
-		// Confirm initialization didn't result in an error.
-		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
-	}
+        // Confirm initialization didn't result in an error.
+        $this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
+    }
 
-	/**
-	 * Performs actions after each test.
-	 * 
-	 * @since 	1.9.6.9
-	 */
-	public function tearDown(): void
-	{
-		// Delete API Key, API Secret and Resources from Plugin's settings.
-		delete_option($this->settings::SETTINGS_NAME);
-		delete_option($this->resource->settings_name);
-		delete_option($this->resource->settings_name . '_last_queried');
+    /**
+     * Performs actions after each test.
+     * 
+     * @since 1.9.6.9
+     */
+    public function tearDown(): void
+    {
+        // Delete API Key, API Secret and Resources from Plugin's settings.
+        delete_option($this->settings::SETTINGS_NAME);
+        delete_option($this->resource->settings_name);
+        delete_option($this->resource->settings_name . '_last_queried');
 
-		// Destroy the resource class we tested.
-		unset($this->resource);
+        // Destroy the resource class we tested.
+        unset($this->resource);
 
-		// Deactivate Plugin.
-		deactivate_plugins('convertkit/wp-convertkit.php');
+        // Deactivate Plugin.
+        deactivate_plugins('convertkit/wp-convertkit.php');
 		
-		parent::tearDown();
-	}
+        parent::tearDown();
+    }
 
-	/**
-	 * Test that the refresh() function performs as expected, storing data in the options table.
-	 * 
-	 * @since 	1.9.8.5
-	 */
-	public function testRefresh()
-	{
-		// Confirm that the data is stored in the options table and includes some expected keys.
-		$result = $this->resource->refresh();
-		$this->assertNotInstanceOf(WP_Error::class, $result);
-		$this->assertIsArray($result);
-		$this->assertCount(0, $result);
-	}
+    /**
+     * Test that the refresh() function performs as expected, storing data in the options table.
+     * 
+     * @since 1.9.8.5
+     */
+    public function testRefresh()
+    {
+        // Confirm that the data is stored in the options table and includes some expected keys.
+        $result = $this->resource->refresh();
+        $this->assertNotInstanceOf(WP_Error::class, $result);
+        $this->assertIsArray($result);
+        $this->assertCount(0, $result);
+    }
 
-	/**
-	 * Test that the expiry timestamp is set and returns the expected value.
-	 * 
-	 * @since 	1.9.8.5
-	 */
-	public function testExpiry()
-	{
-		// Define the expected expiry date based on the resource class' $cache_duration setting.
-		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+    /**
+     * Test that the expiry timestamp is set and returns the expected value.
+     * 
+     * @since 1.9.8.5
+     */
+    public function testExpiry()
+    {
+        // Define the expected expiry date based on the resource class' $cache_duration setting.
+        $expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
 
-		// Fetch the actual expiry date set when the resource class was initialized.
-		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+        // Fetch the actual expiry date set when the resource class was initialized.
+        $expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
 
-		// Confirm both dates match.
-		$this->assertEquals($expectedExpiryDate, $expiryDate);
-	}
+        // Confirm both dates match.
+        $this->assertEquals($expectedExpiryDate, $expiryDate);
+    }
 
-	/**
-	 * Test that the get() function performs as expected.
-	 * 
-	 * @since 	1.9.8.5
-	 */
-	public function testGet()
-	{
-		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
-		$result = $this->resource->get();
-		$this->assertNotInstanceOf(WP_Error::class, $result);
-		$this->assertIsArray($result);
-		$this->assertCount(0, $result);
-	}
+    /**
+     * Test that the get() function performs as expected.
+     * 
+     * @since 1.9.8.5
+     */
+    public function testGet()
+    {
+        // Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+        $result = $this->resource->get();
+        $this->assertNotInstanceOf(WP_Error::class, $result);
+        $this->assertIsArray($result);
+        $this->assertCount(0, $result);
+    }
 
-	/**
-	 * Test that the count() function returns the number of resources.
-	 * 
-	 * @since 	1.9.7.6
-	 */
-	public function testCount()
-	{
-		$result = $this->resource->get();
-		$this->assertEquals($this->resource->count(), count($result));
-	}
+    /**
+     * Test that the count() function returns the number of resources.
+     * 
+     * @since 1.9.7.6
+     */
+    public function testCount()
+    {
+        $result = $this->resource->get();
+        $this->assertEquals($this->resource->count(), count($result));
+    }
 
-	/**
-	 * Test that the exist() function performs as expected.
-	 * 
-	 * @since 	1.9.8.5
-	 */
-	public function testExist()
-	{
-		// Confirm that the function returns true, because resources exist.
-		$result = $this->resource->exist();
-		$this->assertSame($result, false);
-	}
+    /**
+     * Test that the exist() function performs as expected.
+     * 
+     * @since 1.9.8.5
+     */
+    public function testExist()
+    {
+        // Confirm that the function returns true, because resources exist.
+        $result = $this->resource->exist();
+        $this->assertSame($result, false);
+    }
 }

--- a/tests/wpunit/ResourceProductsNoDataTest.php
+++ b/tests/wpunit/ResourceProductsNoDataTest.php
@@ -1,38 +1,40 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Products class when no data is present in the API.
- * 
- * @since 	1.9.8.5
+ *
+ * @since   1.9.8.5
  */
 class ResourceProductsNoDataTest extends \Codeception\TestCase\WPTestCase
 {
 	/**
-	 * @var \WpunitTester
+	 * The testing implementation.
+	 *
+	 * @var \WpunitTester.
 	 */
 	protected $tester;
 
 	/**
 	 * Holds the ConvertKit Settings class.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @var 	ConvertKit_Settings
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @var     ConvertKit_Settings
 	 */
 	private $settings;
 
 	/**
 	 * Holds the ConvertKit Resource class.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @var 	ConvertKit_Resource_Products
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @var     ConvertKit_Resource_Products
 	 */
 	private $resource;
 
 	/**
 	 * Performs actions before each test.
-	 * 
-	 * @since 	1.9.8.5
+	 *
+	 * @since   1.9.8.5
 	 */
 	public function setUp(): void
 	{
@@ -43,10 +45,13 @@ class ResourceProductsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 		// Store API Key and Secret in Plugin's settings.
 		$this->settings = new ConvertKit_Settings();
-		update_option($this->settings::SETTINGS_NAME, [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
-		]);
+		update_option(
+			$this->settings::SETTINGS_NAME,
+			[
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+			]
+		);
 
 		// Initialize the resource class we want to test.
 		$this->resource = new ConvertKit_Resource_Products();
@@ -57,8 +62,8 @@ class ResourceProductsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Performs actions after each test.
-	 * 
-	 * @since 	1.9.6.9
+	 *
+	 * @since   1.9.6.9
 	 */
 	public function tearDown(): void
 	{
@@ -72,14 +77,14 @@ class ResourceProductsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 		// Deactivate Plugin.
 		deactivate_plugins('convertkit/wp-convertkit.php');
-		
+
 		parent::tearDown();
 	}
 
 	/**
 	 * Test that the refresh() function performs as expected, storing data in the options table.
-	 * 
-	 * @since 	1.9.8.5
+	 *
+	 * @since   1.9.8.5
 	 */
 	public function testRefresh()
 	{
@@ -92,8 +97,8 @@ class ResourceProductsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the expiry timestamp is set and returns the expected value.
-	 * 
-	 * @since 	1.9.8.5
+	 *
+	 * @since   1.9.8.5
 	 */
 	public function testExpiry()
 	{
@@ -109,8 +114,8 @@ class ResourceProductsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the get() function performs as expected.
-	 * 
-	 * @since 	1.9.8.5
+	 *
+	 * @since   1.9.8.5
 	 */
 	public function testGet()
 	{
@@ -123,8 +128,8 @@ class ResourceProductsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the count() function returns the number of resources.
-	 * 
-	 * @since 	1.9.7.6
+	 *
+	 * @since   1.9.7.6
 	 */
 	public function testCount()
 	{
@@ -134,8 +139,8 @@ class ResourceProductsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the exist() function performs as expected.
-	 * 
-	 * @since 	1.9.8.5
+	 *
+	 * @since   1.9.8.5
 	 */
 	public function testExist()
 	{

--- a/tests/wpunit/ResourceProductsTest.php
+++ b/tests/wpunit/ResourceProductsTest.php
@@ -7,6 +7,8 @@
 class ResourceProductsTest extends \Codeception\TestCase\WPTestCase
 {
     /**
+     * The test object.
+     *
      * @var \WpunitTester
      */
     protected $tester;

--- a/tests/wpunit/ResourceProductsTest.php
+++ b/tests/wpunit/ResourceProductsTest.php
@@ -1,38 +1,40 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Products class.
- * 
- * @since 	1.9.8.5
+ *
+ * @since   1.9.8.5
  */
 class ResourceProductsTest extends \Codeception\TestCase\WPTestCase
 {
 	/**
-	 * @var \WpunitTester
+	 * The testing implementation.
+	 *
+	 * @var \WpunitTester.
 	 */
 	protected $tester;
 
 	/**
 	 * Holds the ConvertKit Settings class.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @var 	ConvertKit_Settings
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @var     ConvertKit_Settings
 	 */
 	private $settings;
 
 	/**
 	 * Holds the ConvertKit Resource class.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @var 	ConvertKit_Resource_Products
+	 *
+	 * @since   1.9.8.5
+	 *
+	 * @var     ConvertKit_Resource_Products
 	 */
 	private $resource;
 
 	/**
 	 * Performs actions before each test.
-	 * 
-	 * @since 	1.9.8.5
+	 *
+	 * @since   1.9.8.5
 	 */
 	public function setUp(): void
 	{
@@ -43,10 +45,13 @@ class ResourceProductsTest extends \Codeception\TestCase\WPTestCase
 
 		// Store API Key and Secret in Plugin's settings.
 		$this->settings = new ConvertKit_Settings();
-		update_option($this->settings::SETTINGS_NAME, [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-		]);
+		update_option(
+			$this->settings::SETTINGS_NAME,
+			[
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+			]
+		);
 
 		// Initialize the resource class we want to test.
 		$this->resource = new ConvertKit_Resource_Products();
@@ -57,8 +62,8 @@ class ResourceProductsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Performs actions after each test.
-	 * 
-	 * @since 	1.9.6.9
+	 *
+	 * @since   1.9.6.9
 	 */
 	public function tearDown(): void
 	{
@@ -72,14 +77,14 @@ class ResourceProductsTest extends \Codeception\TestCase\WPTestCase
 
 		// Deactivate Plugin.
 		deactivate_plugins('convertkit/wp-convertkit.php');
-		
+
 		parent::tearDown();
 	}
 
 	/**
 	 * Test that the refresh() function performs as expected.
-	 * 
-	 * @since 	1.9.8.5
+	 *
+	 * @since   1.9.8.5
 	 */
 	public function testRefresh()
 	{
@@ -92,8 +97,8 @@ class ResourceProductsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the expiry timestamp is set and returns the expected value.
-	 * 
-	 * @since 	1.9.8.5
+	 *
+	 * @since   1.9.8.5
 	 */
 	public function testExpiry()
 	{
@@ -109,8 +114,8 @@ class ResourceProductsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the get() function performs as expected.
-	 * 
-	 * @since 	1.9.8.5
+	 *
+	 * @since   1.9.8.5
 	 */
 	public function testGet()
 	{
@@ -124,8 +129,8 @@ class ResourceProductsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the count() function returns the number of resources.
-	 * 
-	 * @since 	1.9.7.6
+	 *
+	 * @since   1.9.7.6
 	 */
 	public function testCount()
 	{
@@ -135,8 +140,8 @@ class ResourceProductsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the exist() function performs as expected.
-	 * 
-	 * @since 	1.9.8.5
+	 *
+	 * @since   1.9.8.5
 	 */
 	public function testExist()
 	{

--- a/tests/wpunit/ResourceProductsTest.php
+++ b/tests/wpunit/ResourceProductsTest.php
@@ -1,145 +1,147 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Products class.
- *
- * @since 1.9.8.5
+ * 
+ * @since 	1.9.8.5
  */
-class ResourceProductsTest extends \Codeception\TestCase\WPTestCase {
-
+class ResourceProductsTest extends \Codeception\TestCase\WPTestCase
+{
 	/**
-	 * The test object.
-	 *
 	 * @var \WpunitTester
 	 */
 	protected $tester;
 
 	/**
 	 * Holds the ConvertKit Settings class.
-	 *
-	 * @since 1.9.8.5
-	 *
-	 * @var ConvertKit_Settings
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @var 	ConvertKit_Settings
 	 */
 	private $settings;
 
 	/**
 	 * Holds the ConvertKit Resource class.
-	 *
-	 * @since 1.9.8.5
-	 *
-	 * @var ConvertKit_Resource_Products
+	 * 
+	 * @since 	1.9.8.5
+	 * 
+	 * @var 	ConvertKit_Resource_Products
 	 */
 	private $resource;
 
 	/**
 	 * Performs actions before each test.
-	 *
-	 * @since 1.9.8.5
+	 * 
+	 * @since 	1.9.8.5
 	 */
-	public function setUp(): void {
+	public function setUp(): void
+	{
 		parent::setUp();
 
 		// Activate Plugin.
-		activate_plugins( 'convertkit/wp-convertkit.php' );
+		activate_plugins('convertkit/wp-convertkit.php');
 
 		// Store API Key and Secret in Plugin's settings.
 		$this->settings = new ConvertKit_Settings();
-		update_option(
-			$this->settings::SETTINGS_NAME,
-			array(
-				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-			)
-		);
+		update_option($this->settings::SETTINGS_NAME, [
+			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+		]);
 
 		// Initialize the resource class we want to test.
 		$this->resource = new ConvertKit_Resource_Products();
 
 		// Confirm initialization didn't result in an error.
-		$this->assertNotInstanceOf( WP_Error::class, $this->resource->resources );
+		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
 	}
 
 	/**
 	 * Performs actions after each test.
-	 *
-	 * @since 1.9.6.9
+	 * 
+	 * @since 	1.9.6.9
 	 */
-	public function tearDown(): void {
+	public function tearDown(): void
+	{
 		// Delete API Key, API Secret and Resources from Plugin's settings.
-		delete_option( $this->settings::SETTINGS_NAME );
-		delete_option( $this->resource->settings_name );
-		delete_option( $this->resource->settings_name . '_last_queried' );
+		delete_option($this->settings::SETTINGS_NAME);
+		delete_option($this->resource->settings_name);
+		delete_option($this->resource->settings_name . '_last_queried');
 
 		// Destroy the resource class we tested.
-		unset( $this->resource );
+		unset($this->resource);
 
 		// Deactivate Plugin.
-		deactivate_plugins( 'convertkit/wp-convertkit.php' );
-
+		deactivate_plugins('convertkit/wp-convertkit.php');
+		
 		parent::tearDown();
 	}
 
 	/**
 	 * Test that the refresh() function performs as expected.
-	 *
-	 * @since 1.9.8.5
+	 * 
+	 * @since 	1.9.8.5
 	 */
-	public function testRefresh() {
+	public function testRefresh()
+	{
 		// Confirm that the data is stored in the options table and includes some expected keys.
 		$result = $this->resource->refresh();
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'id', reset( $result ) );
-		$this->assertArrayHasKey( 'name', reset( $result ) );
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
 	}
 
 	/**
 	 * Test that the expiry timestamp is set and returns the expected value.
-	 *
-	 * @since 1.9.8.5
+	 * 
+	 * @since 	1.9.8.5
 	 */
-	public function testExpiry() {
+	public function testExpiry()
+	{
 		// Define the expected expiry date based on the resource class' $cache_duration setting.
-		$expectedExpiryDate = date( 'Y-m-d', time() + $this->resource->cache_duration );
+		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
 
 		// Fetch the actual expiry date set when the resource class was initialized.
-		$expiryDate = date( 'Y-m-d', $this->resource->last_queried + $this->resource->cache_duration );
+		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
 
 		// Confirm both dates match.
-		$this->assertEquals( $expectedExpiryDate, $expiryDate );
+		$this->assertEquals($expectedExpiryDate, $expiryDate);
 	}
 
 	/**
 	 * Test that the get() function performs as expected.
-	 *
-	 * @since 1.9.8.5
+	 * 
+	 * @since 	1.9.8.5
 	 */
-	public function testGet() {
+	public function testGet()
+	{
 		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
 		$result = $this->resource->get();
-		$this->assertNotInstanceOf( WP_Error::class, $result );
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'id', reset( $result ) );
-		$this->assertArrayHasKey( 'name', reset( $result ) );
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
 	}
 
 	/**
 	 * Test that the count() function returns the number of resources.
-	 *
-	 * @since 1.9.7.6
+	 * 
+	 * @since 	1.9.7.6
 	 */
-	public function testCount() {
+	public function testCount()
+	{
 		$result = $this->resource->get();
-		$this->assertEquals( $this->resource->count(), count( $result ) );
+		$this->assertEquals($this->resource->count(), count($result));
 	}
 
 	/**
 	 * Test that the exist() function performs as expected.
-	 *
-	 * @since 1.9.8.5
+	 * 
+	 * @since 	1.9.8.5
 	 */
-	public function testExist() {
+	public function testExist()
+	{
 		// Confirm that the function returns true, because resources exist.
 		$result = $this->resource->exist();
-		$this->assertSame( $result, true );
+		$this->assertSame($result, true);
 	}
 }

--- a/tests/wpunit/ResourceProductsTest.php
+++ b/tests/wpunit/ResourceProductsTest.php
@@ -1,151 +1,145 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Products class.
- * 
+ *
  * @since 1.9.8.5
  */
-class ResourceProductsTest extends \Codeception\TestCase\WPTestCase
-{
-    /**
-     * The test object.
-     *
-     * @var \WpunitTester
-     */
-    protected $tester;
+class ResourceProductsTest extends \Codeception\TestCase\WPTestCase {
 
-    /**
-     * Holds the ConvertKit Settings class.
-     * 
-     * @since 1.9.8.5
-     * 
-     * @var ConvertKit_Settings
-     */
-    private $settings;
+	/**
+	 * The test object.
+	 *
+	 * @var \WpunitTester
+	 */
+	protected $tester;
 
-    /**
-     * Holds the ConvertKit Resource class.
-     * 
-     * @since 1.9.8.5
-     * 
-     * @var ConvertKit_Resource_Products
-     */
-    private $resource;
+	/**
+	 * Holds the ConvertKit Settings class.
+	 *
+	 * @since 1.9.8.5
+	 *
+	 * @var ConvertKit_Settings
+	 */
+	private $settings;
 
-    /**
-     * Performs actions before each test.
-     * 
-     * @since 1.9.8.5
-     */
-    public function setUp(): void
-    {
-        parent::setUp();
+	/**
+	 * Holds the ConvertKit Resource class.
+	 *
+	 * @since 1.9.8.5
+	 *
+	 * @var ConvertKit_Resource_Products
+	 */
+	private $resource;
 
-        // Activate Plugin.
-        activate_plugins('convertkit/wp-convertkit.php');
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since 1.9.8.5
+	 */
+	public function setUp(): void {
+		parent::setUp();
 
-        // Store API Key and Secret in Plugin's settings.
-        $this->settings = new ConvertKit_Settings();
-        update_option(
-            $this->settings::SETTINGS_NAME, [
-            'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-            'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-            ]
-        );
+		// Activate Plugin.
+		activate_plugins( 'convertkit/wp-convertkit.php' );
 
-        // Initialize the resource class we want to test.
-        $this->resource = new ConvertKit_Resource_Products();
+		// Store API Key and Secret in Plugin's settings.
+		$this->settings = new ConvertKit_Settings();
+		update_option(
+			$this->settings::SETTINGS_NAME,
+			array(
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+			)
+		);
 
-        // Confirm initialization didn't result in an error.
-        $this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
-    }
+		// Initialize the resource class we want to test.
+		$this->resource = new ConvertKit_Resource_Products();
 
-    /**
-     * Performs actions after each test.
-     * 
-     * @since 1.9.6.9
-     */
-    public function tearDown(): void
-    {
-        // Delete API Key, API Secret and Resources from Plugin's settings.
-        delete_option($this->settings::SETTINGS_NAME);
-        delete_option($this->resource->settings_name);
-        delete_option($this->resource->settings_name . '_last_queried');
+		// Confirm initialization didn't result in an error.
+		$this->assertNotInstanceOf( WP_Error::class, $this->resource->resources );
+	}
 
-        // Destroy the resource class we tested.
-        unset($this->resource);
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since 1.9.6.9
+	 */
+	public function tearDown(): void {
+		// Delete API Key, API Secret and Resources from Plugin's settings.
+		delete_option( $this->settings::SETTINGS_NAME );
+		delete_option( $this->resource->settings_name );
+		delete_option( $this->resource->settings_name . '_last_queried' );
 
-        // Deactivate Plugin.
-        deactivate_plugins('convertkit/wp-convertkit.php');
-		
-        parent::tearDown();
-    }
+		// Destroy the resource class we tested.
+		unset( $this->resource );
 
-    /**
-     * Test that the refresh() function performs as expected.
-     * 
-     * @since 1.9.8.5
-     */
-    public function testRefresh()
-    {
-        // Confirm that the data is stored in the options table and includes some expected keys.
-        $result = $this->resource->refresh();
-        $this->assertIsArray($result);
-        $this->assertArrayHasKey('id', reset($result));
-        $this->assertArrayHasKey('name', reset($result));
-    }
+		// Deactivate Plugin.
+		deactivate_plugins( 'convertkit/wp-convertkit.php' );
 
-    /**
-     * Test that the expiry timestamp is set and returns the expected value.
-     * 
-     * @since 1.9.8.5
-     */
-    public function testExpiry()
-    {
-        // Define the expected expiry date based on the resource class' $cache_duration setting.
-        $expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+		parent::tearDown();
+	}
 
-        // Fetch the actual expiry date set when the resource class was initialized.
-        $expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+	/**
+	 * Test that the refresh() function performs as expected.
+	 *
+	 * @since 1.9.8.5
+	 */
+	public function testRefresh() {
+		// Confirm that the data is stored in the options table and includes some expected keys.
+		$result = $this->resource->refresh();
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'id', reset( $result ) );
+		$this->assertArrayHasKey( 'name', reset( $result ) );
+	}
 
-        // Confirm both dates match.
-        $this->assertEquals($expectedExpiryDate, $expiryDate);
-    }
+	/**
+	 * Test that the expiry timestamp is set and returns the expected value.
+	 *
+	 * @since 1.9.8.5
+	 */
+	public function testExpiry() {
+		// Define the expected expiry date based on the resource class' $cache_duration setting.
+		$expectedExpiryDate = date( 'Y-m-d', time() + $this->resource->cache_duration );
 
-    /**
-     * Test that the get() function performs as expected.
-     * 
-     * @since 1.9.8.5
-     */
-    public function testGet()
-    {
-        // Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
-        $result = $this->resource->get();
-        $this->assertNotInstanceOf(WP_Error::class, $result);
-        $this->assertIsArray($result);
-        $this->assertArrayHasKey('id', reset($result));
-        $this->assertArrayHasKey('name', reset($result));
-    }
+		// Fetch the actual expiry date set when the resource class was initialized.
+		$expiryDate = date( 'Y-m-d', $this->resource->last_queried + $this->resource->cache_duration );
 
-    /**
-     * Test that the count() function returns the number of resources.
-     * 
-     * @since 1.9.7.6
-     */
-    public function testCount()
-    {
-        $result = $this->resource->get();
-        $this->assertEquals($this->resource->count(), count($result));
-    }
+		// Confirm both dates match.
+		$this->assertEquals( $expectedExpiryDate, $expiryDate );
+	}
 
-    /**
-     * Test that the exist() function performs as expected.
-     * 
-     * @since 1.9.8.5
-     */
-    public function testExist()
-    {
-        // Confirm that the function returns true, because resources exist.
-        $result = $this->resource->exist();
-        $this->assertSame($result, true);
-    }
+	/**
+	 * Test that the get() function performs as expected.
+	 *
+	 * @since 1.9.8.5
+	 */
+	public function testGet() {
+		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+		$result = $this->resource->get();
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'id', reset( $result ) );
+		$this->assertArrayHasKey( 'name', reset( $result ) );
+	}
+
+	/**
+	 * Test that the count() function returns the number of resources.
+	 *
+	 * @since 1.9.7.6
+	 */
+	public function testCount() {
+		$result = $this->resource->get();
+		$this->assertEquals( $this->resource->count(), count( $result ) );
+	}
+
+	/**
+	 * Test that the exist() function performs as expected.
+	 *
+	 * @since 1.9.8.5
+	 */
+	public function testExist() {
+		// Confirm that the function returns true, because resources exist.
+		$result = $this->resource->exist();
+		$this->assertSame( $result, true );
+	}
 }

--- a/tests/wpunit/ResourceProductsTest.php
+++ b/tests/wpunit/ResourceProductsTest.php
@@ -2,146 +2,148 @@
 /**
  * Tests for the ConvertKit_Resource_Products class.
  * 
- * @since 	1.9.8.5
+ * @since 1.9.8.5
  */
 class ResourceProductsTest extends \Codeception\TestCase\WPTestCase
 {
-	/**
-	 * @var \WpunitTester
-	 */
-	protected $tester;
+    /**
+     * @var \WpunitTester
+     */
+    protected $tester;
 
-	/**
-	 * Holds the ConvertKit Settings class.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @var 	ConvertKit_Settings
-	 */
-	private $settings;
+    /**
+     * Holds the ConvertKit Settings class.
+     * 
+     * @since 1.9.8.5
+     * 
+     * @var ConvertKit_Settings
+     */
+    private $settings;
 
-	/**
-	 * Holds the ConvertKit Resource class.
-	 * 
-	 * @since 	1.9.8.5
-	 * 
-	 * @var 	ConvertKit_Resource_Products
-	 */
-	private $resource;
+    /**
+     * Holds the ConvertKit Resource class.
+     * 
+     * @since 1.9.8.5
+     * 
+     * @var ConvertKit_Resource_Products
+     */
+    private $resource;
 
-	/**
-	 * Performs actions before each test.
-	 * 
-	 * @since 	1.9.8.5
-	 */
-	public function setUp(): void
-	{
-		parent::setUp();
+    /**
+     * Performs actions before each test.
+     * 
+     * @since 1.9.8.5
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
 
-		// Activate Plugin.
-		activate_plugins('convertkit/wp-convertkit.php');
+        // Activate Plugin.
+        activate_plugins('convertkit/wp-convertkit.php');
 
-		// Store API Key and Secret in Plugin's settings.
-		$this->settings = new ConvertKit_Settings();
-		update_option($this->settings::SETTINGS_NAME, [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-		]);
+        // Store API Key and Secret in Plugin's settings.
+        $this->settings = new ConvertKit_Settings();
+        update_option(
+            $this->settings::SETTINGS_NAME, [
+            'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+            'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+            ]
+        );
 
-		// Initialize the resource class we want to test.
-		$this->resource = new ConvertKit_Resource_Products();
+        // Initialize the resource class we want to test.
+        $this->resource = new ConvertKit_Resource_Products();
 
-		// Confirm initialization didn't result in an error.
-		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
-	}
+        // Confirm initialization didn't result in an error.
+        $this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
+    }
 
-	/**
-	 * Performs actions after each test.
-	 * 
-	 * @since 	1.9.6.9
-	 */
-	public function tearDown(): void
-	{
-		// Delete API Key, API Secret and Resources from Plugin's settings.
-		delete_option($this->settings::SETTINGS_NAME);
-		delete_option($this->resource->settings_name);
-		delete_option($this->resource->settings_name . '_last_queried');
+    /**
+     * Performs actions after each test.
+     * 
+     * @since 1.9.6.9
+     */
+    public function tearDown(): void
+    {
+        // Delete API Key, API Secret and Resources from Plugin's settings.
+        delete_option($this->settings::SETTINGS_NAME);
+        delete_option($this->resource->settings_name);
+        delete_option($this->resource->settings_name . '_last_queried');
 
-		// Destroy the resource class we tested.
-		unset($this->resource);
+        // Destroy the resource class we tested.
+        unset($this->resource);
 
-		// Deactivate Plugin.
-		deactivate_plugins('convertkit/wp-convertkit.php');
+        // Deactivate Plugin.
+        deactivate_plugins('convertkit/wp-convertkit.php');
 		
-		parent::tearDown();
-	}
+        parent::tearDown();
+    }
 
-	/**
-	 * Test that the refresh() function performs as expected.
-	 * 
-	 * @since 	1.9.8.5
-	 */
-	public function testRefresh()
-	{
-		// Confirm that the data is stored in the options table and includes some expected keys.
-		$result = $this->resource->refresh();
-		$this->assertIsArray($result);
-		$this->assertArrayHasKey('id', reset($result));
-		$this->assertArrayHasKey('name', reset($result));
-	}
+    /**
+     * Test that the refresh() function performs as expected.
+     * 
+     * @since 1.9.8.5
+     */
+    public function testRefresh()
+    {
+        // Confirm that the data is stored in the options table and includes some expected keys.
+        $result = $this->resource->refresh();
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('id', reset($result));
+        $this->assertArrayHasKey('name', reset($result));
+    }
 
-	/**
-	 * Test that the expiry timestamp is set and returns the expected value.
-	 * 
-	 * @since 	1.9.8.5
-	 */
-	public function testExpiry()
-	{
-		// Define the expected expiry date based on the resource class' $cache_duration setting.
-		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+    /**
+     * Test that the expiry timestamp is set and returns the expected value.
+     * 
+     * @since 1.9.8.5
+     */
+    public function testExpiry()
+    {
+        // Define the expected expiry date based on the resource class' $cache_duration setting.
+        $expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
 
-		// Fetch the actual expiry date set when the resource class was initialized.
-		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+        // Fetch the actual expiry date set when the resource class was initialized.
+        $expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
 
-		// Confirm both dates match.
-		$this->assertEquals($expectedExpiryDate, $expiryDate);
-	}
+        // Confirm both dates match.
+        $this->assertEquals($expectedExpiryDate, $expiryDate);
+    }
 
-	/**
-	 * Test that the get() function performs as expected.
-	 * 
-	 * @since 	1.9.8.5
-	 */
-	public function testGet()
-	{
-		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
-		$result = $this->resource->get();
-		$this->assertNotInstanceOf(WP_Error::class, $result);
-		$this->assertIsArray($result);
-		$this->assertArrayHasKey('id', reset($result));
-		$this->assertArrayHasKey('name', reset($result));
-	}
+    /**
+     * Test that the get() function performs as expected.
+     * 
+     * @since 1.9.8.5
+     */
+    public function testGet()
+    {
+        // Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+        $result = $this->resource->get();
+        $this->assertNotInstanceOf(WP_Error::class, $result);
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('id', reset($result));
+        $this->assertArrayHasKey('name', reset($result));
+    }
 
-	/**
-	 * Test that the count() function returns the number of resources.
-	 * 
-	 * @since 	1.9.7.6
-	 */
-	public function testCount()
-	{
-		$result = $this->resource->get();
-		$this->assertEquals($this->resource->count(), count($result));
-	}
+    /**
+     * Test that the count() function returns the number of resources.
+     * 
+     * @since 1.9.7.6
+     */
+    public function testCount()
+    {
+        $result = $this->resource->get();
+        $this->assertEquals($this->resource->count(), count($result));
+    }
 
-	/**
-	 * Test that the exist() function performs as expected.
-	 * 
-	 * @since 	1.9.8.5
-	 */
-	public function testExist()
-	{
-		// Confirm that the function returns true, because resources exist.
-		$result = $this->resource->exist();
-		$this->assertSame($result, true);
-	}
+    /**
+     * Test that the exist() function performs as expected.
+     * 
+     * @since 1.9.8.5
+     */
+    public function testExist()
+    {
+        // Confirm that the function returns true, because resources exist.
+        $result = $this->resource->exist();
+        $this->assertSame($result, true);
+    }
 }

--- a/tests/wpunit/ResourceTagsNoDataTest.php
+++ b/tests/wpunit/ResourceTagsNoDataTest.php
@@ -1,150 +1,144 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Tags class when no data is present in the API.
- * 
+ *
  * @since 1.9.7.8
  */
-class ResourceTagsNoDataTest extends \Codeception\TestCase\WPTestCase
-{
-    /**
-     * The test object.
-     *
-     * @var \WpunitTester
-     */
-    protected $tester;
+class ResourceTagsNoDataTest extends \Codeception\TestCase\WPTestCase {
 
-    /**
-     * Holds the ConvertKit Settings class.
-     * 
-     * @since 1.9.7.8
-     * 
-     * @var ConvertKit_Settings
-     */
-    private $settings;
+	/**
+	 * The test object.
+	 *
+	 * @var \WpunitTester
+	 */
+	protected $tester;
 
-    /**
-     * Holds the ConvertKit Resource class.
-     * 
-     * @since 1.9.7.8
-     * 
-     * @var ConvertKit_Resource_Forms
-     */
-    private $resource;
+	/**
+	 * Holds the ConvertKit Settings class.
+	 *
+	 * @since 1.9.7.8
+	 *
+	 * @var ConvertKit_Settings
+	 */
+	private $settings;
 
-    /**
-     * Performs actions before each test.
-     * 
-     * @since 1.9.7.8
-     */
-    public function setUp(): void
-    {
-        parent::setUp();
+	/**
+	 * Holds the ConvertKit Resource class.
+	 *
+	 * @since 1.9.7.8
+	 *
+	 * @var ConvertKit_Resource_Forms
+	 */
+	private $resource;
 
-        // Activate Plugin.
-        activate_plugins('convertkit/wp-convertkit.php');
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since 1.9.7.8
+	 */
+	public function setUp(): void {
+		parent::setUp();
 
-        // Store API Key and Secret in Plugin's settings.
-        $this->settings = new ConvertKit_Settings();
-        update_option(
-            $this->settings::SETTINGS_NAME, [
-            'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
-            'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
-            ]
-        );
+		// Activate Plugin.
+		activate_plugins( 'convertkit/wp-convertkit.php' );
 
-        // Initialize the resource class we want to test.
-        $this->resource = new ConvertKit_Resource_Forms();
+		// Store API Key and Secret in Plugin's settings.
+		$this->settings = new ConvertKit_Settings();
+		update_option(
+			$this->settings::SETTINGS_NAME,
+			array(
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+			)
+		);
 
-        // Confirm initialization didn't result in an error.
-        $this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
-    }
+		// Initialize the resource class we want to test.
+		$this->resource = new ConvertKit_Resource_Forms();
 
-    /**
-     * Performs actions after each test.
-     * 
-     * @since 1.9.6.9
-     */
-    public function tearDown(): void
-    {
-        // Delete API Key, API Secret and Resources from Plugin's settings.
-        delete_option($this->settings::SETTINGS_NAME);
-        delete_option($this->resource->settings_name);
-        delete_option($this->resource->settings_name . '_last_queried');
+		// Confirm initialization didn't result in an error.
+		$this->assertNotInstanceOf( WP_Error::class, $this->resource->resources );
+	}
 
-        // Destroy the resource class we tested.
-        unset($this->resource);
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since 1.9.6.9
+	 */
+	public function tearDown(): void {
+		// Delete API Key, API Secret and Resources from Plugin's settings.
+		delete_option( $this->settings::SETTINGS_NAME );
+		delete_option( $this->resource->settings_name );
+		delete_option( $this->resource->settings_name . '_last_queried' );
 
-        // Deactivate Plugin.
-        deactivate_plugins('convertkit/wp-convertkit.php');
-		
-        parent::tearDown();
-    }
+		// Destroy the resource class we tested.
+		unset( $this->resource );
 
-    /**
-     * Test that the refresh() function performs as expected.
-     * 
-     * @since 1.9.7.8
-     */
-    public function testRefresh()
-    {
-        // Confirm that the data is stored in the options table and includes some expected keys.
-        $result = $this->resource->refresh();
-        $this->assertNotInstanceOf(WP_Error::class, $result);
-        $this->assertIsArray($result);
-        $this->assertCount(0, $result);
-    }
+		// Deactivate Plugin.
+		deactivate_plugins( 'convertkit/wp-convertkit.php' );
 
-    /**
-     * Test that the expiry timestamp is set and returns the expected value.
-     * 
-     * @since 1.9.7.8
-     */
-    public function testExpiry()
-    {
-        // Define the expected expiry date based on the resource class' $cache_duration setting.
-        $expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+		parent::tearDown();
+	}
 
-        // Fetch the actual expiry date set when the resource class was initialized.
-        $expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+	/**
+	 * Test that the refresh() function performs as expected.
+	 *
+	 * @since 1.9.7.8
+	 */
+	public function testRefresh() {
+		// Confirm that the data is stored in the options table and includes some expected keys.
+		$result = $this->resource->refresh();
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertIsArray( $result );
+		$this->assertCount( 0, $result );
+	}
 
-        // Confirm both dates match.
-        $this->assertEquals($expectedExpiryDate, $expiryDate);
-    }
+	/**
+	 * Test that the expiry timestamp is set and returns the expected value.
+	 *
+	 * @since 1.9.7.8
+	 */
+	public function testExpiry() {
+		// Define the expected expiry date based on the resource class' $cache_duration setting.
+		$expectedExpiryDate = date( 'Y-m-d', time() + $this->resource->cache_duration );
 
-    /**
-     * Test that the get() function performs as expected.
-     * 
-     * @since 1.9.7.8
-     */
-    public function testGet()
-    {
-        // Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
-        $result = $this->resource->get();
-        $this->assertNotInstanceOf(WP_Error::class, $result);
-        $this->assertIsArray($result);
-        $this->assertCount(0, $result);
-    }
+		// Fetch the actual expiry date set when the resource class was initialized.
+		$expiryDate = date( 'Y-m-d', $this->resource->last_queried + $this->resource->cache_duration );
 
-    /**
-     * Test that the count() function returns the number of resources.
-     * 
-     * @since 1.9.7.6
-     */
-    public function testCount()
-    {
-        $result = $this->resource->get();
-        $this->assertEquals($this->resource->count(), count($result));
-    }
+		// Confirm both dates match.
+		$this->assertEquals( $expectedExpiryDate, $expiryDate );
+	}
 
-    /**
-     * Test that the exist() function performs as expected.
-     * 
-     * @since 1.9.7.8
-     */
-    public function testExist()
-    {
-        // Confirm that the function returns true, because resources exist.
-        $result = $this->resource->exist();
-        $this->assertSame($result, false);
-    }
+	/**
+	 * Test that the get() function performs as expected.
+	 *
+	 * @since 1.9.7.8
+	 */
+	public function testGet() {
+		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+		$result = $this->resource->get();
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertIsArray( $result );
+		$this->assertCount( 0, $result );
+	}
+
+	/**
+	 * Test that the count() function returns the number of resources.
+	 *
+	 * @since 1.9.7.6
+	 */
+	public function testCount() {
+		$result = $this->resource->get();
+		$this->assertEquals( $this->resource->count(), count( $result ) );
+	}
+
+	/**
+	 * Test that the exist() function performs as expected.
+	 *
+	 * @since 1.9.7.8
+	 */
+	public function testExist() {
+		// Confirm that the function returns true, because resources exist.
+		$result = $this->resource->exist();
+		$this->assertSame( $result, false );
+	}
 }

--- a/tests/wpunit/ResourceTagsNoDataTest.php
+++ b/tests/wpunit/ResourceTagsNoDataTest.php
@@ -2,145 +2,147 @@
 /**
  * Tests for the ConvertKit_Resource_Tags class when no data is present in the API.
  * 
- * @since 	1.9.7.8
+ * @since 1.9.7.8
  */
 class ResourceTagsNoDataTest extends \Codeception\TestCase\WPTestCase
 {
-	/**
-	 * @var \WpunitTester
-	 */
-	protected $tester;
+    /**
+     * @var \WpunitTester
+     */
+    protected $tester;
 
-	/**
-	 * Holds the ConvertKit Settings class.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @var 	ConvertKit_Settings
-	 */
-	private $settings;
+    /**
+     * Holds the ConvertKit Settings class.
+     * 
+     * @since 1.9.7.8
+     * 
+     * @var ConvertKit_Settings
+     */
+    private $settings;
 
-	/**
-	 * Holds the ConvertKit Resource class.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @var 	ConvertKit_Resource_Forms
-	 */
-	private $resource;
+    /**
+     * Holds the ConvertKit Resource class.
+     * 
+     * @since 1.9.7.8
+     * 
+     * @var ConvertKit_Resource_Forms
+     */
+    private $resource;
 
-	/**
-	 * Performs actions before each test.
-	 * 
-	 * @since 	1.9.7.8
-	 */
-	public function setUp(): void
-	{
-		parent::setUp();
+    /**
+     * Performs actions before each test.
+     * 
+     * @since 1.9.7.8
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
 
-		// Activate Plugin.
-		activate_plugins('convertkit/wp-convertkit.php');
+        // Activate Plugin.
+        activate_plugins('convertkit/wp-convertkit.php');
 
-		// Store API Key and Secret in Plugin's settings.
-		$this->settings = new ConvertKit_Settings();
-		update_option($this->settings::SETTINGS_NAME, [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
-		]);
+        // Store API Key and Secret in Plugin's settings.
+        $this->settings = new ConvertKit_Settings();
+        update_option(
+            $this->settings::SETTINGS_NAME, [
+            'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+            'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+            ]
+        );
 
-		// Initialize the resource class we want to test.
-		$this->resource = new ConvertKit_Resource_Forms();
+        // Initialize the resource class we want to test.
+        $this->resource = new ConvertKit_Resource_Forms();
 
-		// Confirm initialization didn't result in an error.
-		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
-	}
+        // Confirm initialization didn't result in an error.
+        $this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
+    }
 
-	/**
-	 * Performs actions after each test.
-	 * 
-	 * @since 	1.9.6.9
-	 */
-	public function tearDown(): void
-	{
-		// Delete API Key, API Secret and Resources from Plugin's settings.
-		delete_option($this->settings::SETTINGS_NAME);
-		delete_option($this->resource->settings_name);
-		delete_option($this->resource->settings_name . '_last_queried');
+    /**
+     * Performs actions after each test.
+     * 
+     * @since 1.9.6.9
+     */
+    public function tearDown(): void
+    {
+        // Delete API Key, API Secret and Resources from Plugin's settings.
+        delete_option($this->settings::SETTINGS_NAME);
+        delete_option($this->resource->settings_name);
+        delete_option($this->resource->settings_name . '_last_queried');
 
-		// Destroy the resource class we tested.
-		unset($this->resource);
+        // Destroy the resource class we tested.
+        unset($this->resource);
 
-		// Deactivate Plugin.
-		deactivate_plugins('convertkit/wp-convertkit.php');
+        // Deactivate Plugin.
+        deactivate_plugins('convertkit/wp-convertkit.php');
 		
-		parent::tearDown();
-	}
+        parent::tearDown();
+    }
 
-	/**
-	 * Test that the refresh() function performs as expected.
-	 * 
-	 * @since 	1.9.7.8
-	 */
-	public function testRefresh()
-	{
-		// Confirm that the data is stored in the options table and includes some expected keys.
-		$result = $this->resource->refresh();
-		$this->assertNotInstanceOf(WP_Error::class, $result);
-		$this->assertIsArray($result);
-		$this->assertCount(0, $result);
-	}
+    /**
+     * Test that the refresh() function performs as expected.
+     * 
+     * @since 1.9.7.8
+     */
+    public function testRefresh()
+    {
+        // Confirm that the data is stored in the options table and includes some expected keys.
+        $result = $this->resource->refresh();
+        $this->assertNotInstanceOf(WP_Error::class, $result);
+        $this->assertIsArray($result);
+        $this->assertCount(0, $result);
+    }
 
-	/**
-	 * Test that the expiry timestamp is set and returns the expected value.
-	 * 
-	 * @since 	1.9.7.8
-	 */
-	public function testExpiry()
-	{
-		// Define the expected expiry date based on the resource class' $cache_duration setting.
-		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+    /**
+     * Test that the expiry timestamp is set and returns the expected value.
+     * 
+     * @since 1.9.7.8
+     */
+    public function testExpiry()
+    {
+        // Define the expected expiry date based on the resource class' $cache_duration setting.
+        $expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
 
-		// Fetch the actual expiry date set when the resource class was initialized.
-		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+        // Fetch the actual expiry date set when the resource class was initialized.
+        $expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
 
-		// Confirm both dates match.
-		$this->assertEquals($expectedExpiryDate, $expiryDate);
-	}
+        // Confirm both dates match.
+        $this->assertEquals($expectedExpiryDate, $expiryDate);
+    }
 
-	/**
-	 * Test that the get() function performs as expected.
-	 * 
-	 * @since 	1.9.7.8
-	 */
-	public function testGet()
-	{
-		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
-		$result = $this->resource->get();
-		$this->assertNotInstanceOf(WP_Error::class, $result);
-		$this->assertIsArray($result);
-		$this->assertCount(0, $result);
-	}
+    /**
+     * Test that the get() function performs as expected.
+     * 
+     * @since 1.9.7.8
+     */
+    public function testGet()
+    {
+        // Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+        $result = $this->resource->get();
+        $this->assertNotInstanceOf(WP_Error::class, $result);
+        $this->assertIsArray($result);
+        $this->assertCount(0, $result);
+    }
 
-	/**
-	 * Test that the count() function returns the number of resources.
-	 * 
-	 * @since 	1.9.7.6
-	 */
-	public function testCount()
-	{
-		$result = $this->resource->get();
-		$this->assertEquals($this->resource->count(), count($result));
-	}
+    /**
+     * Test that the count() function returns the number of resources.
+     * 
+     * @since 1.9.7.6
+     */
+    public function testCount()
+    {
+        $result = $this->resource->get();
+        $this->assertEquals($this->resource->count(), count($result));
+    }
 
-	/**
-	 * Test that the exist() function performs as expected.
-	 * 
-	 * @since 	1.9.7.8
-	 */
-	public function testExist()
-	{
-		// Confirm that the function returns true, because resources exist.
-		$result = $this->resource->exist();
-		$this->assertSame($result, false);
-	}
+    /**
+     * Test that the exist() function performs as expected.
+     * 
+     * @since 1.9.7.8
+     */
+    public function testExist()
+    {
+        // Confirm that the function returns true, because resources exist.
+        $result = $this->resource->exist();
+        $this->assertSame($result, false);
+    }
 }

--- a/tests/wpunit/ResourceTagsNoDataTest.php
+++ b/tests/wpunit/ResourceTagsNoDataTest.php
@@ -1,38 +1,40 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Tags class when no data is present in the API.
- * 
- * @since 	1.9.7.8
+ *
+ * @since   1.9.7.8
  */
 class ResourceTagsNoDataTest extends \Codeception\TestCase\WPTestCase
 {
 	/**
-	 * @var \WpunitTester
+	 * The testing implementation.
+	 *
+	 * @var \WpunitTester.
 	 */
 	protected $tester;
 
 	/**
 	 * Holds the ConvertKit Settings class.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @var 	ConvertKit_Settings
+	 *
+	 * @since   1.9.7.8
+	 *
+	 * @var     ConvertKit_Settings
 	 */
 	private $settings;
 
 	/**
 	 * Holds the ConvertKit Resource class.
-	 * 
-	 * @since 	1.9.7.8
-	 * 
-	 * @var 	ConvertKit_Resource_Forms
+	 *
+	 * @since   1.9.7.8
+	 *
+	 * @var     ConvertKit_Resource_Forms
 	 */
 	private $resource;
 
 	/**
 	 * Performs actions before each test.
-	 * 
-	 * @since 	1.9.7.8
+	 *
+	 * @since   1.9.7.8
 	 */
 	public function setUp(): void
 	{
@@ -43,10 +45,13 @@ class ResourceTagsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 		// Store API Key and Secret in Plugin's settings.
 		$this->settings = new ConvertKit_Settings();
-		update_option($this->settings::SETTINGS_NAME, [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
-		]);
+		update_option(
+			$this->settings::SETTINGS_NAME,
+			[
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+			]
+		);
 
 		// Initialize the resource class we want to test.
 		$this->resource = new ConvertKit_Resource_Forms();
@@ -57,8 +62,8 @@ class ResourceTagsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Performs actions after each test.
-	 * 
-	 * @since 	1.9.6.9
+	 *
+	 * @since   1.9.6.9
 	 */
 	public function tearDown(): void
 	{
@@ -72,14 +77,14 @@ class ResourceTagsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 		// Deactivate Plugin.
 		deactivate_plugins('convertkit/wp-convertkit.php');
-		
+
 		parent::tearDown();
 	}
 
 	/**
 	 * Test that the refresh() function performs as expected.
-	 * 
-	 * @since 	1.9.7.8
+	 *
+	 * @since   1.9.7.8
 	 */
 	public function testRefresh()
 	{
@@ -92,8 +97,8 @@ class ResourceTagsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the expiry timestamp is set and returns the expected value.
-	 * 
-	 * @since 	1.9.7.8
+	 *
+	 * @since   1.9.7.8
 	 */
 	public function testExpiry()
 	{
@@ -109,8 +114,8 @@ class ResourceTagsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the get() function performs as expected.
-	 * 
-	 * @since 	1.9.7.8
+	 *
+	 * @since   1.9.7.8
 	 */
 	public function testGet()
 	{
@@ -123,8 +128,8 @@ class ResourceTagsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the count() function returns the number of resources.
-	 * 
-	 * @since 	1.9.7.6
+	 *
+	 * @since   1.9.7.6
 	 */
 	public function testCount()
 	{
@@ -134,8 +139,8 @@ class ResourceTagsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the exist() function performs as expected.
-	 * 
-	 * @since 	1.9.7.8
+	 *
+	 * @since   1.9.7.8
 	 */
 	public function testExist()
 	{

--- a/tests/wpunit/ResourceTagsNoDataTest.php
+++ b/tests/wpunit/ResourceTagsNoDataTest.php
@@ -1,144 +1,146 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Tags class when no data is present in the API.
- *
- * @since 1.9.7.8
+ * 
+ * @since 	1.9.7.8
  */
-class ResourceTagsNoDataTest extends \Codeception\TestCase\WPTestCase {
-
+class ResourceTagsNoDataTest extends \Codeception\TestCase\WPTestCase
+{
 	/**
-	 * The test object.
-	 *
 	 * @var \WpunitTester
 	 */
 	protected $tester;
 
 	/**
 	 * Holds the ConvertKit Settings class.
-	 *
-	 * @since 1.9.7.8
-	 *
-	 * @var ConvertKit_Settings
+	 * 
+	 * @since 	1.9.7.8
+	 * 
+	 * @var 	ConvertKit_Settings
 	 */
 	private $settings;
 
 	/**
 	 * Holds the ConvertKit Resource class.
-	 *
-	 * @since 1.9.7.8
-	 *
-	 * @var ConvertKit_Resource_Forms
+	 * 
+	 * @since 	1.9.7.8
+	 * 
+	 * @var 	ConvertKit_Resource_Forms
 	 */
 	private $resource;
 
 	/**
 	 * Performs actions before each test.
-	 *
-	 * @since 1.9.7.8
+	 * 
+	 * @since 	1.9.7.8
 	 */
-	public function setUp(): void {
+	public function setUp(): void
+	{
 		parent::setUp();
 
 		// Activate Plugin.
-		activate_plugins( 'convertkit/wp-convertkit.php' );
+		activate_plugins('convertkit/wp-convertkit.php');
 
 		// Store API Key and Secret in Plugin's settings.
 		$this->settings = new ConvertKit_Settings();
-		update_option(
-			$this->settings::SETTINGS_NAME,
-			array(
-				'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
-				'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
-			)
-		);
+		update_option($this->settings::SETTINGS_NAME, [
+			'api_key'    => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
+			'api_secret' => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
+		]);
 
 		// Initialize the resource class we want to test.
 		$this->resource = new ConvertKit_Resource_Forms();
 
 		// Confirm initialization didn't result in an error.
-		$this->assertNotInstanceOf( WP_Error::class, $this->resource->resources );
+		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
 	}
 
 	/**
 	 * Performs actions after each test.
-	 *
-	 * @since 1.9.6.9
+	 * 
+	 * @since 	1.9.6.9
 	 */
-	public function tearDown(): void {
+	public function tearDown(): void
+	{
 		// Delete API Key, API Secret and Resources from Plugin's settings.
-		delete_option( $this->settings::SETTINGS_NAME );
-		delete_option( $this->resource->settings_name );
-		delete_option( $this->resource->settings_name . '_last_queried' );
+		delete_option($this->settings::SETTINGS_NAME);
+		delete_option($this->resource->settings_name);
+		delete_option($this->resource->settings_name . '_last_queried');
 
 		// Destroy the resource class we tested.
-		unset( $this->resource );
+		unset($this->resource);
 
 		// Deactivate Plugin.
-		deactivate_plugins( 'convertkit/wp-convertkit.php' );
-
+		deactivate_plugins('convertkit/wp-convertkit.php');
+		
 		parent::tearDown();
 	}
 
 	/**
 	 * Test that the refresh() function performs as expected.
-	 *
-	 * @since 1.9.7.8
+	 * 
+	 * @since 	1.9.7.8
 	 */
-	public function testRefresh() {
+	public function testRefresh()
+	{
 		// Confirm that the data is stored in the options table and includes some expected keys.
 		$result = $this->resource->refresh();
-		$this->assertNotInstanceOf( WP_Error::class, $result );
-		$this->assertIsArray( $result );
-		$this->assertCount( 0, $result );
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
 	}
 
 	/**
 	 * Test that the expiry timestamp is set and returns the expected value.
-	 *
-	 * @since 1.9.7.8
+	 * 
+	 * @since 	1.9.7.8
 	 */
-	public function testExpiry() {
+	public function testExpiry()
+	{
 		// Define the expected expiry date based on the resource class' $cache_duration setting.
-		$expectedExpiryDate = date( 'Y-m-d', time() + $this->resource->cache_duration );
+		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
 
 		// Fetch the actual expiry date set when the resource class was initialized.
-		$expiryDate = date( 'Y-m-d', $this->resource->last_queried + $this->resource->cache_duration );
+		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
 
 		// Confirm both dates match.
-		$this->assertEquals( $expectedExpiryDate, $expiryDate );
+		$this->assertEquals($expectedExpiryDate, $expiryDate);
 	}
 
 	/**
 	 * Test that the get() function performs as expected.
-	 *
-	 * @since 1.9.7.8
+	 * 
+	 * @since 	1.9.7.8
 	 */
-	public function testGet() {
+	public function testGet()
+	{
 		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
 		$result = $this->resource->get();
-		$this->assertNotInstanceOf( WP_Error::class, $result );
-		$this->assertIsArray( $result );
-		$this->assertCount( 0, $result );
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
 	}
 
 	/**
 	 * Test that the count() function returns the number of resources.
-	 *
-	 * @since 1.9.7.6
+	 * 
+	 * @since 	1.9.7.6
 	 */
-	public function testCount() {
+	public function testCount()
+	{
 		$result = $this->resource->get();
-		$this->assertEquals( $this->resource->count(), count( $result ) );
+		$this->assertEquals($this->resource->count(), count($result));
 	}
 
 	/**
 	 * Test that the exist() function performs as expected.
-	 *
-	 * @since 1.9.7.8
+	 * 
+	 * @since 	1.9.7.8
 	 */
-	public function testExist() {
+	public function testExist()
+	{
 		// Confirm that the function returns true, because resources exist.
 		$result = $this->resource->exist();
-		$this->assertSame( $result, false );
+		$this->assertSame($result, false);
 	}
 }

--- a/tests/wpunit/ResourceTagsNoDataTest.php
+++ b/tests/wpunit/ResourceTagsNoDataTest.php
@@ -7,6 +7,8 @@
 class ResourceTagsNoDataTest extends \Codeception\TestCase\WPTestCase
 {
     /**
+     * The test object.
+     *
      * @var \WpunitTester
      */
     protected $tester;

--- a/tests/wpunit/ResourceTagsTest.php
+++ b/tests/wpunit/ResourceTagsTest.php
@@ -1,151 +1,145 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Tags class.
- * 
+ *
  * @since 1.9.7.4
  */
-class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
-{
-    /**
-     * The test object.
-     *
-     * @var \WpunitTester
-     */
-    protected $tester;
+class ResourceTagsTest extends \Codeception\TestCase\WPTestCase {
 
-    /**
-     * Holds the ConvertKit Settings class.
-     * 
-     * @since 1.9.7.4
-     * 
-     * @var ConvertKit_Settings
-     */
-    private $settings;
+	/**
+	 * The test object.
+	 *
+	 * @var \WpunitTester
+	 */
+	protected $tester;
 
-    /**
-     * Holds the ConvertKit Resource class.
-     * 
-     * @since 1.9.7.4
-     * 
-     * @var ConvertKit_Resource_Tags
-     */
-    private $resource;
+	/**
+	 * Holds the ConvertKit Settings class.
+	 *
+	 * @since 1.9.7.4
+	 *
+	 * @var ConvertKit_Settings
+	 */
+	private $settings;
 
-    /**
-     * Performs actions before each test.
-     * 
-     * @since 1.9.7.4
-     */
-    public function setUp(): void
-    {
-        parent::setUp();
+	/**
+	 * Holds the ConvertKit Resource class.
+	 *
+	 * @since 1.9.7.4
+	 *
+	 * @var ConvertKit_Resource_Tags
+	 */
+	private $resource;
 
-        // Activate Plugin.
-        activate_plugins('convertkit/wp-convertkit.php');
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since 1.9.7.4
+	 */
+	public function setUp(): void {
+		parent::setUp();
 
-        // Store API Key and Secret in Plugin's settings.
-        $this->settings = new ConvertKit_Settings();
-        update_option(
-            $this->settings::SETTINGS_NAME, [
-            'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-            'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-            ]
-        );
+		// Activate Plugin.
+		activate_plugins( 'convertkit/wp-convertkit.php' );
 
-        // Initialize the resource class we want to test.
-        $this->resource = new ConvertKit_Resource_Tags();
+		// Store API Key and Secret in Plugin's settings.
+		$this->settings = new ConvertKit_Settings();
+		update_option(
+			$this->settings::SETTINGS_NAME,
+			array(
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+			)
+		);
 
-        // Confirm initialization didn't result in an error.
-        $this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
-    }
+		// Initialize the resource class we want to test.
+		$this->resource = new ConvertKit_Resource_Tags();
 
-    /**
-     * Performs actions after each test.
-     * 
-     * @since 1.9.6.9
-     */
-    public function tearDown(): void
-    {
-        // Delete API Key, API Secret and Resources from Plugin's settings.
-        delete_option($this->settings::SETTINGS_NAME);
-        delete_option($this->resource->settings_name);
-        delete_option($this->resource->settings_name . '_last_queried');
+		// Confirm initialization didn't result in an error.
+		$this->assertNotInstanceOf( WP_Error::class, $this->resource->resources );
+	}
 
-        // Destroy the resource class we tested.
-        unset($this->resource);
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since 1.9.6.9
+	 */
+	public function tearDown(): void {
+		// Delete API Key, API Secret and Resources from Plugin's settings.
+		delete_option( $this->settings::SETTINGS_NAME );
+		delete_option( $this->resource->settings_name );
+		delete_option( $this->resource->settings_name . '_last_queried' );
 
-        // Deactivate Plugin.
-        deactivate_plugins('convertkit/wp-convertkit.php');
-		
-        parent::tearDown();
-    }
+		// Destroy the resource class we tested.
+		unset( $this->resource );
 
-    /**
-     * Test that the refresh() function performs as expected.
-     * 
-     * @since 1.9.7.4
-     */
-    public function testRefresh()
-    {
-        // Confirm that the data is stored in the options table and includes some expected keys.
-        $result = $this->resource->refresh();
-        $this->assertIsArray($result);
-        $this->assertArrayHasKey('id', reset($result));
-        $this->assertArrayHasKey('name', reset($result));
-    }
+		// Deactivate Plugin.
+		deactivate_plugins( 'convertkit/wp-convertkit.php' );
 
-    /**
-     * Test that the expiry timestamp is set and returns the expected value.
-     * 
-     * @since 1.9.7.4
-     */
-    public function testExpiry()
-    {
-        // Define the expected expiry date based on the resource class' $cache_duration setting.
-        $expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+		parent::tearDown();
+	}
 
-        // Fetch the actual expiry date set when the resource class was initialized.
-        $expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+	/**
+	 * Test that the refresh() function performs as expected.
+	 *
+	 * @since 1.9.7.4
+	 */
+	public function testRefresh() {
+		// Confirm that the data is stored in the options table and includes some expected keys.
+		$result = $this->resource->refresh();
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'id', reset( $result ) );
+		$this->assertArrayHasKey( 'name', reset( $result ) );
+	}
 
-        // Confirm both dates match.
-        $this->assertEquals($expectedExpiryDate, $expiryDate);
-    }
+	/**
+	 * Test that the expiry timestamp is set and returns the expected value.
+	 *
+	 * @since 1.9.7.4
+	 */
+	public function testExpiry() {
+		// Define the expected expiry date based on the resource class' $cache_duration setting.
+		$expectedExpiryDate = date( 'Y-m-d', time() + $this->resource->cache_duration );
 
-    /**
-     * Test that the get() function performs as expected.
-     * 
-     * @since 1.9.7.4
-     */
-    public function testGet()
-    {
-        // Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
-        $result = $this->resource->get();
-        $this->assertNotInstanceOf(WP_Error::class, $result);
-        $this->assertIsArray($result);
-        $this->assertArrayHasKey('id', reset($result));
-        $this->assertArrayHasKey('name', reset($result));
-    }
+		// Fetch the actual expiry date set when the resource class was initialized.
+		$expiryDate = date( 'Y-m-d', $this->resource->last_queried + $this->resource->cache_duration );
 
-    /**
-     * Test that the count() function returns the number of resources.
-     * 
-     * @since 1.9.7.6
-     */
-    public function testCount()
-    {
-        $result = $this->resource->get();
-        $this->assertEquals($this->resource->count(), count($result));
-    }
+		// Confirm both dates match.
+		$this->assertEquals( $expectedExpiryDate, $expiryDate );
+	}
 
-    /**
-     * Test that the exist() function performs as expected.
-     * 
-     * @since 1.9.7.4
-     */
-    public function testExist()
-    {
-        // Confirm that the function returns true, because resources exist.
-        $result = $this->resource->exist();
-        $this->assertSame($result, true);
-    }
+	/**
+	 * Test that the get() function performs as expected.
+	 *
+	 * @since 1.9.7.4
+	 */
+	public function testGet() {
+		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+		$result = $this->resource->get();
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'id', reset( $result ) );
+		$this->assertArrayHasKey( 'name', reset( $result ) );
+	}
+
+	/**
+	 * Test that the count() function returns the number of resources.
+	 *
+	 * @since 1.9.7.6
+	 */
+	public function testCount() {
+		$result = $this->resource->get();
+		$this->assertEquals( $this->resource->count(), count( $result ) );
+	}
+
+	/**
+	 * Test that the exist() function performs as expected.
+	 *
+	 * @since 1.9.7.4
+	 */
+	public function testExist() {
+		// Confirm that the function returns true, because resources exist.
+		$result = $this->resource->exist();
+		$this->assertSame( $result, true );
+	}
 }

--- a/tests/wpunit/ResourceTagsTest.php
+++ b/tests/wpunit/ResourceTagsTest.php
@@ -2,146 +2,148 @@
 /**
  * Tests for the ConvertKit_Resource_Tags class.
  * 
- * @since 	1.9.7.4
+ * @since 1.9.7.4
  */
 class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 {
-	/**
-	 * @var \WpunitTester
-	 */
-	protected $tester;
+    /**
+     * @var \WpunitTester
+     */
+    protected $tester;
 
-	/**
-	 * Holds the ConvertKit Settings class.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @var 	ConvertKit_Settings
-	 */
-	private $settings;
+    /**
+     * Holds the ConvertKit Settings class.
+     * 
+     * @since 1.9.7.4
+     * 
+     * @var ConvertKit_Settings
+     */
+    private $settings;
 
-	/**
-	 * Holds the ConvertKit Resource class.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @var 	ConvertKit_Resource_Tags
-	 */
-	private $resource;
+    /**
+     * Holds the ConvertKit Resource class.
+     * 
+     * @since 1.9.7.4
+     * 
+     * @var ConvertKit_Resource_Tags
+     */
+    private $resource;
 
-	/**
-	 * Performs actions before each test.
-	 * 
-	 * @since 	1.9.7.4
-	 */
-	public function setUp(): void
-	{
-		parent::setUp();
+    /**
+     * Performs actions before each test.
+     * 
+     * @since 1.9.7.4
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
 
-		// Activate Plugin.
-		activate_plugins('convertkit/wp-convertkit.php');
+        // Activate Plugin.
+        activate_plugins('convertkit/wp-convertkit.php');
 
-		// Store API Key and Secret in Plugin's settings.
-		$this->settings = new ConvertKit_Settings();
-		update_option($this->settings::SETTINGS_NAME, [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-		]);
+        // Store API Key and Secret in Plugin's settings.
+        $this->settings = new ConvertKit_Settings();
+        update_option(
+            $this->settings::SETTINGS_NAME, [
+            'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+            'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+            ]
+        );
 
-		// Initialize the resource class we want to test.
-		$this->resource = new ConvertKit_Resource_Tags();
+        // Initialize the resource class we want to test.
+        $this->resource = new ConvertKit_Resource_Tags();
 
-		// Confirm initialization didn't result in an error.
-		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
-	}
+        // Confirm initialization didn't result in an error.
+        $this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
+    }
 
-	/**
-	 * Performs actions after each test.
-	 * 
-	 * @since 	1.9.6.9
-	 */
-	public function tearDown(): void
-	{
-		// Delete API Key, API Secret and Resources from Plugin's settings.
-		delete_option($this->settings::SETTINGS_NAME);
-		delete_option($this->resource->settings_name);
-		delete_option($this->resource->settings_name . '_last_queried');
+    /**
+     * Performs actions after each test.
+     * 
+     * @since 1.9.6.9
+     */
+    public function tearDown(): void
+    {
+        // Delete API Key, API Secret and Resources from Plugin's settings.
+        delete_option($this->settings::SETTINGS_NAME);
+        delete_option($this->resource->settings_name);
+        delete_option($this->resource->settings_name . '_last_queried');
 
-		// Destroy the resource class we tested.
-		unset($this->resource);
+        // Destroy the resource class we tested.
+        unset($this->resource);
 
-		// Deactivate Plugin.
-		deactivate_plugins('convertkit/wp-convertkit.php');
+        // Deactivate Plugin.
+        deactivate_plugins('convertkit/wp-convertkit.php');
 		
-		parent::tearDown();
-	}
+        parent::tearDown();
+    }
 
-	/**
-	 * Test that the refresh() function performs as expected.
-	 * 
-	 * @since 	1.9.7.4
-	 */
-	public function testRefresh()
-	{
-		// Confirm that the data is stored in the options table and includes some expected keys.
-		$result = $this->resource->refresh();
-		$this->assertIsArray($result);
-		$this->assertArrayHasKey('id', reset($result));
-		$this->assertArrayHasKey('name', reset($result));
-	}
+    /**
+     * Test that the refresh() function performs as expected.
+     * 
+     * @since 1.9.7.4
+     */
+    public function testRefresh()
+    {
+        // Confirm that the data is stored in the options table and includes some expected keys.
+        $result = $this->resource->refresh();
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('id', reset($result));
+        $this->assertArrayHasKey('name', reset($result));
+    }
 
-	/**
-	 * Test that the expiry timestamp is set and returns the expected value.
-	 * 
-	 * @since 	1.9.7.4
-	 */
-	public function testExpiry()
-	{
-		// Define the expected expiry date based on the resource class' $cache_duration setting.
-		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+    /**
+     * Test that the expiry timestamp is set and returns the expected value.
+     * 
+     * @since 1.9.7.4
+     */
+    public function testExpiry()
+    {
+        // Define the expected expiry date based on the resource class' $cache_duration setting.
+        $expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
 
-		// Fetch the actual expiry date set when the resource class was initialized.
-		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+        // Fetch the actual expiry date set when the resource class was initialized.
+        $expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
 
-		// Confirm both dates match.
-		$this->assertEquals($expectedExpiryDate, $expiryDate);
-	}
+        // Confirm both dates match.
+        $this->assertEquals($expectedExpiryDate, $expiryDate);
+    }
 
-	/**
-	 * Test that the get() function performs as expected.
-	 * 
-	 * @since 	1.9.7.4
-	 */
-	public function testGet()
-	{
-		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
-		$result = $this->resource->get();
-		$this->assertNotInstanceOf(WP_Error::class, $result);
-		$this->assertIsArray($result);
-		$this->assertArrayHasKey('id', reset($result));
-		$this->assertArrayHasKey('name', reset($result));
-	}
+    /**
+     * Test that the get() function performs as expected.
+     * 
+     * @since 1.9.7.4
+     */
+    public function testGet()
+    {
+        // Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+        $result = $this->resource->get();
+        $this->assertNotInstanceOf(WP_Error::class, $result);
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('id', reset($result));
+        $this->assertArrayHasKey('name', reset($result));
+    }
 
-	/**
-	 * Test that the count() function returns the number of resources.
-	 * 
-	 * @since 	1.9.7.6
-	 */
-	public function testCount()
-	{
-		$result = $this->resource->get();
-		$this->assertEquals($this->resource->count(), count($result));
-	}
+    /**
+     * Test that the count() function returns the number of resources.
+     * 
+     * @since 1.9.7.6
+     */
+    public function testCount()
+    {
+        $result = $this->resource->get();
+        $this->assertEquals($this->resource->count(), count($result));
+    }
 
-	/**
-	 * Test that the exist() function performs as expected.
-	 * 
-	 * @since 	1.9.7.4
-	 */
-	public function testExist()
-	{
-		// Confirm that the function returns true, because resources exist.
-		$result = $this->resource->exist();
-		$this->assertSame($result, true);
-	}
+    /**
+     * Test that the exist() function performs as expected.
+     * 
+     * @since 1.9.7.4
+     */
+    public function testExist()
+    {
+        // Confirm that the function returns true, because resources exist.
+        $result = $this->resource->exist();
+        $this->assertSame($result, true);
+    }
 }

--- a/tests/wpunit/ResourceTagsTest.php
+++ b/tests/wpunit/ResourceTagsTest.php
@@ -1,38 +1,40 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Tags class.
- * 
- * @since 	1.9.7.4
+ *
+ * @since   1.9.7.4
  */
 class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 {
 	/**
-	 * @var \WpunitTester
+	 * The testing implementation.
+	 *
+	 * @var \WpunitTester.
 	 */
 	protected $tester;
 
 	/**
 	 * Holds the ConvertKit Settings class.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @var 	ConvertKit_Settings
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @var     ConvertKit_Settings
 	 */
 	private $settings;
 
 	/**
 	 * Holds the ConvertKit Resource class.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @var 	ConvertKit_Resource_Tags
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @var     ConvertKit_Resource_Tags
 	 */
 	private $resource;
 
 	/**
 	 * Performs actions before each test.
-	 * 
-	 * @since 	1.9.7.4
+	 *
+	 * @since   1.9.7.4
 	 */
 	public function setUp(): void
 	{
@@ -43,10 +45,13 @@ class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 
 		// Store API Key and Secret in Plugin's settings.
 		$this->settings = new ConvertKit_Settings();
-		update_option($this->settings::SETTINGS_NAME, [
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-		]);
+		update_option(
+			$this->settings::SETTINGS_NAME,
+			[
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+			]
+		);
 
 		// Initialize the resource class we want to test.
 		$this->resource = new ConvertKit_Resource_Tags();
@@ -57,8 +62,8 @@ class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Performs actions after each test.
-	 * 
-	 * @since 	1.9.6.9
+	 *
+	 * @since   1.9.6.9
 	 */
 	public function tearDown(): void
 	{
@@ -72,14 +77,14 @@ class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 
 		// Deactivate Plugin.
 		deactivate_plugins('convertkit/wp-convertkit.php');
-		
+
 		parent::tearDown();
 	}
 
 	/**
 	 * Test that the refresh() function performs as expected.
-	 * 
-	 * @since 	1.9.7.4
+	 *
+	 * @since   1.9.7.4
 	 */
 	public function testRefresh()
 	{
@@ -92,8 +97,8 @@ class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the expiry timestamp is set and returns the expected value.
-	 * 
-	 * @since 	1.9.7.4
+	 *
+	 * @since   1.9.7.4
 	 */
 	public function testExpiry()
 	{
@@ -109,8 +114,8 @@ class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the get() function performs as expected.
-	 * 
-	 * @since 	1.9.7.4
+	 *
+	 * @since   1.9.7.4
 	 */
 	public function testGet()
 	{
@@ -124,8 +129,8 @@ class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the count() function returns the number of resources.
-	 * 
-	 * @since 	1.9.7.6
+	 *
+	 * @since   1.9.7.6
 	 */
 	public function testCount()
 	{
@@ -135,8 +140,8 @@ class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the exist() function performs as expected.
-	 * 
-	 * @since 	1.9.7.4
+	 *
+	 * @since   1.9.7.4
 	 */
 	public function testExist()
 	{

--- a/tests/wpunit/ResourceTagsTest.php
+++ b/tests/wpunit/ResourceTagsTest.php
@@ -7,6 +7,8 @@
 class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 {
     /**
+     * The test object.
+     *
      * @var \WpunitTester
      */
     protected $tester;

--- a/tests/wpunit/ResourceTagsTest.php
+++ b/tests/wpunit/ResourceTagsTest.php
@@ -1,145 +1,147 @@
 <?php
 /**
  * Tests for the ConvertKit_Resource_Tags class.
- *
- * @since 1.9.7.4
+ * 
+ * @since 	1.9.7.4
  */
-class ResourceTagsTest extends \Codeception\TestCase\WPTestCase {
-
+class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
+{
 	/**
-	 * The test object.
-	 *
 	 * @var \WpunitTester
 	 */
 	protected $tester;
 
 	/**
 	 * Holds the ConvertKit Settings class.
-	 *
-	 * @since 1.9.7.4
-	 *
-	 * @var ConvertKit_Settings
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @var 	ConvertKit_Settings
 	 */
 	private $settings;
 
 	/**
 	 * Holds the ConvertKit Resource class.
-	 *
-	 * @since 1.9.7.4
-	 *
-	 * @var ConvertKit_Resource_Tags
+	 * 
+	 * @since 	1.9.7.4
+	 * 
+	 * @var 	ConvertKit_Resource_Tags
 	 */
 	private $resource;
 
 	/**
 	 * Performs actions before each test.
-	 *
-	 * @since 1.9.7.4
+	 * 
+	 * @since 	1.9.7.4
 	 */
-	public function setUp(): void {
+	public function setUp(): void
+	{
 		parent::setUp();
 
 		// Activate Plugin.
-		activate_plugins( 'convertkit/wp-convertkit.php' );
+		activate_plugins('convertkit/wp-convertkit.php');
 
 		// Store API Key and Secret in Plugin's settings.
 		$this->settings = new ConvertKit_Settings();
-		update_option(
-			$this->settings::SETTINGS_NAME,
-			array(
-				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-			)
-		);
+		update_option($this->settings::SETTINGS_NAME, [
+			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+		]);
 
 		// Initialize the resource class we want to test.
 		$this->resource = new ConvertKit_Resource_Tags();
 
 		// Confirm initialization didn't result in an error.
-		$this->assertNotInstanceOf( WP_Error::class, $this->resource->resources );
+		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
 	}
 
 	/**
 	 * Performs actions after each test.
-	 *
-	 * @since 1.9.6.9
+	 * 
+	 * @since 	1.9.6.9
 	 */
-	public function tearDown(): void {
+	public function tearDown(): void
+	{
 		// Delete API Key, API Secret and Resources from Plugin's settings.
-		delete_option( $this->settings::SETTINGS_NAME );
-		delete_option( $this->resource->settings_name );
-		delete_option( $this->resource->settings_name . '_last_queried' );
+		delete_option($this->settings::SETTINGS_NAME);
+		delete_option($this->resource->settings_name);
+		delete_option($this->resource->settings_name . '_last_queried');
 
 		// Destroy the resource class we tested.
-		unset( $this->resource );
+		unset($this->resource);
 
 		// Deactivate Plugin.
-		deactivate_plugins( 'convertkit/wp-convertkit.php' );
-
+		deactivate_plugins('convertkit/wp-convertkit.php');
+		
 		parent::tearDown();
 	}
 
 	/**
 	 * Test that the refresh() function performs as expected.
-	 *
-	 * @since 1.9.7.4
+	 * 
+	 * @since 	1.9.7.4
 	 */
-	public function testRefresh() {
+	public function testRefresh()
+	{
 		// Confirm that the data is stored in the options table and includes some expected keys.
 		$result = $this->resource->refresh();
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'id', reset( $result ) );
-		$this->assertArrayHasKey( 'name', reset( $result ) );
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
 	}
 
 	/**
 	 * Test that the expiry timestamp is set and returns the expected value.
-	 *
-	 * @since 1.9.7.4
+	 * 
+	 * @since 	1.9.7.4
 	 */
-	public function testExpiry() {
+	public function testExpiry()
+	{
 		// Define the expected expiry date based on the resource class' $cache_duration setting.
-		$expectedExpiryDate = date( 'Y-m-d', time() + $this->resource->cache_duration );
+		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
 
 		// Fetch the actual expiry date set when the resource class was initialized.
-		$expiryDate = date( 'Y-m-d', $this->resource->last_queried + $this->resource->cache_duration );
+		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
 
 		// Confirm both dates match.
-		$this->assertEquals( $expectedExpiryDate, $expiryDate );
+		$this->assertEquals($expectedExpiryDate, $expiryDate);
 	}
 
 	/**
 	 * Test that the get() function performs as expected.
-	 *
-	 * @since 1.9.7.4
+	 * 
+	 * @since 	1.9.7.4
 	 */
-	public function testGet() {
+	public function testGet()
+	{
 		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
 		$result = $this->resource->get();
-		$this->assertNotInstanceOf( WP_Error::class, $result );
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'id', reset( $result ) );
-		$this->assertArrayHasKey( 'name', reset( $result ) );
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
 	}
 
 	/**
 	 * Test that the count() function returns the number of resources.
-	 *
-	 * @since 1.9.7.6
+	 * 
+	 * @since 	1.9.7.6
 	 */
-	public function testCount() {
+	public function testCount()
+	{
 		$result = $this->resource->get();
-		$this->assertEquals( $this->resource->count(), count( $result ) );
+		$this->assertEquals($this->resource->count(), count($result));
 	}
 
 	/**
 	 * Test that the exist() function performs as expected.
-	 *
-	 * @since 1.9.7.4
+	 * 
+	 * @since 	1.9.7.4
 	 */
-	public function testExist() {
+	public function testExist()
+	{
 		// Confirm that the function returns true, because resources exist.
 		$result = $this->resource->exist();
-		$this->assertSame( $result, true );
+		$this->assertSame($result, true);
 	}
 }


### PR DESCRIPTION
## Summary

Applies Coding Standards to tests, covering:
- Code formatting to improve readability when reviewing PRs that contain tests (before and after)
- Ensure code meets WordPress Documentation standards
- Removal of some unused function parameters
- Minor fixes where e.g. a class was declared twice

@noelherrick Appreciate this is a large PR, but specifically it resolves the spacing issues on GitHub vs. IDE that you raised [here](https://github.com/ConvertKit/convertkit-wordpress/pull/375/files/296e50bbb34d66f4878038f3a1cc81d15933296c#r1001754663), which might be easier to review:

Before:
![Screenshot 2022-10-26 at 13 32 08](https://user-images.githubusercontent.com/1462305/198026749-da36eeae-10c7-48dd-88bc-ff35a3dd5ae7.png)
https://github.com/ConvertKit/convertkit-wordpress/pull/375/files/296e50bbb34d66f4878038f3a1cc81d15933296c#diff-993e892fa117bdf5a01be5219d1bbcaa9ab6770bddf6ed5874f2978e3208b5fbR86-R91

After:
![Screenshot 2022-10-26 at 13 31 47](https://user-images.githubusercontent.com/1462305/198026789-c6db6bf4-0ef1-4a66-919f-adda67877036.png)
https://github.com/ConvertKit/convertkit-wordpress/compare/coding-standards-tests?expand=1#diff-993e892fa117bdf5a01be5219d1bbcaa9ab6770bddf6ed5874f2978e3208b5fbR90-R99

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)