### PR TITLE
Update Refresh Resources Tests

### DIFF
--- a/admin/class-convertkit-admin-refresh-resources.php
+++ b/admin/class-convertkit-admin-refresh-resources.php
@@ -98,7 +98,7 @@ class ConvertKit_Admin_Refresh_Resources {
 	public function enqueue_scripts( $hook ) {
 
 		// Bail if we are not on an Edit or Term screen.
-		if ( $hook !== 'edit.php' && $hook !== 'post-new.php' && $hook !== 'term.php' && $hook !== 'edit-tags.php' && $hook !== 'post.php' ) {
+		if ( ! in_array( $hook, array( 'edit.php', 'post-new.php', 'term.php', 'edit-tags.php', 'post.php' ), true ) ) {
 			return;
 		}
 

--- a/admin/class-convertkit-admin-refresh-resources.php
+++ b/admin/class-convertkit-admin-refresh-resources.php
@@ -98,7 +98,7 @@ class ConvertKit_Admin_Refresh_Resources {
 	public function enqueue_scripts( $hook ) {
 
 		// Bail if we are not on an Edit or Term screen.
-		if ( $hook !== 'edit.php' && $hook !== 'post-new.php' && $hook !== 'term.php' && $hook !== 'post.php' ) {
+		if ( $hook !== 'edit.php' && $hook !== 'post-new.php' && $hook !== 'term.php' && $hook !== 'edit-tags.php' && $hook !== 'post.php' ) {
 			return;
 		}
 


### PR DESCRIPTION
## Summary

- Enables the refresh resource button functionality on the `Add New Category` screen
- Adds tests for the refresh resource button for the `Add New Category` screen

## Testing

- `RefreshResourcesButtonCest:testRefreshResourcesOnAddCategory`: Test the refresh resource button works when adding a new Category at Posts > Categories
- `RefreshResourcesButtonCest:testRefreshResourcesOnEditCategory`: Test the refresh resource button works when adding an existing Category at Posts > Categories
- `RefreshResourcesButtonCest:testRefreshResourcesErrorNoticeOnAddCategory`: Test the expected error message displays when the refresh resource button is used, and invalid API credentials are specified, when adding a new Category at Posts > Categories
- `RefreshResourcesButtonCest:testRefreshResourcesErrorNoticeOnEditCategory`: Test the expected error message displays when the refresh resource button is used, and invalid API credentials are specified, when editing an existing Category at Posts > Categories

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)