### PR TITLE
Escape Shortcode and Block Attributes

### DIFF
--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -425,13 +425,13 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 
 		// Build attributes array.
 		$atts = array(
-			'date_format'         => sanitize_text_field( $_REQUEST['date_format'] ),
-			'limit'               => sanitize_text_field( $_REQUEST['limit'] ),
+			'date_format'         => stripslashes( sanitize_text_field( $_REQUEST['date_format'] ) ),
+			'limit'               => stripslashes( sanitize_text_field( $_REQUEST['limit'] ) ),
 			'page'                => absint( $_REQUEST['page'] ),
 			'paginate'            => absint( $_REQUEST['paginate'] ),
 			'paginate_label_next' => stripslashes( sanitize_text_field( $_REQUEST['paginate_label_next'] ) ),
 			'paginate_label_prev' => stripslashes( sanitize_text_field( $_REQUEST['paginate_label_prev'] ) ),
-			'link_color'          => sanitize_text_field( $_REQUEST['link_color'] ),
+			'link_color'          => stripslashes( sanitize_text_field( $_REQUEST['link_color'] ) ),
 		);
 
 		// Parse attributes, defining fallback defaults if required

--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -429,8 +429,8 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 			'limit'               => sanitize_text_field( $_REQUEST['limit'] ),
 			'page'                => absint( $_REQUEST['page'] ),
 			'paginate'            => absint( $_REQUEST['paginate'] ),
-			'paginate_label_next' => sanitize_text_field( $_REQUEST['paginate_label_next'] ),
-			'paginate_label_prev' => sanitize_text_field( $_REQUEST['paginate_label_prev'] ),
+			'paginate_label_next' => stripslashes( sanitize_text_field( $_REQUEST['paginate_label_next'] ) ),
+			'paginate_label_prev' => stripslashes( sanitize_text_field( $_REQUEST['paginate_label_prev'] ) ),
 			'link_color'          => sanitize_text_field( $_REQUEST['link_color'] ),
 		);
 
@@ -484,7 +484,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 
 		// Include container, if required.
 		if ( $include_container ) {
-			$html = '<div class="' . esc_attr( implode( ' ', $atts['_css_classes'] ) ) . '" style="' . implode( ';', $atts['_css_styles'] ) . '" ' . $this->get_atts_as_html_data_attributes( $atts ) . '>';
+			$html = '<div class="' . implode( ' ', map_deep( $atts['_css_classes'], 'sanitize_html_class' ) ) . '" style="' . implode( ';', map_deep( $atts['_css_styles'], 'esc_attr' ) ) . '" ' . $this->get_atts_as_html_data_attributes( $atts ) . '>';
 		}
 
 		// Start list.
@@ -506,8 +506,8 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 
 			// Add broadcast as list item.
 			$html .= '<li class="convertkit-broadcast">
-				<time datetime="' . date_i18n( 'Y-m-d', $date_timestamp ) . '">' . date_i18n( $atts['date_format'], $date_timestamp ) . '</time>
-				<a href="' . $url . '" target="_blank" rel="nofollow noopener"' . $this->get_link_style_tag( $atts ) . '>' . $broadcast['title'] . '</a>
+				<time datetime="' . esc_attr( date_i18n( 'Y-m-d', $date_timestamp ) ) . '">' . esc_html( date_i18n( $atts['date_format'], $date_timestamp ) ) . '</time>
+				<a href="' . esc_attr( $url ) . '" target="_blank" rel="nofollow noopener"' . $this->get_link_style_tag( $atts ) . '>' . esc_html( $broadcast['title'] ) . '</a>
 			</li>';
 		}
 
@@ -563,7 +563,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 	private function get_pagination_link_prev_html( $atts, $nonce ) {
 
 		return '<a href="' . esc_attr( $this->get_pagination_link( $atts['page'] - 1, $nonce ) ) . '" title="' . esc_attr( $atts['paginate_label_prev'] ) . '" data-page="' . esc_attr( (string) ( $atts['page'] - 1 ) ) . '" data-nonce="' . esc_attr( $nonce ) . '"' . $this->get_link_style_tag( $atts ) . '>
-			' . esc_attr( $atts['paginate_label_prev'] ) . '
+			' . esc_html( $atts['paginate_label_prev'] ) . '
 		</a>';
 
 	}
@@ -581,7 +581,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 	private function get_pagination_link_next_html( $atts, $nonce ) {
 
 		return '<a href="' . esc_attr( $this->get_pagination_link( $atts['page'] + 1, $nonce ) ) . '" title="' . esc_attr( $atts['paginate_label_next'] ) . '" data-page="' . esc_attr( (string) ( $atts['page'] + 1 ) ) . '" data-nonce="' . esc_attr( $nonce ) . '"' . $this->get_link_style_tag( $atts ) . '>
-			' . esc_attr( $atts['paginate_label_next'] ) . '
+			' . esc_html( $atts['paginate_label_next'] ) . '
 		</a>';
 
 	}
@@ -671,7 +671,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 			return '';
 		}
 
-		return ' style="color:' . $atts['link_color'] . '"';
+		return ' style="color:' . esc_attr( $atts['link_color'] ) . '"';
 
 	}
 

--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -108,7 +108,7 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource {
 		}
 
 		// If here, return Form <script> embed.
-		return '<script async data-uid="' . $this->resources[ $id ]['uid'] . '" src="' . $this->resources[ $id ]['embed_js'] . '"></script>';
+		return '<script async data-uid="' . esc_attr( $this->resources[ $id ]['uid'] ) . '" src="' . esc_attr( $this->resources[ $id ]['embed_js'] ) . '"></script>';
 
 	}
 

--- a/includes/class-convertkit-resource-products.php
+++ b/includes/class-convertkit-resource-products.php
@@ -129,10 +129,10 @@ class ConvertKit_Resource_Products extends ConvertKit_Resource {
 		if ( $return_as_span ) {
 			$html .= '<span';
 		} else {
-			$html .= '<a href="' . $this->resources[ $id ]['url'] . '"';
+			$html .= '<a href="' . esc_attr( $this->resources[ $id ]['url'] ) . '"';
 		}
 
-		$html .= ' class="wp-block-button__link ' . esc_attr( implode( ' ', $css_classes ) ) . '" style="' . implode( ';', $css_styles ) . '" data-commerce>';
+		$html .= ' class="wp-block-button__link ' . implode( ' ', map_deep( $css_classes, 'sanitize_html_class' ) ) . '" style="' . implode( ';', map_deep( $css_styles, 'esc_attr' ) ) . '" data-commerce>';
 		$html .= esc_html( $button_text );
 
 		if ( $return_as_span ) {

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: email marketing, email newsletter, newsletter, convertkit
 Requires at least: 5.0
 Tested up to: 6.1.1
 Requires PHP: 5.6.20
-Stable tag: 2.0.4
+Stable tag: 2.0.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -116,6 +116,12 @@ Full Plugin documentation can be found [here](https://help.convertkit.com/en/art
 7. Track subscriber growth
 
 == Changelog ==
+
+### 2.0.5 2022-12-15
+* Fix: Broadcasts: Strip slashes on output when pagination clicked and Broadcasts are reloaded
+* Fix: Broadcasts: Sanitize and escape HTML attributes on output
+* Fix: Forms: Escape HTML attributes on output
+* Fix: Products: Sanitize and escape HTML attributes on output
 
 ### 2.0.4 2022-12-13
 * Fix: Products: PHP warning when attempting to parse an invalid Product URL

--- a/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
@@ -397,6 +397,49 @@ class PageBlockBroadcastsCest
 	}
 
 	/**
+	 * Test the Broadcasts block's parameters are correctly escaped on output,
+	 * to prevent XSS.
+	 *
+	 * @since   2.0.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsBlockParameterEscaping(AcceptanceTester $I)
+	{
+		// Setup Plugin and enable debug log.
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
+
+		// Define a 'bad' block.  This is difficult to do in Gutenberg, but let's assume it's possible.
+		$I->havePageInDatabase(
+			[
+				'post_name'    => 'convertkit-page-broadcasts-block-parameter-escaping',
+				'post_content' => '<!-- wp:convertkit/broadcasts {"limit":1,"paginate":true,"style":{"color":{"text":"red\" onmouseover=\"alert(1)\""}}} /-->',
+			]
+		);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/convertkit-page-broadcasts-block-parameter-escaping');
+
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible('body.page-template-default');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the output is escaped.
+		$I->seeInSource('style="color:red&quot; onmouseover=&quot;alert(1)&quot;"');
+		$I->dontSeeInSource('style="color:red" onmouseover="alert(1)""');
+
+		// Test pagination.
+		$I->testBroadcastsPagination($I, 'Previous', 'Next');
+
+		// Confirm that the output is still escaped.
+		$I->seeInSource('style="color:red&quot; onmouseover=&quot;alert(1)&quot;"');
+		$I->dontSeeInSource('style="color:red" onmouseover="alert(1)""');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
@@ -446,6 +446,45 @@ class PageShortcodeBroadcastsCest
 	}
 
 	/**
+	 * Test the [convertkit_broadcasts] shortcode parameters are correctly escaped on output,
+	 * to prevent XSS.
+	 *
+	 * @since   2.0.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsShortcodeParameterEscaping(AcceptanceTester $I)
+	{
+		// Define a 'bad' shortcode.
+		$I->havePageInDatabase(
+			[
+				'post_name'    => 'convertkit-page-broadcasts-shortcode-parameter-escaping',
+				'post_content' => '[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next" link_color=\'red" onmouseover="alert(1)"\']',
+			]
+		);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/convertkit-page-broadcasts-shortcode-parameter-escaping');
+
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible('body.page-template-default');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the output is escaped.
+		$I->seeInSource('style="color:red&quot; onmouseover=&quot;alert(1)&quot;"');
+		$I->dontSeeInSource('style="color:red" onmouseover="alert(1)""');
+
+		// Test pagination.
+		$I->testBroadcastsPagination($I, 'Previous', 'Next');
+
+		// Confirm that the output is still escaped.
+		$I->seeInSource('style="color:red&quot; onmouseover=&quot;alert(1)&quot;"');
+		$I->dontSeeInSource('style="color:red" onmouseover="alert(1)""');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -9,7 +9,7 @@
  * Plugin Name: ConvertKit
  * Plugin URI: https://convertkit.com/
  * Description: Quickly and easily integrate ConvertKit forms into your site.
- * Version: 2.0.4
+ * Version: 2.0.5
  * Author: ConvertKit
  * Author URI: https://convertkit.com/
  * Text Domain: convertkit
@@ -25,7 +25,7 @@ define( 'CONVERTKIT_PLUGIN_NAME', 'ConvertKit' ); // Used for user-agent in API 
 define( 'CONVERTKIT_PLUGIN_FILE', plugin_basename( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_PATH', __DIR__ );
-define( 'CONVERTKIT_PLUGIN_VERSION', '2.0.4' );
+define( 'CONVERTKIT_PLUGIN_VERSION', '2.0.5' );
 
 // Load shared classes, if they have not been included by another ConvertKit Plugin.
 if ( ! class_exists( 'ConvertKit_API' ) ) {


### PR DESCRIPTION
## Summary

Escapes Shortcode and Block attributes on output, resolving [this reported issue](https://n7studios-workspace.slack.com/archives/C02KFR6N1GF/p1671075539275659).

## Testing

- `testBroadcastsBlockParameterEscaping`: Tests that output is correctly escaped when using the Broadcasts block
- `testBroadcastsShortcodeParameterEscaping`: Tests that output is correctly escaped when using the Broadcasts shortcode
- `testProductBlockParameterEscaping`: Tests that output is correctly escaped when using the Product block
- `testProductShortcodeParameterEscaping`: Tests that output is correctly escaped when using the Product shortcode

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)