### PR TITLE
Restrict Content: Administration functionality

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,8 @@ jobs:
       CONVERTKIT_API_SECRET: ${{ secrets.CONVERTKIT_API_SECRET }} # ConvertKit API Secret, stored in the repository's Settings > Secrets
       CONVERTKIT_API_KEY_NO_DATA: ${{ secrets.CONVERTKIT_API_KEY_NO_DATA }} # ConvertKit API Key for ConvertKit account with no data, stored in the repository's Settings > Secrets
       CONVERTKIT_API_SECRET_NO_DATA: ${{ secrets.CONVERTKIT_API_SECRET_NO_DATA }} # ConvertKit API Secret for ConvertKit account with no data, stored in the repository's Settings > Secrets
-
+      CONVERTKIT_API_SIGNED_SUBSCRIBER_ID: ${{ secrets.CONVERTKIT_API_SIGNED_SUBSCRIBER_ID }} # ConvertKit API Signed Subscriber ID, stored in the repository's Settings > Secrets
+      
     # Defines the WordPress and PHP Versions matrix to run tests on
     # WooCommerce 5.9.0 requires WordPress 5.6 or greater, so we do not test on earlier versions
     # If testing older WordPress versions, ensure they are e.g. 5.7.4, 5.6.6 that have the X3 SSL fix: https://core.trac.wordpress.org/ticket/54207
@@ -180,6 +181,7 @@ jobs:
             CONVERTKIT_API_SECRET=${{ env.CONVERTKIT_API_SECRET }}
             CONVERTKIT_API_KEY_NO_DATA=${{ env.CONVERTKIT_API_KEY_NO_DATA }}
             CONVERTKIT_API_SECRET_NO_DATA=${{ env.CONVERTKIT_API_SECRET_NO_DATA }}
+            CONVERTKIT_API_SIGNED_SUBSCRIBER_ID=${{ env.CONVERTKIT_API_SIGNED_SUBSCRIBER_ID }}
           write-mode: append
 
       # Installs wp-browser, Codeception, PHP CodeSniffer and anything else needed to run tests.

--- a/admin/class-convertkit-admin-bulk-edit.php
+++ b/admin/class-convertkit-admin-bulk-edit.php
@@ -132,9 +132,10 @@ class ConvertKit_Admin_Bulk_Edit {
 			return;
 		}
 
-		// Fetch Forms, Landing Pages and Tags.
+		// Fetch Forms, Landing Pages, Products and Tags.
 		$convertkit_forms         = new ConvertKit_Resource_Forms();
 		$convertkit_landing_pages = new ConvertKit_Resource_Landing_Pages();
+		$convertkit_products      = new ConvertKit_Resource_Products();
 		$convertkit_tags          = new ConvertKit_Resource_Tags();
 
 		// Output view.

--- a/admin/class-convertkit-admin-post.php
+++ b/admin/class-convertkit-admin-post.php
@@ -122,6 +122,7 @@ class ConvertKit_Admin_Post {
 		$convertkit_post          = new ConvertKit_Post( $post->ID );
 		$convertkit_forms         = new ConvertKit_Resource_Forms();
 		$convertkit_landing_pages = new ConvertKit_Resource_Landing_Pages();
+		$convertkit_products      = new ConvertKit_Resource_Products();
 		$convertkit_tags          = new ConvertKit_Resource_Tags();
 
 		// Get settings page link.

--- a/admin/class-convertkit-admin-quick-edit.php
+++ b/admin/class-convertkit-admin-quick-edit.php
@@ -110,9 +110,10 @@ class ConvertKit_Admin_Quick_Edit {
 			return;
 		}
 
-		// Fetch Forms, Landing Pages and Tags.
+		// Fetch Forms, Landing Pages, Products and Tags.
 		$convertkit_forms         = new ConvertKit_Resource_Forms();
 		$convertkit_landing_pages = new ConvertKit_Resource_Landing_Pages();
+		$convertkit_products      = new ConvertKit_Resource_Products();
 		$convertkit_tags          = new ConvertKit_Resource_Tags();
 
 		// Output view.

--- a/admin/class-convertkit-admin-restrict-content.php
+++ b/admin/class-convertkit-admin-restrict-content.php
@@ -43,11 +43,8 @@ class ConvertKit_Admin_Restrict_Content {
 	 */
 	public function __construct() {
 
-		// Add New Member Content button.
+		// Filter Page's post state.
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-		foreach ( convertkit_get_supported_restrict_content_post_types() as $post_type ) {
-			add_filter( 'views_edit-' . $post_type, array( $this, 'output_wp_list_table_buttons' ) );
-		}
 
 		// Filter WP_List_Table by Restrict Content setting.
 		add_action( 'pre_get_posts', array( $this, 'filter_wp_list_table_output' ) );
@@ -56,22 +53,12 @@ class ConvertKit_Admin_Restrict_Content {
 	}
 
 	/**
-	 * Enqueue JavaScript when viewing a list of Pages, Posts or Custom Post Types
-	 * in a WP_List_Table that supports Restrict Content functionality.
+	 * Filter Page's post state to maybe include a label denoting that Restricted Content is enabled.
 	 *
 	 * @since   2.1.0
 	 */
 	public function enqueue_scripts() {
 
-		// Bail if we're not on a WP_List_Table screen for a supported Post Type.
-		if ( ! $this->is_wp_list_table_request_for_supported_post_type() ) {
-			return;
-		}
-
-		// Enqueue JS.
-		wp_enqueue_script( 'convertkit-admin-wp-list-table-buttons', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/wp-list-table-buttons.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
-
-		// Filter Page's post state to maybe include a label denoting that Restricted Content is enabled.
 		add_filter( 'display_post_states', array( $this, 'maybe_display_restrict_content_post_state' ), 10, 2 );
 
 	}
@@ -137,30 +124,6 @@ class ConvertKit_Admin_Restrict_Content {
 	}
 
 	/**
-	 * Outputs a button in the WP_List_Table filters to run the Restrict Content Setup process.
-	 *
-	 * JS will move this button to be displayed next to the "Add New" button when viewing the table of Pages or Posts,
-	 * as there is not a native WordPress action/filter for registering buttons next to the "Add New" button.
-	 *
-	 * @since   2.1.0
-	 *
-	 * @param   array $views  Views.
-	 * @return  array           Views
-	 */
-	public function output_wp_list_table_buttons( $views ) {
-
-		// If no API credentials have been set, don't output the button.
-		$settings = new ConvertKit_Settings();
-		if ( ! $settings->has_api_key_and_secret() ) {
-			return $views;
-		}
-
-		$views['convertkit_restrict_content_setup'] = '<a href="admin.php?page=convertkit-restrict-content-setup&post_type=' . $this->get_current_post_type() . '" class="convertkit-action page-title-action hidden">' . __( 'Add New Member Content', 'convertkit' ) . '</a>';
-		return $views;
-
-	}
-
-	/**
 	 * Outputs a dropdown filter on a WP_List_Table filter section to permit
 	 * filtering by a Restrict Content Form, Tag or Product.
 	 *
@@ -217,48 +180,6 @@ class ConvertKit_Admin_Restrict_Content {
 
 		// Return.
 		return $post_states;
-
-	}
-
-	/**
-	 * Determines if the current request is for a WP_List_Table, and if so that
-	 * the Post Type we're viewing supports Restrict Content functionality.
-	 *
-	 * @since   2.1.0
-	 *
-	 * @return  bool    Is WP_List_Table request for a supported Post Type.
-	 */
-	private function is_wp_list_table_request_for_supported_post_type() {
-
-		// Bail if we cannot determine the screen.
-		if ( ! function_exists( 'get_current_screen' ) ) {
-			return false;
-		}
-
-		// Get screen.
-		$screen = get_current_screen();
-
-		// Bail if we're not on an edit.php screen.
-		if ( $screen->base !== 'edit' ) {
-			return false;
-		}
-
-		// Return whether Post Type is supported for Restrict Content functionality.
-		return in_array( $screen->post_type, convertkit_get_supported_restrict_content_post_types(), true );
-
-	}
-
-	/**
-	 * Get the current post type based on the screen that is viewed.
-	 *
-	 * @since   2.1.0
-	 *
-	 * @return  string
-	 */
-	private function get_current_post_type() {
-
-		$screen = get_current_screen();
-		return $screen->post_type;
 
 	}
 

--- a/admin/class-convertkit-admin-restrict-content.php
+++ b/admin/class-convertkit-admin-restrict-content.php
@@ -44,22 +44,11 @@ class ConvertKit_Admin_Restrict_Content {
 	public function __construct() {
 
 		// Filter Page's post state.
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_filter( 'display_post_states', array( $this, 'maybe_display_restrict_content_post_state' ), 10, 2 );
 
 		// Filter WP_List_Table by Restrict Content setting.
 		add_action( 'pre_get_posts', array( $this, 'filter_wp_list_table_output' ) );
 		add_action( 'restrict_manage_posts', array( $this, 'output_wp_list_table_filters' ) );
-
-	}
-
-	/**
-	 * Filter Page's post state to maybe include a label denoting that Restricted Content is enabled.
-	 *
-	 * @since   2.1.0
-	 */
-	public function enqueue_scripts() {
-
-		add_filter( 'display_post_states', array( $this, 'maybe_display_restrict_content_post_state' ), 10, 2 );
 
 	}
 

--- a/admin/class-convertkit-admin-restrict-content.php
+++ b/admin/class-convertkit-admin-restrict-content.php
@@ -1,0 +1,265 @@
+<?php
+/**
+ * ConvertKit Admin Restrict Content class.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Modifies the Pages WP_List_Table to provide:
+ * - an 'Add New Member Content' button next to the 'Add New' button
+ * - a dropdown filter to show Pages restricted to a Form, Tag or Product
+ * - a 'ConvertKit Member Content' label appended to the Page's title when a Form, Tag or Product is selected
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+class ConvertKit_Admin_Restrict_Content {
+
+	/**
+	 * Holds the ConvertKit Products resource class.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @var     bool|ConvertKit_Resource_Products
+	 */
+	public $products = false;
+
+	/**
+	 * Holds the value chosen for the Restrict Content filter dropdown
+	 * in the WP_List_Table.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @var     int|string
+	 */
+	public $restrict_content_filter = 0;
+
+	/**
+	 * Registers action and filter hooks.
+	 *
+	 * @since   2.1.0
+	 */
+	public function __construct() {
+
+		// Add New Member Content button.
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		foreach ( convertkit_get_supported_restrict_content_post_types() as $post_type ) {
+			add_filter( 'views_edit-' . $post_type, array( $this, 'output_wp_list_table_buttons' ) );
+		}
+
+		// Filter WP_List_Table by Restrict Content setting.
+		add_action( 'pre_get_posts', array( $this, 'filter_wp_list_table_output' ) );
+		add_action( 'restrict_manage_posts', array( $this, 'output_wp_list_table_filters' ) );
+
+	}
+
+	/**
+	 * Enqueue JavaScript when viewing a list of Pages, Posts or Custom Post Types
+	 * in a WP_List_Table that supports Restrict Content functionality.
+	 *
+	 * @since   2.1.0
+	 */
+	public function enqueue_scripts() {
+
+		// Bail if we're not on a WP_List_Table screen for a supported Post Type.
+		if ( ! $this->is_wp_list_table_request_for_supported_post_type() ) {
+			return;
+		}
+
+		// Enqueue JS.
+		wp_enqueue_script( 'convertkit-admin-wp-list-table-buttons', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/wp-list-table-buttons.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
+
+		// Filter Page's post state to maybe include a label denoting that Restricted Content is enabled.
+		add_filter( 'display_post_states', array( $this, 'maybe_display_restrict_content_post_state' ), 10, 2 );
+
+	}
+
+	/**
+	 * Query Pages in the WP_List_Table by the Restrict Content filter, if a filter
+	 * was included in the request.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   WP_Query $query  WordPress Query.
+	 */
+	public function filter_wp_list_table_output( $query ) {
+
+		// Bail if no Restrict Content filter specified.
+		if ( ! array_key_exists( 'convertkit_restrict_content', $_REQUEST ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			return;
+		}
+		if ( ! $_REQUEST['convertkit_restrict_content'] ) { // phpcs:ignore WordPress.Security.NonceVerification
+			return;
+		}
+
+		// Don't filter if we're not querying a Post Type that supports Restricted Content.
+		if ( ! in_array( $query->get( 'post_type' ), convertkit_get_supported_restrict_content_post_types(), true ) ) {
+			return;
+		}
+
+		// Build query.
+		// Because WordPress stores metadata in a single serialized string for a single key, we have to search
+		// the string for the Restrict Content setting. However, other settings will also be in this serialized string,
+		// so to avoid false positives, we define our search value formatted as a serialized string comprising of the
+		// setting name and value, to be as accurate as possible.
+		$value = maybe_serialize(
+			array(
+				'restrict_content' => sanitize_text_field( $_REQUEST['convertkit_restrict_content'] ), // phpcs:ignore WordPress.Security.NonceVerification
+			)
+		);
+
+		// Strip a:1:{ and final }, as a Post's serialized settings will include other settings.
+		$value = str_replace( 'a:1:{', '', $value ); // e.g. s:16:"restrict_content";s:13:"product_36377";}.
+		$value = substr( $value, 0, strlen( $value ) - 1 ); // e.g. s:16:"restrict_content";s:13:"product_36377";.
+
+		// Add value to query.
+		$meta_query = array(
+			'key'     => '_wp_convertkit_post_meta',
+			'value'   => $value,
+			'compare' => 'LIKE',
+		);
+
+		// If the existing meta query is an array, append our query to it, so we honor
+		// any other constraints that have been defined by WordPress or third party code.
+		$existing_meta_query = $query->get( 'meta_query' );
+		if ( is_array( $existing_meta_query ) ) {
+			$existing_meta_query[] = $meta_query;
+			$query->set( 'meta_query', $existing_meta_query );
+		} else {
+			$query->set( 'meta_query', array( $meta_query ) );
+		}
+
+		// Store Restrict Content filter value.
+		$this->restrict_content_filter = sanitize_text_field( $_REQUEST['convertkit_restrict_content'] ); // phpcs:ignore WordPress.Security.NonceVerification
+
+	}
+
+	/**
+	 * Outputs a button in the WP_List_Table filters to run the Restrict Content Setup process.
+	 *
+	 * JS will move this button to be displayed next to the "Add New" button when viewing the table of Pages or Posts,
+	 * as there is not a native WordPress action/filter for registering buttons next to the "Add New" button.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   array $views  Views.
+	 * @return  array           Views
+	 */
+	public function output_wp_list_table_buttons( $views ) {
+
+		// If no API credentials have been set, don't output the button.
+		$settings = new ConvertKit_Settings();
+		if ( ! $settings->has_api_key_and_secret() ) {
+			return $views;
+		}
+
+		$views['convertkit_restrict_content_setup'] = '<a href="admin.php?page=convertkit-restrict-content-setup&post_type=' . $this->get_current_post_type() . '" class="convertkit-action page-title-action hidden">' . __( 'Add New Member Content', 'convertkit' ) . '</a>';
+		return $views;
+
+	}
+
+	/**
+	 * Outputs a dropdown filter on a WP_List_Table filter section to permit
+	 * filtering by a Restrict Content Form, Tag or Product.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   string $post_type  Post Type.
+	 */
+	public function output_wp_list_table_filters( $post_type ) {
+
+		// Don't output filters if we're not viewing a Post Type that supports Restricted Content.
+		if ( ! in_array( $post_type, convertkit_get_supported_restrict_content_post_types(), true ) ) {
+			return;
+		}
+
+		// Don't output filters if API credentials have not been defined in the Plugin's settings.
+		$settings = new ConvertKit_Settings();
+		if ( ! $settings->has_api_key_and_secret() ) {
+			return;
+		}
+
+		// Fetch Products.
+		$this->products = new ConvertKit_Resource_Products();
+
+		// Don't display filter if no Products exist.
+		if ( ! $this->products->exist() ) {
+			return;
+		}
+
+		// Output filter.
+		include_once CONVERTKIT_PLUGIN_PATH . '/views/backend/post/wp-list-table-filter.php';
+
+	}
+
+	/**
+	 * Appends the 'ConvertKit Member Content' text to a Page's Title in the WP_List_Table,
+	 * if the given Page has a Restrict Content setting.
+	 *
+	 * @param   string[] $post_states    An array of post display states.
+	 * @param   WP_Post  $post           The current post object.
+	 * @return  string[]                    An array of post display states
+	 */
+	public function maybe_display_restrict_content_post_state( $post_states, $post ) {
+
+		// Fetch Post's settings.
+		$convertkit_post = new ConvertKit_Post( $post->ID );
+
+		// Return post states, unedited, if Restrict Content isn't enabled on this Post.
+		if ( ! $convertkit_post->restrict_content_enabled() ) {
+			return $post_states;
+		}
+
+		// Add Post State.
+		$post_states['convertkit_restrict_content'] = esc_html__( 'ConvertKit Member Content', 'convertkit' );
+
+		// Return.
+		return $post_states;
+
+	}
+
+	/**
+	 * Determines if the current request is for a WP_List_Table, and if so that
+	 * the Post Type we're viewing supports Restrict Content functionality.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @return  bool    Is WP_List_Table request for a supported Post Type.
+	 */
+	private function is_wp_list_table_request_for_supported_post_type() {
+
+		// Bail if we cannot determine the screen.
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return false;
+		}
+
+		// Get screen.
+		$screen = get_current_screen();
+
+		// Bail if we're not on an edit.php screen.
+		if ( $screen->base !== 'edit' ) {
+			return false;
+		}
+
+		// Return whether Post Type is supported for Restrict Content functionality.
+		return in_array( $screen->post_type, convertkit_get_supported_restrict_content_post_types(), true );
+
+	}
+
+	/**
+	 * Get the current post type based on the screen that is viewed.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @return  string
+	 */
+	private function get_current_post_type() {
+
+		$screen = get_current_screen();
+		return $screen->post_type;
+
+	}
+
+}

--- a/admin/class-convertkit-admin-setup-wizard.php
+++ b/admin/class-convertkit-admin-setup-wizard.php
@@ -80,7 +80,7 @@ class ConvertKit_Admin_Setup_Wizard {
 	 *
 	 * @var     bool|string
 	 */
-	private $current_step_url = false; // @phpstan-ignore-line
+	public $current_step_url = false;
 
 	/**
 	 * Holds the URL to the next step in the setup process.
@@ -89,7 +89,7 @@ class ConvertKit_Admin_Setup_Wizard {
 	 *
 	 * @var     bool|string
 	 */
-	private $next_step_url = false; // @phpstan-ignore-line
+	public $next_step_url = false;
 
 	/**
 	 * Holds the URL to the previous step in the setup process.
@@ -98,7 +98,7 @@ class ConvertKit_Admin_Setup_Wizard {
 	 *
 	 * @var     bool|string
 	 */
-	private $previous_step_url = false; // @phpstan-ignore-line
+	public $previous_step_url = false;
 
 	/**
 	 * Registers action and filter hooks.

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php
@@ -1,0 +1,567 @@
+<?php
+/**
+ * ConvertKit Admin Setup Wizard for Restrict Content class.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Provides a UI for setting up Member's Only Content.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+class ConvertKit_Admin_Setup_Wizard_Restrict_Content extends ConvertKit_Admin_Setup_Wizard {
+
+	/**
+	 * Holds the Post Type to generate Members Content for.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @var     string
+	 */
+	public $post_type = 'page';
+
+	/**
+	 * Holds the type of Member's Content to generate (course|download).
+	 *
+	 * @since   2.1.0
+	 *
+	 * @var     string
+	 */
+	public $type = 'download';
+
+	/**
+	 * Holds the label for the type of Member's Content to generate.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @var     string
+	 */
+	public $type_label = '';
+
+	/**
+	 * Holds the ConvertKit Products resource class.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @var     bool|ConvertKit_Resource_Products
+	 */
+	public $products = false;
+
+	/**
+	 * Holds the Pages created by this setup wizard.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @var     bool|array
+	 */
+	public $pages = false;
+
+	/**
+	 * Holds the URL to the setup wizard screen for the Download type of content.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @var     bool|string
+	 */
+	public $download_url = false;
+
+	/**
+	 * Holds the URL to the setup wizard screen for the Course type of content.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @var     bool|string
+	 */
+	public $course_url = false;
+
+	/**
+	 * The required user capability to access the setup wizard.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @var     string
+	 */
+	public $required_capability = 'edit_posts';
+
+	/**
+	 * The programmatic name for this wizard.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @var     string
+	 */
+	public $page_name = 'convertkit-restrict-content-setup';
+
+	/**
+	 * The URL to take the user to when they click the Exit link.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @var     string
+	 */
+	public $exit_url = 'edit.php?post_type=page';
+
+	/**
+	 * Registers action and filter hooks.
+	 *
+	 * @since   2.1.0
+	 */
+	public function __construct() {
+
+		// Define details for each step in the setup process.
+		$this->steps = array(
+			1 => array(
+				'name' => __( 'Setup', 'convertkit' ),
+			),
+			2 => array(
+				'name'        => __( 'Configure', 'convertkit' ),
+				'next_button' => array(
+					'label' => __( 'Submit', 'convertkit' ),
+				),
+			),
+			3 => array(
+				'name' => __( 'Done', 'convertkit' ),
+			),
+		);
+
+		add_action( 'convertkit_admin_setup_wizard_process_form_convertkit-restrict-content-setup', array( $this, 'process_form' ) );
+		add_action( 'convertkit_admin_setup_wizard_load_screen_data_convertkit-restrict-content-setup', array( $this, 'load_screen_data' ) );
+
+		// Call parent class constructor.
+		parent::__construct();
+
+	}
+
+	/**
+	 * Process posted data from the submitted form.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   int $step   Current step.
+	 */
+	public function process_form( $step ) {
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing
+		// Nonce verification has been performed in ConvertKit_Admin_Setup_Wizard:process_form(), prior to calling this function.
+
+		// Depending on the step, process the form data.
+		switch ( $step ) {
+			case 3:
+				// Sanitize configuration.
+				$configuration = array(
+					'type'             => sanitize_text_field( stripslashes( $_POST['type'] ) ),
+					'title'            => sanitize_text_field( stripslashes( $_POST['title'] ) ),
+					'description'      => sanitize_textarea_field( stripslashes( $_POST['description'] ) ),
+					'number_of_pages'  => ( isset( $_POST['number_of_pages'] ) ? absint( $_POST['number_of_pages'] ) : 0 ),
+					'restrict_content' => sanitize_text_field( stripslashes( $_POST['restrict_content'] ) ),
+					'post_type'        => $this->post_type,
+				);
+
+				// Depending on the type of content selected, create WordPress Page(s) now.
+				switch ( $configuration['type'] ) {
+					/**
+					 * Download
+					 * - Single page with a link to a downloadable product.
+					 */
+					case 'download':
+						$result = $this->create_download( $configuration );
+						break;
+
+					/**
+					 * Course
+					 */
+					case 'course':
+					default:
+						$result = $this->create_course( $configuration );
+						break;
+				}
+
+				// If here, an error occured as create_download() and create_course() perform a redirect on success.
+				// Show an error message if Account Details could not be fetched e.g. API credentials supplied are invalid.
+				// Decrement the step.
+				$this->step  = ( $this->step - 1 );
+				$this->error = $result->get_error_message();
+				return;
+
+		}
+
+		// phpcs:enable
+
+	}
+
+	/**
+	 * Load any data into class variables for the given setup wizard name and current step.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   int $step   Current step.
+	 */
+	public function load_screen_data( $step ) {
+
+		// Show an error screen if API credentials have not been specified.
+		// This shouldn't happen, because the 'Add New Member Content' button is only displayed
+		// if valid credentials have been specified.
+		$settings = new ConvertKit_Settings();
+		if ( ! $settings->has_api_key_and_secret() ) {
+			wp_die( esc_html__( 'Add a valid API Key and Secret in the ConvertKit Plugin\'s settings to get started', 'convertkit' ) );
+		}
+
+		// Bail if the Post Type isn't supported.
+		$this->post_type = isset( $_REQUEST['post_type'] ) ? sanitize_text_field( $_REQUEST['post_type'] ) : 'page'; // phpcs:ignore WordPress.Security.NonceVerification
+		if ( ! in_array( $this->post_type, convertkit_get_supported_restrict_content_post_types(), true ) ) {
+			wp_die(
+				sprintf(
+					/* translators: Post Type */
+					esc_html__( 'The post type `%s` is not supported for Member Content.', 'convertkit' ),
+					esc_html( $this->post_type )
+				),
+				esc_html__( 'WordPress Error', 'convertkit' ),
+				array(
+					'back_link' => true,
+				)
+			);
+		}
+
+		// Define Exit URL to take the user back to the WP_List_Table for the Post Type they were viewing.
+		$this->exit_url = add_query_arg(
+			array(
+				'post_type' => $this->post_type,
+			),
+			admin_url( 'edit.php' )
+		);
+
+		// Load data depending on the current step.
+		switch ( $step ) {
+			case 2:
+				// Define Member Content Type.
+				$this->type = sanitize_text_field( $_REQUEST['type'] ); // phpcs:ignore WordPress.Security.NonceVerification
+
+				// Define Label for Title.
+				switch ( $this->type ) {
+					case 'download':
+						$this->type_label = __( 'Download', 'convertkit' );
+						break;
+					case 'course':
+						$this->type_label = __( 'Course', 'convertkit' );
+						break;
+				}
+
+				// Fetch Products.
+				$this->products = new ConvertKit_Resource_Products( 'restrict_content_wizard' );
+				break;
+
+			case 1:
+				// Define Download and Course button links.
+				$this->download_url = add_query_arg(
+					array(
+						'type'      => 'download',
+						'post_type' => $this->post_type,
+					),
+					$this->next_step_url
+				);
+
+				$this->course_url = add_query_arg(
+					array(
+						'type'      => 'course',
+						'post_type' => $this->post_type,
+					),
+					$this->next_step_url
+				);
+				break;
+		}
+
+	}
+
+	/**
+	 * Creates a single WordPress Page for a downloadable product, restricted by
+	 * a ConvertKit Form, Tag or Product, based on the supplied configuration.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   array $configuration  Configuration.
+	 * @return  WP_Error              WP_Error or Page ID
+	 */
+	private function create_download( $configuration ) {
+
+		// Create Page.
+		$page_id = $this->create_page(
+			$configuration['title'],
+			$configuration['description'],
+			$configuration['post_type'],
+			__( 'The downloadable content (that is available when the visitor has paid for the ConvertKit product) goes here.', 'convertkit' ),
+			$configuration['restrict_content']
+		);
+
+		// Bail if an error occured.
+		if ( is_wp_error( $page_id ) ) {
+			return $page_id;
+		}
+
+		// Redirect to the Pages WP_List_Table screen, showing the generated page.
+		wp_safe_redirect(
+			add_query_arg(
+				array(
+					's'         => rawurlencode( $configuration['title'] ),
+					'post_type' => $configuration['post_type'],
+				),
+				'edit.php'
+			)
+		);
+		die();
+
+	}
+
+	/**
+	 * Creates multiple WordPress Pages for a course, restricted by
+	 * a ConvertKit Form, Tag or Product, based on the supplied configuration.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   array $configuration  Configuration.
+	 * @return  WP_Error              WP_Error on error, wp_safe_redirect() on success.
+	 */
+	private function create_course( $configuration ) {
+
+		// If here, we need to generate multiple pages.
+		// Build top level Page, which pages will be children of.
+		$parent_page_id = $this->create_page(
+			$configuration['title'],
+			$configuration['description'],
+			$configuration['post_type']
+		);
+
+		// Bail if an error occured.
+		if ( is_wp_error( $parent_page_id ) ) {
+			return $parent_page_id;
+		}
+
+		// Build child Pages.
+		$page_ids = array();
+		for ( $i = 1; $i <= $configuration['number_of_pages']; $i++ ) {
+			$result = $this->create_page(
+				sprintf(
+					'%s: %s/%s',
+					$configuration['title'],
+					$i,
+					$configuration['number_of_pages']
+				), // e.g. Title: 1/10.
+				sprintf(
+					'%s %s',
+					esc_html__( 'Some introductory text about lesson', 'convertkit' ),
+					$i
+				),
+				$configuration['post_type'],
+				sprintf(
+					'%s %s %s',
+					esc_html__( 'Lesson', 'convertkit' ),
+					$i,
+					esc_html__( 'content (that is available when the visitor has paid for the ConvertKit product) goes here.', 'convertkit' )
+				),
+				$configuration['restrict_content'],
+				$i,
+				$configuration['number_of_pages'],
+				$parent_page_id
+			);
+
+			// Bail if an error occured.
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+
+			// Add Page ID to array.
+			$page_ids[] = $result;
+		}
+
+		// Add a link from the parent page to the first child page.
+		$this->add_link_from_parent_to_child_page( $parent_page_id, $page_ids[0] );
+
+		// Redirect to the Pages WP_List_Table screen, showing the generated pages.
+		wp_safe_redirect(
+			add_query_arg(
+				array(
+					's'         => rawurlencode( $configuration['title'] ),
+					'post_type' => $configuration['post_type'],
+				),
+				'edit.php'
+			)
+		);
+		die();
+
+	}
+
+	/**
+	 * Creates a WordPress Page for the given title, restricted to the given restrict content setting.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   string      $title                      Page Title.
+	 * @param   string      $content                    Non-restricted Content.
+	 * @param   string      $post_type                  Post Type.
+	 * @param   bool|string $restricted_content         Restricted Content.
+	 * @param   bool|string $restrict_content_setting   ConvertKit Form, Tag or Product to restrict content to.
+	 * @param   int         $page_number                Page Number.
+	 * @param   int         $total_pages                Total Pages that will be created.
+	 * @param   bool|int    $parent_page_id             Parent Page ID (false if none).
+	 * @return  WP_Error|int                            Error or Page ID
+	 */
+	private function create_page( $title, $content, $post_type = 'page', $restricted_content = false, $restrict_content_setting = false, $page_number = 0, $total_pages = 0, $parent_page_id = false ) {
+
+		// Build content.
+		$content = $this->element_paragraph( $content );
+
+		// If restricted content is defined, append it to the post content using a more block.
+		if ( $restricted_content && $restrict_content_setting ) {
+			$content .= $this->element_more_tag();
+			$content .= $this->element_paragraph( $restricted_content );
+		}
+
+		// Define previous / next links, depending on the page number and total pages.
+		$content .= $this->element_navigation( $page_number, $total_pages );
+
+		// Build arguments to create Page.
+		$args = array(
+			'post_type'    => $post_type,
+			'post_status'  => 'publish',
+			'post_author'  => get_current_user_id(),
+			'post_title'   => $title,
+			'post_content' => $content,
+			'menu_order'   => $page_number,
+		);
+
+		// If a parent page is specified, apply it to the arguments.
+		if ( $parent_page_id !== false ) {
+			$args['post_parent'] = $parent_page_id;
+		}
+
+		// Create Page.
+		$page_id = wp_insert_post( $args, true );
+
+		// Bail if an error occured.
+		if ( is_wp_error( $page_id ) ) {
+			return $page_id;
+		}
+
+		// Define Page's settings, ensuring no default Form displays.
+		// If a restrict content setting was supplied, it's set to the Page now.
+		WP_ConvertKit()->get_class( 'admin_post' )->save_post_settings(
+			$page_id,
+			array(
+				'form'             => '0', // Don't display a Form.
+				'restrict_content' => ( $restrict_content_setting !== false ? $restrict_content_setting : '0' ),
+			)
+		);
+
+		// Return.
+		return $page_id;
+
+	}
+
+	/**
+	 * Returns a paragraph for the given text, depending on if the Classic Editor or Block Editor is used.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   string $text   Text.
+	 * @return  string          Text
+	 */
+	private function element_paragraph( $text ) {
+
+		return '<!-- wp:paragraph --><p>' . $text . '</p><!-- /wp:paragraph -->';
+
+	}
+
+	/**
+	 * Returns the more tag, depending on if the Classic Editor or Block Editor is used.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @return  string  More Tag
+	 */
+	private function element_more_tag() {
+
+		return '<!-- wp:more --><!--more--><!-- /wp:more -->';
+
+	}
+
+	/**
+	 * Returns previous/next links, depending on if the Classic Editor or Block Editor is used.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   int $page_number    Page Number.
+	 * @param   int $total_pages    Total Pages.
+	 * @return  string                  Previous / Next Links
+	 */
+	private function element_navigation( $page_number, $total_pages ) {
+
+		// Assume no previous or next link required.
+		$previous_link = '';
+		$next_link     = '';
+
+		// If the page number is greater than zero, a previous link is required.
+		if ( $page_number > 0 ) {
+			$previous_link = '<!-- wp:post-navigation-link {"type":"previous","label":"Previous Lesson"} /-->';
+		}
+
+		// If the page number is less than the total pages, a next link is required.
+		if ( $page_number < $total_pages ) {
+			$next_link = '<!-- wp:post-navigation-link {"textAlign":"right","label":"Next Lesson"} /-->';
+		}
+
+		// Return a blank string if no previous or next links required.
+		if ( empty( $previous_link ) && empty( $next_link ) ) {
+			return '';
+		}
+
+		// Return links.
+		return '<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column -->
+<div class="wp-block-column">' . $previous_link . '</div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column">' . $next_link . '</div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->';
+
+	}
+
+	/**
+	 * Adds a link from the parent page to the child page.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   int $parent_page_id     Parent Page ID.
+	 * @param   int $child_page_id      Child Page ID.
+	 */
+	private function add_link_from_parent_to_child_page( $parent_page_id, $child_page_id ) {
+
+		// Define button block linking to first child page.
+		$button_block = '<!-- wp:buttons -->
+<div class="wp-block-buttons">
+<!-- wp:button -->
+<div class="wp-block-button">
+<a class="wp-block-button__link" href="' . get_permalink( $child_page_id ) . '">' . __( 'Start Course', 'convertkit' ) . '</a>
+</div>
+<!-- /wp:button -->
+</div>
+<!-- /wp:buttons -->';
+
+		// Fetch parent page's content.
+		$parent_page = get_post( $parent_page_id );
+
+		// Update parent page's content to include a link to the first child page.
+		return wp_update_post(
+			array(
+				'ID'           => $parent_page_id,
+				'post_content' => $parent_page->post_content .= $button_block,
+			),
+			true
+		);
+
+	}
+
+}

--- a/includes/class-convertkit-output-restrict-content.php
+++ b/includes/class-convertkit-output-restrict-content.php
@@ -1,0 +1,709 @@
+<?php
+/**
+ * ConvertKit Output Restrict Content class.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Restricts (or displays) a single Page, Post or Custom Post Type's content
+ * based on the Post's "Restrict Content" configuration.
+ *
+ * @since   2.1.0
+ */
+class ConvertKit_Output_Restrict_Content {
+
+	/**
+	 * Holds the success message to display on screen as a notification.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @var     bool|string
+	 */
+	private $success = false; // @phpstan-ignore-line.
+
+	/**
+	 * Holds the WP_Error object if an API call / authentication failed,
+	 * to display on screen as a notification.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @var     bool|WP_Error
+	 */
+	private $error = false; // @phpstan-ignore-line.
+
+	/**
+	 * Holds the ConvertKit Plugin Settings class
+	 *
+	 * @since   2.1.0
+	 *
+	 * @var     bool|ConvertKit_Settings
+	 */
+	private $settings = false;
+
+	/**
+	 * Holds the ConvertKit Restrict Content Settings class
+	 *
+	 * @since   2.1.0
+	 *
+	 * @var     bool|ConvertKit_Settings_Restrict_Content
+	 */
+	private $restrict_content_settings = false;
+
+	/**
+	 * Holds the ConvertKit Post Settings class
+	 *
+	 * @since   2.1.0
+	 *
+	 * @var     bool|ConvertKit_Post
+	 */
+	private $post_settings = false;
+
+	/**
+	 * Holds the Post ID
+	 *
+	 * @since   2.1.0
+	 *
+	 * @var     bool|int
+	 */
+	private $post_id = false;
+
+	/**
+	 * Holds the ConvertKit API class
+	 *
+	 * @since   2.1.0
+	 *
+	 * @var     bool|ConvertKit_API
+	 */
+	private $api = false;
+
+	/**
+	 * Holds the token returned from calling the subscriber_authentication_send_code API endpoint.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @var     bool|string
+	 */
+	private $token = false;
+
+	/**
+	 * Constructor. Registers actions and filters to possibly limit output of a Page/Post/CPT's
+	 * content on the frontend site.
+	 *
+	 * @since   2.1.0
+	 */
+	public function __construct() {
+
+		// Initialize classes that will be used.
+		$this->settings                  = new ConvertKit_Settings();
+		$this->restrict_content_settings = new ConvertKit_Settings_Restrict_Content();
+
+		add_action( 'init', array( $this, 'maybe_run_subscriber_authentication' ), 1 );
+		add_action( 'init', array( $this, 'maybe_run_subscriber_verification' ), 2 );
+		add_filter( 'the_content', array( $this, 'maybe_restrict_content' ) );
+		add_filter( 'get_previous_post_where', array( $this, 'maybe_change_previous_post_where_clause' ), 10, 5 );
+		add_filter( 'get_next_post_where', array( $this, 'maybe_change_next_post_where_clause' ), 10, 5 );
+		add_filter( 'get_previous_post_sort', array( $this, 'maybe_change_previous_next_post_order_by_clause' ), 10, 3 );
+		add_filter( 'get_next_post_sort', array( $this, 'maybe_change_previous_next_post_order_by_clause' ), 10, 3 );
+
+	}
+
+	/**
+	 * Checks if the request is a Restrict Content login request with an email address,
+	 * calling the API to send the subscriber a magic link by email.
+	 *
+	 * Once they click the link in the email, maybe_run_subscriber_verification() will run.
+	 *
+	 * @since   2.1.0
+	 */
+	public function maybe_run_subscriber_authentication() {
+
+		// Bail if no nonce was specified.
+		if ( ! array_key_exists( '_wpnonce', $_REQUEST ) ) {
+			return;
+		}
+
+		// Bail if the nonce failed validation.
+		if ( ! wp_verify_nonce( sanitize_key( $_REQUEST['_wpnonce'] ), 'convertkit_restrict_content_login' ) ) {
+			$this->error = new WP_Error( 'convertkit_output_restrict_content_error', __( 'Invalid nonce specified. Please try again.', 'convertkit' ) );
+			return;
+		}
+
+		// If the Plugin API keys have not been configured, we can't get this subscriber's ID by email.
+		if ( ! $this->settings->has_api_key_and_secret() ) {
+			return;
+		}
+
+		// Initialize the API.
+		$this->api = new ConvertKit_API( $this->settings->get_api_key(), $this->settings->get_api_secret(), $this->settings->debug_enabled() );
+
+		// Send email to subscriber with a link to authenticate they have access to the email address submitted.
+		$result = $this->api->subscriber_authentication_send_code(
+			sanitize_text_field( $_REQUEST['convertkit_email'] ),
+			$this->get_url()
+		);
+
+		// Bail if an error occured.
+		if ( is_wp_error( $result ) ) {
+			$this->error = $result;
+			return;
+		}
+
+		// Clear any existing subscriber ID cookie, as the authentication flow has started by sending the email.
+		$subscriber = new ConvertKit_Subscriber();
+		$subscriber->forget();
+
+		// Store the token so it's included in the subscriber code form.
+		$this->token = $result;
+
+		// Show a message telling the subscriber to check their email and click the link in the email.
+		$this->success = $this->restrict_content_settings->get_by_key( 'email_check_text' );
+
+	}
+
+	/**
+	 * Checks if the request contains a token and subscriber_code i.e. the subscriber clicked
+	 * the link in the email sent by the maybe_run_subscriber_authentication() function above.
+	 *
+	 * This calls the API to verify the token and subscriber code, which tells us that the email
+	 * address supplied truly belongs to the user, and that we can safely trust their subscriber ID
+	 * to be valid.
+	 *
+	 * @since   2.1.0
+	 */
+	public function maybe_run_subscriber_verification() {
+
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		// Bail if the expected token and subscriber code is missing.
+		if ( ! array_key_exists( 'token', $_REQUEST ) ) {
+			return;
+		}
+		if ( ! array_key_exists( 'subscriber_code', $_REQUEST ) ) {
+			return;
+		}
+
+		// If the Plugin API keys have not been configured, we can't get this subscriber's ID by email.
+		if ( ! $this->settings->has_api_key_and_secret() ) {
+			return;
+		}
+
+		// Store the token so it's included in the subscriber code form if verification fails.
+		$this->token = sanitize_text_field( $_REQUEST['token'] );
+
+		// Initialize the API.
+		$this->api = new ConvertKit_API( $this->settings->get_api_key(), $this->settings->get_api_secret(), $this->settings->debug_enabled() );
+
+		// Verify the token and subscriber code.
+		$subscriber_id = $this->api->subscriber_authentication_verify(
+			sanitize_text_field( $_REQUEST['token'] ),
+			sanitize_text_field( $_REQUEST['subscriber_code'] )
+		);
+		// phpcs:enable
+
+		// Bail if an error occured.
+		if ( is_wp_error( $subscriber_id ) ) {
+			$this->error = $subscriber_id;
+			return;
+		}
+
+		// Store subscriber ID in cookie.
+		// We don't need to use validate_and_store_subscriber_id() as we just validated the subscriber via authentication above.
+		$subscriber = new ConvertKit_Subscriber();
+		$subscriber->set( $subscriber_id );
+
+		// Redirect to the Post without the token and subscriber parameters.
+		// This will then run maybe_restrict_content() to get the subscriber's ID from the cookie,
+		// and determine if the content can be displayed.
+		wp_safe_redirect( $this->get_url() );
+		exit;
+
+	}
+
+	/**
+	 * Displays (or hides) content on a singular Page, Post or Custom Post Type's Content,
+	 * depending on whether the visitor is an authenticated ConvertKit subscriber and has
+	 * subscribed to the ConvertKit Product.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   string $content    Post Content.
+	 * @return  string              Post Content with content restricted/not restricted
+	 */
+	public function maybe_restrict_content( $content ) {
+
+		// Bail if the Restrict Content setting is not enabled on this Page.
+		if ( ! $this->is_restricted_content() ) {
+			return $content;
+		}
+
+		// Get resource type (Product) that the visitor must be subscribed against to access this content.
+		$resource_type = $this->get_resource_type( $this->post_id );
+
+		// Return the Post Content, unedited, if the Resource Type is false.
+		if ( ! $resource_type ) {
+			return $content;
+		}
+
+		// Get resource ID (Product ID) that the visitor must be subscribed against to access this content.
+		$resource_id = $this->get_resource_id( $this->post_id );
+
+		// Return the Post Content, unedited, if the Resource ID is false.
+		if ( ! $resource_id ) {
+			return $content;
+		}
+
+		// Initialize the API.
+		$this->api = new ConvertKit_API( $this->settings->get_api_key(), $this->settings->get_api_secret(), $this->settings->debug_enabled() );
+
+		// Determine if the visitor is subscribed to the given resource type and ID.
+		if ( $this->has_access( $resource_type, $resource_id ) ) {
+			// Visitor is a subscriber to the product.
+			// Show the content.
+			return $content;
+		}
+
+		// Fetch a content preview.
+		$preview_content = $this->get_content_preview( $content );
+
+		// Fetch the restricted content call to action.
+		$call_to_action = $this->get_call_to_action( $this->post_id, $resource_type, $resource_id );
+
+		// Return the preview plus call to action.
+		return $preview_content . $call_to_action;
+
+	}
+
+	/**
+	 * Changes how WordPress' get_adjacent_post() function queries Pages, to determine what
+	 * the previous Page link is when using the Previous navigation block on a Page that
+	 * has the Restrict Content setting defined.
+	 *
+	 * By default, get_adjacent_post() will query by post_date, which we change to menu_order.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   string  $where          The `WHERE` clause in the SQL.
+	 * @param   bool    $in_same_term   Whether post should be in a same taxonomy term.
+	 * @param   array   $excluded_terms Array of excluded term IDs.
+	 * @param   string  $taxonomy       Taxonomy. Used to identify the term used when `$in_same_term` is true.
+	 * @param   WP_Post $post           WP_Post object.
+	 * @return  string                  Modified `WHERE` clause
+	 */
+	public function maybe_change_previous_post_where_clause( $where, $in_same_term, $excluded_terms, $taxonomy, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
+
+		// Bail if the Restrict Content setting is not enabled on this Page.
+		if ( ! $this->is_restricted_content() ) {
+			return $where;
+		}
+
+		// Bail if the Page doesn't match the current Page being viewed, or has no parent Page.
+		if ( ! $this->has_parent_page( $post ) ) {
+			return $where;
+		}
+
+		// Build replacement where statement.
+		$new_where = 'p.post_parent = ' . $post->post_parent . ' AND p.menu_order < ' . $post->menu_order;
+
+		// Replace existing where statement with new statement.
+		$where = 'WHERE ' . $new_where . ' ' . substr( $where, strpos( $where, 'AND' ) );
+
+		// Return.
+		return $where;
+
+	}
+
+	/**
+	 * Changes how WordPress' get_adjacent_post() function queries Pages, to determine what
+	 * the next Page link is when using the Previous navigation block on a Page that
+	 * has the Restrict Content setting defined.
+	 *
+	 * By default, get_adjacent_post() will query by post_date, which we change to menu_order.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   string  $where          The `WHERE` clause in the SQL.
+	 * @param   bool    $in_same_term   Whether post should be in a same taxonomy term.
+	 * @param   array   $excluded_terms Array of excluded term IDs.
+	 * @param   string  $taxonomy       Taxonomy. Used to identify the term used when `$in_same_term` is true.
+	 * @param   WP_Post $post           WP_Post object.
+	 * @return  string                  Modified `WHERE` clause
+	 */
+	public function maybe_change_next_post_where_clause( $where, $in_same_term, $excluded_terms, $taxonomy, $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
+
+		// Bail if the Restrict Content setting is not enabled on this Page.
+		if ( ! $this->is_restricted_content() ) {
+			return $where;
+		}
+
+		// Bail if the Page doesn't match the current Page being viewed, or has no parent Page.
+		if ( ! $this->has_parent_page( $post ) ) {
+			return $where;
+		}
+
+		// Build replacement where statement.
+		$new_where = 'p.post_parent = ' . $post->post_parent . ' AND p.menu_order > ' . $post->menu_order;
+
+		// Replace existing where statement with new statement.
+		$where = 'WHERE ' . $new_where . ' ' . substr( $where, strpos( $where, 'AND' ) );
+
+		// Return.
+		return $where;
+
+	}
+
+	/**
+	 * Changes how WordPress' get_adjacent_post() function orders Pages, to determine what
+	 * the next and previous Page links are when using Previous / Next navigation blocks
+	 * on a Page that has the Restrict Content setting defined.
+	 *
+	 * By default, get_adjacent_post() will sort by Post Date, which we change to Page Order
+	 * (called menu_order in WordPress).
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   string  $order_by   SQL ORDER BY statement.
+	 * @param   WP_Post $post       WordPress Post.
+	 * @param   string  $order      Order.
+	 * @return  string              Modified SQL ORDER BY statement.
+	 */
+	public function maybe_change_previous_next_post_order_by_clause( $order_by, $post, $order ) {
+
+		// Bail if the Restrict Content setting is not enabled on this Page.
+		if ( ! $this->is_restricted_content() ) {
+			return $order_by;
+		}
+
+		// Bail if the Page doesn't match the current Page being viewed, or has no parent Page.
+		if ( ! $this->has_parent_page( $post ) ) {
+			return $order_by;
+		}
+
+		// Order by Page order (menu_order), highest to lowest, instead of post_date.
+		return 'ORDER BY p.menu_order ' . $order . ' LIMIT 1';
+
+	}
+
+	/**
+	 * Returns the URL for the current request, excluding any query parameters.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @return  string  URL.
+	 */
+	private function get_url() {
+
+		$url = wp_parse_url( get_site_url() . $_SERVER['REQUEST_URI'] );
+		return $url['scheme'] . '://' . $url['host'] . $url['path'];
+
+	}
+
+	/**
+	 * Determines if the request is for a WordPress Page that has the Restrict Content
+	 * setting defined.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @return  bool
+	 */
+	private function is_restricted_content() {
+
+		// Bail if not a singular Post Type.
+		if ( ! is_singular() ) {
+			return false;
+		}
+
+		// If a Post ID is already defined in this class, this check has already been performed,
+		// and the Post's settings class has been initialized.
+		if ( $this->post_id ) {
+			return true;
+		}
+
+		// Get Post ID.
+		$this->post_id = get_the_ID();
+
+		// Initialize Settings and Post Setting classes.
+		$this->post_settings = new ConvertKit_Post( $this->post_id );
+
+		// If the Plugin API keys have not been configured, we can't determine the validity of this subscriber ID
+		// or which resource(s) they have access to.
+		if ( ! $this->settings->has_api_key_and_secret() ) {
+			return false;
+		}
+
+		// Return whether the Post's settings are set to restrict content.
+		return $this->post_settings->restrict_content_enabled();
+
+	}
+
+	/**
+	 * Checks if the given WordPress Page matches the Page ID viewed, and has a parent.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   WP_Post $post   WordPress Post.
+	 * @return  bool                Has parent page
+	 */
+	private function has_parent_page( $post ) {
+
+		// Bail if the Page doesn't match the current Page being viewed.
+		// This prevents us accidentally interfering with other previous / next link queries, which shouldn't happen
+		// as we check if we're viewing a restricted content page above.
+		if ( $post->ID !== $this->post_id ) {
+			return false;
+		}
+
+		// Bail if the Page doesn't have a parent Page.
+		// We don't want to modify the default sort behaviour in this instance.
+		if ( $post->post_parent === 0 ) {
+			return false;
+		}
+
+		return true;
+
+	}
+
+	/**
+	 * Get the Post's Restricted Content resource type.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   int $post_id    Post ID.
+	 * @return  bool|string     Resource Type (product).
+	 */
+	private function get_resource_type( $post_id ) {
+
+		// Get resource type.
+		$resource_type = $this->post_settings->get_restrict_content_type();
+
+		/**
+		 * Define the ConvertKit Resource Type that the visitor must be subscribed against
+		 * to access this content, overriding the Post setting.
+		 *
+		 * Return false or an empty string to not restrict content.
+		 *
+		 * @since   2.1.0
+		 *
+		 * @param   string $resource_type   Resource Type (product)
+		 * @param   int    $post_id         Post ID
+		 */
+		$resource_type = apply_filters( 'convertkit_output_restrict_content_get_resource_type', $resource_type, $post_id );
+
+		// If resource type is blank, set it to false.
+		if ( empty( $resource_type ) ) {
+			$resource_type = false;
+		}
+
+		// Return.
+		return $resource_type;
+
+	}
+
+	/**
+	 * Get the Post's Restricted Content resource ID.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   int $post_id    Post ID.
+	 * @return  int             Resource ID (product ID).
+	 */
+	private function get_resource_id( $post_id ) {
+
+		// Get resource ID.
+		$resource_id = $this->post_settings->get_restrict_content_id();
+
+		/**
+		 * Define the ConvertKit Resource ID that the visitor must be subscribed against
+		 * to access this content, overriding the Post setting.
+		 *
+		 * Return 0 to not restrict content.
+		 *
+		 * @since   2.1.0
+		 *
+		 * @param   int    $resource_id     Resource ID
+		 * @param   int    $post_id         Post ID
+		 */
+		$resource_id = apply_filters( 'convertkit_output_restrict_content_get_resource_id', $resource_id, $post_id );
+
+		// Return.
+		return $resource_id;
+
+	}
+
+	/**
+	 * Determines if the given subscriber has an active subscription to
+	 * the given resource and its ID.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   string $resource_type  Resource Type (product).
+	 * @param   int    $resource_id    Resource ID (Product ID).
+	 * @return  bool                    Can view restricted content
+	 */
+	private function has_access( $resource_type, $resource_id ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
+
+		// Get the subscriber ID, either from the request or an existing cookie.
+		$subscriber_id = $this->get_subscriber_id_from_request();
+
+		// If no subscriber ID exists, the visitor cannot view the content.
+		if ( ! $subscriber_id ) {
+			return false;
+		}
+
+		// Initialize the API.
+		$this->api = new ConvertKit_API( $this->settings->get_api_key(), $this->settings->get_api_secret(), $this->settings->debug_enabled() );
+
+		// Depending on the resource type, determine if the subscriber has access to it.
+		// This is deliberately a switch statement, because we will likely add in support
+		// for restrict by tag and form later.
+		switch ( $resource_type ) {
+			case 'product':
+				// Get products that the subscriber has access to.
+				$result = $this->api->profile( $subscriber_id );
+
+				// If an error occured, the subscriber ID is invalid.
+				if ( is_wp_error( $result ) ) {
+					return false;
+				}
+
+				// If no products exist, there's no access.
+				if ( ! $result['products'] || ! count( $result['products'] ) ) {
+					return false;
+				}
+
+				// Return if the subscriber is not subscribed to the product.
+				if ( ! in_array( absint( $resource_id ), $result['products'], true ) ) {
+					return false;
+				}
+
+				// If here, the subscriber is subscribed to the product.
+				return true;
+		}
+
+		// If here, the subscriber does not have access.
+		return false;
+
+	}
+
+	/**
+	 * Gets the subscriber ID from the request (either the cookie or the URL).
+	 *
+	 * @since   2.1.0
+	 *
+	 * @return  int|string   Subscriber ID or Signed ID
+	 */
+	public function get_subscriber_id_from_request() {
+
+		// Use ConvertKit_Subscriber class to fetch and validate the subscriber ID.
+		$subscriber    = new ConvertKit_Subscriber();
+		$subscriber_id = $subscriber->get_subscriber_id();
+
+		// If an error occured, the subscriber ID in the request/cookie is not a valid subscriber.
+		if ( is_wp_error( $subscriber_id ) ) {
+			return 0;
+		}
+
+		return $subscriber_id;
+
+	}
+
+	/**
+	 * Returns a preview of the given content for visitors that don't have access to restricted content.
+	 *
+	 * The preview is determined by:
+	 * - A single <!--more--> tag being placed between WordPress paragraphs when using the Classic Editor.
+	 * Content before the tag will be returned as the preview, unless 'noteaser' is enabled.
+	 * - A single 'Read More' block being placed between WordPress blocks when using the Gutenberg Editor.
+	 * Content before the Read More block will be returned as the preview, unless 'Hide th excerpt
+	 * on the full content page' is enabled.
+	 *
+	 * No preview content is returned if the above conditions are not met.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   string $content    Post Content.
+	 * @return  string              Post Content Preview.
+	 */
+	private function get_content_preview( $content ) {
+
+		global $post;
+
+		// Check if the content contains a <!--more--> tag, which the editor might have placed
+		// in the content through WordPress' Classic Editor.
+		$content_breakdown = get_extended( $content );
+
+		// If the <!-- more --> tag exists, the 'extended' key will contain the restricted content.
+		if ( ! empty( $content_breakdown['extended'] ) ) {
+			// Return the preview content.
+			return $content_breakdown['main'];
+		}
+
+		// Check if the content contains a 'Read More' block, which the editor might have placed
+		// in the content through the Gutenberg Editor.
+		$block_editor_tag = '<span id="more-' . $post->ID . '"></span>';
+		if ( strpos( $content, $block_editor_tag ) !== false ) {
+			// Split content into an array by the tag.
+			$content_breakdown = explode( $block_editor_tag, $content );
+
+			// Return the content before the tag.
+			// If noteaser is enabled, this will correctly be blank.
+			return $content_breakdown[0];
+		}
+
+		// If here, there is no preview content available. Don't return any content.
+		return '';
+
+	}
+
+	/**
+	 * Returns the HTML output for the call to action for visitors not subscribed to the required
+	 * resource type and ID.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   int    $post_id        Post ID.
+	 * @param   string $resource_type  Resource Type (product).
+	 * @param   int    $resource_id    Resource ID (Product ID).
+	 * @return  string                  HTML
+	 */
+	private function get_call_to_action( $post_id, $resource_type, $resource_id ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
+
+		// This is deliberately a switch statement, because we will likely add in support
+		// for restrict by tag and form later.
+		switch ( $resource_type ) {
+			case 'product':
+				// Enqueue styles.
+				wp_enqueue_style( 'convertkit-restrict-content', CONVERTKIT_PLUGIN_URL . 'resources/frontend/css/restrict-content.css', array(), CONVERTKIT_PLUGIN_VERSION );
+
+				// Output product code form if this request is after the user entered their email address.
+				if ( $this->token ) { // phpcs:ignore WordPress.Security.NonceVerification
+					ob_start();
+					include CONVERTKIT_PLUGIN_PATH . '/views/frontend/restrict-content/product-code.php';
+					return trim( ob_get_clean() );
+				}
+
+				// Output product restricted message and email form.
+				// Get Product.
+				$products = new ConvertKit_Resource_Products( 'restrict_content' );
+				$product  = $products->get_by_id( $resource_id );
+
+				// Get commerce.js URL and enqueue.
+				$url = $products->get_commerce_js_url();
+				if ( $url ) {
+					wp_enqueue_script( 'convertkit-commerce', $url, array(), CONVERTKIT_PLUGIN_VERSION, true );
+				}
+
+				// Output.
+				ob_start();
+				$button = $products->get_html( $resource_id, $this->restrict_content_settings->get_by_key( 'subscribe_button_label' ) );
+				include CONVERTKIT_PLUGIN_PATH . '/views/frontend/restrict-content/product.php';
+				return trim( ob_get_clean() );
+
+			default:
+				return '';
+
+		}
+
+	}
+
+}

--- a/includes/class-convertkit-post.php
+++ b/includes/class-convertkit-post.php
@@ -129,6 +129,74 @@ class ConvertKit_Post {
 	}
 
 	/**
+	 * Returns the restrict content setting for the Post, which might be a
+	 * Form, Tag or Product.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @return  string
+	 */
+	public function get_restrict_content() {
+
+		return $this->settings['restrict_content'];
+
+	}
+
+	/**
+	 * Returns the restrict content setting's resource type.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @return  string
+	 */
+	public function get_restrict_content_type() {
+
+		// No type if restrict content isn't enabled on this Post.
+		if ( ! $this->restrict_content_enabled() ) {
+			return '';
+		}
+
+		// No type if the setting isn't of the expected format resource_ID.
+		if ( strpos( $this->settings['restrict_content'], '_' ) === false ) {
+			return '';
+		}
+
+		// Extract resource type from the setting.
+		list( $resource_type, $resource_id ) = explode( '_', $this->settings['restrict_content'] );
+
+		// Return resource type.
+		return $resource_type;
+
+	}
+
+	/**
+	 * Returns the restrict content setting's resource ID.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @return  bool|int
+	 */
+	public function get_restrict_content_id() {
+
+		// No ID if restrict content isn't enabled on this Post.
+		if ( ! $this->restrict_content_enabled() ) {
+			return false;
+		}
+
+		// No ID if the setting isn't of the expected format resource_ID.
+		if ( strpos( $this->settings['restrict_content'], '_' ) === false ) {
+			return false;
+		}
+
+		// Extract resource ID from the setting.
+		list( $resource_type, $resource_id ) = explode( '_', $this->settings['restrict_content'] );
+
+		// Return resource ID.
+		return (int) $resource_id;
+
+	}
+
+	/**
 	 * Whether the Post has a ConvertKit Form defined.
 	 *
 	 * @since   1.9.6
@@ -194,6 +262,19 @@ class ConvertKit_Post {
 	}
 
 	/**
+	 * Whether the Post has a ConvertKit Form, Tag or Product defined for restricted content.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return  bool
+	 */
+	public function restrict_content_enabled() {
+
+		return ! empty( $this->settings['restrict_content'] );
+
+	}
+
+	/**
 	 * Saves Post settings to the Post.
 	 *
 	 * @since   1.9.6
@@ -218,9 +299,10 @@ class ConvertKit_Post {
 	public function get_default_settings() {
 
 		$defaults = array(
-			'form'         => '-1', // -1: Plugin Default Form, 0: No Form, 1+: Specific Form ID on ConvertKit.
-			'landing_page' => '',
-			'tag'          => '',
+			'form'             => '-1', // -1: Plugin Default Form, 0: No Form, 1+: Specific Form ID on ConvertKit.
+			'landing_page'     => '',
+			'tag'              => '',
+			'restrict_content' => '',
 		);
 
 		/**

--- a/includes/class-convertkit-settings-restrict-content.php
+++ b/includes/class-convertkit-settings-restrict-content.php
@@ -74,8 +74,15 @@ class ConvertKit_Settings_Restrict_Content {
 	 */
 	public function get_by_key( $key ) {
 
+		// If the setting doesn't exist, bail.
 		if ( ! array_key_exists( $key, $this->settings ) ) {
 			return '';
+		}
+
+		// If the setting is empty, fallback to the default.
+		if ( empty( $this->settings[ $key ] ) ) {
+			$defaults = $this->get_defaults();
+			return $defaults[ $key ];
 		}
 
 		return $this->settings[ $key ];

--- a/includes/class-convertkit-subscriber.php
+++ b/includes/class-convertkit-subscriber.php
@@ -29,13 +29,13 @@ class ConvertKit_Subscriber {
 	 *
 	 * @since   2.0.0
 	 *
-	 * @return  WP_Error|bool|int    Error | false | Subscriber ID
+	 * @return  WP_Error|bool|int|string    Error | false | Subscriber ID | Signed Subscriber ID
 	 */
 	public function get_subscriber_id() {
 
 		// If the subscriber ID is in the request URI, use it.
 		if ( isset( $_REQUEST[ $this->key ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			return $this->validate_and_store_subscriber_id( absint( $_REQUEST[ $this->key ] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+			return $this->validate_and_store_subscriber_id( sanitize_text_field( $_REQUEST[ $this->key ] ) ); // phpcs:ignore WordPress.Security.NonceVerification
 		}
 
 		// If the subscriber ID is in a cookie, return it.
@@ -56,8 +56,8 @@ class ConvertKit_Subscriber {
 	 *
 	 * @since   2.0.0
 	 *
-	 * @param   int $subscriber_id  Possible Subscriber ID.
-	 * @return  WP_Error|int                    Error | Confirmed Subscriber ID
+	 * @param   int|string $subscriber_id  Possible Subscriber ID or Signed Subscriber ID.
+	 * @return  WP_Error|int|string                 Error | Confirmed Subscriber ID or Signed Subscriber ID
 	 */
 	public function validate_and_store_subscriber_id( $subscriber_id ) {
 
@@ -89,7 +89,7 @@ class ConvertKit_Subscriber {
 		$this->set( $subscriber['id'] );
 
 		// Return subscriber ID.
-		return absint( $subscriber['id'] );
+		return $subscriber['id'];
 
 	}
 
@@ -100,7 +100,7 @@ class ConvertKit_Subscriber {
 	 * @since   2.0.0
 	 *
 	 * @param   string $subscriber_email   Possible Subscriber Email.
-	 * @return  WP_Error|int                        Error | Confirmed Subscriber ID
+	 * @return  WP_Error|int|string                     Error | Confirmed Subscriber ID or Signed Subscriber ID
 	 */
 	public function validate_and_store_subscriber_email( $subscriber_email ) {
 
@@ -132,7 +132,7 @@ class ConvertKit_Subscriber {
 		$this->set( $subscriber['id'] );
 
 		// Return subscriber ID.
-		return absint( $subscriber['id'] );
+		return $subscriber['id'];
 
 	}
 
@@ -143,7 +143,7 @@ class ConvertKit_Subscriber {
 	 */
 	private function get_subscriber_id_from_cookie() {
 
-		return absint( $_COOKIE[ $this->key ] );
+		return $_COOKIE[ $this->key ];
 
 	}
 
@@ -152,7 +152,7 @@ class ConvertKit_Subscriber {
 	 *
 	 * @since   2.0.0
 	 *
-	 * @param   int $subscriber_id  Subscriber ID.
+	 * @param   int|string $subscriber_id  Subscriber ID.
 	 */
 	public function set( $subscriber_id ) {
 

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -139,7 +139,6 @@ class WP_ConvertKit {
 		}
 
 		$this->classes['output']                  = new ConvertKit_Output();
-		$this->classes['output_restrict_content'] = new ConvertKit_Output_Restrict_Content();
 
 		/**
 		 * Initialize integration classes for the frontend web site.

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -64,16 +64,16 @@ class WP_ConvertKit {
 			return;
 		}
 
-		$this->classes['admin_bulk_edit']                     = new ConvertKit_Admin_Bulk_Edit();
-		$this->classes['admin_category']                      = new ConvertKit_Admin_Category();
-		$this->classes['admin_post']                          = new ConvertKit_Admin_Post();
-		$this->classes['admin_quick_edit']                    = new ConvertKit_Admin_Quick_Edit();
-		$this->classes['admin_refresh_resources']             = new ConvertKit_Admin_Refresh_Resources();
-		$this->classes['admin_restrict_content']              = new ConvertKit_Admin_Restrict_Content();
-		$this->classes['admin_settings']                      = new ConvertKit_Admin_Settings();
-		$this->classes['admin_setup_wizard_plugin']           = new ConvertKit_Admin_Setup_Wizard_Plugin();
-		$this->classes['admin_tinymce']                       = new ConvertKit_Admin_TinyMCE();
-		$this->classes['admin_user']                          = new ConvertKit_Admin_User();
+		$this->classes['admin_bulk_edit']           = new ConvertKit_Admin_Bulk_Edit();
+		$this->classes['admin_category']            = new ConvertKit_Admin_Category();
+		$this->classes['admin_post']                = new ConvertKit_Admin_Post();
+		$this->classes['admin_quick_edit']          = new ConvertKit_Admin_Quick_Edit();
+		$this->classes['admin_refresh_resources']   = new ConvertKit_Admin_Refresh_Resources();
+		$this->classes['admin_restrict_content']    = new ConvertKit_Admin_Restrict_Content();
+		$this->classes['admin_settings']            = new ConvertKit_Admin_Settings();
+		$this->classes['admin_setup_wizard_plugin'] = new ConvertKit_Admin_Setup_Wizard_Plugin();
+		$this->classes['admin_tinymce']             = new ConvertKit_Admin_TinyMCE();
+		$this->classes['admin_user']                = new ConvertKit_Admin_User();
 
 		/**
 		 * Initialize integration classes for the WordPress Administration interface.
@@ -138,7 +138,7 @@ class WP_ConvertKit {
 			return;
 		}
 
-		$this->classes['output']                  = new ConvertKit_Output();
+		$this->classes['output'] = new ConvertKit_Output();
 
 		/**
 		 * Initialize integration classes for the frontend web site.

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -64,15 +64,16 @@ class WP_ConvertKit {
 			return;
 		}
 
-		$this->classes['admin_bulk_edit']           = new ConvertKit_Admin_Bulk_Edit();
-		$this->classes['admin_category']            = new ConvertKit_Admin_Category();
-		$this->classes['admin_post']                = new ConvertKit_Admin_Post();
-		$this->classes['admin_quick_edit']          = new ConvertKit_Admin_Quick_Edit();
-		$this->classes['admin_refresh_resources']   = new ConvertKit_Admin_Refresh_Resources();
-		$this->classes['admin_settings']            = new ConvertKit_Admin_Settings();
-		$this->classes['admin_setup_wizard_plugin'] = new ConvertKit_Admin_Setup_Wizard_Plugin();
-		$this->classes['admin_tinymce']             = new ConvertKit_Admin_TinyMCE();
-		$this->classes['admin_user']                = new ConvertKit_Admin_User();
+		$this->classes['admin_bulk_edit']                     = new ConvertKit_Admin_Bulk_Edit();
+		$this->classes['admin_category']                      = new ConvertKit_Admin_Category();
+		$this->classes['admin_post']                          = new ConvertKit_Admin_Post();
+		$this->classes['admin_quick_edit']                    = new ConvertKit_Admin_Quick_Edit();
+		$this->classes['admin_refresh_resources']             = new ConvertKit_Admin_Refresh_Resources();
+		$this->classes['admin_restrict_content']              = new ConvertKit_Admin_Restrict_Content();
+		$this->classes['admin_settings']                      = new ConvertKit_Admin_Settings();
+		$this->classes['admin_setup_wizard_plugin']           = new ConvertKit_Admin_Setup_Wizard_Plugin();
+		$this->classes['admin_tinymce']                       = new ConvertKit_Admin_TinyMCE();
+		$this->classes['admin_user']                          = new ConvertKit_Admin_User();
 
 		/**
 		 * Initialize integration classes for the WordPress Administration interface.
@@ -137,7 +138,8 @@ class WP_ConvertKit {
 			return;
 		}
 
-		$this->classes['output'] = new ConvertKit_Output();
+		$this->classes['output']                  = new ConvertKit_Output();
+		$this->classes['output_restrict_content'] = new ConvertKit_Output_Restrict_Content();
 
 		/**
 		 * Initialize integration classes for the frontend web site.
@@ -159,8 +161,8 @@ class WP_ConvertKit {
 		$this->classes['ajax']                         = new ConvertKit_AJAX();
 		$this->classes['blocks_convertkit_broadcasts'] = new ConvertKit_Block_Broadcasts();
 		$this->classes['blocks_convertkit_content']    = new ConvertKit_Block_Content();
-		$this->classes['blocks_convertkit_product']    = new ConvertKit_Block_Product();
 		$this->classes['blocks_convertkit_form']       = new ConvertKit_Block_Form();
+		$this->classes['blocks_convertkit_product']    = new ConvertKit_Block_Product();
 		$this->classes['elementor']                    = new ConvertKit_Elementor();
 		$this->classes['gutenberg']                    = new ConvertKit_Gutenberg();
 		$this->classes['post_type_product']            = new ConvertKit_Post_Type_Product();

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -64,16 +64,17 @@ class WP_ConvertKit {
 			return;
 		}
 
-		$this->classes['admin_bulk_edit']           = new ConvertKit_Admin_Bulk_Edit();
-		$this->classes['admin_category']            = new ConvertKit_Admin_Category();
-		$this->classes['admin_post']                = new ConvertKit_Admin_Post();
-		$this->classes['admin_quick_edit']          = new ConvertKit_Admin_Quick_Edit();
-		$this->classes['admin_refresh_resources']   = new ConvertKit_Admin_Refresh_Resources();
-		$this->classes['admin_restrict_content']    = new ConvertKit_Admin_Restrict_Content();
-		$this->classes['admin_settings']            = new ConvertKit_Admin_Settings();
-		$this->classes['admin_setup_wizard_plugin'] = new ConvertKit_Admin_Setup_Wizard_Plugin();
-		$this->classes['admin_tinymce']             = new ConvertKit_Admin_TinyMCE();
-		$this->classes['admin_user']                = new ConvertKit_Admin_User();
+		$this->classes['admin_bulk_edit']                     = new ConvertKit_Admin_Bulk_Edit();
+		$this->classes['admin_category']                      = new ConvertKit_Admin_Category();
+		$this->classes['admin_post']                          = new ConvertKit_Admin_Post();
+		$this->classes['admin_quick_edit']                    = new ConvertKit_Admin_Quick_Edit();
+		$this->classes['admin_refresh_resources']             = new ConvertKit_Admin_Refresh_Resources();
+		$this->classes['admin_restrict_content']              = new ConvertKit_Admin_Restrict_Content();
+		$this->classes['admin_settings']                      = new ConvertKit_Admin_Settings();
+		$this->classes['admin_setup_wizard_plugin']           = new ConvertKit_Admin_Setup_Wizard_Plugin();
+		$this->classes['admin_setup_wizard_restrict_content'] = new ConvertKit_Admin_Setup_Wizard_Restrict_Content();
+		$this->classes['admin_tinymce']                       = new ConvertKit_Admin_TinyMCE();
+		$this->classes['admin_user']                          = new ConvertKit_Admin_User();
 
 		/**
 		 * Initialize integration classes for the WordPress Administration interface.
@@ -138,7 +139,8 @@ class WP_ConvertKit {
 			return;
 		}
 
-		$this->classes['output'] = new ConvertKit_Output();
+		$this->classes['output']                  = new ConvertKit_Output();
+		$this->classes['output_restrict_content'] = new ConvertKit_Output_Restrict_Content();
 
 		/**
 		 * Initialize integration classes for the frontend web site.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -126,6 +126,32 @@ function convertkit_get_supported_post_types() {
 }
 
 /**
+ * Helper method to get supported Post Types for Restricted Content (Member's Content)
+ *
+ * @since   2.1.0
+ *
+ * @return  array   Post Types
+ */
+function convertkit_get_supported_restrict_content_post_types() {
+
+	$post_types = array(
+		'page',
+	);
+
+	/**
+	 * Defines the Post Types that support Restricted Content / Members Content functionality.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @param   array   $post_types     Post Types
+	 */
+	$post_types = apply_filters( 'convertkit_get_supported_restrict_content_post_types', $post_types );
+
+	return $post_types;
+
+}
+
+/**
  * Helper method to get registered Shortcodes.
  *
  * @since   1.9.6.5

--- a/resources/backend/js/restrict-content.js
+++ b/resources/backend/js/restrict-content.js
@@ -1,0 +1,35 @@
+/**
+ * Restrict Content
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Displays and hides form fields on the Restrict Content setup screen depending
+ * on other form field options that have been selected.
+ *
+ * @since 	2.1.0
+ */
+jQuery( document ).ready(
+	function( $ ) {
+
+		$( 'input[name=type]' ).on(
+			'change',
+			function( e ) {
+
+				// For all type radio buttons, hide elements with a class matching the value.
+				$( 'input[name=type]' ).each(
+					function() {
+						$( 'div.' + $( this ).val() ).hide();
+					}
+				);
+
+				// For the selected radio button, show elements with a class matching the value.
+				$( 'div.' + $( 'input[name=type]:checked' ).val() ).show();
+
+			}
+		).trigger( 'change' );
+
+	}
+);

--- a/resources/backend/js/wp-list-table-buttons.js
+++ b/resources/backend/js/wp-list-table-buttons.js
@@ -1,0 +1,31 @@
+/**
+ * Moves any buttons added from the filter list in a WP_List_Table
+ * to be displayed next to the "Add New" button.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+jQuery( document ).ready(
+	function( $ ) {
+
+		// Move any buttons from the filter list to display next to the Add New button.
+		$( 'ul.subsubsub a' ).each(
+			function() {
+
+				// Ignore if not a ConvertKit Group Action.
+				if ( ! $( this ).hasClass( 'convertkit-action' ) ) {
+					return;
+				}
+
+				// Move.
+				$( this ).clone().removeClass( 'hidden' ).insertAfter( 'a.page-title-action' );
+
+				// Remove original.
+				$( this ).parent().remove();
+
+			}
+		);
+
+	}
+);

--- a/resources/frontend/css/restrict-content.css
+++ b/resources/frontend/css/restrict-content.css
@@ -1,0 +1,77 @@
+#convertkit-restrict-content {
+	background: #f6f8fa;
+	box-shadow: 0 2px 5px #0000000d;
+	color: #373f45;
+	margin: 30px 0;
+	padding: 40px 30px 30px 30px;
+	border: 1px solid #EDF2F4;
+	text-align: center;
+	box-sizing: border-box;
+}
+#convertkit-restrict-content * {
+	box-sizing: border-box;
+}
+#convertkit-restrict-content p, #convertkit-restrict-content div {
+	margin: 0 0 20px 0;
+	padding: 0;
+}
+
+#convertkit-restrict-content .convertkit-restrict-content-actions {
+	margin: 0;
+}
+#convertkit-restrict-content .convertkit-restrict-content-actions p:last-child {
+	margin: 0;
+}
+#convertkit-restrict-content .convertkit-restrict-content-actions hr {
+	margin: 0 0 20px 0;
+	padding: 0;
+	width: 100%;
+	height: 1px;
+	border: none;
+	background: #EDF2F4;
+}
+#convertkit-restrict-content .convertkit-restrict-content-actions .convertkit-product a {
+	display: inline-block;
+}
+
+#convertkit-restrict-content .convertkit-restrict-content-notice {
+	margin: 0 0 20px 0;
+	padding: 10px;
+}
+#convertkit-restrict-content .convertkit-restrict-content-notice-success {
+	background: #daf7e1;
+}
+#convertkit-restrict-content .convertkit-restrict-content-notice-error {
+	background: #f7dada;
+}
+
+#convertkit-restrict-content input[type=email], #convertkit-restrict-content input[type=text] {
+	display: inline-block;
+	width: 75%;
+	height: 48px;
+	margin: 0;
+	padding: 0 10px;
+	border: 1px solid #949494;
+	font-family: inherit;
+}
+#convertkit-restrict-content input#convertkit_subscriber_code {
+	width: 100%;
+	margin-bottom: 20px;
+	font-size: 24px;
+}
+#convertkit-restrict-content #convertkit-restrict-content input[type=submit] {
+	display: inline-block;
+	border: none;
+}
+
+@media screen and (max-width: 450px) {
+	#convertkit-restrict-content {
+		padding: 0;
+	}
+	#convertkit-restrict-content .convertkit-restrict-content-actions {
+		padding: 10px;
+	}
+	#convertkit-restrict-content input[type=email], #convertkit-restrict-content input[type=text], #convertkit-restrict-content input#convertkit_subscriber_code {
+		width: 100%;
+	}
+}

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -193,13 +193,6 @@ class Plugin extends \Codeception\Module
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Check the value of the fields match the inputs provided.
-		if ( $settings ) {
-			foreach ( $settings as $key => $value ) {
-				$I->seeInField('_wp_convertkit_settings_restrict_content[' . $key . ']', $value);
-			}
-		}
 	}
 
 	/**
@@ -484,6 +477,24 @@ class Plugin extends \Codeception\Module
 	}
 
 	/**
+	 * Returns the expected default settings for Restricted Content.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @return  array
+	 */
+	public function getRestrictedContentDefaultSettings()
+	{
+		return array(
+			'subscribe_text'         => 'This content is only available to premium subscribers',
+			'subscribe_button_label' => 'Subscribe',
+			'email_text'             => 'Already a premium subscriber? Enter the email address used when purchasing below, to receive a login link to access.',
+			'email_button_label'     => 'Send email',
+			'email_check_text'       => 'Check your email and click the link to login, or enter the code from the email below.',
+		);
+	}
+
+	/**
 	 * Creates a Page in the database with the given title for restricted content.
 	 *
 	 * The Page's content comprises of a mix of visible and member's only content.
@@ -521,6 +532,158 @@ class Plugin extends \Codeception\Module
 				],
 			]
 		);
+	}
+
+	/**
+	 * Run frontend tests for restricted content, to confirm that visible and member's content
+	 * is / is not displayed when logging in with valid and invalid subscriber email addresses.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I                  Tester.
+	 * @param   string|int       $urlOrPageID        URL or ID of Restricted Content Page.
+	 * @param   string           $visibleContent     Content that should always be visible.
+	 * @param   string           $memberContent      Content that should only be available to authenticated subscribers.
+	 * @param   bool|array       $textItems          Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 */
+	public function testRestrictedContentOnFrontend($I, $urlOrPageID, $visibleContent = 'Visible content.', $memberContent = 'Member only content.', $textItems = false)
+	{
+		// Define expected text and labels if not supplied.
+		if ( ! $textItems ) {
+			$textItems = array(
+				'subscribe_text'         => 'This content is only available to premium subscribers',
+				'subscribe_button_label' => 'Subscribe',
+				'email_text'             => 'Already a premium subscriber? Enter the email address used when purchasing below, to receive a login link to access.',
+				'email_button_label'     => 'Send email',
+				'email_check_text'       => 'Check your email and click the link to login, or enter the code from the email below.',
+			);
+		}
+
+		// Navigate to the page.
+		if ( is_numeric( $urlOrPageID ) ) {
+			$I->amOnPage('?p=' . $urlOrPageID);
+		} else {
+			$I->amOnUrl($urlOrPageID);
+		}
+
+		// Check content is / is not displayed, and CTA displays with expected text.
+		$this->testRestrictContentHidesContentWithCTA($I, $visibleContent, $memberContent, $textItems);
+
+		// Login as a ConvertKit subscriber who does not exist in ConvertKit.
+		$I->waitForElementVisible('input#convertkit_email');
+		$I->fillField('convertkit_email', 'fail@convertkit.com');
+		$I->click('input.wp-block-button__link');
+
+		// Check content is / is not displayed, and CTA displays with expected text.
+		$I->see('Email address is invalid'); // Response from the API.
+		$this->testRestrictContentHidesContentWithCTA($I, $visibleContent, $memberContent, $textItems);
+
+		// Login as a ConvertKit subscriber who has subscribed to the product.
+		$I->waitForElementVisible('input#convertkit_email');
+		$I->fillField('convertkit_email', $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']);
+		$I->click('input.wp-block-button__link');
+
+		// Confirm that confirmation an email has been sent is displayed.
+		$this->testRestrictContentShowsEmailCodeForm($I, $visibleContent, $memberContent);
+
+		// Set cookie with signed subscriber ID, as if we entered the code sent in the email.
+		$I->setCookie('ck_subscriber_id', $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID']);
+
+		// Reload the restricted content page.
+		if ( is_numeric( $urlOrPageID ) ) {
+			$I->amOnPage('?p=' . $urlOrPageID);
+		} else {
+			$I->amOnUrl($urlOrPageID);
+		}
+
+		// Confirm cookie was set with the expected value.
+		$I->assertEquals($I->grabCookie('ck_subscriber_id'), $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID']);
+
+		// Confirm that the restricted content is now displayed, as we've authenticated as a subscriber
+		// who has access to this Product.
+		$I->testRestrictContentDisplaysContent($I, $visibleContent, $memberContent);
+	}
+
+	/**
+	 * Run frontend tests for restricted content, to confirm that:
+	 * - visible content is displayed,
+	 * - member's content is not displayed,
+	 * - the CTA is displayed with the expected text
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I                  Tester.
+	 * @param   string           $visibleContent     Content that should always be visible.
+	 * @param   string           $memberContent      Content that should only be available to authenticated subscribers.
+	 * @param   bool|array       $textItems          Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 */
+	public function testRestrictContentHidesContentWithCTA($I, $visibleContent = 'Visible content.', $memberContent = 'Member only content.', $textItems = false)
+	{
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the visible text displays, hidden text does not display and the CTA displays.
+		$I->see($visibleContent);
+		$I->dontSee($memberContent);
+
+		// Confirm that the CTA displays with the expected text.
+		$I->seeElementInDOM('#convertkit-restrict-content');
+		$I->see($textItems['subscribe_text']);
+		$I->see($textItems['subscribe_button_label']);
+		$I->see($textItems['email_text']);
+		$I->seeInSource('<input type="submit" class="wp-block-button__link wp-block-button__link" value="' . $textItems['email_button_label'] . '">');
+	}
+
+	/**
+	 * Run frontend tests for restricted content, to confirm that:
+	 * - visible content is displayed,
+	 * - member's content is not displayed,
+	 * - the email code form is displayed with the expected text.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I                  Tester.
+	 * @param   string           $visibleContent     Content that should always be visible.
+	 * @param   string           $memberContent      Content that should only be available to authenticated subscribers.
+	 */
+	public function testRestrictContentShowsEmailCodeForm($I, $visibleContent = 'Visible content.', $memberContent = 'Member only content.')
+	{
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the visible text displays, hidden text does not display and the CTA displays.
+		$I->see($visibleContent);
+		$I->dontSee($memberContent);
+
+		// Confirm that the CTA displays with the expected text.
+		$I->seeElementInDOM('#convertkit-restrict-content');
+		$I->seeElementInDOM('input#convertkit_subscriber_code');
+		$I->seeElementInDOM('input.wp-block-button__link');
+	}
+
+	/**
+	 * Run frontend tests for restricted content, to confirm that:
+	 * - visible content is displayed,
+	 * - member's content is displayed,
+	 * - the CTA is not displayed
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I                  Tester.
+	 * @param   string           $visibleContent     Content that should always be visible.
+	 * @param   string           $memberContent      Content that should only be available to authenticated subscribers.
+	 */
+	public function testRestrictContentDisplaysContent($I, $visibleContent = 'Visible content.', $memberContent = 'Member only content.')
+	{
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the visible and hidden text displays.
+		$I->see($visibleContent);
+		$I->see($memberContent);
+
+		// Confirm that the CTA is not displayed.
+		$I->dontSeeElementInDOM('#convertkit-restrict-content');
 	}
 
 	/**

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -484,6 +484,46 @@ class Plugin extends \Codeception\Module
 	}
 
 	/**
+	 * Creates a Page in the database with the given title for restricted content.
+	 *
+	 * The Page's content comprises of a mix of visible and member's only content.
+	 * The default form setting is set to 'None'.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I                          Tester.
+	 * @param   string           $title                      Title.
+	 * @param   string           $visibleContent             Content that should always be visible.
+	 * @param   string           $memberContent              Content that should only be available to authenticated subscribers.
+	 * @param   string           $restrictContentSetting     Restrict Content setting.
+	 * @return  int                                          Page ID.
+	 */
+	public function createRestrictedContentPage($I, $title, $visibleContent = 'Visible content.', $memberContent = 'Member only content.', $restrictContentSetting = '')
+	{
+		return $I->havePostInDatabase(
+			[
+				'post_type'    => 'page',
+				'post_title'   => $title,
+
+				// Emulate Gutenberg content with visible and members only content sections.
+				'post_content' => '<!-- wp:paragraph --><p>' . $visibleContent . '</p><!-- /wp:paragraph -->
+<!-- wp:more --><!--more--><!-- /wp:more -->
+<!-- wp:paragraph -->' . $memberContent . '<!-- /wp:paragraph -->',
+
+				// Don't display a Form on this Page, so we test against Restrict Content's Form.
+				'meta_input'   => [
+					'_wp_convertkit_post_meta' => [
+						'form'             => '-1',
+						'landing_page'     => '',
+						'tag'              => '',
+						'restrict_content' => $restrictContentSetting,
+					],
+				],
+			]
+		);
+	}
+
+	/**
 	 * Check that expected HTML exists in the DOM of the page we're viewing for
 	 * a Product block or shortcode, and that the button loads the expected
 	 * ConvertKit Product modal.

--- a/tests/_support/Helper/Acceptance/WPClassicEditor.php
+++ b/tests/_support/Helper/Acceptance/WPClassicEditor.php
@@ -49,7 +49,7 @@ class WPClassicEditor extends \Codeception\Module
 		// Scroll to the applicable TinyMCE editor.
 		switch ($targetEditor) {
 			case 'excerpt':
-				$I->scrollTo('#postexcerpt');
+				$I->scrollTo('#postcustom');
 				break;
 			default:
 				$I->scrollTo('h1.wp-heading-inline');

--- a/tests/_support/Helper/Acceptance/WPClassicEditor.php
+++ b/tests/_support/Helper/Acceptance/WPClassicEditor.php
@@ -116,7 +116,7 @@ class WPClassicEditor extends \Codeception\Module
 		// Scroll to the applicable TinyMCE editor.
 		switch ($targetEditor) {
 			case 'excerpt':
-				$I->scrollTo('#postexcerpt');
+				$I->scrollTo('#postcustom');
 				break;
 			default:
 				$I->scrollTo('h1.wp-heading-inline');

--- a/tests/_support/Helper/Acceptance/WPClassicEditor.php
+++ b/tests/_support/Helper/Acceptance/WPClassicEditor.php
@@ -49,7 +49,7 @@ class WPClassicEditor extends \Codeception\Module
 		// Scroll to the applicable TinyMCE editor.
 		switch ($targetEditor) {
 			case 'excerpt':
-				$I->scrollTo('#postcustom');
+				$I->scrollTo('#tagsdiv-product_tag');
 				break;
 			default:
 				$I->scrollTo('h1.wp-heading-inline');
@@ -116,7 +116,7 @@ class WPClassicEditor extends \Codeception\Module
 		// Scroll to the applicable TinyMCE editor.
 		switch ($targetEditor) {
 			case 'excerpt':
-				$I->scrollTo('#postcustom');
+				$I->scrollTo('#tagsdiv-product_tag');
 				break;
 			default:
 				$I->scrollTo('h1.wp-heading-inline');

--- a/tests/_support/Helper/Acceptance/WPGutenberg.php
+++ b/tests/_support/Helper/Acceptance/WPGutenberg.php
@@ -78,6 +78,9 @@ class WPGutenberg extends \Codeception\Module
 		$I->seeElementInDOM('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
 		$I->click('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
 
+		// Close block inserter.
+		$I->click('button.edit-post-header-toolbar__inserter-toggle');
+
 		// If a Block configuration is specified, apply it to the Block now.
 		if ($blockConfiguration) {
 			$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
@@ -113,8 +116,9 @@ class WPGutenberg extends \Codeception\Module
 	 */
 	public function addGutenbergParagraphBlock($I, $text)
 	{
+		$I->addGutenbergBlock($I, 'Paragraph', 'paragraph');
 		$I->click('.is-root-container');
-		$I->fillField('.is-root-container p', $text);
+		$I->fillField('.is-root-container p[data-empty="true"]', $text);
 	}
 
 	/**
@@ -223,6 +227,29 @@ class WPGutenberg extends \Codeception\Module
 	 */
 	public function publishAndViewGutenbergPage($I)
 	{
+		// Publish Gutenberg Page.
+		$url = $I->publishGutenbergPage($I);
+
+		// Load the Page on the frontend site.
+		$I->amOnUrl($url);
+
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible('body');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+	}
+
+	/**
+	 * Publish a Page, Post or Custom Post Type initiated by the addGutenbergPage() function,
+	 * returning the published URL.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I                      Acceptance Tester.
+	 */
+	public function publishGutenbergPage($I)
+	{
 		// Click the Publish button.
 		$I->click('.editor-post-publish-button__button');
 
@@ -237,13 +264,7 @@ class WPGutenberg extends \Codeception\Module
 		// Wait for confirmation that the Page published.
 		$I->waitForElementVisible('.post-publish-panel__postpublish-buttons a.components-button');
 
-		// Load the Page on the frontend site.
-		$I->click('.post-publish-panel__postpublish-buttons a.components-button');
-
-		// Wait for frontend web site to load.
-		$I->waitForElementVisible('body');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Return URL from 'View page' button.
+		return $I->grabAttributeFrom('.post-publish-panel__postpublish-buttons a.components-button', 'href');
 	}
 }

--- a/tests/acceptance/general/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/general/RefreshResourcesButtonCest.php
@@ -36,7 +36,7 @@ class RefreshResourcesButtonCest
 	}
 
 	/**
-	 * Test that the refresh buttons for Forms, Landing Pages and Tags works when adding a new Page.
+	 * Test that the refresh buttons for Forms, Landing Pages, Tags and Restrict Content works when adding a new Page.
 	 *
 	 * @since   1.9.8.0
 	 *
@@ -79,6 +79,16 @@ class RefreshResourcesButtonCest
 		// Change resource to value specified in the .env file, which should now be available.
 		// If the expected dropdown value does not exist in the Select2 field, this will fail the test.
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-tag-container', $_ENV['CONVERTKIT_API_TAG_NAME']);
+
+		// Click the Restrict Content refresh button.
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="products"]');
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="products"]:not(:disabled)');
+
+		// Change resource to value specified in the .env file, which should now be available.
+		// If the expected dropdown value does not exist in the Select2 field, this will fail the test.
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-restrict_content-container', $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
 	}
 
 	/**
@@ -120,6 +130,16 @@ class RefreshResourcesButtonCest
 		// Change resource to value specified in the .env file, which should now be available.
 		// If the expected dropdown value does not exist, this will fail the test.
 		$I->selectOption('#wp-convertkit-quick-edit-tag', $_ENV['CONVERTKIT_API_TAG_NAME']);
+
+		// Click the Products refresh button.
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="products"]');
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="products"]:not(:disabled)');
+
+		// Change resource to value specified in the .env file, which should now be available.
+		// If the expected dropdown value does not exist, this will fail the test.
+		$I->selectOption('#wp-convertkit-quick-edit-restrict_content', $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
 	}
 
 	/**
@@ -169,6 +189,16 @@ class RefreshResourcesButtonCest
 		// Change resource to value specified in the .env file, which should now be available.
 		// If the expected dropdown value does not exist, this will fail the test.
 		$I->selectOption('#wp-convertkit-bulk-edit-tag', $_ENV['CONVERTKIT_API_TAG_NAME']);
+
+		// Click the Products refresh button.
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="products"]');
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="products"]:not(:disabled)');
+
+		// Change resource to value specified in the .env file, which should now be available.
+		// If the expected dropdown value does not exist, this will fail the test.
+		$I->selectOption('#wp-convertkit-bulk-edit-restrict_content', $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
 	}
 
 	/**
@@ -256,9 +286,8 @@ class RefreshResourcesButtonCest
 		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
 
 		// Confirm that an error notification is displayed on screen, with the expected error message.
-
 		$I->seeElementInDOM('div.components-notice-list div.is-error');
-		$I->see('Authorization Failed: API Key not valid');
+		$I->see('API Key not valid');
 
 		// Confirm that the notice is dismissible.
 		$I->click('div.components-notice-list div.is-error button.components-notice__dismiss');
@@ -299,7 +328,7 @@ class RefreshResourcesButtonCest
 
 		// Confirm that an error notification is displayed on screen, with the expected error message.
 		$I->seeElementInDOM('div.convertkit-error');
-		$I->see('Authorization Failed: API Key not valid');
+		$I->see('API Key not valid');
 
 		// Confirm that the notice is dismissible.
 		$I->click('div.convertkit-error button.notice-dismiss');
@@ -348,7 +377,7 @@ class RefreshResourcesButtonCest
 
 		// Confirm that an error notification is displayed on screen, with the expected error message.
 		$I->seeElementInDOM('div.convertkit-error');
-		$I->see('Authorization Failed: API Key not valid');
+		$I->see('API Key not valid');
 
 		// Confirm that the notice is dismissible.
 		$I->click('div.convertkit-error button.notice-dismiss');
@@ -405,7 +434,7 @@ class RefreshResourcesButtonCest
 
 		// Confirm that an error notification is displayed on screen, with the expected error message.
 		$I->seeElementInDOM('div.convertkit-error');
-		$I->see('Authorization Failed: API Key not valid');
+		$I->see('API Key not valid');
 
 		// Confirm that the notice is dismissible.
 		$I->click('div.convertkit-error button.notice-dismiss');
@@ -446,7 +475,7 @@ class RefreshResourcesButtonCest
 
 		// Confirm that an error notification is displayed on screen, with the expected error message.
 		$I->seeElementInDOM('div.convertkit-error');
-		$I->see('Authorization Failed: API Key not valid');
+		$I->see('API Key not valid');
 
 		// Confirm that the notice is dismissible.
 		$I->click('div.convertkit-error button.notice-dismiss');
@@ -491,7 +520,7 @@ class RefreshResourcesButtonCest
 
 		// Confirm that an error notification is displayed on screen, with the expected error message.
 		$I->seeElementInDOM('div.convertkit-error');
-		$I->see('Authorization Failed: API Key not valid');
+		$I->see('API Key not valid');
 
 		// Confirm that the notice is dismissible.
 		$I->click('div.convertkit-error button.notice-dismiss');

--- a/tests/acceptance/restrict-content/RestrictContentFilterCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentFilterCest.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Tests the filter dropdown for Restrict Content in the Pages WP_List_Table.
+ *
+ * @since   2.1.0
+ */
+class RestrictContentFilterCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		// Activate ConvertKit plugin.
+		$I->activateConvertKitPlugin($I);
+
+	}
+
+	/**
+	 * Test that no dropdown filter on the Pages screen is displayed when no API keys are configured.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testNoFilterDisplayedWhenNoAPIKeys(AcceptanceTester $I)
+	{
+		// Navigate to Pages.
+		$I->amOnAdminPage('edit.php?post_type=page');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check no filter is displayed, as the Plugin isn't configured.
+		$I->dontSeeElementInDOM('#wp-convertkit-restrict-content-filter');
+
+	}
+
+	/**
+	 * Test that no dropdown filter on the Pages screen is displayed when the ConvertKit
+	 * account has no Forms, Tag and Products.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testNoFilterDisplayedWhenNoResources(AcceptanceTester $I)
+	{
+		// Setup Plugin using API keys that have no resources.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
+		$I->enableDebugLog($I);
+
+		// Navigate to Pages.
+		$I->amOnAdminPage('edit.php?post_type=page');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check no filter is displayed, as the ConvertKit account has no resources.
+		$I->dontSeeElementInDOM('#wp-convertkit-restrict-content-filter');
+	}
+
+	/**
+	 * Test that filtering by Product works on the Pages screen.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFilterByProduct(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
+
+		// Create Page, set to restrict content to a Product.
+		$I->createRestrictedContentPage(
+			$I,
+			'ConvertKit: Page: Restricted Content: Product: Filter Test',
+			'Visible content.',
+			'Member only content.',
+			'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+		);
+
+		// Navigate to Pages.
+		$I->amOnAdminPage('edit.php?post_type=page');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Page is listed, and has the 'ConvertKit Member Content' label.
+		$I->see('ConvertKit: Page: Restricted Content: Product: Filter Test');
+		$I->see('ConvertKit Member Content');
+
+		// Filter by Product.
+		$I->selectOption('#wp-convertkit-restrict-content-filter', $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
+		$I->click('Filter');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Page is still listed, and has the 'ConvertKit Member Content' label.
+		$I->see('ConvertKit: Page: Restricted Content: Product: Filter Test');
+		$I->see('ConvertKit Member Content');
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
+	}
+}

--- a/tests/acceptance/restrict-content/RestrictContentProductCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentProductCest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Tests Restrict Content by Product functionality.
+ *
+ * @since   2.1.0
+ */
+class RestrictContentProductCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		// Activate and Setup ConvertKit plugin.
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
+	}
+
+	/**
+	 * Test that restricting content by a Product specified in the Page Settings works when
+	 * creating and viewing a new WordPress Page.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentByProduct(AcceptanceTester $I)
+	{
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Restrict Content: Product');
+
+		// Configure metabox's Restrict Content setting = Tag name.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form'             => [ 'select2', 'None' ],
+				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+			]
+		);
+
+		// Add blocks.
+		$I->addGutenbergParagraphBlock($I, 'Visible content.');
+		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergParagraphBlock($I, 'Member only content.');
+
+		// Publish Page.
+		$url = $I->publishGutenbergPage($I);
+	}
+
+	/**
+	 * Test that restricting content by a Product specified in the Page Settings works when
+	 * using the Quick Edit functionality.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentByProductUsingQuickEdit(AcceptanceTester $I)
+	{
+		// Programmatically create a Page.
+		$pageID = $I->createRestrictedContentPage($I, 'ConvertKit: Page: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Quick Edit');
+
+		// Quick Edit the Page in the Pages WP_List_Table.
+		$I->quickEdit(
+			$I,
+			'page',
+			$pageID,
+			[
+				'restrict_content' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+			]
+		);
+	}
+
+	/**
+	 * Test that restricting content by a Product specified in the Page Settings works when
+	 * using the Bulk Edit functionality.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentByProductUsingBulkEdit(AcceptanceTester $I)
+	{
+		// Programmatically create two Pages.
+		$pageIDs = array(
+			$I->createRestrictedContentPage($I, 'ConvertKit: Page: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Bulk Edit #1'),
+			$I->createRestrictedContentPage($I, 'ConvertKit: Page: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Bulk Edit #2'),
+		);
+
+		// Bulk Edit the Pages in the Pages WP_List_Table.
+		$I->bulkEdit(
+			$I,
+			'page',
+			$pageIDs,
+			[
+				'restrict_content' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+			]
+		);
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->resetCookie('ck_subscriber_id');
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
+	}
+}

--- a/tests/acceptance/restrict-content/RestrictContentProductCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentProductCest.php
@@ -51,6 +51,14 @@ class RestrictContentProductCest
 
 		// Publish Page.
 		$url = $I->publishGutenbergPage($I);
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentOnFrontend(
+			$I,
+			$url,
+			'Visible content.',
+			'Member only content.'
+		);
 	}
 
 	/**
@@ -75,6 +83,9 @@ class RestrictContentProductCest
 				'restrict_content' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			]
 		);
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentOnFrontend($I, $pageID);
 	}
 
 	/**
@@ -102,6 +113,13 @@ class RestrictContentProductCest
 				'restrict_content' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			]
 		);
+
+		// Iterate through Pages to run frontend tests.
+		foreach ($pageIDs as $pageID) {
+			// Test Restrict Content functionality.
+			$I->testRestrictedContentOnFrontend($I, $pageID);
+			$I->resetCookie('ck_subscriber_id');
+		}
 	}
 
 	/**

--- a/tests/acceptance/restrict-content/RestrictContentSettingsCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentSettingsCest.php
@@ -30,8 +30,30 @@ class RestrictContentSettingsCest
 	 */
 	public function testSaveDefaultSettings(AcceptanceTester $I)
 	{
+		// Define visible and member only content.
+		$visibleContent = 'Visible content.';
+		$memberContent  = 'Member only content.';
+
 		// Save settings.
 		$I->setupConvertKitPluginRestrictContent($I);
+
+		// Confirm default values were saved and display in the form fields.
+		$defaults = $I->getRestrictedContentDefaultSettings();
+		foreach ( $defaults as $key => $value ) {
+			$I->seeInField('_wp_convertkit_settings_restrict_content[' . $key . ']', $value);
+		}
+
+		// Create Restricted Content Page.
+		$pageID = $I->createRestrictedContentPage(
+			$I,
+			'ConvertKit: Restrict Content: Settings',
+			$visibleContent,
+			$memberContent,
+			'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+		);
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentOnFrontend($I, $pageID, $visibleContent, $memberContent);
 	}
 
 	/**
@@ -44,6 +66,10 @@ class RestrictContentSettingsCest
 	 */
 	public function testSaveBlankSettings(AcceptanceTester $I)
 	{
+		// Define visible and member only content.
+		$visibleContent = 'Visible content.';
+		$memberContent  = 'Member only content.';
+
 		// Define settings.
 		$settings = array(
 			'subscribe_text'         => '',
@@ -55,6 +81,24 @@ class RestrictContentSettingsCest
 
 		// Save settings.
 		$I->setupConvertKitPluginRestrictContent($I, $settings);
+
+		// Confirm default values were saved and display in the form fields.
+		$defaults = $I->getRestrictedContentDefaultSettings();
+		foreach ( $defaults as $key => $value ) {
+			$I->seeInField('_wp_convertkit_settings_restrict_content[' . $key . ']', $value);
+		}
+
+		// Create Restricted Content Page.
+		$pageID = $I->createRestrictedContentPage(
+			$I,
+			'ConvertKit: Restrict Content: Settings: Blank',
+			$visibleContent,
+			$memberContent,
+			'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+		);
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentOnFrontend($I, $pageID, $visibleContent, $memberContent);
 	}
 
 	/**
@@ -67,6 +111,10 @@ class RestrictContentSettingsCest
 	 */
 	public function testSaveSettings(AcceptanceTester $I)
 	{
+		// Define visible and member only content.
+		$visibleContent = 'Visible content.';
+		$memberContent  = 'Member only content.';
+
 		// Define settings.
 		$settings = array(
 			'subscribe_text'         => 'Subscribe Text',
@@ -78,6 +126,23 @@ class RestrictContentSettingsCest
 
 		// Save settings.
 		$I->setupConvertKitPluginRestrictContent($I, $settings);
+
+		// Confirm custom values were saved and display in the form fields.
+		foreach ( $settings as $key => $value ) {
+			$I->seeInField('_wp_convertkit_settings_restrict_content[' . $key . ']', $value);
+		}
+
+		// Create Restricted Content Page.
+		$pageID = $I->createRestrictedContentPage(
+			$I,
+			'ConvertKit: Restrict Content: Settings: Custom',
+			$visibleContent,
+			$memberContent,
+			'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+		);
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentOnFrontend($I, $pageID, $visibleContent, $memberContent, $settings);
 	}
 
 	/**

--- a/tests/acceptance/restrict-content/RestrictContentSetupCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentSetupCest.php
@@ -1,0 +1,255 @@
+<?php
+/**
+ * Tests Restrict Content's Setup functionality.
+ *
+ * @since   2.1.0
+ */
+class RestrictContentSetupCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		// Activate ConvertKit Plugin.
+		$I->activateConvertKitPlugin($I);
+	}
+
+	/**
+	 * Test that the Add New Member Content button does not display on the Pages screen when no API keys are configured.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewMemberContentButtonNotDisplayedWhenNoAPIKeys(AcceptanceTester $I)
+	{
+		// Navigate to Pages.
+		$I->amOnAdminPage('edit.php?post_type=page');
+
+		// Check the button isn't displayed.
+		$I->dontSeeElementInDOM('a.convertkit-action page-title-action');
+	}
+
+	/**
+	 * Test that the Add New Member Content button does not display on the Pages screen when the ConvertKit
+	 * account has no Forms, Tag and Products.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewMemberContentButtonNotDisplayedWhenNoResources(AcceptanceTester $I)
+	{
+		// Setup Plugin using API keys that have no resources.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
+		$I->enableDebugLog($I);
+
+		// Navigate to Pages.
+		$I->amOnAdminPage('edit.php?post_type=page');
+
+		// Check the button isn't displayed.
+		$I->dontSeeElementInDOM('a.convertkit-action page-title-action');
+	}
+
+	/**
+	 * Test that the Add New Member Content > Exit wizard link returns to the Pages screen.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewMemberContentExitWizardLink(AcceptanceTester $I)
+	{
+		// Setup Plugin and navigate to Add New Member Content screen.
+		$this->_setupAndLoadAddNewMemberContentScreen($I);
+
+		// Click Exit wizard link.
+		$I->click('Exit wizard');
+
+		// Confirm exit.
+		$I->acceptPopup();
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm the Pages screen is displayed.
+		$I->see('Pages');
+		$I->see('Add New Member Content');
+	}
+
+	/**
+	 * Test that the Add New Member Content > Downloads generates the expected Pages.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewMemberContentDownloads(AcceptanceTester $I)
+	{
+		// Setup Plugin and navigate to Add New Member Content screen.
+		$this->_setupAndLoadAddNewMemberContentScreen($I);
+
+		// Click Downloads button.
+		$I->click('Download');
+
+		// Confirm the Configure Download screen is displayed.
+		$I->see('Configure Download');
+
+		// Enter a title and description.
+		$I->fillField('title', 'ConvertKit: Member Content: Download');
+		$I->fillField('description', 'Visible content.');
+
+		// Confirm that the limit option is not visible, as this is only for courses.
+		$I->dontSee('How many lessons does this course consist of?');
+
+		// Restrict by Product.
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-restrict_content-container', $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
+
+		// Click submit button.
+		$I->click('Submit');
+
+		// Confirm that one Page is listed in the WP_List_Table.
+		$I->see('ConvertKit: Member Content: Download');
+		$I->seeInSource('<span class="post-state">ConvertKit Member Content</span>');
+
+		// Hover mouse over Post's table row.
+		$I->moveMouseOver('tr.iedit');
+
+		// Get link to Page.
+		$url = $I->grabAttributeFrom('tr.iedit span.view a', 'href');
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentOnFrontend(
+			$I,
+			$url,
+			'Visible content.',
+			'The downloadable content (that is available when the visitor has paid for the ConvertKit product) goes here.'
+		);
+	}
+
+	/**
+	 * Test that the Add New Member Content > Course generates the expected Pages.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewMemberContentCourse(AcceptanceTester $I)
+	{
+		// Setup Plugin and navigate to Add New Member Content screen.
+		$this->_setupAndLoadAddNewMemberContentScreen($I);
+
+		// Click Course button.
+		$I->click('Course');
+
+		// Confirm the Configure Course screen is displayed.
+		$I->see('Configure Course');
+
+		// Enter a title, description and lesson count.
+		$I->fillField('title', 'ConvertKit: Member Content: Course');
+		$I->fillField('description', 'Visible content.');
+		$I->fillField('number_of_pages', '3');
+
+		// Restrict by Product.
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-restrict_content-container', $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
+
+		// Click submit button.
+		$I->click('Submit');
+
+		// Confirm that four Pages are listed in the WP_List_Table.
+		$I->see('ConvertKit: Member Content: Course');
+		$I->see('— ConvertKit: Member Content: Course: 1/3');
+		$I->see('— ConvertKit: Member Content: Course: 2/3');
+		$I->see('— ConvertKit: Member Content: Course: 3/3');
+		$I->see('ConvertKit Member Content | Parent Page: ConvertKit: Member Content: Course');
+
+		// Hover mouse over Post's table row.
+		$I->moveMouseOver('tr.iedit:first-child');
+
+		// Wait for View link to be visible.
+		$I->waitForElementVisible('tr.iedit:first-child span.view a');
+
+		// Click View link.
+		$I->click('tr.iedit:first-child span.view a');
+
+		// Confirm the Start Course button exists.
+		$I->see('Start Course');
+
+		// Get URL to first restricted content page.
+		$url = $I->grabAttributeFrom('.wp-block-button a', 'href');
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentOnFrontend(
+			$I,
+			$url,
+			'Some introductory text about lesson 1',
+			'Lesson 1 content (that is available when the visitor has paid for the ConvertKit product) goes here.'
+		);
+
+		// Test Next / Previous links.
+		$I->click('Next Lesson');
+		$I->see('ConvertKit: Member Content: Course: 2/3');
+		$I->see('Some introductory text about lesson 2');
+		$I->see('Lesson 2 content (that is available when the visitor has paid for the ConvertKit product) goes here');
+
+		$I->click('Next Lesson');
+		$I->see('ConvertKit: Member Content: Course: 3/3');
+		$I->see('Some introductory text about lesson 3');
+		$I->see('Lesson 3 content (that is available when the visitor has paid for the ConvertKit product) goes here');
+
+		$I->click('Previous Lesson');
+		$I->see('ConvertKit: Member Content: Course: 2/3');
+		$I->see('Some introductory text about lesson 2');
+		$I->see('Lesson 2 content (that is available when the visitor has paid for the ConvertKit product) goes here');
+
+		$I->click('Previous Lesson');
+		$I->see('ConvertKit: Member Content: Course: 1/3');
+		$I->see('Some introductory text about lesson 1');
+		$I->see('Lesson 1 content (that is available when the visitor has paid for the ConvertKit product) goes here');
+	}
+
+	/**
+	 * Sets up the ConvertKit Plugin, and starts the Setup Wizard for Member Content.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	private function _setupAndLoadAddNewMemberContentScreen(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->enableDebugLog($I);
+
+		// Navigate to Pages.
+		$I->amOnAdminPage('edit.php?post_type=page');
+
+		// Click Add New Member Content button.
+		$I->click('Add New Member Content');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		// Clear cookies for next request.
+		$I->resetCookie('ck_subscriber_id');
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
+	}
+}

--- a/views/backend/post/bulk-edit.php
+++ b/views/backend/post/bulk-edit.php
@@ -69,7 +69,46 @@
 		<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Tags from ConvertKit account', 'convertkit' ); ?>" data-resource="tags" data-field="#wp-convertkit-bulk-edit-tag">
 			<span class="dashicons dashicons-update"></span>
 		</button>
-		<?php wp_nonce_field( 'wp-convertkit-save-meta', 'wp-convertkit-save-meta-nonce' ); ?>
 	</div>
-</div>
 
+	<!-- Restrict Content -->
+	<div>
+		<label for="wp-convertkit-bulk-edit-restrict_content">
+			<span class="title"><?php esc_html_e( 'Member', 'convertkit' ); ?></span>
+			<select name="wp-convertkit[restrict_content]" id="wp-convertkit-bulk-edit-restrict_content" size="1">
+				<?php
+				// For Bulk Edit, the 'No Change' value is -1. However, because this Plugin has historically used -1
+				// to mean that the Default form for the Post Type should be displayed, using -1 as 'No Change' in Bulk Edit
+				// would result in Posts/Pages having (or not having) the Form setting updated, when the user may/may not
+				// have selected the 'Default' option.
+				// Therefore, we use -2 to denote 'No Change', even though this setting is for the Tag, so we're at least consistent.
+				?>
+				<option value="-2"><?php esc_html_e( '— No Change —', 'convertkit' ); ?></option>
+				<option value="0">
+					<?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?>
+				</option>
+
+				<?php
+				// Products.
+				if ( $convertkit_products->exist() ) {
+					?>
+					<optgroup label="<?php esc_attr_e( 'Products', 'convertkit' ); ?>">
+						<?php
+						foreach ( $convertkit_products->get() as $product ) {
+							?>
+							<option value="product_<?php echo esc_attr( $product['id'] ); ?>">
+								<?php echo esc_attr( $product['name'] ); ?>
+							</option>
+							<?php
+						}
+						?>
+					</optgroup>
+					<?php
+				}
+				?>
+			</select>
+		</label>
+	</div>
+
+	<?php wp_nonce_field( 'wp-convertkit-save-meta', 'wp-convertkit-save-meta-nonce' ); ?>
+</div>

--- a/views/backend/post/bulk-edit.php
+++ b/views/backend/post/bulk-edit.php
@@ -83,8 +83,8 @@
 				// have selected the 'Default' option.
 				// Therefore, we use -2 to denote 'No Change', even though this setting is for the Tag, so we're at least consistent.
 				?>
-				<option value="-2"><?php esc_html_e( '— No Change —', 'convertkit' ); ?></option>
-				<option value="0">
+				<option value="-2" data-preserve-on-refresh="1"><?php esc_html_e( '— No Change —', 'convertkit' ); ?></option>
+				<option value="0" data-preserve-on-refresh="1">
 					<?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?>
 				</option>
 
@@ -108,6 +108,9 @@
 				?>
 			</select>
 		</label>
+		<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Products from ConvertKit account', 'convertkit' ); ?>" data-resource="products" data-field="#wp-convertkit-bulk-edit-restrict_content">
+			<span class="dashicons dashicons-update"></span>
+		</button>
 	</div>
 
 	<?php wp_nonce_field( 'wp-convertkit-save-meta', 'wp-convertkit-save-meta-nonce' ); ?>

--- a/views/backend/post/meta-box.php
+++ b/views/backend/post/meta-box.php
@@ -152,6 +152,47 @@
 				</div>
 			</td>
 		</tr>
+
+		<tr valign="top">
+			<th scope="row">
+				<label for="wp-convertkit-restrict_content"><?php esc_html_e( 'Member Content', 'convertkit' ); ?></label>
+			</th>
+			<td>
+				<div class="convertkit-select2-container convertkit-select2-container-grid">
+					<?php
+					if ( ! $convertkit_products->exist() ) {
+						esc_html_e( 'No products exist in ConvertKit.', 'convertkit' );
+					} else {
+						?>
+						<select name="wp-convertkit[restrict_content]" id="wp-convertkit-restrict_content" class="convertkit-select2">
+							<option value="0"<?php selected( '', $convertkit_post->get_restrict_content() ); ?> data-preserve-on-refresh="1">
+								<?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?>
+							</option>
+
+							<optgroup label="<?php esc_attr_e( 'Products', 'convertkit' ); ?>">
+								<?php
+								foreach ( $convertkit_products->get() as $product ) {
+									?>
+									<option value="product_<?php echo esc_attr( $product['id'] ); ?>"<?php selected( 'product_' . $product['id'], $convertkit_post->get_restrict_content() ); ?>>
+										<?php echo esc_attr( $product['name'] ); ?>
+									</option>
+									<?php
+								}
+								?>
+							</optgroup>
+						</select>
+						<?php
+					}
+					?>
+					<button class="wp-convertkit-refresh-resources" class="button button-secondary hide-if-no-js" title="<?php esc_attr_e( 'Refresh Products Pages from ConvertKit account', 'convertkit' ); ?>" data-resource="products" data-field="#wp-convertkit-restrict_content">
+						<span class="dashicons dashicons-update"></span>
+					</button>
+					<p class="description">
+						<?php esc_html_e( 'Select the ConvertKit product that the visitor must be subscribed to, permitting them access to view this members only content.', 'convertkit' ); ?>
+					</p>
+				</div>
+			</td>
+		</tr>
 	</tbody>
 </table>
 

--- a/views/backend/post/meta-box.php
+++ b/views/backend/post/meta-box.php
@@ -159,16 +159,14 @@
 			</th>
 			<td>
 				<div class="convertkit-select2-container convertkit-select2-container-grid">
-					<?php
-					if ( ! $convertkit_products->exist() ) {
-						esc_html_e( 'No products exist in ConvertKit.', 'convertkit' );
-					} else {
-						?>
-						<select name="wp-convertkit[restrict_content]" id="wp-convertkit-restrict_content" class="convertkit-select2">
-							<option value="0"<?php selected( '', $convertkit_post->get_restrict_content() ); ?> data-preserve-on-refresh="1">
-								<?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?>
-							</option>
+					<select name="wp-convertkit[restrict_content]" id="wp-convertkit-restrict_content" class="convertkit-select2">
+						<option value="0"<?php selected( '', $convertkit_post->get_restrict_content() ); ?> data-preserve-on-refresh="1">
+							<?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?>
+						</option>
 
+						<?php
+						if ( $convertkit_products->exist() ) {
+							?>
 							<optgroup label="<?php esc_attr_e( 'Products', 'convertkit' ); ?>">
 								<?php
 								foreach ( $convertkit_products->get() as $product ) {
@@ -180,10 +178,10 @@
 								}
 								?>
 							</optgroup>
-						</select>
-						<?php
-					}
-					?>
+							<?php
+						}
+						?>
+					</select>
 					<button class="wp-convertkit-refresh-resources" class="button button-secondary hide-if-no-js" title="<?php esc_attr_e( 'Refresh Products Pages from ConvertKit account', 'convertkit' ); ?>" data-resource="products" data-field="#wp-convertkit-restrict_content">
 						<span class="dashicons dashicons-update"></span>
 					</button>

--- a/views/backend/post/quick-edit.php
+++ b/views/backend/post/quick-edit.php
@@ -60,7 +60,7 @@
 		<label for="wp-convertkit-quick-edit-restrict_content">
 			<span class="title"><?php esc_html_e( 'Member', 'convertkit' ); ?></span>
 			<select name="wp-convertkit[restrict_content]" id="wp-convertkit-quick-edit-restrict_content" size="1">
-				<option value="0">
+				<option value="0" data-preserve-on-refresh="1">
 					<?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?>
 				</option>
 
@@ -84,6 +84,9 @@
 				?>
 			</select>
 		</label>
+		<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Products from ConvertKit account', 'convertkit' ); ?>" data-resource="products" data-field="#wp-convertkit-quick-edit-restrict_content">
+			<span class="dashicons dashicons-update"></span>
+		</button>
 	</div>
 
 	<?php wp_nonce_field( 'wp-convertkit-save-meta', 'wp-convertkit-save-meta-nonce' ); ?>

--- a/views/backend/post/quick-edit.php
+++ b/views/backend/post/quick-edit.php
@@ -53,7 +53,38 @@
 		<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Tags from ConvertKit account', 'convertkit' ); ?>" data-resource="tags" data-field="#wp-convertkit-quick-edit-tag">
 			<span class="dashicons dashicons-update"></span>
 		</button>
-		<?php wp_nonce_field( 'wp-convertkit-save-meta', 'wp-convertkit-save-meta-nonce' ); ?>
 	</div>
-</div>
 
+	<!-- Restrict Content -->
+	<div>
+		<label for="wp-convertkit-quick-edit-restrict_content">
+			<span class="title"><?php esc_html_e( 'Member', 'convertkit' ); ?></span>
+			<select name="wp-convertkit[restrict_content]" id="wp-convertkit-quick-edit-restrict_content" size="1">
+				<option value="0">
+					<?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?>
+				</option>
+
+				<?php
+				// Products.
+				if ( $convertkit_products->exist() ) {
+					?>
+					<optgroup label="<?php esc_attr_e( 'Products', 'convertkit' ); ?>">
+						<?php
+						foreach ( $convertkit_products->get() as $product ) {
+							?>
+							<option value="product_<?php echo esc_attr( $product['id'] ); ?>">
+								<?php echo esc_attr( $product['name'] ); ?>
+							</option>
+							<?php
+						}
+						?>
+					</optgroup>
+					<?php
+				}
+				?>
+			</select>
+		</label>
+	</div>
+
+	<?php wp_nonce_field( 'wp-convertkit-save-meta', 'wp-convertkit-save-meta-nonce' ); ?>
+</div>

--- a/views/backend/post/wp-list-table-filter.php
+++ b/views/backend/post/wp-list-table-filter.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Outputs a dropdown filter comprising of Forms, Tags and Products
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+?>
+<select name="convertkit_restrict_content" id="wp-convertkit-restrict-content-filter">
+	<option value="0">
+		<?php esc_html_e( 'All content', 'convertkit' ); ?>
+	</option>
+
+	<?php
+	// Products.
+	if ( $this->products->exist() ) {
+		?>
+		<optgroup label="<?php esc_attr_e( 'Products', 'convertkit' ); ?>">
+			<?php
+			foreach ( $this->products->get() as $product ) {
+				?>
+				<option value="product_<?php echo esc_attr( $product['id'] ); ?>"<?php selected( 'product_' . $product['id'], $this->restrict_content_filter ); ?>>
+					<?php echo esc_attr( $product['name'] ); ?>
+				</option>
+				<?php
+			}
+			?>
+		</optgroup>
+		<?php
+	}
+	?>
+</select>

--- a/views/backend/setup-wizard/convertkit-restrict-content-setup/content-1.php
+++ b/views/backend/setup-wizard/convertkit-restrict-content-setup/content-1.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Outputs the content for the Restrict Content Setup Wizard > Setup step.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+?>
+
+<h1><?php esc_html_e( 'Member Content', 'convertkit' ); ?></h1>
+<p>
+	<?php
+	echo sprintf(
+		/* translators: Link to ConvertKit Products */
+		esc_html__( 'This will generate content that visitors can access once they purchase a %s.', 'convertkit' ),
+		sprintf(
+			'<a href="%1$s" target="_blank">%2$s</a>',
+			esc_attr( 'https://app.convertkit.com/products' ),
+			esc_html__( 'ConvertKit product', 'convertkit' )
+		)
+	);
+	?>
+</p>
+
+<hr />
+
+<h2><?php esc_html_e( 'What type of content are you offering?', 'convertkit' ); ?></h2>
+
+<div class="convertkit-setup-wizard-grid">
+	<div>
+		<a href="<?php echo esc_attr( $this->download_url ); ?>" class="button button-primary">
+			<?php esc_html_e( 'Download', 'convertkit' ); ?>
+		</a>
+		<span class="description">
+			<?php esc_html_e( 'Require visitors to purchase a ConvertKit product, granting access to a single Page\'s content, which includes downloadable assets.', 'convertkit' ); ?>
+		</span>
+	</div>
+
+	<div>
+		<a href="<?php echo esc_attr( $this->course_url ); ?>" class="button button-primary">
+			<?php esc_html_e( 'Course', 'convertkit' ); ?>
+		</a>
+		<span class="description">
+			<?php esc_html_e( 'Require visitors to purchase a ConvertKit product, granting access to a sequential series of Pages, such as a course, lessons or tutorials.', 'convertkit' ); ?>
+		</span>
+	</div>
+</div>

--- a/views/backend/setup-wizard/convertkit-restrict-content-setup/content-2.php
+++ b/views/backend/setup-wizard/convertkit-restrict-content-setup/content-2.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Outputs the content for the Restrict Content Setup Wizard > Configure step.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+?>
+
+<h1>
+	<?php
+	echo sprintf(
+		/* translators: Type of content (download, course) */
+		esc_html__( 'Configure %s', 'convertkit' ),
+		esc_html( $this->type_label )
+	);
+	?>
+</h1>
+
+<hr />
+
+<div>
+	<label for="title">
+		<?php esc_html_e( 'What is the name of the content?', 'convertkit' ); ?>
+	</label>
+	<input type="text" name="title" id="title" class="widefat" placeholder="<?php esc_attr_e( 'e.g. Free PDF, Macro Photography Course', 'convertkit' ); ?>" required />
+	<input type="hidden" name="type" value="<?php echo esc_attr( $this->type ); ?>" />
+</div>
+
+<div>
+	<label for="description">
+		<?php esc_html_e( 'Describe the content for non-members.', 'convertkit' ); ?>
+	</label>
+	<textarea name="description" id="description" class="widefat" required></textarea>
+	<p class="description"><?php esc_html_e( 'This will be displayed above product\'s call to action button.', 'convertkit' ); ?></p>
+</div>
+
+<?php
+if ( $this->type === 'course' ) {
+	?>
+	<div class="course">
+		<div>
+			<label for="number_of_pages">
+				<?php esc_html_e( 'How many lessons does this course consist of?', 'convertkit' ); ?>
+			</label>
+			<input type="number" name="number_of_pages" min="1" max="99" step="1" id="number_of_pages" value="3" required />
+		</div>
+	</div>
+	<?php
+}
+?>
+
+<div>
+	<label for="wp-convertkit-restrict_content">
+		<?php esc_html_e( 'The ConvertKit Product the visitor must purchase to see the content.', 'convertkit' ); ?>
+	</label>
+
+	<div class="convertkit-select2-container">
+		<select name="restrict_content" id="wp-convertkit-restrict_content" class="convertkit-select2 widefat">
+			<?php
+			// Products.
+			if ( $this->products->exist() ) {
+				?>
+				<optgroup label="<?php esc_attr_e( 'Products', 'convertkit' ); ?>">
+					<?php
+					foreach ( $this->products->get() as $product ) {
+						?>
+						<option value="product_<?php echo esc_attr( $product['id'] ); ?>">
+							<?php echo esc_attr( $product['name'] ); ?>
+						</option>
+						<?php
+					}
+					?>
+				</optgroup>
+				<?php
+			}
+			?>
+		</select>
+	</div>
+</div>

--- a/views/frontend/restrict-content/notices.php
+++ b/views/frontend/restrict-content/notices.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Outputs success / error notices in the restrict content call to action.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+// If a success message exists, show it now.
+if ( $this->success !== false ) {
+	?>
+	<div class="convertkit-restrict-content-notice convertkit-restrict-content-notice-success">
+		<?php echo esc_html( $this->success ); ?>
+	</div>
+	<?php
+}
+
+// If an error occured, show it now.
+if ( is_wp_error( $this->error ) ) {
+	?>
+	<div class="convertkit-restrict-content-notice convertkit-restrict-content-notice-error">
+		<?php echo esc_html( $this->error->get_error_message() ); ?>
+	</div>
+	<?php
+}

--- a/views/frontend/restrict-content/product-code.php
+++ b/views/frontend/restrict-content/product-code.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Outputs the subscriber code form, where the user can enter
+ * the six digit code sent to their email after using the login
+ * form, confirming they own the email address entered.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+?>
+
+<div id="convertkit-restrict-content">
+	<?php
+	require 'notices.php';
+	?>
+
+	<div class="convertkit-restrict-content-actions">
+		<form class="convertkit-restrict-content-subscriber-code" action="<?php echo esc_attr( add_query_arg( array( 'convertkit_login' => 1 ), get_permalink( $post_id ) ) ); ?>" method="post">
+			<div>
+				<input type="text" name="subscriber_code" id="convertkit_subscriber_code" inputmode="numeric" pattern="[0-9]{6}" autocomplete="one-time-code" value="" placeholder="<?php esc_attr_e( 'Email Code', 'convertkit' ); ?>" />
+
+				<input type="submit" class="wp-block-button__link" value="<?php esc_html_e( 'Verify', 'convertkit' ); ?>" />
+
+				<input type="hidden" name="token" value="<?php echo esc_attr( $this->token ); ?>" />
+
+				<?php wp_nonce_field( 'convertkit_restrict_content_subscriber_code' ); ?>
+			</div>
+		</form>
+	</div>
+</div>

--- a/views/frontend/restrict-content/product.php
+++ b/views/frontend/restrict-content/product.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Outputs the restricted content product message,
+ * and a form for the subscriber to enter their
+ * email address if they've already subscribed
+ * to the ConvertKit Product.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+?>
+
+<div id="convertkit-restrict-content">
+	<?php
+	require 'notices.php';
+	?>
+
+	<div class="convertkit-restrict-content-actions">
+		<p><?php echo esc_html( $this->restrict_content_settings->get_by_key( 'subscribe_text' ) ); ?></p>
+
+		<?php
+		echo $button; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		?>
+
+		<hr />
+
+		<p>
+			<?php
+			echo esc_html( $this->restrict_content_settings->get_by_key( 'email_text' ) );
+			?>
+		</p>
+
+		<form class="convertkit-restrict-content-login" action="<?php echo esc_attr( add_query_arg( array( 'convertkit_login' => 1 ), get_permalink( $post_id ) ) ); ?>#convertkit-restrict-content" method="post">
+			<div>
+				<input type="email" name="convertkit_email" id="convertkit_email" value="" placeholder="example@convertkit.com" />
+			</div>
+			<div>
+				<input type="submit" class="wp-block-button__link wp-block-button__link" value="<?php echo esc_attr( $this->restrict_content_settings->get_by_key( 'email_button_label' ) ); ?>" />
+
+				<?php wp_nonce_field( 'convertkit_restrict_content_login' ); ?>
+			</div>
+		</form>
+	</div>
+</div>

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -109,6 +109,7 @@ if ( is_admin() ) {
 	require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php';
 
 	// Restrict Content Integration.
+	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-restrict-content.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-settings-restrict-content.php';
 }
 

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -48,6 +48,7 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-wp-convertkit.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-ajax.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-gutenberg.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-output.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-output-restrict-content.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-post.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-post-type-product.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-preview-output.php';
@@ -111,6 +112,7 @@ if ( is_admin() ) {
 	// Restrict Content Integration.
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-restrict-content.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-settings-restrict-content.php';
+	require_once CONVERTKIT_PLUGIN_PATH . '/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php';
 }
 
 // Register Plugin activation and deactivation functions.


### PR DESCRIPTION
## Summary

(See [here](https://n7studios-workspace.slack.com/archives/C02KFR6N1GF/p1672416207059939?thread_ts=1670631223.079979&cid=C02KFR6N1GF) for several videos demonstrating Restrict Content functionality; it may be useful to view these for context prior to reviewing PRs individually)

Adds options to:

Assign a WordPress Page to a ConvertKit Product
<img width="1307" alt="Screenshot 2022-12-30 at 14 48 48" src="https://user-images.githubusercontent.com/1462305/210082906-914bb6fc-067b-436b-b973-4af93626fc49.png">

Filter the administration list of Pages by ConvertKit Product
Display a label in the administration list of Pages for Pages restricted to a ConvertKit Product
<img width="1302" alt="Screenshot 2022-12-30 at 14 48 29" src="https://user-images.githubusercontent.com/1462305/210082900-c68b37e8-2f05-461e-abfd-7d8319a11444.png">

## Testing

- `RestrictContentFilterCest`: Tests to confirm that filtering Pages by ConvertKit Product works
- `RestrictContentProductCest`: Tests to confirm that assigning Pages to a ConvertKit Product works

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)