### PR TITLE
Broadcasts, Products: Use default value when string is empty

### DIFF
--- a/includes/blocks/class-convertkit-block.php
+++ b/includes/blocks/class-convertkit-block.php
@@ -208,6 +208,15 @@ class ConvertKit_Block {
 				case 'boolean':
 					$atts[ $att ] = (bool) $value;
 					break;
+
+				case 'string':
+					// If the attribute's value is empty, check if the default attribute has a value.
+					// If so, apply it now.
+					// shortcode_atts() will only do this if the attribute key isn't specified.
+					if ( empty( $value ) && ! empty( $this->get_default_value( $att ) ) ) {
+						$atts[ $att ] = $this->get_default_value( $att );
+					}
+					break;
 			}
 		}
 

--- a/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
@@ -267,6 +267,42 @@ class PageBlockBroadcastsCest
 	}
 
 	/**
+	 * Test the Broadcasts block's default pagination labels display when not defined in the block.
+	 *
+	 * @since   2.0.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsBlockWithBlankPaginationLabelParameters(AcceptanceTester $I)
+	{
+		// Setup Plugin and enable debug log.
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Blank Pagination Labels');
+
+		// Add block to Page, setting the limit.
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			[
+				'limit'                   => [ 'input', '1' ],
+				'.components-form-toggle' => [ 'toggle', true ],
+				'paginate_label_prev'     => [ 'input', '' ],
+				'paginate_label_next'     => [ 'input', '' ],
+			]
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Test pagination.
+		$I->testBroadcastsPagination($I, 'Previous', 'Next');
+	}
+
+	/**
 	 * Test the Broadcasts block's theme color parameters works.
 	 *
 	 * @since   1.9.7.4

--- a/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
@@ -158,7 +158,7 @@ class PageShortcodeBroadcastsCest
 	}
 
 	/**
-	 * Test the [convertkit_broadcasts] shortcode pagination works when enabled,
+	 * Test the [convertkit_broadcasts] shortcode pagination labels display when defined,
 	 * using the Classic Editor (TinyMCE / Visual).
 	 *
 	 * @since   1.9.7.6
@@ -188,6 +188,39 @@ class PageShortcodeBroadcastsCest
 
 		// Test pagination.
 		$I->testBroadcastsPagination($I, 'Older', 'Newer');
+	}
+
+	/**
+	 * Test the [convertkit_broadcasts] default pagination labels display when not defined
+	 * in the shortcode, using the Classic Editor (TinyMCE / Visual).
+	 *
+	 * @since   2.0.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsShortcodeInVisualEditorWithBlankPaginationLabelParameters(AcceptanceTester $I)
+	{
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Blank Pagination Labels');
+
+		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+		$I->addVisualEditorShortcode(
+			$I,
+			'ConvertKit Broadcasts',
+			[
+				'limit'               => [ 'input', '1' ],
+				'paginate'            => [ 'toggle', 'Yes' ],
+				'paginate_label_prev' => [ 'input', '' ],
+				'paginate_label_next' => [ 'input', '' ],
+			],
+			'[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1"]'
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage($I);
+
+		// Test pagination.
+		$I->testBroadcastsPagination($I, 'Previous', 'Next');
 	}
 
 	/**

--- a/tests/acceptance/broadcasts/WidgetBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/WidgetBroadcastsCest.php
@@ -180,6 +180,35 @@ class WidgetBroadcastsCest
 	}
 
 	/**
+	 * Test the Broadcasts block's default pagination labels display when not defined in the block.
+	 *
+	 * @since   2.0.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsBlockWithBlankPaginationLabelParameters(AcceptanceTester $I)
+	{
+		// Add block widget.
+		$I->addBlockWidget(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			[
+				'.components-form-toggle' => [ 'toggle', true ],
+				'limit'                   => [ 'input', '1' ],
+				'paginate_label_prev'     => [ 'input', '' ],
+				'paginate_label_next'     => [ 'input', '' ],
+			]
+		);
+
+		// View the home page.
+		$I->amOnPage('/');
+
+		// Test pagination.
+		$I->testBroadcastsPagination($I, 'Previous', 'Next');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/acceptance/products/PageBlockProductCest.php
+++ b/tests/acceptance/products/PageBlockProductCest.php
@@ -128,6 +128,36 @@ class PageBlockProductCest
 	}
 
 	/**
+	 * Test the Product block's default text value is output when the text parameter is blank.
+	 *
+	 * @since   2.0.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testProductBlockWithBlankTextParameter(AcceptanceTester $I)
+	{
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Blank Text Param');
+
+		// Add block to Page, setting the date format.
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Product',
+			'convertkit-product',
+			[
+				'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+				'text'    => [ 'text', '' ],
+			]
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that the block displays.
+		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
+	}
+
+	/**
 	 * Test the Product block's theme color parameters works.
 	 *
 	 * @since   1.9.8.5

--- a/tests/acceptance/products/PageShortcodeProductCest.php
+++ b/tests/acceptance/products/PageShortcodeProductCest.php
@@ -108,6 +108,66 @@ class PageShortcodeProductCest
 	}
 
 	/**
+	 * Test the Product shortcode's text parameter works.
+	 *
+	 * @since   2.0.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testProductShortcodeInVisualEditorWithTextParameter(AcceptanceTester $I)
+	{
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Product: Shortcode: Text Param');
+
+		// Add shortcode to Page, setting the Product setting to the value specified in the .env file.
+		$I->addVisualEditorShortcode(
+			$I,
+			'ConvertKit Product',
+			[
+				'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+				'text'	  => 'Buy now',
+			],
+			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy now"]'
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage($I);
+
+		// Confirm that the ConvertKit Product is displayed.
+		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy now');
+	}
+
+	/**
+	 * Test the Product shortcode's default text value is output when the text parameter is blank.
+	 *
+	 * @since   2.0.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testProductShortcodeInVisualEditorWithBlankTextParameter(AcceptanceTester $I)
+	{
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Product: Shortcode: Blank Text Param');
+
+		// Add shortcode to Page, setting the Product setting to the value specified in the .env file.
+		$I->addVisualEditorShortcode(
+			$I,
+			'ConvertKit Product',
+			[
+				'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+				'text'	  => '',
+			],
+			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text=""]'
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage($I);
+
+		// Confirm that the ConvertKit Product is displayed.
+		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
+	}
+
+	/**
 	 * Test the [convertkit_product] shortcode hex colors works when defined.
 	 *
 	 * @since   1.9.8.5

--- a/tests/acceptance/products/PageShortcodeProductCest.php
+++ b/tests/acceptance/products/PageShortcodeProductCest.php
@@ -125,7 +125,7 @@ class PageShortcodeProductCest
 			'ConvertKit Product',
 			[
 				'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
-				'text'	  => 'Buy now',
+				'text'    => [ 'input', 'Buy now' ],
 			],
 			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy now"]'
 		);
@@ -155,9 +155,9 @@ class PageShortcodeProductCest
 			'ConvertKit Product',
 			[
 				'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
-				'text'	  => '',
+				'text'    => [ 'input', '' ],
 			],
-			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text=""]'
+			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '"]'
 		);
 
 		// Publish and view the Page on the frontend site.


### PR DESCRIPTION
## Summary

If a block/shortcode attribute is a string, and it's empty, use the default value.

This fixes:

### Broadcasts

Adding a block/shortcode with blank previous/next pagination labels would result in no pagination being displayed.

Before:
![Screenshot 2022-12-06 at 16 35 42](https://user-images.githubusercontent.com/1462305/205969632-40d67de3-49ef-43bd-8345-017a3ba4b490.png)

After:
![Screenshot 2022-12-06 at 16 35 10](https://user-images.githubusercontent.com/1462305/205969604-6f73289b-0644-4cf0-831c-2892b054dea5.png)

### Products

Adding a block/shortcode with no button text would result in a blank button being displayed.

Before:
![Screenshot 2022-12-06 at 16 35 35](https://user-images.githubusercontent.com/1462305/205969630-fadbb005-c180-4117-afdd-05d24db4eabb.png)

After:
![Screenshot 2022-12-06 at 16 35 19](https://user-images.githubusercontent.com/1462305/205969622-4e521952-7033-4e3c-8968-2b63c2b891f9.png)

## Testing

The following tests have been added, to test that supplying blank labels / text results in the default pagination / button text displaying: 

PageBlockBroadcastsCest
- testBroadcastsBlockWithBlankPaginationLabelParameters

PageShortcodeBroadcastsCest
- testBroadcastsShortcodeInVisualEditorWithBlankPaginationLabelParameters

WidgetBroadcastsCest
- testBroadcastsBlockWithBlankPaginationLabelParameters

PageBlockProductCest
- testProductBlockWithBlankTextParameter

PageShortcodeProductCest
- testProductShortcodeInVisualEditorWithTextParameter (added as other tests include this)
- testProductShortcodeInVisualEditorWithBlankTextParameter

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)