### PR TITLE
Tests: Compatibility with WooCommerce 7.2

### DIFF
--- a/tests/_support/Helper/Acceptance/WPClassicEditor.php
+++ b/tests/_support/Helper/Acceptance/WPClassicEditor.php
@@ -117,7 +117,6 @@ class WPClassicEditor extends \Codeception\Module
 		switch ($targetEditor) {
 			case 'excerpt':
 				$I->scrollTo('#postexcerpt');
-				$I->click('#postexcerpt button.handlediv');
 				break;
 			default:
 				$I->scrollTo('h1.wp-heading-inline');

--- a/tests/_support/Helper/Acceptance/WPClassicEditor.php
+++ b/tests/_support/Helper/Acceptance/WPClassicEditor.php
@@ -50,7 +50,6 @@ class WPClassicEditor extends \Codeception\Module
 		switch ($targetEditor) {
 			case 'excerpt':
 				$I->scrollTo('#postexcerpt');
-				$I->click('#postexcerpt button.handlediv');
 				break;
 			default:
 				$I->scrollTo('h1.wp-heading-inline');

--- a/tests/acceptance/integrations/WooCommerceProductFormCest.php
+++ b/tests/acceptance/integrations/WooCommerceProductFormCest.php
@@ -90,6 +90,9 @@ class WooCommerceProductFormCest
 		// Navigate to Products > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=product');
 
+		// Scroll to ConvertKit meta box.
+		$I->scrollTo('#wp-convertkit-meta-box');
+
 		// Change Form to None.
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None', 'aria-owns');
 
@@ -119,6 +122,9 @@ class WooCommerceProductFormCest
 		// Navigate to Products > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=product');
 
+		// Scroll to ConvertKit meta box.
+		$I->scrollTo('#wp-convertkit-meta-box');
+
 		// Change Form to Form setting in .env file.
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME'], 'aria-owns');
 
@@ -147,6 +153,9 @@ class WooCommerceProductFormCest
 	{
 		// Add a Product using the Classic Editor.
 		$I->addClassicEditorPage($I, 'product', 'ConvertKit: Product: Form: Shortcode: Visual Editor');
+
+		// Scroll to ConvertKit meta box.
+		$I->scrollTo('#wp-convertkit-meta-box');
 
 		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None', 'aria-owns');
@@ -194,6 +203,9 @@ class WooCommerceProductFormCest
 	{
 		// Add a Product using the Classic Editor.
 		$I->addClassicEditorPage($I, 'product', 'ConvertKit: Product: Form: Shortcode: Text Editor');
+
+		// Scroll to ConvertKit meta box.
+		$I->scrollTo('#wp-convertkit-meta-box');
 
 		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', 'None', 'aria-owns');


### PR DESCRIPTION
## Summary

Removes the click event on tests to display the product short description field, as [WooCommerce 7.2 no longer auto collapses it](https://github.com/woocommerce/woocommerce/pull/35213).

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)