### PR TITLE
Tag subscriber when Page's "Add a Tag" option defined

### DIFF
--- a/includes/class-convertkit-ajax.php
+++ b/includes/class-convertkit-ajax.php
@@ -167,12 +167,15 @@ class ConvertKit_AJAX {
 			wp_send_json_error( $subscriber->get_error_message() );
 		}
 
+		// Extract the subscriber's email.
+		$email = $subscriber['email_address'];
+
 		// Store the subscriber ID as a cookie.
 		$subscriber = new ConvertKit_Subscriber();
 		$subscriber->set( $subscriber_id );
 
 		// Tag the subscriber with the Post's tag.
-		$tag = $api->tag_subscribe( $tag_id, $subscriber['email_address'] );
+		$tag = $api->tag_subscribe( $tag_id, $email );
 
 		// Bail if an error occured tagging the subscriber.
 		if ( is_wp_error( $tag ) ) {

--- a/includes/class-convertkit-ajax.php
+++ b/includes/class-convertkit-ajax.php
@@ -182,9 +182,6 @@ class ConvertKit_AJAX {
 			wp_send_json_error( $tag );
 		}
 
-		// Store the subscriber ID as a cookie.
-		setcookie( 'ck_subscriber_id', $subscriber['id'], time() + ( 365 * DAY_IN_SECONDS ), '/' );
-
 		wp_send_json_success( $tag );
 
 	}

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -35,8 +35,8 @@ class ConvertKitAPI extends \Codeception\Module
 	 * Check the given subscriber ID has been assigned to the given tag ID.
 	 *
 	 * @param   AcceptanceTester $I             AcceptanceTester.
-	 * @param 	int 			 $subscriberID 	Subscriber ID.
-	 * @param 	int 			 $tagID 		Tag ID.
+	 * @param   int              $subscriberID  Subscriber ID.
+	 * @param   int              $tagID         Tag ID.
 	 */
 	public function apiCheckSubscriberHasTag($I, $subscriberID, $tagID)
 	{
@@ -74,20 +74,19 @@ class ConvertKitAPI extends \Codeception\Module
 	/**
 	 * Subscribes the given email address to the given form. Useful for
 	 * creating a subscriber to use in tests.
-	 * 
-	 * @param   AcceptanceTester 	$I              AcceptanceTester.
-	 * @param 	string  			$emailAddress 	Email Address.
-	 * @param 	int 				$formID 		Form ID.
-	 * @return 	int 								Subscriber ID
+	 *
+	 * @param   string $emailAddress   Email Address.
+	 * @param   int    $formID         Form ID.
+	 * @return  int                                 Subscriber ID
 	 */
-	public function apiSubscribe($I, $emailAddress, $formID)
+	public function apiSubscribe($emailAddress, $formID)
 	{
 		// Run request.
 		$result = $this->apiRequest(
 			'forms/' . $formID . '/subscribe',
 			'POST',
 			[
-				'email' 	=> $emailAddress,
+				'email' => $emailAddress,
 			]
 		);
 

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -32,6 +32,25 @@ class ConvertKitAPI extends \Codeception\Module
 	}
 
 	/**
+	 * Check the given subscriber ID has been assigned to the given tag ID.
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester.
+	 * @param 	int 			 $subscriberID 	Subscriber ID.
+	 * @param 	int 			 $tagID 		Tag ID.
+	 */
+	public function apiCheckSubscriberHasTag($I, $subscriberID, $tagID)
+	{
+		// Run request.
+		$results = $this->apiRequest(
+			'subscribers/' . $subscriberID . '/tags',
+			'GET'
+		);
+
+		// Confirm the tag has been assigned to the subscriber.
+		$I->assertEquals($tagID, $results['tags'][0]['id']);
+	}
+
+	/**
 	 * Check the given email address does not exists as a subscriber.
 	 *
 	 * @param   AcceptanceTester $I             AcceptanceTester.
@@ -50,6 +69,30 @@ class ConvertKitAPI extends \Codeception\Module
 
 		// Check no subscribers are returned by this request.
 		$I->assertEquals(0, $results['total_subscribers']);
+	}
+
+	/**
+	 * Subscribes the given email address to the given form. Useful for
+	 * creating a subscriber to use in tests.
+	 * 
+	 * @param   AcceptanceTester 	$I              AcceptanceTester.
+	 * @param 	string  			$emailAddress 	Email Address.
+	 * @param 	int 				$formID 		Form ID.
+	 * @return 	int 								Subscriber ID
+	 */
+	public function apiSubscribe($I, $emailAddress, $formID)
+	{
+		// Run request.
+		$result = $this->apiRequest(
+			'forms/' . $formID . '/subscribe',
+			'POST',
+			[
+				'email' 	=> $emailAddress,
+			]
+		);
+
+		// Return subscriber ID.
+		return $result['subscription']['subscriber']['id'];
 	}
 
 	/**

--- a/tests/_support/Helper/Acceptance/Email.php
+++ b/tests/_support/Helper/Acceptance/Email.php
@@ -17,9 +17,11 @@ class Email extends \Codeception\Module
 	 * isn't used for two tests across parallel testing runs.
 	 *
 	 * @since   1.9.6.7
+	 *
+	 * @param   string $domain     Domain (default: convertkit.com).
 	 */
-	public function generateEmailAddress()
+	public function generateEmailAddress($domain = 'convertkit.com')
 	{
-		return 'wordpress-' . date( 'Y-m-d-H-i-s' ) . '-php-' . PHP_VERSION_ID . '@convertkit.com';
+		return 'wordpress-' . date( 'Y-m-d-H-i-s' ) . '-php-' . PHP_VERSION_ID . '@' . $domain;
 	}
 }

--- a/tests/acceptance/tags/PageTagCest.php
+++ b/tests/acceptance/tags/PageTagCest.php
@@ -86,6 +86,51 @@ class PageTagCest
 	}
 
 	/**
+	 * Test that a page set to tag subscribers with a specified tag works when accessed
+	 * with a valid subscriber ID in the ?ck_subscriber_id request parameter.
+	 * 
+	 * @since 	2.0.6
+	 * 
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testDefinedTagAppliesToValidSubscriberID(AcceptanceTester $I)
+	{
+		// Add Page, configured to tag subscribers to visit it with the given tag ID.
+		$pageID = $I->havePageInDatabase(
+			[
+				'post_title' => 'ConvertKit: Tag: Valid Subscriber ID',
+				'post_name'	 => 'convertkit-tag-valid-subscriber-id',
+				'meta_input' => [
+					'_wp_convertkit_post_meta' => [
+						'form'         => '-1',
+						'landing_page' => '',
+						'tag'          => $_ENV['CONVERTKIT_API_TAG_ID'],
+					],
+				],
+			]
+		);
+
+		// Programmatically create a subscriber in ConvertKit.
+		$emailAddress = $I->generateEmailAddress();
+		$subscriberID = $I->apiSubscribe($I, $emailAddress, $_ENV['CONVERTKIT_API_FORM_ID']);
+
+		// Load the page with the ?ck_subscriber_id parameter, as if the subscriber clicked a link in a ConvertKit broadcast.
+		$I->amOnPage('?p=' . $pageID . '&ck_subscriber_id=' . $subscriberID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the post_has_tag parameter is set to true in the source code.
+		$I->seeInSource('"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"');
+
+		// Wait a moment for the AJAX request to complete the API request to tag the subscriber.
+		$I->wait(2);
+
+		// Check that the subscriber has been assigned to the tag.
+		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
+	}
+
+	/**
 	 * Test that the defined tag is honored when chosen via
 	 * WordPress' Quick Edit functionality.
 	 *

--- a/tests/acceptance/tags/PageTagCest.php
+++ b/tests/acceptance/tags/PageTagCest.php
@@ -88,9 +88,9 @@ class PageTagCest
 	/**
 	 * Test that a page set to tag subscribers with a specified tag works when accessed
 	 * with a valid subscriber ID in the ?ck_subscriber_id request parameter.
-	 * 
-	 * @since 	2.0.6
-	 * 
+	 *
+	 * @since   2.0.6
+	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testDefinedTagAppliesToValidSubscriberID(AcceptanceTester $I)
@@ -99,7 +99,7 @@ class PageTagCest
 		$pageID = $I->havePageInDatabase(
 			[
 				'post_title' => 'ConvertKit: Tag: Valid Subscriber ID',
-				'post_name'	 => 'convertkit-tag-valid-subscriber-id',
+				'post_name'  => 'convertkit-tag-valid-subscriber-id',
 				'meta_input' => [
 					'_wp_convertkit_post_meta' => [
 						'form'         => '-1',
@@ -111,8 +111,11 @@ class PageTagCest
 		);
 
 		// Programmatically create a subscriber in ConvertKit.
-		$emailAddress = $I->generateEmailAddress();
-		$subscriberID = $I->apiSubscribe($I, $emailAddress, $_ENV['CONVERTKIT_API_FORM_ID']);
+		// Must be a domain email doesn't bounce on, otherwise subscriber won't be confirmed even if the Form's
+		// "Auto-confirm new subscribers" setting is enabled.
+		// We need the subscriber to be confirmed so they can then be tagged.
+		$emailAddress = $I->generateEmailAddress('n7studios.com');
+		$subscriberID = $I->apiSubscribe($emailAddress, $_ENV['CONVERTKIT_API_FORM_ID']);
 
 		// Load the page with the ?ck_subscriber_id parameter, as if the subscriber clicked a link in a ConvertKit broadcast.
 		$I->amOnPage('?p=' . $pageID . '&ck_subscriber_id=' . $subscriberID);


### PR DESCRIPTION
## Summary

Fixes [this issue](https://convertkit.atlassian.net/browse/T3-112), where subscribers failed to be assigned a tag, when a Page is set to tag them.

This was caused by [this commit](https://github.com/ConvertKit/convertkit-wordpress/blame/ffb1eab47b519dfaad70f0b1d994dab12245485f/includes/class-convertkit-ajax.php#L170-L175), where the `$subscriber` array became overwritten with the `ConvertKit_Subscriber` class, meaning that access to the `email_address` later in the code would fail.

This wasn't caught as no test existed for this specific functionality, and the nature of the AJAX call meant no on screen error would be presented to the user.

## Testing

- `PageTagCest:testDefinedTagAppliesToValidSubscriber`: Tests that accessing a Page configured to tag subscribers correctly tags the subscriber when a valid `ck_subscriber_id` subscriber ID is included in the request URI.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)