### PR TITLE
PHPStan for WordPress 1.1.5 compatbility

### DIFF
--- a/admin/class-convertkit-admin-bulk-edit.php
+++ b/admin/class-convertkit-admin-bulk-edit.php
@@ -57,7 +57,7 @@ class ConvertKit_Admin_Bulk_Edit {
 		wp_enqueue_style( 'convertkit-bulk-edit', CONVERTKIT_PLUGIN_URL . 'resources/backend/css/bulk-edit.css', array(), CONVERTKIT_PLUGIN_VERSION );
 
 		// Output Bulk Edit fields in the footer of the Administration screen.
-		add_action( 'in_admin_footer', array( $this, 'bulk_edit_fields' ), 10, 2 );
+		add_action( 'in_admin_footer', array( $this, 'bulk_edit_fields' ), 10 );
 
 	}
 

--- a/admin/class-convertkit-admin-quick-edit.php
+++ b/admin/class-convertkit-admin-quick-edit.php
@@ -90,7 +90,7 @@ class ConvertKit_Admin_Quick_Edit {
 		}
 
 		// Output Quick Edit fields in the footer of the Administration screen.
-		add_action( 'in_admin_footer', array( $this, 'quick_edit_fields' ), 10, 2 );
+		add_action( 'in_admin_footer', array( $this, 'quick_edit_fields' ), 10 );
 
 	}
 

--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
@@ -187,8 +187,14 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 }
 
 // Register Admin Settings section.
-add_filter(
+add_filter( // @phpstan-ignore-line
 	'convertkit_admin_settings_register_sections',
+	/**
+	 * Register WishList Member as a section at Settings > ConvertKit.
+	 *
+	 * @param   array   $sections   Settings Sections.
+	 * @return  array
+	 */
 	function( $sections ) {
 
 		// Bail if Contact Form 7 isn't enabled.

--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
@@ -187,7 +187,7 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 }
 
 // Register Admin Settings section.
-add_filter( // @phpstan-ignore-line
+add_filter(
 	'convertkit_admin_settings_register_sections',
 	/**
 	 * Register WishList Member as a section at Settings > ConvertKit.

--- a/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php
@@ -185,8 +185,14 @@ class ConvertKit_Wishlist_Admin_Settings extends ConvertKit_Settings_Base {
 }
 
 // Register Admin Settings section.
-add_filter(
+add_filter( // @phpstan-ignore-line
 	'convertkit_admin_settings_register_sections',
+	/**
+	 * Register WishList Member as a section at Settings > ConvertKit.
+	 *
+	 * @param   array   $sections   Settings Sections.
+	 * @return  array
+	 */
 	function( $sections ) {
 
 		// Bail if WishList Member isn't enabled.

--- a/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php
@@ -185,7 +185,7 @@ class ConvertKit_Wishlist_Admin_Settings extends ConvertKit_Settings_Base {
 }
 
 // Register Admin Settings section.
-add_filter( // @phpstan-ignore-line
+add_filter(
 	'convertkit_admin_settings_register_sections',
 	/**
 	 * Register WishList Member as a section at Settings > ConvertKit.


### PR DESCRIPTION
## Summary

Fixes failing static analysis tests due to improvements in static analysis in PHPStan for WordPress 1.1.5.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)