### PR TITLE
Restrict Content: Refresh Products Button

### DIFF
--- a/tests/_support/Helper/Acceptance/WPClassicEditor.php
+++ b/tests/_support/Helper/Acceptance/WPClassicEditor.php
@@ -49,7 +49,7 @@ class WPClassicEditor extends \Codeception\Module
 		// Scroll to the applicable TinyMCE editor.
 		switch ($targetEditor) {
 			case 'excerpt':
-				$I->scrollTo('#postcustom');
+				$I->scrollTo('#tagsdiv-product_tag');
 				break;
 			default:
 				$I->scrollTo('h1.wp-heading-inline');
@@ -116,7 +116,7 @@ class WPClassicEditor extends \Codeception\Module
 		// Scroll to the applicable TinyMCE editor.
 		switch ($targetEditor) {
 			case 'excerpt':
-				$I->scrollTo('#postcustom');
+				$I->scrollTo('#tagsdiv-product_tag');
 				break;
 			default:
 				$I->scrollTo('h1.wp-heading-inline');

--- a/tests/acceptance/general/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/general/RefreshResourcesButtonCest.php
@@ -36,7 +36,7 @@ class RefreshResourcesButtonCest
 	}
 
 	/**
-	 * Test that the refresh buttons for Forms, Landing Pages and Tags works when adding a new Page.
+	 * Test that the refresh buttons for Forms, Landing Pages, Tags and Restrict Content works when adding a new Page.
 	 *
 	 * @since   1.9.8.0
 	 *
@@ -79,6 +79,16 @@ class RefreshResourcesButtonCest
 		// Change resource to value specified in the .env file, which should now be available.
 		// If the expected dropdown value does not exist in the Select2 field, this will fail the test.
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-tag-container', $_ENV['CONVERTKIT_API_TAG_NAME']);
+
+		// Click the Restrict Content refresh button.
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="products"]');
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="products"]:not(:disabled)');
+
+		// Change resource to value specified in the .env file, which should now be available.
+		// If the expected dropdown value does not exist in the Select2 field, this will fail the test.
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-restrict_content-container', $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
 	}
 
 	/**
@@ -120,6 +130,16 @@ class RefreshResourcesButtonCest
 		// Change resource to value specified in the .env file, which should now be available.
 		// If the expected dropdown value does not exist, this will fail the test.
 		$I->selectOption('#wp-convertkit-quick-edit-tag', $_ENV['CONVERTKIT_API_TAG_NAME']);
+
+		// Click the Products refresh button.
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="products"]');
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="products"]:not(:disabled)');
+
+		// Change resource to value specified in the .env file, which should now be available.
+		// If the expected dropdown value does not exist, this will fail the test.
+		$I->selectOption('#wp-convertkit-quick-edit-restrict_content', $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
 	}
 
 	/**
@@ -169,6 +189,16 @@ class RefreshResourcesButtonCest
 		// Change resource to value specified in the .env file, which should now be available.
 		// If the expected dropdown value does not exist, this will fail the test.
 		$I->selectOption('#wp-convertkit-bulk-edit-tag', $_ENV['CONVERTKIT_API_TAG_NAME']);
+
+		// Click the Products refresh button.
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="products"]');
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="products"]:not(:disabled)');
+
+		// Change resource to value specified in the .env file, which should now be available.
+		// If the expected dropdown value does not exist, this will fail the test.
+		$I->selectOption('#wp-convertkit-bulk-edit-restrict_content', $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
 	}
 
 	/**
@@ -256,9 +286,8 @@ class RefreshResourcesButtonCest
 		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
 
 		// Confirm that an error notification is displayed on screen, with the expected error message.
-
 		$I->seeElementInDOM('div.components-notice-list div.is-error');
-		$I->see('Authorization Failed: API Key not valid');
+		$I->see('API Key not valid');
 
 		// Confirm that the notice is dismissible.
 		$I->click('div.components-notice-list div.is-error button.components-notice__dismiss');
@@ -299,7 +328,7 @@ class RefreshResourcesButtonCest
 
 		// Confirm that an error notification is displayed on screen, with the expected error message.
 		$I->seeElementInDOM('div.convertkit-error');
-		$I->see('Authorization Failed: API Key not valid');
+		$I->see('API Key not valid');
 
 		// Confirm that the notice is dismissible.
 		$I->click('div.convertkit-error button.notice-dismiss');
@@ -348,7 +377,7 @@ class RefreshResourcesButtonCest
 
 		// Confirm that an error notification is displayed on screen, with the expected error message.
 		$I->seeElementInDOM('div.convertkit-error');
-		$I->see('Authorization Failed: API Key not valid');
+		$I->see('API Key not valid');
 
 		// Confirm that the notice is dismissible.
 		$I->click('div.convertkit-error button.notice-dismiss');
@@ -405,7 +434,7 @@ class RefreshResourcesButtonCest
 
 		// Confirm that an error notification is displayed on screen, with the expected error message.
 		$I->seeElementInDOM('div.convertkit-error');
-		$I->see('Authorization Failed: API Key not valid');
+		$I->see('API Key not valid');
 
 		// Confirm that the notice is dismissible.
 		$I->click('div.convertkit-error button.notice-dismiss');
@@ -446,7 +475,7 @@ class RefreshResourcesButtonCest
 
 		// Confirm that an error notification is displayed on screen, with the expected error message.
 		$I->seeElementInDOM('div.convertkit-error');
-		$I->see('Authorization Failed: API Key not valid');
+		$I->see('API Key not valid');
 
 		// Confirm that the notice is dismissible.
 		$I->click('div.convertkit-error button.notice-dismiss');
@@ -491,7 +520,7 @@ class RefreshResourcesButtonCest
 
 		// Confirm that an error notification is displayed on screen, with the expected error message.
 		$I->seeElementInDOM('div.convertkit-error');
-		$I->see('Authorization Failed: API Key not valid');
+		$I->see('API Key not valid');
 
 		// Confirm that the notice is dismissible.
 		$I->click('div.convertkit-error button.notice-dismiss');

--- a/views/backend/post/bulk-edit.php
+++ b/views/backend/post/bulk-edit.php
@@ -83,8 +83,8 @@
 				// have selected the 'Default' option.
 				// Therefore, we use -2 to denote 'No Change', even though this setting is for the Tag, so we're at least consistent.
 				?>
-				<option value="-2"><?php esc_html_e( '— No Change —', 'convertkit' ); ?></option>
-				<option value="0">
+				<option value="-2" data-preserve-on-refresh="1"><?php esc_html_e( '— No Change —', 'convertkit' ); ?></option>
+				<option value="0" data-preserve-on-refresh="1">
 					<?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?>
 				</option>
 
@@ -108,6 +108,9 @@
 				?>
 			</select>
 		</label>
+		<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Products from ConvertKit account', 'convertkit' ); ?>" data-resource="products" data-field="#wp-convertkit-bulk-edit-restrict_content">
+			<span class="dashicons dashicons-update"></span>
+		</button>
 	</div>
 
 	<?php wp_nonce_field( 'wp-convertkit-save-meta', 'wp-convertkit-save-meta-nonce' ); ?>

--- a/views/backend/post/meta-box.php
+++ b/views/backend/post/meta-box.php
@@ -159,16 +159,14 @@
 			</th>
 			<td>
 				<div class="convertkit-select2-container convertkit-select2-container-grid">
-					<?php
-					if ( ! $convertkit_products->exist() ) {
-						esc_html_e( 'No products exist in ConvertKit.', 'convertkit' );
-					} else {
-						?>
-						<select name="wp-convertkit[restrict_content]" id="wp-convertkit-restrict_content" class="convertkit-select2">
-							<option value="0"<?php selected( '', $convertkit_post->get_restrict_content() ); ?> data-preserve-on-refresh="1">
-								<?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?>
-							</option>
+					<select name="wp-convertkit[restrict_content]" id="wp-convertkit-restrict_content" class="convertkit-select2">
+						<option value="0"<?php selected( '', $convertkit_post->get_restrict_content() ); ?> data-preserve-on-refresh="1">
+							<?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?>
+						</option>
 
+						<?php
+						if ( $convertkit_products->exist() ) {
+							?>
 							<optgroup label="<?php esc_attr_e( 'Products', 'convertkit' ); ?>">
 								<?php
 								foreach ( $convertkit_products->get() as $product ) {
@@ -180,10 +178,10 @@
 								}
 								?>
 							</optgroup>
-						</select>
-						<?php
-					}
-					?>
+							<?php
+						}
+						?>
+					</select>
 					<button class="wp-convertkit-refresh-resources" class="button button-secondary hide-if-no-js" title="<?php esc_attr_e( 'Refresh Products Pages from ConvertKit account', 'convertkit' ); ?>" data-resource="products" data-field="#wp-convertkit-restrict_content">
 						<span class="dashicons dashicons-update"></span>
 					</button>

--- a/views/backend/post/quick-edit.php
+++ b/views/backend/post/quick-edit.php
@@ -60,7 +60,7 @@
 		<label for="wp-convertkit-quick-edit-restrict_content">
 			<span class="title"><?php esc_html_e( 'Member', 'convertkit' ); ?></span>
 			<select name="wp-convertkit[restrict_content]" id="wp-convertkit-quick-edit-restrict_content" size="1">
-				<option value="0">
+				<option value="0" data-preserve-on-refresh="1">
 					<?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?>
 				</option>
 
@@ -84,6 +84,9 @@
 				?>
 			</select>
 		</label>
+		<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Products from ConvertKit account', 'convertkit' ); ?>" data-resource="products" data-field="#wp-convertkit-quick-edit-restrict_content">
+			<span class="dashicons dashicons-update"></span>
+		</button>
 	</div>
 
 	<?php wp_nonce_field( 'wp-convertkit-save-meta', 'wp-convertkit-save-meta-nonce' ); ?>


### PR DESCRIPTION
## Summary

(See [here](https://n7studios-workspace.slack.com/archives/C02KFR6N1GF/p1672416207059939?thread_ts=1670631223.079979&cid=C02KFR6N1GF) for several videos demonstrating Restrict Content functionality; it may be useful to view these for context prior to reviewing PRs individually)

Adds a refresh resource button next to the Member's Content setting when Bulk or Quick editing Pages/Posts
<img width="1252" alt="Screenshot 2023-01-02 at 20 07 47" src="https://user-images.githubusercontent.com/1462305/210274453-59bbb68a-ff20-4fad-9801-4f20bd6fa0fe.png">

## Testing

- `RefreshResourcesButtonCest`: Test that the refresh resource button works for Member's Content settings.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)