### PR TITLE
Remove double forwardslash on product.css URL

### DIFF
--- a/includes/blocks/class-convertkit-block-product.php
+++ b/includes/blocks/class-convertkit-block-product.php
@@ -75,7 +75,7 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 	 */
 	public function enqueue_styles() {
 
-		wp_enqueue_style( 'convertkit-gutenberg-block-product-frontend', CONVERTKIT_PLUGIN_URL . '/resources/frontend/css/product.css', array(), CONVERTKIT_PLUGIN_VERSION );
+		wp_enqueue_style( 'convertkit-gutenberg-block-product-frontend', CONVERTKIT_PLUGIN_URL . 'resources/frontend/css/product.css', array(), CONVERTKIT_PLUGIN_VERSION );
 
 	}
 
@@ -128,7 +128,7 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 			'gutenberg_icon'                => file_get_contents( CONVERTKIT_PLUGIN_PATH . '/resources/backend/images/block-icon-product.svg' ), /* phpcs:ignore */
 
 			// Gutenberg: Example image showing how this block looks when choosing it in Gutenberg.
-			'gutenberg_example_image'           => CONVERTKIT_PLUGIN_URL . '/resources/backend/images/block-example-product.png',
+			'gutenberg_example_image'           => CONVERTKIT_PLUGIN_URL . 'resources/backend/images/block-example-product.png',
 
 			// Gutenberg: Help description, displayed when no settings defined for a newly added Block.
 			'gutenberg_help_description'        => __( 'Select a Product using the Product option in the Gutenberg sidebar.', 'convertkit' ),

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -448,6 +448,9 @@ class Plugin extends \Codeception\Module
 	 */
 	public function seeProductOutput($I, $productURL, $text = false, $textColor = false, $backgroundColor = false)
 	{
+		// Confirm that the product stylesheet loaded.
+		$I->seeInSource('<link rel="stylesheet" id="convertkit-gutenberg-block-product-frontend-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/product.css');
+
 		// Confirm that the block displays.
 		$I->seeElementInDOM('a.convertkit-product.wp-block-button__link');
 

--- a/tests/acceptance/general/PluginSettingsGeneralCest.php
+++ b/tests/acceptance/general/PluginSettingsGeneralCest.php
@@ -360,8 +360,8 @@ class PluginSettingsGeneralCest
 		// Navigate to the home page.
 		$I->amOnPage('/');
 
-		// Confirm no CSS is output by the Plugin.
-		$I->seeInSource('broadcasts.css');
+		// Confirm CSS is output by the Plugin.
+		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Removes the double forwardslash when the `product.css` stylesheet is loaded, as reported [here](https://convertkit.atlassian.net/browse/BUG-113):
![image-20221209-184311](https://user-images.githubusercontent.com/1462305/207097642-b224eba1-67ca-48af-bf54-e3391fdf260b.png)

Also removes a double forwardslash when the product block preview image is output.

Both URLs do work with the double forwardslash, but it's best not to have it.

## Testing

- `seeProductOutput()`: Check that the full `product.css` URL is correctly formed; this helper function is used for all Broadcast block and shortcode tests.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)