### PR TITLE
Improve Test Performance

### DIFF
--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -41,25 +41,27 @@ class Plugin extends \Codeception\Module
 	 *
 	 * @since   1.9.6
 	 *
-	 * @param   AcceptanceTester 	$I          AcceptanceTester.
-	 * @param   bool|string         $apiKey     API Key (if specified, used instead of CONVERTKIT_API_KEY).
-	 * @param   bool|string         $apiSecret  API Secret (if specified, used instead of CONVERTKIT_API_SECRET).
-	 * @param   bool|string         $pageFormID Default Form ID for Pages (if specified, used instead of CONVERTKIT_API_FORM_ID).
-	 * @param   bool|string         $postFormID Default Form ID for Posts (if specified, used instead of CONVERTKIT_API_FORM_ID).
+	 * @param   AcceptanceTester $I              AcceptanceTester.
+	 * @param   bool|string      $apiKey         API Key (if specified, used instead of CONVERTKIT_API_KEY).
+	 * @param   bool|string      $apiSecret      API Secret (if specified, used instead of CONVERTKIT_API_SECRET).
+	 * @param   bool|string      $pageFormID     Default Form ID for Pages (if specified, used instead of CONVERTKIT_API_FORM_ID).
+	 * @param   bool|string      $postFormID     Default Form ID for Posts (if specified, used instead of CONVERTKIT_API_FORM_ID).
+	 * @param   bool|string      $productFormID  Default Form ID for Products (if specified, used instead of CONVERTKIT_API_FORM_ID).
 	 */
-	public function setupConvertKitPlugin($I, $apiKey = false, $apiSecret = false, $pageFormID = false, $postFormID = false)
+	public function setupConvertKitPlugin($I, $apiKey = false, $apiSecret = false, $pageFormID = false, $postFormID = false, $productFormID = false)
 	{
 		// Define the API Key and Secret, with Debug Log enabled.
 		$I->haveOptionInDatabase(
 			'_wp_convertkit_settings',
 			[
-				'api_key'    => ( $apiKey !== false ? $apiKey : $_ENV['CONVERTKIT_API_KEY'] ),
-				'api_secret' => ( $apiSecret !== false ? $apiSecret : $_ENV['CONVERTKIT_API_SECRET'] ),
-				'debug'      => 'on',
-				'no_scripts' => '',
-				'no_css'     => '',
-				'post_form'  => ( $postFormID !== false ? $postFormID : $_ENV['CONVERTKIT_API_FORM_ID'] ),
-				'page_form'  => ( $pageFormID !== false ? $pageFormID : $_ENV['CONVERTKIT_API_FORM_ID'] ),
+				'api_key'      => ( $apiKey !== false ? $apiKey : $_ENV['CONVERTKIT_API_KEY'] ),
+				'api_secret'   => ( $apiSecret !== false ? $apiSecret : $_ENV['CONVERTKIT_API_SECRET'] ),
+				'debug'        => 'on',
+				'no_scripts'   => '',
+				'no_css'       => '',
+				'post_form'    => ( $postFormID !== false ? $postFormID : $_ENV['CONVERTKIT_API_FORM_ID'] ),
+				'page_form'    => ( $pageFormID !== false ? $pageFormID : $_ENV['CONVERTKIT_API_FORM_ID'] ),
+				'product_form' => ( $productFormID !== false ? $productFormID : $_ENV['CONVERTKIT_API_FORM_ID'] ),
 			]
 		);
 	}
@@ -67,13 +69,17 @@ class Plugin extends \Codeception\Module
 	/**
 	 * Helper method to define cached Resources (Forms, Landing Pages, Posts, Products and Tags),
 	 * directly into the database, instead of querying the API for them via the Resource classes.
-	 * 
+	 *
 	 * This can safely be done for Acceptance tests, as WPUnit tests ensure that
 	 * caching Resources from calls made to the API work and store data in the expected
 	 * structure.
-	 * 
+	 *
 	 * Defining cached Resources here reduces the number of API calls made for each test,
-	 * reducing the likelihood of hitting a rate limit due to running tests in parallel. 
+	 * reducing the likelihood of hitting a rate limit due to running tests in parallel.
+	 *
+	 * @since   2.0.7
+	 *
+	 * @param   AcceptanceTester $I              AcceptanceTester.
 	 */
 	public function setupConvertKitPluginResources($I)
 	{
@@ -81,74 +87,74 @@ class Plugin extends \Codeception\Module
 		$I->haveOptionInDatabase(
 			'convertkit_forms',
 			[
-				470099 => [
-				    'id' => 470099,
-				    'name' => 'Legacy Form',
-				    'created_at' => null,
-				    'type' => 'embed',
-				    'url' => 'https://app.convertkit.com/landing_pages/470099',
-				    'embed_js' => 'https://api.convertkit.com/api/v3/forms/470099.js?api_key=' . $_ENV['CONVERTKIT_API_KEY'],
-				    'embed_url' => 'https://api.convertkit.com/api/v3/forms/470099.html?api_key=' . $_ENV['CONVERTKIT_API_KEY'],
-				    'title' => 'Join the newsletter',
-				    'description' => '<p>Subscribe to get our latest content by email.</p>',
-				    'sign_up_button_text' => 'Subscribe',
-				    'success_message' => 'Success! Now check your email to confirm your subscription.',
-				    'archived' => false,
+				470099  => [
+					'id'                  => 470099,
+					'name'                => 'Legacy Form',
+					'created_at'          => null,
+					'type'                => 'embed',
+					'url'                 => 'https://app.convertkit.com/landing_pages/470099',
+					'embed_js'            => 'https://api.convertkit.com/api/v3/forms/470099.js?api_key=' . $_ENV['CONVERTKIT_API_KEY'],
+					'embed_url'           => 'https://api.convertkit.com/api/v3/forms/470099.html?api_key=' . $_ENV['CONVERTKIT_API_KEY'],
+					'title'               => 'Join the newsletter',
+					'description'         => '<p>Subscribe to get our latest content by email.</p>',
+					'sign_up_button_text' => 'Subscribe',
+					'success_message'     => 'Success! Now check your email to confirm your subscription.',
+					'archived'            => false,
 				],
 				2780977 => [
-				    'id' => 2780977,
-				    'name' => 'Modal Form',
-				    'created_at' => '2021-11-17T04:22:06.000Z',
-				    'type' => 'embed',
-				    'format' => 'modal',
-				    'embed_js' => 'https://cheerful-architect-3237.ck.page/397e876257/index.js',
-				    'embed_url' => 'https://cheerful-architect-3237.ck.page/397e876257',
-				    'archived' => false,
-				    'uid' => '397e876257',
+					'id'         => 2780977,
+					'name'       => 'Modal Form',
+					'created_at' => '2021-11-17T04:22:06.000Z',
+					'type'       => 'embed',
+					'format'     => 'modal',
+					'embed_js'   => 'https://cheerful-architect-3237.ck.page/397e876257/index.js',
+					'embed_url'  => 'https://cheerful-architect-3237.ck.page/397e876257',
+					'archived'   => false,
+					'uid'        => '397e876257',
 				],
 				2765139 => [
-				    'id' => 2765139,
-				    'name' => 'Page Form',
-				    'created_at' => '2021-11-11T15:30:40.000Z',
-				    'type' => 'embed',
-				    'format' => 'inline',
-				    'embed_js' => 'https://cheerful-architect-3237.ck.page/85629c512d/index.js',
-				    'embed_url' => 'https://cheerful-architect-3237.ck.page/85629c512d',
-				    'archived' => false,
-				    'uid' => '85629c512d',
+					'id'         => 2765139,
+					'name'       => 'Page Form',
+					'created_at' => '2021-11-11T15:30:40.000Z',
+					'type'       => 'embed',
+					'format'     => 'inline',
+					'embed_js'   => 'https://cheerful-architect-3237.ck.page/85629c512d/index.js',
+					'embed_url'  => 'https://cheerful-architect-3237.ck.page/85629c512d',
+					'archived'   => false,
+					'uid'        => '85629c512d',
 				],
 				2780979 => [
-				    'id' => 2780979,
-				    'name' => 'Slide In Form',
-				    'created_at' => '2021-11-17T04:22:24.000Z',
-				    'type' => 'embed',
-				    'format' => 'slide in',
-				    'embed_js' => 'https://cheerful-architect-3237.ck.page/e0d65bed9d/index.js',
-				    'embed_url' => 'https://cheerful-architect-3237.ck.page/e0d65bed9d',
-				    'archived' => false,
-				    'uid' => 'e0d65bed9d',
+					'id'         => 2780979,
+					'name'       => 'Slide In Form',
+					'created_at' => '2021-11-17T04:22:24.000Z',
+					'type'       => 'embed',
+					'format'     => 'slide in',
+					'embed_js'   => 'https://cheerful-architect-3237.ck.page/e0d65bed9d/index.js',
+					'embed_url'  => 'https://cheerful-architect-3237.ck.page/e0d65bed9d',
+					'archived'   => false,
+					'uid'        => 'e0d65bed9d',
 				],
 				2780980 => [
-				    'id' => 2780980,
-				    'name' => 'Sticky Bar Form',
-				    'created_at' => '2021-11-17T04:22:42.000Z',
-				    'type' => 'embed',
-				    'format' => 'sticky bar',
-				    'embed_js' => 'https://cheerful-architect-3237.ck.page/9f5c601482/index.js',
-				    'embed_url' => 'https://cheerful-architect-3237.ck.page/9f5c601482',
-				    'archived' => false,
-				    'uid' => '9f5c601482',
+					'id'         => 2780980,
+					'name'       => 'Sticky Bar Form',
+					'created_at' => '2021-11-17T04:22:42.000Z',
+					'type'       => 'embed',
+					'format'     => 'sticky bar',
+					'embed_js'   => 'https://cheerful-architect-3237.ck.page/9f5c601482/index.js',
+					'embed_url'  => 'https://cheerful-architect-3237.ck.page/9f5c601482',
+					'archived'   => false,
+					'uid'        => '9f5c601482',
 				],
 				3003590 => [
-				    'id' => 3003590,
-				    'name' => 'Third Party Integrations Form',
-				    'created_at' => '2022-02-17T15:05:31.000Z',
-				    'type' => 'embed',
-				    'format' => 'inline',
-				    'embed_js' => 'https://cheerful-architect-3237.ck.page/71cbcc4042/index.js',
-				    'embed_url' => 'https://cheerful-architect-3237.ck.page/71cbcc4042',
-				    'archived' => false,
-				    'uid' => '71cbcc4042',
+					'id'         => 3003590,
+					'name'       => 'Third Party Integrations Form',
+					'created_at' => '2022-02-17T15:05:31.000Z',
+					'type'       => 'embed',
+					'format'     => 'inline',
+					'embed_js'   => 'https://cheerful-architect-3237.ck.page/71cbcc4042/index.js',
+					'embed_url'  => 'https://cheerful-architect-3237.ck.page/71cbcc4042',
+					'archived'   => false,
+					'uid'        => '71cbcc4042',
 				],
 			]
 		);
@@ -158,40 +164,40 @@ class Plugin extends \Codeception\Module
 			'convertkit_landing_pages',
 			[
 				2849151 => [
-				    'id' => 2849151,
-				    'name' => 'Character Encoding',
-				    'created_at' => '2021-12-16T14:55:58.000Z',
-				    'type' => 'hosted',
-				    'format' => null,
-				    'embed_js' => 'https://cheerful-architect-3237.ck.page/cc5eb21744/index.js',
-				    'embed_url' => 'https://cheerful-architect-3237.ck.page/cc5eb21744',
-				    'archived' => false,
-				    'uid' => 'cc5eb21744',
+					'id'         => 2849151,
+					'name'       => 'Character Encoding',
+					'created_at' => '2021-12-16T14:55:58.000Z',
+					'type'       => 'hosted',
+					'format'     => null,
+					'embed_js'   => 'https://cheerful-architect-3237.ck.page/cc5eb21744/index.js',
+					'embed_url'  => 'https://cheerful-architect-3237.ck.page/cc5eb21744',
+					'archived'   => false,
+					'uid'        => 'cc5eb21744',
 				],
 				2765196 => [
-				    'id' => 2765196,
-				    'name' => 'Landing Page',
-				    'created_at' => '2021-11-11T15:45:33.000Z',
-				    'type' => 'hosted',
-				    'format' => null,
-				    'embed_js' => 'https://cheerful-architect-3237.ck.page/99f1db6843/index.js',
-				    'embed_url' => 'https://cheerful-architect-3237.ck.page/99f1db6843',
-				    'archived' => false,
-				    'uid' => '99f1db6843',
+					'id'         => 2765196,
+					'name'       => 'Landing Page',
+					'created_at' => '2021-11-11T15:45:33.000Z',
+					'type'       => 'hosted',
+					'format'     => null,
+					'embed_js'   => 'https://cheerful-architect-3237.ck.page/99f1db6843/index.js',
+					'embed_url'  => 'https://cheerful-architect-3237.ck.page/99f1db6843',
+					'archived'   => false,
+					'uid'        => '99f1db6843',
 				],
-				470103 => [
-				    'id' => 470103,
-				    'name' => 'Legacy Landing Page',
-				    'created_at' => null,
-				    'type' => 'hosted',
-				    'url' => 'https://app.convertkit.com/landing_pages/470103',
-				    'embed_js' => 'https://api.convertkit.com/api/v3/forms/470103.js?api_key=' . $_ENV['CONVERTKIT_API_KEY'],
-				    'embed_url' => 'https://api.convertkit.com/api/v3/forms/470103.html?api_key=' . $_ENV['CONVERTKIT_API_KEY'],
-				    'title' => '',
-				    'description' => '',
-				    'sign_up_button_text' => 'Register',
-				    'success_message' => null,
-				    'archived' => false,
+				470103  => [
+					'id'                  => 470103,
+					'name'                => 'Legacy Landing Page',
+					'created_at'          => null,
+					'type'                => 'hosted',
+					'url'                 => 'https://app.convertkit.com/landing_pages/470103',
+					'embed_js'            => 'https://api.convertkit.com/api/v3/forms/470103.js?api_key=' . $_ENV['CONVERTKIT_API_KEY'],
+					'embed_url'           => 'https://api.convertkit.com/api/v3/forms/470103.html?api_key=' . $_ENV['CONVERTKIT_API_KEY'],
+					'title'               => '',
+					'description'         => '',
+					'sign_up_button_text' => 'Register',
+					'success_message'     => null,
+					'archived'            => false,
 				],
 			]
 		);
@@ -201,32 +207,32 @@ class Plugin extends \Codeception\Module
 			'convertkit_posts',
 			[
 				572575 => [
-				    'id' => 572575,
-				    'title' => 'Paid Subscriber Broadcast',
-				    'url' => 'https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast',
-				    'published_at' => '2022-05-03T14:51:50.000Z',
-				    'is_paid' => true,
+					'id'           => 572575,
+					'title'        => 'Paid Subscriber Broadcast',
+					'url'          => 'https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast',
+					'published_at' => '2022-05-03T14:51:50.000Z',
+					'is_paid'      => true,
 				],
 				489467 => [
-				    'id' => 489467,
-				    'title' => 'Broadcast 1',
-				    'url' => 'https://cheerful-architect-3237.ck.page/posts/broadcast-1',
-				    'published_at' => '2022-04-08T00:00:00.000Z',
-				    'is_paid' => false,
+					'id'           => 489467,
+					'title'        => 'Broadcast 1',
+					'url'          => 'https://cheerful-architect-3237.ck.page/posts/broadcast-1',
+					'published_at' => '2022-04-08T00:00:00.000Z',
+					'is_paid'      => false,
 				],
 				489480 => [
-				    'id' => 489480,
-				    'title' => 'Broadcast 2',
-				    'url' => 'https://cheerful-architect-3237.ck.page/posts/broadcast-2',
-				    'published_at' => '2022-04-08T00:00:00.000Z',
-				    'is_paid' => null,
+					'id'           => 489480,
+					'title'        => 'Broadcast 2',
+					'url'          => 'https://cheerful-architect-3237.ck.page/posts/broadcast-2',
+					'published_at' => '2022-04-08T00:00:00.000Z',
+					'is_paid'      => null,
 				],
 				224758 => [
-				    'id' => 224758,
-				    'title' => 'Test Subject',
-				    'url' => 'https://cheerful-architect-3237.ck.page/posts/test-subject',
-				    'published_at' => '2022-01-24T00:00:00.000Z',
-				    'is_paid' => null,
+					'id'           => 224758,
+					'title'        => 'Test Subject',
+					'url'          => 'https://cheerful-architect-3237.ck.page/posts/test-subject',
+					'published_at' => '2022-01-24T00:00:00.000Z',
+					'is_paid'      => null,
 				],
 			]
 		);
@@ -236,11 +242,11 @@ class Plugin extends \Codeception\Module
 			'convertkit_products',
 			[
 				36377 => [
-				    'id' => 36377,
-				    'name' => 'Newsletter Subscription',
-				    'url' => 'https://cheerful-architect-3237.ck.page/products/newsletter-subscription',
-				    'published' => true,
-				]	
+					'id'        => 36377,
+					'name'      => 'Newsletter Subscription',
+					'url'       => 'https://cheerful-architect-3237.ck.page/products/newsletter-subscription',
+					'published' => true,
+				],
 			]
 		);
 
@@ -249,10 +255,10 @@ class Plugin extends \Codeception\Module
 			'convertkit_tags',
 			[
 				2744672 => [
-		            'id' => 2744672,
-		            'name' => 'wordpress',
-		            'created_at' => '2021-11-11T19:30:06.000Z',
-		        ],
+					'id'         => 2744672,
+					'name'       => 'wordpress',
+					'created_at' => '2021-11-11T19:30:06.000Z',
+				],
 			]
 		);
 

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -87,8 +87,8 @@ class Plugin extends \Codeception\Module
 				    'created_at' => null,
 				    'type' => 'embed',
 				    'url' => 'https://app.convertkit.com/landing_pages/470099',
-				    'embed_js' => 'https://api.convertkit.com/api/v3/forms/470099.js?api_key=' . $apiKey,
-				    'embed_url' => 'https://api.convertkit.com/api/v3/forms/470099.html?api_key=' . $apiKey,
+				    'embed_js' => 'https://api.convertkit.com/api/v3/forms/470099.js?api_key=' . $_ENV['CONVERTKIT_API_KEY'],
+				    'embed_url' => 'https://api.convertkit.com/api/v3/forms/470099.html?api_key=' . $_ENV['CONVERTKIT_API_KEY'],
 				    'title' => 'Join the newsletter',
 				    'description' => '<p>Subscribe to get our latest content by email.</p>',
 				    'sign_up_button_text' => 'Subscribe',
@@ -185,8 +185,8 @@ class Plugin extends \Codeception\Module
 				    'created_at' => null,
 				    'type' => 'hosted',
 				    'url' => 'https://app.convertkit.com/landing_pages/470103',
-				    'embed_js' => 'https://api.convertkit.com/api/v3/forms/470103.js?api_key=' . $apiKey,
-				    'embed_url' => 'https://api.convertkit.com/api/v3/forms/470103.html?api_key=' . $apiKey,
+				    'embed_js' => 'https://api.convertkit.com/api/v3/forms/470103.js?api_key=' . $_ENV['CONVERTKIT_API_KEY'],
+				    'embed_url' => 'https://api.convertkit.com/api/v3/forms/470103.html?api_key=' . $_ENV['CONVERTKIT_API_KEY'],
 				    'title' => '',
 				    'description' => '',
 				    'sign_up_button_text' => 'Register',
@@ -265,103 +265,6 @@ class Plugin extends \Codeception\Module
 	}
 
 	/**
-	 * Helper method to setup the Plugin's Default Form setting for Pages and Posts.
-	 *
-	 * @since   1.9.6
-	 *
-	 * @param   AcceptanceTester $I     AcceptanceTester.
-	 */
-	public function setupConvertKitPluginDefaultForm($I)
-	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen($I);
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Select Default Form for Pages and Posts.
-		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
-		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_post_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
-
-		// Click the Save Changes button.
-		$I->click('Save Changes');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Check the value of the fields match the inputs provided.
-		$I->seeInField('_wp_convertkit_settings[page_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
-		$I->seeInField('_wp_convertkit_settings[post_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
-
-		// Return Form ID for Pages.
-		return $I->grabValueFrom('_wp_convertkit_settings[page_form]');
-	}
-
-	/**
-	 * Helper method to setup the Plugin's Default Legacy Form setting for Pages and Posts.
-	 *
-	 * @since   1.9.6
-	 *
-	 * @param   AcceptanceTester $I     AcceptanceTester.
-	 */
-	public function setupConvertKitPluginDefaultLegacyForm($I)
-	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen($I);
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Select Default Form for Pages and Posts.
-		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
-		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_post_form-container', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
-
-		// Click the Save Changes button.
-		$I->click('Save Changes');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Check the value of the fields match the inputs provided.
-		$I->seeInField('_wp_convertkit_settings[page_form]', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
-		$I->seeInField('_wp_convertkit_settings[post_form]', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
-
-		// Return Form ID for Pages.
-		return $I->grabValueFrom('_wp_convertkit_settings[page_form]');
-	}
-
-	/**
-	 * Helper method to setup the Plugin's Default Form setting for WooCommerce Products.
-	 *
-	 * @since   1.9.6
-	 *
-	 * @param   AcceptanceTester $I     AcceptanceTester.
-	 */
-	public function setupConvertKitPluginDefaultFormForWooCommerceProducts($I)
-	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen($I);
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Select option.
-		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_product_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
-
-		// Click the Save Changes button.
-		$I->click('Save Changes');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Check the value of the fields match the inputs provided.
-		$I->seeInField('_wp_convertkit_settings[product_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
-
-		// Return Form ID.
-		return $I->grabValueFrom('_wp_convertkit_settings[product_form]');
-	}
-
-	/**
 	 * Helper method to reset the ConvertKit Plugin settings, as if it's a clean installation.
 	 *
 	 * @since   1.9.6.7
@@ -422,25 +325,6 @@ class Plugin extends \Codeception\Module
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
-	}
-
-	/**
-	 * Helper method to enable the Plugin's Settings > General > Debug option.
-	 *
-	 * @since   1.9.6
-	 *
-	 * @param   AcceptanceTester $I     AcceptanceTester.
-	 */
-	public function enableDebugLog($I)
-	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen($I);
-
-		// Tick field.
-		$I->checkOption('#debug');
-
-		// Click the Save Changes button.
-		$I->click('Save Changes');
 	}
 
 	/**

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -36,39 +36,225 @@ class Plugin extends \Codeception\Module
 	}
 
 	/**
-	 * Helper method to setup the Plugin's API Key and Secret.
+	 * Helper method to programmatically setup the Plugin's API Key and Secret,
+	 * enabling debug logging.
 	 *
 	 * @since   1.9.6
 	 *
-	 * @param   AcceptanceTester $I          AcceptanceTester.
-	 * @param   mixed            $apiKey     API Key (if specified, used instead of CONVERTKIT_API_KEY).
-	 * @param   mixed            $apiSecret  API Secret (if specified, used instead of CONVERTKIT_API_SECRET).
+	 * @param   AcceptanceTester 	$I          AcceptanceTester.
+	 * @param   bool|string         $apiKey     API Key (if specified, used instead of CONVERTKIT_API_KEY).
+	 * @param   bool|string         $apiSecret  API Secret (if specified, used instead of CONVERTKIT_API_SECRET).
+	 * @param   bool|string         $pageFormID Default Form ID for Pages (if specified, used instead of CONVERTKIT_API_FORM_ID).
+	 * @param   bool|string         $postFormID Default Form ID for Posts (if specified, used instead of CONVERTKIT_API_FORM_ID).
 	 */
-	public function setupConvertKitPlugin($I, $apiKey = false, $apiSecret = false)
+	public function setupConvertKitPlugin($I, $apiKey = false, $apiSecret = false, $pageFormID = false, $postFormID = false)
 	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen($I);
+		// Define the API Key and Secret, with Debug Log enabled.
+		$I->haveOptionInDatabase(
+			'_wp_convertkit_settings',
+			[
+				'api_key'    => ( $apiKey !== false ? $apiKey : $_ENV['CONVERTKIT_API_KEY'] ),
+				'api_secret' => ( $apiSecret !== false ? $apiSecret : $_ENV['CONVERTKIT_API_SECRET'] ),
+				'debug'      => 'on',
+				'no_scripts' => '',
+				'no_css'     => '',
+				'post_form'  => ( $postFormID !== false ? $postFormID : $_ENV['CONVERTKIT_API_FORM_ID'] ),
+				'page_form'  => ( $pageFormID !== false ? $pageFormID : $_ENV['CONVERTKIT_API_FORM_ID'] ),
+			]
+		);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Define cached Resources (Forms, Landing Pages, Products, Tags).
+		// This can safely be done for Acceptance tests, as WPUnit tests ensure that
+		// caching Resources from calls made to the API work and store data in the expected
+		// structure.
+		// Defining cached Resources here reduces the number of API calls made for each test,
+		// reducing the likelihood of hitting a rate limit due to running tests in parallel. 
 
-		// Determine API Key and Secret to use.
-		$convertKitAPIKey    = ( $apiKey !== false ? $apiKey : $_ENV['CONVERTKIT_API_KEY'] );
-		$convertKitAPISecret = ( $apiSecret !== false ? $apiSecret : $_ENV['CONVERTKIT_API_SECRET'] );
+		// Define Forms as if the Forms resource class populated them from the API.
+		$I->haveOptionInDatabase(
+			'convertkit_forms',
+			[
+				470099 => [
+				    'id' => 470099,
+				    'name' => 'Legacy Form',
+				    'created_at' => null,
+				    'type' => 'embed',
+				    'url' => 'https://app.convertkit.com/landing_pages/470099',
+				    'embed_js' => 'https://api.convertkit.com/api/v3/forms/470099.js?api_key=' . $apiKey,
+				    'embed_url' => 'https://api.convertkit.com/api/v3/forms/470099.html?api_key=' . $apiKey,
+				    'title' => 'Join the newsletter',
+				    'description' => '<p>Subscribe to get our latest content by email.</p>',
+				    'sign_up_button_text' => 'Subscribe',
+				    'success_message' => 'Success! Now check your email to confirm your subscription.',
+				    'archived' => false,
+				],
+				2780977 => [
+				    'id' => 2780977,
+				    'name' => 'Modal Form',
+				    'created_at' => '2021-11-17T04:22:06.000Z',
+				    'type' => 'embed',
+				    'format' => 'modal',
+				    'embed_js' => 'https://cheerful-architect-3237.ck.page/397e876257/index.js',
+				    'embed_url' => 'https://cheerful-architect-3237.ck.page/397e876257',
+				    'archived' => false,
+				    'uid' => '397e876257',
+				],
+				2765139 => [
+				    'id' => 2765139,
+				    'name' => 'Page Form',
+				    'created_at' => '2021-11-11T15:30:40.000Z',
+				    'type' => 'embed',
+				    'format' => 'inline',
+				    'embed_js' => 'https://cheerful-architect-3237.ck.page/85629c512d/index.js',
+				    'embed_url' => 'https://cheerful-architect-3237.ck.page/85629c512d',
+				    'archived' => false,
+				    'uid' => '85629c512d',
+				],
+				2780979 => [
+				    'id' => 2780979,
+				    'name' => 'Slide In Form',
+				    'created_at' => '2021-11-17T04:22:24.000Z',
+				    'type' => 'embed',
+				    'format' => 'slide in',
+				    'embed_js' => 'https://cheerful-architect-3237.ck.page/e0d65bed9d/index.js',
+				    'embed_url' => 'https://cheerful-architect-3237.ck.page/e0d65bed9d',
+				    'archived' => false,
+				    'uid' => 'e0d65bed9d',
+				],
+				2780980 => [
+				    'id' => 2780980,
+				    'name' => 'Sticky Bar Form',
+				    'created_at' => '2021-11-17T04:22:42.000Z',
+				    'type' => 'embed',
+				    'format' => 'sticky bar',
+				    'embed_js' => 'https://cheerful-architect-3237.ck.page/9f5c601482/index.js',
+				    'embed_url' => 'https://cheerful-architect-3237.ck.page/9f5c601482',
+				    'archived' => false,
+				    'uid' => '9f5c601482',
+				],
+				3003590 => [
+				    'id' => 3003590,
+				    'name' => 'Third Party Integrations Form',
+				    'created_at' => '2022-02-17T15:05:31.000Z',
+				    'type' => 'embed',
+				    'format' => 'inline',
+				    'embed_js' => 'https://cheerful-architect-3237.ck.page/71cbcc4042/index.js',
+				    'embed_url' => 'https://cheerful-architect-3237.ck.page/71cbcc4042',
+				    'archived' => false,
+				    'uid' => '71cbcc4042',
+				],
+			]
+		);
 
-		// Complete API Fields.
-		$I->fillField('_wp_convertkit_settings[api_key]', $convertKitAPIKey);
-		$I->fillField('_wp_convertkit_settings[api_secret]', $convertKitAPISecret);
+		// Define Landing Pages.
+		$I->haveOptionInDatabase(
+			'convertkit_landing_pages',
+			[
+				2849151 => [
+				    'id' => 2849151,
+				    'name' => 'Character Encoding',
+				    'created_at' => '2021-12-16T14:55:58.000Z',
+				    'type' => 'hosted',
+				    'format' => null,
+				    'embed_js' => 'https://cheerful-architect-3237.ck.page/cc5eb21744/index.js',
+				    'embed_url' => 'https://cheerful-architect-3237.ck.page/cc5eb21744',
+				    'archived' => false,
+				    'uid' => 'cc5eb21744',
+				],
+				2765196 => [
+				    'id' => 2765196,
+				    'name' => 'Landing Page',
+				    'created_at' => '2021-11-11T15:45:33.000Z',
+				    'type' => 'hosted',
+				    'format' => null,
+				    'embed_js' => 'https://cheerful-architect-3237.ck.page/99f1db6843/index.js',
+				    'embed_url' => 'https://cheerful-architect-3237.ck.page/99f1db6843',
+				    'archived' => false,
+				    'uid' => '99f1db6843',
+				],
+				470103 => [
+				    'id' => 470103,
+				    'name' => 'Legacy Landing Page',
+				    'created_at' => null,
+				    'type' => 'hosted',
+				    'url' => 'https://app.convertkit.com/landing_pages/470103',
+				    'embed_js' => 'https://api.convertkit.com/api/v3/forms/470103.js?api_key=' . $apiKey,
+				    'embed_url' => 'https://api.convertkit.com/api/v3/forms/470103.html?api_key=' . $apiKey,
+				    'title' => '',
+				    'description' => '',
+				    'sign_up_button_text' => 'Register',
+				    'success_message' => null,
+				    'archived' => false,
+				],
+			]
+		);
 
-		// Click the Save Changes button.
-		$I->click('Save Changes');
+		// Define Posts.
+		$I->haveOptionInDatabase(
+			'convertkit_posts',
+			[
+				572575 => [
+				    'id' => 572575,
+				    'title' => 'Paid Subscriber Broadcast',
+				    'url' => 'https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast',
+				    'published_at' => '2022-05-03T14:51:50.000Z',
+				    'is_paid' => true,
+				],
+				489467 => [
+				    'id' => 489467,
+				    'title' => 'Broadcast 1',
+				    'url' => 'https://cheerful-architect-3237.ck.page/posts/broadcast-1',
+				    'published_at' => '2022-04-08T00:00:00.000Z',
+				    'is_paid' => false,
+				],
+				489480 => [
+				    'id' => 489480,
+				    'title' => 'Broadcast 2',
+				    'url' => 'https://cheerful-architect-3237.ck.page/posts/broadcast-2',
+				    'published_at' => '2022-04-08T00:00:00.000Z',
+				    'is_paid' => null,
+				],
+				224758 => [
+				    'id' => 224758,
+				    'title' => 'Test Subject',
+				    'url' => 'https://cheerful-architect-3237.ck.page/posts/test-subject',
+				    'published_at' => '2022-01-24T00:00:00.000Z',
+				    'is_paid' => null,
+				],
+			]
+		);
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+		// Define Products.
+		$I->haveOptionInDatabase(
+			'convertkit_products',
+			[
+				36377 => [
+				    'id' => 36377,
+				    'name' => 'Newsletter Subscription',
+				    'url' => 'https://cheerful-architect-3237.ck.page/products/newsletter-subscription',
+				    'published' => true,
+				]	
+			]
+		);
 
-		// Check the value of the fields match the inputs provided.
-		$I->seeInField('_wp_convertkit_settings[api_key]', $convertKitAPIKey);
-		$I->seeInField('_wp_convertkit_settings[api_secret]', $convertKitAPISecret);
+		// Define Tags.
+		$I->haveOptionInDatabase(
+			'convertkit_tags',
+			[
+				2744672 => [
+		            'id' => 2744672,
+		            'name' => 'wordpress',
+		            'created_at' => '2021-11-11T19:30:06.000Z',
+		        ],
+			]
+		);
+
+		// Define last queried to now for all resources, so they're not automatically immediately refreshed by the Plugin's logic.
+		$I->haveOptionInDatabase( 'convertkit_forms_last_queried', strtotime( 'now' ) );
+		$I->haveOptionInDatabase( 'convertkit_landing_pages_last_queried', strtotime( 'now' ) );
+		$I->haveOptionInDatabase( 'convertkit_posts_last_queried', strtotime( 'now' ) );
+		$I->haveOptionInDatabase( 'convertkit_products_last_queried', strtotime( 'now' ) );
+		$I->haveOptionInDatabase( 'convertkit_tags_last_queried', strtotime( 'now' ) );
 	}
 
 	/**
@@ -186,6 +372,10 @@ class Plugin extends \Codeception\Module
 		$I->dontHaveOptionInDatabase('convertkit_forms_last_queried');
 		$I->dontHaveOptionInDatabase('convertkit_landing_pages');
 		$I->dontHaveOptionInDatabase('convertkit_landing_pages_last_queried');
+		$I->dontHaveOptionInDatabase('convertkit_posts');
+		$I->dontHaveOptionInDatabase('convertkit_posts_last_queried');
+		$I->dontHaveOptionInDatabase('convertkit_products');
+		$I->dontHaveOptionInDatabase('convertkit_products_last_queried');
 		$I->dontHaveOptionInDatabase('convertkit_tags');
 		$I->dontHaveOptionInDatabase('convertkit_tags_last_queried');
 

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -62,14 +62,21 @@ class Plugin extends \Codeception\Module
 				'page_form'  => ( $pageFormID !== false ? $pageFormID : $_ENV['CONVERTKIT_API_FORM_ID'] ),
 			]
 		);
+	}
 
-		// Define cached Resources (Forms, Landing Pages, Products, Tags).
-		// This can safely be done for Acceptance tests, as WPUnit tests ensure that
-		// caching Resources from calls made to the API work and store data in the expected
-		// structure.
-		// Defining cached Resources here reduces the number of API calls made for each test,
-		// reducing the likelihood of hitting a rate limit due to running tests in parallel. 
-
+	/**
+	 * Helper method to define cached Resources (Forms, Landing Pages, Posts, Products and Tags),
+	 * directly into the database, instead of querying the API for them via the Resource classes.
+	 * 
+	 * This can safely be done for Acceptance tests, as WPUnit tests ensure that
+	 * caching Resources from calls made to the API work and store data in the expected
+	 * structure.
+	 * 
+	 * Defining cached Resources here reduces the number of API calls made for each test,
+	 * reducing the likelihood of hitting a rate limit due to running tests in parallel. 
+	 */
+	public function setupConvertKitPluginResources($I)
+	{
 		// Define Forms as if the Forms resource class populated them from the API.
 		$I->haveOptionInDatabase(
 			'convertkit_forms',

--- a/tests/_support/Helper/Acceptance/WPGutenberg.php
+++ b/tests/_support/Helper/Acceptance/WPGutenberg.php
@@ -227,19 +227,21 @@ class WPGutenberg extends \Codeception\Module
 		$I->click('.editor-post-publish-button__button');
 
 		// When the pre-publish panel displays, click Publish again.
+		$I->waitForElementVisible('.editor-post-publish-panel__header-publish-button');
 		$I->performOn(
-			'.editor-post-publish-panel__prepublish',
+			'.editor-post-publish-panel__header-publish-button',
 			function($I) {
-				$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');
+				$I->click('.editor-post-publish-panel__header-publish-button button');
 			},
 			15
 		);
 
 		// When the page is confirmed as published, load the Page on the frontend site.
+		$I->waitForElementVisible('.post-publish-panel__postpublish-buttons');
 		$I->performOn(
-			'.post-publish-panel__postpublish-buttons a.components-button',
+			'.post-publish-panel__postpublish-buttons',
 			function($I) {
-				$I->click('.post-publish-panel__postpublish-buttons a.components-button');
+				$I->click('.post-publish-panel__postpublish-buttons a.is-primary');
 			},
 			15
 		);

--- a/tests/_support/Helper/Acceptance/WPGutenberg.php
+++ b/tests/_support/Helper/Acceptance/WPGutenberg.php
@@ -231,14 +231,18 @@ class WPGutenberg extends \Codeception\Module
 			'.editor-post-publish-panel__prepublish',
 			function($I) {
 				$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');
-			}
+			},
+			15
 		);
 
-		// Wait for confirmation that the Page published.
-		$I->waitForElementVisible('.post-publish-panel__postpublish-buttons a.components-button');
-
-		// Load the Page on the frontend site.
-		$I->click('.post-publish-panel__postpublish-buttons a.components-button');
+		// When the page is confirmed as published, load the Page on the frontend site.
+		$I->performOn(
+			'.post-publish-panel__postpublish-buttons a.components-button',
+			function($I) {
+				$I->click('.post-publish-panel__postpublish-buttons a.components-button');
+			},
+			15
+		);
 
 		// Wait for frontend web site to load.
 		$I->waitForElementVisible('body');

--- a/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
@@ -29,7 +29,8 @@ class PageBlockBroadcastsCest
 	{
 		// Setup Plugin with API keys for ConvertKit Account that has no Broadcasts, and enable debug log.
 		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
-		$I->enableDebugLog($I);
+
+		// @TODO FIX LOGIC AS RESOURCES POPD
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: No Broadcasts');
@@ -63,7 +64,6 @@ class PageBlockBroadcastsCest
 	{
 		// Setup Plugin and enable debug log.
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Default Params');
@@ -95,7 +95,6 @@ class PageBlockBroadcastsCest
 	{
 		// Setup Plugin and enable debug log.
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Date Format Param');
@@ -134,7 +133,6 @@ class PageBlockBroadcastsCest
 	{
 		// Setup Plugin and enable debug log.
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Limit Param');
@@ -170,7 +168,6 @@ class PageBlockBroadcastsCest
 	{
 		// Setup Plugin and enable debug log.
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Blank Limit Param');
@@ -207,7 +204,6 @@ class PageBlockBroadcastsCest
 	{
 		// Setup Plugin and enable debug log.
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Pagination');
@@ -241,7 +237,6 @@ class PageBlockBroadcastsCest
 	{
 		// Setup Plugin and enable debug log.
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Pagination Labels');
@@ -277,7 +272,6 @@ class PageBlockBroadcastsCest
 	{
 		// Setup Plugin and enable debug log.
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Blank Pagination Labels');
@@ -313,7 +307,6 @@ class PageBlockBroadcastsCest
 	{
 		// Setup Plugin and enable debug log.
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 
 		// Define colors.
 		$backgroundColor = 'white';
@@ -360,7 +353,6 @@ class PageBlockBroadcastsCest
 	{
 		// Setup Plugin and enable debug log.
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 
 		// Define colors.
 		$backgroundColor = '#ee1616';
@@ -408,7 +400,6 @@ class PageBlockBroadcastsCest
 	{
 		// Setup Plugin and enable debug log.
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 
 		// Define a 'bad' block.  This is difficult to do in Gutenberg, but let's assume it's possible.
 		$I->havePageInDatabase(

--- a/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
@@ -27,10 +27,8 @@ class PageBlockBroadcastsCest
 	 */
 	public function testBroadcastsBlockWithNoBroadcasts(AcceptanceTester $I)
 	{
-		// Setup Plugin with API keys for ConvertKit Account that has no Broadcasts, and enable debug log.
+		// Setup Plugin with API keys for ConvertKit Account that has no Broadcasts.
 		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
-
-		// @TODO FIX LOGIC AS RESOURCES POPD
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: No Broadcasts');
@@ -64,6 +62,7 @@ class PageBlockBroadcastsCest
 	{
 		// Setup Plugin and enable debug log.
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Default Params');
@@ -95,6 +94,7 @@ class PageBlockBroadcastsCest
 	{
 		// Setup Plugin and enable debug log.
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Date Format Param');
@@ -133,6 +133,7 @@ class PageBlockBroadcastsCest
 	{
 		// Setup Plugin and enable debug log.
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Limit Param');
@@ -168,6 +169,7 @@ class PageBlockBroadcastsCest
 	{
 		// Setup Plugin and enable debug log.
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Blank Limit Param');
@@ -204,6 +206,7 @@ class PageBlockBroadcastsCest
 	{
 		// Setup Plugin and enable debug log.
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Pagination');
@@ -237,6 +240,7 @@ class PageBlockBroadcastsCest
 	{
 		// Setup Plugin and enable debug log.
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Pagination Labels');
@@ -272,6 +276,7 @@ class PageBlockBroadcastsCest
 	{
 		// Setup Plugin and enable debug log.
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Blank Pagination Labels');
@@ -307,6 +312,7 @@ class PageBlockBroadcastsCest
 	{
 		// Setup Plugin and enable debug log.
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Define colors.
 		$backgroundColor = 'white';
@@ -353,6 +359,7 @@ class PageBlockBroadcastsCest
 	{
 		// Setup Plugin and enable debug log.
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Define colors.
 		$backgroundColor = '#ee1616';
@@ -400,6 +407,7 @@ class PageBlockBroadcastsCest
 	{
 		// Setup Plugin and enable debug log.
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Define a 'bad' block.  This is difficult to do in Gutenberg, but let's assume it's possible.
 		$I->havePageInDatabase(

--- a/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
@@ -17,7 +17,6 @@ class PageShortcodeBroadcastsCest
 	{
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 	}
 
 	/**

--- a/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
@@ -17,6 +17,7 @@ class PageShortcodeBroadcastsCest
 	{
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**

--- a/tests/acceptance/broadcasts/WidgetBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/WidgetBroadcastsCest.php
@@ -19,7 +19,6 @@ class WidgetBroadcastsCest
 	{
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 
 		// Activate an older WordPress Theme that supports Widgets.
 		$I->useTheme('twentytwentyone');

--- a/tests/acceptance/broadcasts/WidgetBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/WidgetBroadcastsCest.php
@@ -19,6 +19,7 @@ class WidgetBroadcastsCest
 	{
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Activate an older WordPress Theme that supports Widgets.
 		$I->useTheme('twentytwentyone');

--- a/tests/acceptance/forms/CategoryFormCest.php
+++ b/tests/acceptance/forms/CategoryFormCest.php
@@ -18,6 +18,7 @@ class CategoryFormCest
 		// Activate and Setup ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**

--- a/tests/acceptance/forms/CategoryFormCest.php
+++ b/tests/acceptance/forms/CategoryFormCest.php
@@ -141,9 +141,6 @@ class CategoryFormCest
 	 */
 	public function testAddNewPostUsingDefaultFormWithCategoryCreatedBefore1960(AcceptanceTester $I)
 	{
-		// Setup Default Forms.
-		$I->setupConvertKitPluginDefaultForm($I);
-
 		// Create Category as if it were created / edited when the ConvertKit Plugin < 1.9.6.0
 		// was active.
 		$termID = $I->haveTermInDatabase(

--- a/tests/acceptance/forms/CategoryFormCest.php
+++ b/tests/acceptance/forms/CategoryFormCest.php
@@ -18,7 +18,6 @@ class CategoryFormCest
 		// Activate and Setup ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 	}
 
 	/**

--- a/tests/acceptance/forms/PageBlockFormCest.php
+++ b/tests/acceptance/forms/PageBlockFormCest.php
@@ -17,6 +17,7 @@ class PageBlockFormCest
 	{
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**

--- a/tests/acceptance/forms/PageBlockFormCest.php
+++ b/tests/acceptance/forms/PageBlockFormCest.php
@@ -17,7 +17,6 @@ class PageBlockFormCest
 	{
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 	}
 
 	/**

--- a/tests/acceptance/forms/PageFormCest.php
+++ b/tests/acceptance/forms/PageFormCest.php
@@ -30,6 +30,7 @@ class PageFormCest
 	{
 		// Setup ConvertKit plugin.
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Navigate to Post Type (e.g. Pages / Posts) > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=page');
@@ -53,6 +54,7 @@ class PageFormCest
 	{
 		// Setup ConvertKit plugin with no default Forms configured.
 		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '');
+		$I->setupConvertKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Default: None');
@@ -85,6 +87,7 @@ class PageFormCest
 	{
 		// Setup ConvertKit plugin.
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Default');
@@ -117,6 +120,7 @@ class PageFormCest
 	{
 		// Setup ConvertKit plugin to use legacy Form as default for Pages.
 		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'], '');
+		$I->setupConvertKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Legacy: Default');
@@ -149,6 +153,7 @@ class PageFormCest
 	{
 		// Setup ConvertKit plugin.
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: None');
@@ -181,6 +186,7 @@ class PageFormCest
 	{
 		// Setup ConvertKit plugin.
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME']);
@@ -213,6 +219,7 @@ class PageFormCest
 	{
 		// Setup ConvertKit plugin.
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
@@ -250,6 +257,7 @@ class PageFormCest
 	{
 		// Setup ConvertKit plugin.
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Create Page, with an invalid Form ID, as if it were created prior to API credentials being changed and/or
 		// a Form being deleted in ConvertKit.
@@ -292,6 +300,7 @@ class PageFormCest
 	{
 		// Setup ConvertKit plugin.
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Programmatically create a Page.
 		$pageID = $I->havePostInDatabase(
@@ -333,6 +342,7 @@ class PageFormCest
 	{
 		// Setup ConvertKit plugin.
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Programmatically create a Page.
 		$pageID = $I->havePostInDatabase(
@@ -374,6 +384,7 @@ class PageFormCest
 	{
 		// Setup ConvertKit plugin.
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Programmatically create two Pages.
 		$pageIDs = array(
@@ -426,6 +437,7 @@ class PageFormCest
 	{
 		// Setup ConvertKit plugin.
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Programmatically create two Pages.
 		$pageIDs = array(
@@ -478,6 +490,7 @@ class PageFormCest
 	{
 		// Setup ConvertKit plugin.
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Programmatically create two Pages with a defined form.
 		$pageIDs = array(
@@ -544,6 +557,7 @@ class PageFormCest
 	{
 		// Setup ConvertKit plugin.
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Emulate the user searching for Pages with a query string that yields no results.
 		$I->amOnAdminPage('edit.php?post_type=page&s=nothing');

--- a/tests/acceptance/forms/PageFormCest.php
+++ b/tests/acceptance/forms/PageFormCest.php
@@ -15,10 +15,8 @@ class PageFormCest
 	 */
 	public function _before(AcceptanceTester $I)
 	{
-		// Activate and Setup ConvertKit plugin.
+		// Activate ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 	}
 
 	/**
@@ -30,6 +28,9 @@ class PageFormCest
 	 */
 	public function testAccessibility(AcceptanceTester $I)
 	{
+		// Setup ConvertKit plugin.
+		$I->setupConvertKitPlugin($I);
+
 		// Navigate to Post Type (e.g. Pages / Posts) > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=page');
 
@@ -50,6 +51,9 @@ class PageFormCest
 	 */
 	public function testAddNewPageUsingDefaultFormWithNoDefaultFormSpecifiedInPlugin(AcceptanceTester $I)
 	{
+		// Setup ConvertKit plugin with no default Forms configured.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '');
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Default: None');
 
@@ -79,8 +83,8 @@ class PageFormCest
 	 */
 	public function testAddNewPageUsingDefaultForm(AcceptanceTester $I)
 	{
-		// Specify the Default Form in the Plugin Settings.
-		$defaultFormID = $I->setupConvertKitPluginDefaultForm($I);
+		// Setup ConvertKit plugin.
+		$I->setupConvertKitPlugin($I);
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Default');
@@ -98,7 +102,7 @@ class PageFormCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the ConvertKit Default Form displays.
-		$I->seeElementInDOM('form[data-sv-form="' . $defaultFormID . '"]');
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 	}
 
 	/**
@@ -111,8 +115,8 @@ class PageFormCest
 	 */
 	public function testAddNewPageUsingDefaultLegacyForm(AcceptanceTester $I)
 	{
-		// Specify the Default Legacy Form in the Plugin Settings.
-		$defaultLegacyFormID = $I->setupConvertKitPluginDefaultLegacyForm($I);
+		// Setup ConvertKit plugin to use legacy Form as default for Pages.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'], '');
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Legacy: Default');
@@ -130,7 +134,7 @@ class PageFormCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the ConvertKit Default Legacy Form displays.
-		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $defaultLegacyFormID . '/subscribe" data-remote="true">');
+		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
 	}
 
 	/**
@@ -143,6 +147,9 @@ class PageFormCest
 	 */
 	public function testAddNewPageUsingNoForm(AcceptanceTester $I)
 	{
+		// Setup ConvertKit plugin.
+		$I->setupConvertKitPlugin($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: None');
 
@@ -172,6 +179,9 @@ class PageFormCest
 	 */
 	public function testAddNewPageUsingDefinedForm(AcceptanceTester $I)
 	{
+		// Setup ConvertKit plugin.
+		$I->setupConvertKitPlugin($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME']);
 
@@ -201,6 +211,9 @@ class PageFormCest
 	 */
 	public function testAddNewPageUsingDefinedLegacyForm(AcceptanceTester $I)
 	{
+		// Setup ConvertKit plugin.
+		$I->setupConvertKitPlugin($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
 
@@ -235,8 +248,8 @@ class PageFormCest
 	 */
 	public function testAddNewPageUsingInvalidDefinedForm(AcceptanceTester $I)
 	{
-		// Setup the Default Form for Pages and Posts.
-		$I->setupConvertKitPluginDefaultForm($I);
+		// Setup ConvertKit plugin.
+		$I->setupConvertKitPlugin($I);
 
 		// Create Page, with an invalid Form ID, as if it were created prior to API credentials being changed and/or
 		// a Form being deleted in ConvertKit.
@@ -277,8 +290,8 @@ class PageFormCest
 	 */
 	public function testQuickEditUsingDefaultForm(AcceptanceTester $I)
 	{
-		// Specify the Default Form in the Plugin Settings.
-		$I->setupConvertKitPluginDefaultForm($I);
+		// Setup ConvertKit plugin.
+		$I->setupConvertKitPlugin($I);
 
 		// Programmatically create a Page.
 		$pageID = $I->havePostInDatabase(
@@ -318,6 +331,9 @@ class PageFormCest
 	 */
 	public function testQuickEditUsingDefinedForm(AcceptanceTester $I)
 	{
+		// Setup ConvertKit plugin.
+		$I->setupConvertKitPlugin($I);
+
 		// Programmatically create a Page.
 		$pageID = $I->havePostInDatabase(
 			[
@@ -356,8 +372,8 @@ class PageFormCest
 	 */
 	public function testBulkEditUsingDefaultForm(AcceptanceTester $I)
 	{
-		// Specify the Default Form in the Plugin Settings.
-		$I->setupConvertKitPluginDefaultForm($I);
+		// Setup ConvertKit plugin.
+		$I->setupConvertKitPlugin($I);
 
 		// Programmatically create two Pages.
 		$pageIDs = array(
@@ -408,6 +424,9 @@ class PageFormCest
 	 */
 	public function testBulkEditUsingDefinedForm(AcceptanceTester $I)
 	{
+		// Setup ConvertKit plugin.
+		$I->setupConvertKitPlugin($I);
+
 		// Programmatically create two Pages.
 		$pageIDs = array(
 			$I->havePostInDatabase(
@@ -457,6 +476,9 @@ class PageFormCest
 	 */
 	public function testBulkEditWithNoChanges(AcceptanceTester $I)
 	{
+		// Setup ConvertKit plugin.
+		$I->setupConvertKitPlugin($I);
+
 		// Programmatically create two Pages with a defined form.
 		$pageIDs = array(
 			$I->havePostInDatabase(
@@ -520,6 +542,9 @@ class PageFormCest
 	 */
 	public function testBulkEditFieldsHiddenWhenNoPagesFound(AcceptanceTester $I)
 	{
+		// Setup ConvertKit plugin.
+		$I->setupConvertKitPlugin($I);
+
 		// Emulate the user searching for Pages with a query string that yields no results.
 		$I->amOnAdminPage('edit.php?post_type=page&s=nothing');
 

--- a/tests/acceptance/forms/PageNoFormCest.php
+++ b/tests/acceptance/forms/PageNoFormCest.php
@@ -19,8 +19,6 @@ class PageNoFormCest
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
 
-		// @TODO FIX LOGIC AS RESOURECES POPULATED
-
 		// Navigate to Pages > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=page');
 

--- a/tests/acceptance/forms/PageNoFormCest.php
+++ b/tests/acceptance/forms/PageNoFormCest.php
@@ -18,7 +18,8 @@ class PageNoFormCest
 		// Activate and Setup ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
-		$I->enableDebugLog($I);
+
+		// @TODO FIX LOGIC AS RESOURECES POPULATED
 
 		// Navigate to Pages > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=page');

--- a/tests/acceptance/forms/PageShortcodeFormCest.php
+++ b/tests/acceptance/forms/PageShortcodeFormCest.php
@@ -17,7 +17,6 @@ class PageShortcodeFormCest
 	{
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 	}
 
 	/**

--- a/tests/acceptance/forms/PageShortcodeFormCest.php
+++ b/tests/acceptance/forms/PageShortcodeFormCest.php
@@ -17,6 +17,7 @@ class PageShortcodeFormCest
 	{
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**

--- a/tests/acceptance/forms/PageShortcodeFormCest.php
+++ b/tests/acceptance/forms/PageShortcodeFormCest.php
@@ -16,7 +16,7 @@ class PageShortcodeFormCest
 	public function _before(AcceptanceTester $I)
 	{
 		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', ''); // Don't specify default forms.
 		$I->setupConvertKitPluginResources($I);
 	}
 

--- a/tests/acceptance/forms/PostFormCest.php
+++ b/tests/acceptance/forms/PostFormCest.php
@@ -18,7 +18,6 @@ class PostFormCest
 		// Activate and Setup ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 	}
 
 	/**

--- a/tests/acceptance/forms/PostFormCest.php
+++ b/tests/acceptance/forms/PostFormCest.php
@@ -17,8 +17,6 @@ class PostFormCest
 	{
 		// Activate and Setup ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
-		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**
@@ -30,6 +28,10 @@ class PostFormCest
 	 */
 	public function testAccessibility(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Navigate to Post Type (e.g. Pages / Posts) > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=post');
 
@@ -49,6 +51,10 @@ class PostFormCest
 	 */
 	public function testAddNewPostUsingDefaultFormWithNoDefaultFormSpecifiedInPlugin(AcceptanceTester $I)
 	{
+		// Setup Plugin, without defining default Forms.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Post using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: Default: None');
 
@@ -78,8 +84,9 @@ class PostFormCest
 	 */
 	public function testAddNewPostUsingDefaultForm(AcceptanceTester $I)
 	{
-		// Specify the Default Form in the Plugin Settings.
-		$defaultFormID = $I->setupConvertKitPluginDefaultForm($I);
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Add a Post using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: Default');
@@ -97,7 +104,7 @@ class PostFormCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the ConvertKit Default Form displays.
-		$I->seeElementInDOM('form[data-sv-form="' . $defaultFormID . '"]');
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 	}
 
 	/**
@@ -110,8 +117,9 @@ class PostFormCest
 	 */
 	public function testAddNewPostUsingDefaultLegacyForm(AcceptanceTester $I)
 	{
-		// Specify the Default Legacy Form in the Plugin Settings.
-		$defaultLegacyFormID = $I->setupConvertKitPluginDefaultLegacyForm($I);
+		// Setup Plugin, without defining default Forms.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', $_ENV['CONVERTKIT_API_LEGACY_FORM_ID']);
+		$I->setupConvertKitPluginResources($I);
 
 		// Add a Post using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: Legacy: Default');
@@ -129,7 +137,7 @@ class PostFormCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the ConvertKit Default Legacy Form displays.
-		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $defaultLegacyFormID . '/subscribe" data-remote="true">');
+		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
 	}
 
 	/**
@@ -142,6 +150,10 @@ class PostFormCest
 	 */
 	public function testAddNewPostUsingNoForm(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Post using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: None');
 
@@ -171,6 +183,10 @@ class PostFormCest
 	 */
 	public function testAddNewPostUsingDefinedForm(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Post using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME']);
 
@@ -200,6 +216,10 @@ class PostFormCest
 	 */
 	public function testAddNewPostUsingDefinedLegacyForm(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Post using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
 
@@ -234,8 +254,9 @@ class PostFormCest
 	 */
 	public function testAddNewPostUsingInvalidDefinedForm(AcceptanceTester $I)
 	{
-		// Setup the Default Form for Pages and Posts.
-		$I->setupConvertKitPluginDefaultForm($I);
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Create Post, with an invalid Form ID, as if it were created prior to API credentials being changed and/or
 		// a Form being deleted in ConvertKit.
@@ -276,8 +297,9 @@ class PostFormCest
 	 */
 	public function testQuickEditUsingDefaultForm(AcceptanceTester $I)
 	{
-		// Specify the Default Form in the Plugin Settings.
-		$I->setupConvertKitPluginDefaultForm($I);
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Programmatically create a Post.
 		$postID = $I->havePostInDatabase(
@@ -317,6 +339,10 @@ class PostFormCest
 	 */
 	public function testQuickEditUsingDefinedForm(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Programmatically create a Post.
 		$postID = $I->havePostInDatabase(
 			[
@@ -355,8 +381,9 @@ class PostFormCest
 	 */
 	public function testBulkEditUsingDefaultForm(AcceptanceTester $I)
 	{
-		// Specify the Default Form in the Plugin Settings.
-		$I->setupConvertKitPluginDefaultForm($I);
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Programmatically create two Posts.
 		$postIDs = array(
@@ -407,6 +434,10 @@ class PostFormCest
 	 */
 	public function testBulkEditUsingDefinedForm(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Programmatically create two Posts.
 		$postIDs = array(
 			$I->havePostInDatabase(
@@ -456,6 +487,10 @@ class PostFormCest
 	 */
 	public function testBulkEditWithNoChanges(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Programmatically create two Posts with a defined form.
 		$postIDs = array(
 			$I->havePostInDatabase(
@@ -519,6 +554,10 @@ class PostFormCest
 	 */
 	public function testBulkEditFieldsHiddenWhenNoPostsFound(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Emulate the user searching for Posts with a query string that yields no results.
 		$I->amOnAdminPage('edit.php?post_type=post&s=nothing');
 

--- a/tests/acceptance/forms/PostFormCest.php
+++ b/tests/acceptance/forms/PostFormCest.php
@@ -18,6 +18,7 @@ class PostFormCest
 		// Activate and Setup ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**

--- a/tests/acceptance/forms/WidgetFormCest.php
+++ b/tests/acceptance/forms/WidgetFormCest.php
@@ -23,6 +23,7 @@ class WidgetFormCest
 	{
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Activate an older WordPress Theme that supports Widgets.
 		$I->useTheme('twentytwentyone');

--- a/tests/acceptance/forms/WidgetFormCest.php
+++ b/tests/acceptance/forms/WidgetFormCest.php
@@ -23,7 +23,6 @@ class WidgetFormCest
 	{
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 
 		// Activate an older WordPress Theme that supports Widgets.
 		$I->useTheme('twentytwentyone');

--- a/tests/acceptance/general/ActivateDeactivatePluginCest.php
+++ b/tests/acceptance/general/ActivateDeactivatePluginCest.php
@@ -39,6 +39,6 @@ class ActivateDeactivatePluginCest
 
 		// Setup API Keys at Settings > ConvertKit, which will use WordPress Libraries and show errors
 		// if there's a conflict e.g. an older WordPress Library was loaded from another ConvertKit Plugin.
-		$I->setupConvertKitPlugin($I);
+		// @TODO MAKE MANUAL.
 	}
 }

--- a/tests/acceptance/general/ActivateDeactivatePluginCest.php
+++ b/tests/acceptance/general/ActivateDeactivatePluginCest.php
@@ -39,6 +39,16 @@ class ActivateDeactivatePluginCest
 
 		// Setup API Keys at Settings > ConvertKit, which will use WordPress Libraries and show errors
 		// if there's a conflict e.g. an older WordPress Library was loaded from another ConvertKit Plugin.
-		// @TODO MAKE MANUAL.
+		$I->loadConvertKitSettingsGeneralScreen($I);
+
+		// Complete API Fields.
+		$I->fillField('_wp_convertkit_settings[api_key]', $_ENV['CONVERTKIT_API_KEY']);
+		$I->fillField('_wp_convertkit_settings[api_secret]', $_ENV['CONVERTKIT_API_SECRET']);
+
+		// Click the Save Changes button.
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 	}
 }

--- a/tests/acceptance/general/PluginSettingsGeneralCest.php
+++ b/tests/acceptance/general/PluginSettingsGeneralCest.php
@@ -121,7 +121,22 @@ class PluginSettingsGeneralCest
 	 */
 	public function testSaveValidAPICredentials(AcceptanceTester $I)
 	{
-		$I->setupConvertKitPlugin($I);
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsGeneralScreen($I);
+
+		// Complete API Fields.
+		$I->fillField('_wp_convertkit_settings[api_key]', $_ENV['CONVERTKIT_API_KEY']);
+		$I->fillField('_wp_convertkit_settings[api_secret]', $_ENV['CONVERTKIT_API_SECRET']);
+
+		// Click the Save Changes button.
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check the value of the fields match the inputs provided.
+		$I->seeInField('_wp_convertkit_settings[api_key]', $_ENV['CONVERTKIT_API_KEY']);
+		$I->seeInField('_wp_convertkit_settings[api_secret]', $_ENV['CONVERTKIT_API_SECRET']);
 	}
 
 	/**
@@ -137,9 +152,6 @@ class PluginSettingsGeneralCest
 	{
 		// Go to the Plugin's Settings Screen.
 		$I->loadConvertKitSettingsGeneralScreen($I);
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Complete API Fields.
 		$I->fillField('_wp_convertkit_settings[api_key]', $_ENV['CONVERTKIT_API_KEY_NO_DATA']);
@@ -165,14 +177,25 @@ class PluginSettingsGeneralCest
 	 */
 	public function testChangeDefaultFormSetting(AcceptanceTester $I)
 	{
-		// Setup Plugin.
-		$I->setupConvertKitPlugin($I);
+		// Setup Plugin, without defining default Forms.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '');
 
 		// Go to the Plugin's Settings Screen.
 		$I->loadConvertKitSettingsGeneralScreen($I);
 
-		// Call helper function to define default Page and Post.
-		$I->setupConvertKitPluginDefaultForm($I);
+		// Select Default Form for Pages and Posts.
+		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_post_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+
+		// Click the Save Changes button.
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check the value of the fields match the inputs provided.
+		$I->seeInField('_wp_convertkit_settings[page_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->seeInField('_wp_convertkit_settings[post_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
 	}
 
 	/**
@@ -200,8 +223,8 @@ class PluginSettingsGeneralCest
 			]
 		);
 
-		// Setup Plugin.
-		$I->setupConvertKitPlugin($I);
+		// Setup Plugin, without defining default Forms.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '');
 
 		// Go to the Plugin's Settings Screen.
 		$I->loadConvertKitSettingsGeneralScreen($I);
@@ -270,7 +293,7 @@ class PluginSettingsGeneralCest
 	 */
 	public function testEnableAndDisableDebugSettings(AcceptanceTester $I)
 	{
-		// Setup API Keys in ConvertKit Plugin.
+		// Setup Plugin.
 		$I->setupConvertKitPlugin($I);
 
 		// Go to the Plugin's Settings Screen.
@@ -311,11 +334,13 @@ class PluginSettingsGeneralCest
 	 */
 	public function testEnableAndDisableJavaScriptSettings(AcceptanceTester $I)
 	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I);
+
 		// Go to the Plugin's Settings Screen.
 		$I->loadConvertKitSettingsGeneralScreen($I);
 
-		// Tick fields.
-		$I->checkOption('#debug');
+		// Tick field.
 		$I->checkOption('#no_scripts');
 
 		// Click the Save Changes button.
@@ -324,9 +349,20 @@ class PluginSettingsGeneralCest
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Check the fields are ticked.
-		$I->seeCheckboxIsChecked('#debug');
+		// Check the field remains ticked.
 		$I->seeCheckboxIsChecked('#no_scripts');
+
+		// Untick field.
+		$I->uncheckOption('#no_scripts');
+
+		// Click the Save Changes button.
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check the field remains unticked.
+		$I->dontSeeCheckboxIsChecked('#no_scripts');
 	}
 
 	/**
@@ -338,48 +374,15 @@ class PluginSettingsGeneralCest
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testEnableCSSSetting(AcceptanceTester $I)
+	public function testEnableAndDisableCSSSetting(AcceptanceTester $I)
 	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I);
+
 		// Go to the Plugin's Settings Screen.
 		$I->loadConvertKitSettingsGeneralScreen($I);
 
-		// Tick fields.
-		$I->checkOption('#debug');
-		$I->uncheckOption('#no_css');
-
-		// Click the Save Changes button.
-		$I->click('Save Changes');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Check the fields are ticked.
-		$I->seeCheckboxIsChecked('#debug');
-		$I->dontSeeCheckboxIsChecked('#no_css');
-
-		// Navigate to the home page.
-		$I->amOnPage('/');
-
-		// Confirm CSS is output by the Plugin.
-		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
-	}
-
-	/**
-	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
-	 * when the Disable CSS settings is checked, and that no CSS is output
-	 * on the frontend web site.
-	 *
-	 * @since   1.9.6.9
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 */
-	public function testDisableCSSSetting(AcceptanceTester $I)
-	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsGeneralScreen($I);
-
-		// Tick fields.
-		$I->checkOption('#debug');
+		// Tick field.
 		$I->checkOption('#no_css');
 
 		// Click the Save Changes button.
@@ -388,8 +391,7 @@ class PluginSettingsGeneralCest
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Check the fields are ticked.
-		$I->seeCheckboxIsChecked('#debug');
+		// Check the field remains ticked.
 		$I->seeCheckboxIsChecked('#no_css');
 
 		// Navigate to the home page.
@@ -397,6 +399,27 @@ class PluginSettingsGeneralCest
 
 		// Confirm no CSS is output by the Plugin.
 		$I->dontSeeInSource('broadcasts.css');
+
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsGeneralScreen($I);
+
+		// Untick field.
+		$I->uncheckOption('#no_css');
+
+		// Click the Save Changes button.
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check the field remains unticked.
+		$I->dontSeeCheckboxIsChecked('#no_css');
+
+		// Navigate to the home page.
+		$I->amOnPage('/');
+
+		// Confirm CSS is output by the Plugin.
+		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
 	}
 
 	/**

--- a/tests/acceptance/general/PluginSettingsToolsCest.php
+++ b/tests/acceptance/general/PluginSettingsToolsCest.php
@@ -30,9 +30,7 @@ class PluginSettingsToolsCest
 	public function testDebugLogExists(AcceptanceTester $I)
 	{
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 		$I->loadConvertKitSettingsToolsScreen($I);
-		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check that the Debug Log textarea contains some expected output i.e.
 		// does not show the 'No logs have been generated.' message.
@@ -49,9 +47,7 @@ class PluginSettingsToolsCest
 	public function testDownloadLog(AcceptanceTester $I)
 	{
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 		$I->loadConvertKitSettingsToolsScreen($I);
-		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Click the Export button.
 		// This will download the file to $_ENV['WP_ROOT_FOLDER'].
@@ -78,9 +74,7 @@ class PluginSettingsToolsCest
 	public function testSystemInfoExists(AcceptanceTester $I)
 	{
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 		$I->loadConvertKitSettingsToolsScreen($I);
-		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check that the System Info textarea contains some expected output.
 		$I->assertNotFalse(strpos($I->grabValueFrom('#system-info-textarea'), '### wp-core'));
@@ -105,9 +99,7 @@ class PluginSettingsToolsCest
 	public function testDownloadSystemInfo(AcceptanceTester $I)
 	{
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 		$I->loadConvertKitSettingsToolsScreen($I);
-		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Click the Export button.
 		// This will download the file to $_ENV['WP_ROOT_FOLDER'].
@@ -143,9 +135,7 @@ class PluginSettingsToolsCest
 	public function testExportConfiguration(AcceptanceTester $I)
 	{
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 		$I->loadConvertKitSettingsToolsScreen($I);
-		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Click the Export button.
 		// This will download the file to $_ENV['WP_ROOT_FOLDER'].

--- a/tests/acceptance/general/PluginSettingsToolsCest.php
+++ b/tests/acceptance/general/PluginSettingsToolsCest.php
@@ -30,6 +30,7 @@ class PluginSettingsToolsCest
 	public function testDebugLogExists(AcceptanceTester $I)
 	{
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 		$I->loadConvertKitSettingsToolsScreen($I);
 
 		// Check that the Debug Log textarea contains some expected output i.e.
@@ -47,6 +48,7 @@ class PluginSettingsToolsCest
 	public function testDownloadLog(AcceptanceTester $I)
 	{
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 		$I->loadConvertKitSettingsToolsScreen($I);
 
 		// Click the Export button.
@@ -74,6 +76,7 @@ class PluginSettingsToolsCest
 	public function testSystemInfoExists(AcceptanceTester $I)
 	{
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 		$I->loadConvertKitSettingsToolsScreen($I);
 
 		// Check that the System Info textarea contains some expected output.
@@ -99,6 +102,7 @@ class PluginSettingsToolsCest
 	public function testDownloadSystemInfo(AcceptanceTester $I)
 	{
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 		$I->loadConvertKitSettingsToolsScreen($I);
 
 		// Click the Export button.
@@ -135,6 +139,7 @@ class PluginSettingsToolsCest
 	public function testExportConfiguration(AcceptanceTester $I)
 	{
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 		$I->loadConvertKitSettingsToolsScreen($I);
 
 		// Click the Export button.

--- a/tests/acceptance/general/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/general/RefreshResourcesButtonCest.php
@@ -20,6 +20,8 @@ class RefreshResourcesButtonCest
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
 
+		// @TODO FIX LOGIC AS RESOURCES POPULATED ABOVE.
+
 		// Change API keys in database to ones that have ConvertKit Resources.
 		// We do this directly vs. via the settings screen, so that the Plugin's cached resources remain blank
 		// until a refresh button is clicked.

--- a/tests/acceptance/general/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/general/RefreshResourcesButtonCest.php
@@ -16,25 +16,12 @@ class RefreshResourcesButtonCest
 	 */
 	public function _before(AcceptanceTester $I)
 	{
-		// Activate and Setup ConvertKit plugin using API keys that have no resources (forms, landing pages, tags).
+		// Activate and Setup ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET']);
 
-		// @TODO FIX LOGIC AS RESOURCES POPULATED ABOVE.
-
-		// Change API keys in database to ones that have ConvertKit Resources.
-		// We do this directly vs. via the settings screen, so that the Plugin's cached resources remain blank
+		// We don't call $I->setupConvertKitPluginResources($I), as we want cached resources to remain blank
 		// until a refresh button is clicked.
-		$I->haveOptionInDatabase(
-			'_wp_convertkit_settings',
-			[
-				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-				'debug'      => 'on',
-				'no_scripts' => '',
-				'no_css'     => '',
-			]
-		);
 	}
 
 	/**

--- a/tests/acceptance/general/ReviewRequestCest.php
+++ b/tests/acceptance/general/ReviewRequestCest.php
@@ -28,13 +28,21 @@ class ReviewRequestCest
 	 */
 	public function testReviewRequestOnSaveSettings(AcceptanceTester $I)
 	{
-		// Setup ConvertKit Plugin.
-		$I->setupConvertKitPlugin($I);
+		// Setup Plugin, without defining default Forms.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '');
 
-// @TODO FIX LOGIC.
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsGeneralScreen($I);
 
-		// Define Default Form.
-		$I->setupConvertKitPluginDefaultForm($I);
+		// Select Default Form for Pages and Posts.
+		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_post_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+
+		// Click the Save Changes button.
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check that the options table does have a review request set.
 		$I->seeOptionInDatabase('convertkit-review-request');
@@ -80,6 +88,7 @@ class ReviewRequestCest
 	{
 		// Setup ConvertKit Plugin.
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Test Review Request on Save with Form Specified');
@@ -119,6 +128,7 @@ class ReviewRequestCest
 	{
 		// Setup ConvertKit Plugin.
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Test Review Request on Save with Form Specified');

--- a/tests/acceptance/general/ReviewRequestCest.php
+++ b/tests/acceptance/general/ReviewRequestCest.php
@@ -31,6 +31,8 @@ class ReviewRequestCest
 		// Setup ConvertKit Plugin.
 		$I->setupConvertKitPlugin($I);
 
+// @TODO FIX LOGIC.
+
 		// Define Default Form.
 		$I->setupConvertKitPluginDefaultForm($I);
 

--- a/tests/acceptance/general/SubscriberEmailToIDOnFormSubmitCest.php
+++ b/tests/acceptance/general/SubscriberEmailToIDOnFormSubmitCest.php
@@ -18,8 +18,6 @@ class SubscriberEmailToIDOnFormSubmitCest
 	{
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
-		$I->setupConvertKitPluginDefaultForm($I);
-		$I->enableDebugLog($I);
 
 		// Clear Log, so that entries from previous tests aren't included in this test.
 		$I->clearDebugLog($I);

--- a/tests/acceptance/general/SubscriberEmailToIDOnFormSubmitCest.php
+++ b/tests/acceptance/general/SubscriberEmailToIDOnFormSubmitCest.php
@@ -18,6 +18,7 @@ class SubscriberEmailToIDOnFormSubmitCest
 	{
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Clear Log, so that entries from previous tests aren't included in this test.
 		$I->clearDebugLog($I);

--- a/tests/acceptance/general/UpgradePathsCest.php
+++ b/tests/acceptance/general/UpgradePathsCest.php
@@ -18,7 +18,6 @@ class UpgradePathsCest
 		// Activate and Setup ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 	}
 
 	/**

--- a/tests/acceptance/general/UpgradePathsCest.php
+++ b/tests/acceptance/general/UpgradePathsCest.php
@@ -18,6 +18,7 @@ class UpgradePathsCest
 		// Activate and Setup ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**

--- a/tests/acceptance/integrations/ContactForm7FormCest.php
+++ b/tests/acceptance/integrations/ContactForm7FormCest.php
@@ -18,7 +18,6 @@ class ContactForm7FormCest
 		$I->activateConvertKitPlugin($I);
 		$I->activateThirdPartyPlugin($I, 'contact-form-7');
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 	}
 
 	/**

--- a/tests/acceptance/integrations/ContactForm7FormCest.php
+++ b/tests/acceptance/integrations/ContactForm7FormCest.php
@@ -18,6 +18,7 @@ class ContactForm7FormCest
 		$I->activateConvertKitPlugin($I);
 		$I->activateThirdPartyPlugin($I, 'contact-form-7');
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**

--- a/tests/acceptance/integrations/ElementorBroadcastsCest.php
+++ b/tests/acceptance/integrations/ElementorBroadcastsCest.php
@@ -18,7 +18,6 @@ class ElementorBroadcastsCest
 		$I->activateConvertKitPlugin($I);
 		$I->activateThirdPartyPlugin($I, 'elementor');
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 	}
 
 	/**

--- a/tests/acceptance/integrations/ElementorBroadcastsCest.php
+++ b/tests/acceptance/integrations/ElementorBroadcastsCest.php
@@ -18,6 +18,7 @@ class ElementorBroadcastsCest
 		$I->activateConvertKitPlugin($I);
 		$I->activateThirdPartyPlugin($I, 'elementor');
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**

--- a/tests/acceptance/integrations/ElementorFormCest.php
+++ b/tests/acceptance/integrations/ElementorFormCest.php
@@ -18,7 +18,6 @@ class ElementorFormCest
 		$I->activateConvertKitPlugin($I);
 		$I->activateThirdPartyPlugin($I, 'elementor');
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 	}
 
 	/**

--- a/tests/acceptance/integrations/ElementorFormCest.php
+++ b/tests/acceptance/integrations/ElementorFormCest.php
@@ -17,7 +17,9 @@ class ElementorFormCest
 	{
 		$I->activateConvertKitPlugin($I);
 		$I->activateThirdPartyPlugin($I, 'elementor');
-		$I->setupConvertKitPlugin($I);
+
+		// Setup Plugin, without defining default Forms.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '');
 		$I->setupConvertKitPluginResources($I);
 	}
 

--- a/tests/acceptance/integrations/ElementorFormCest.php
+++ b/tests/acceptance/integrations/ElementorFormCest.php
@@ -18,6 +18,7 @@ class ElementorFormCest
 		$I->activateConvertKitPlugin($I);
 		$I->activateThirdPartyPlugin($I, 'elementor');
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**

--- a/tests/acceptance/integrations/ElementorProductCest.php
+++ b/tests/acceptance/integrations/ElementorProductCest.php
@@ -18,6 +18,7 @@ class ElementorProductCest
 		$I->activateConvertKitPlugin($I);
 		$I->activateThirdPartyPlugin($I, 'elementor');
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**

--- a/tests/acceptance/integrations/ElementorProductCest.php
+++ b/tests/acceptance/integrations/ElementorProductCest.php
@@ -18,7 +18,6 @@ class ElementorProductCest
 		$I->activateConvertKitPlugin($I);
 		$I->activateThirdPartyPlugin($I, 'elementor');
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 	}
 
 	/**

--- a/tests/acceptance/integrations/WishListMemberCest.php
+++ b/tests/acceptance/integrations/WishListMemberCest.php
@@ -18,6 +18,7 @@ class WishListMemberCest
 		$I->activateConvertKitPlugin($I);
 		$I->activateThirdPartyPlugin($I, 'wishlist-member');
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**

--- a/tests/acceptance/integrations/WishListMemberCest.php
+++ b/tests/acceptance/integrations/WishListMemberCest.php
@@ -18,7 +18,6 @@ class WishListMemberCest
 		$I->activateConvertKitPlugin($I);
 		$I->activateThirdPartyPlugin($I, 'wishlist-member');
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 	}
 
 	/**

--- a/tests/acceptance/integrations/WooCommerceProductFormCest.php
+++ b/tests/acceptance/integrations/WooCommerceProductFormCest.php
@@ -18,6 +18,7 @@ class WooCommerceProductFormCest
 		$I->activateConvertKitPlugin($I);
 		$I->activateThirdPartyPlugin($I, 'woocommerce');
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**

--- a/tests/acceptance/integrations/WooCommerceProductFormCest.php
+++ b/tests/acceptance/integrations/WooCommerceProductFormCest.php
@@ -17,8 +17,6 @@ class WooCommerceProductFormCest
 	{
 		$I->activateConvertKitPlugin($I);
 		$I->activateThirdPartyPlugin($I, 'woocommerce');
-		$I->setupConvertKitPlugin($I);
-		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**
@@ -32,6 +30,10 @@ class WooCommerceProductFormCest
 	 */
 	public function testAddNewProductUsingDefaultFormWithNoDefaultFormSpecifiedInPlugin(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Navigate to Products > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=product');
 
@@ -58,8 +60,9 @@ class WooCommerceProductFormCest
 	 */
 	public function testAddNewProductUsingDefaultForm(AcceptanceTester $I)
 	{
-		// Specify the Default Form in the Plugin Settings.
-		$defaultFormID = $I->setupConvertKitPluginDefaultFormForWooCommerceProducts($I);
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Navigate to Products > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=product');
@@ -74,7 +77,7 @@ class WooCommerceProductFormCest
 		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the ConvertKit Default Form displays.
-		$I->seeElementInDOM('form[data-sv-form="' . $defaultFormID . '"]');
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
 	}
 
 	/**
@@ -87,6 +90,10 @@ class WooCommerceProductFormCest
 	 */
 	public function testAddNewProductUsingNoForm(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Navigate to Products > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=product');
 
@@ -119,6 +126,10 @@ class WooCommerceProductFormCest
 	 */
 	public function testAddNewProductUsingDefinedForm(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Navigate to Products > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=product');
 
@@ -151,6 +162,10 @@ class WooCommerceProductFormCest
 	 */
 	public function testAddNewProductUsingFormShortcodeInVisualEditor(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Product using the Classic Editor.
 		$I->addClassicEditorPage($I, 'product', 'ConvertKit: Product: Form: Shortcode: Visual Editor');
 
@@ -201,6 +216,10 @@ class WooCommerceProductFormCest
 	 */
 	public function testAddNewProductUsingFormShortcodeInTextEditor(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Product using the Classic Editor.
 		$I->addClassicEditorPage($I, 'product', 'ConvertKit: Product: Form: Shortcode: Text Editor');
 
@@ -251,8 +270,9 @@ class WooCommerceProductFormCest
 	 */
 	public function testQuickEditUsingDefaultForm(AcceptanceTester $I)
 	{
-		// Specify the Default Form in the Plugin Settings.
-		$I->setupConvertKitPluginDefaultFormForWooCommerceProducts($I);
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Programmatically create a Product.
 		$productID = $I->havePostInDatabase(
@@ -292,6 +312,10 @@ class WooCommerceProductFormCest
 	 */
 	public function testQuickEditUsingDefinedForm(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Programmatically create a Product.
 		$productID = $I->havePostInDatabase(
 			[
@@ -330,8 +354,9 @@ class WooCommerceProductFormCest
 	 */
 	public function testBulkEditUsingDefaultForm(AcceptanceTester $I)
 	{
-		// Specify the Default Form in the Plugin Settings.
-		$I->setupConvertKitPluginDefaultFormForWooCommerceProducts($I);
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 
 		// Programmatically create two Products.
 		$productIDs = array(
@@ -382,6 +407,10 @@ class WooCommerceProductFormCest
 	 */
 	public function testBulkEditUsingDefinedForm(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Programmatically create two Products.
 		$productIDs = array(
 			$I->havePostInDatabase(
@@ -431,6 +460,10 @@ class WooCommerceProductFormCest
 	 */
 	public function testBulkEditWithNoChanges(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Programmatically create two Products with a defined form.
 		$productIDs = array(
 			$I->havePostInDatabase(
@@ -494,6 +527,10 @@ class WooCommerceProductFormCest
 	 */
 	public function testBulkEditFieldsHiddenWhenNoProductsFound(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Emulate the user searching for Products with a query string that yields no results.
 		$I->amOnAdminPage('edit.php?post_type=product&s=nothing');
 

--- a/tests/acceptance/integrations/WooCommerceProductFormCest.php
+++ b/tests/acceptance/integrations/WooCommerceProductFormCest.php
@@ -18,7 +18,6 @@ class WooCommerceProductFormCest
 		$I->activateConvertKitPlugin($I);
 		$I->activateThirdPartyPlugin($I, 'woocommerce');
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 	}
 
 	/**

--- a/tests/acceptance/landing-pages/PageLandingPageCest.php
+++ b/tests/acceptance/landing-pages/PageLandingPageCest.php
@@ -18,6 +18,7 @@ class PageLandingPageCest
 		// Activate and Setup ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**

--- a/tests/acceptance/landing-pages/PageLandingPageCest.php
+++ b/tests/acceptance/landing-pages/PageLandingPageCest.php
@@ -18,7 +18,6 @@ class PageLandingPageCest
 		// Activate and Setup ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 	}
 
 	/**

--- a/tests/acceptance/landing-pages/PageLandingPageCest.php
+++ b/tests/acceptance/landing-pages/PageLandingPageCest.php
@@ -17,7 +17,9 @@ class PageLandingPageCest
 	{
 		// Activate and Setup ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
+
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
 		$I->setupConvertKitPluginResources($I);
 	}
 

--- a/tests/acceptance/landing-pages/PostLandingPageCest.php
+++ b/tests/acceptance/landing-pages/PostLandingPageCest.php
@@ -18,7 +18,6 @@ class PostLandingPageCest
 		// Activate and Setup ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 	}
 
 	/**

--- a/tests/acceptance/landing-pages/PostLandingPageCest.php
+++ b/tests/acceptance/landing-pages/PostLandingPageCest.php
@@ -17,12 +17,14 @@ class PostLandingPageCest
 	{
 		// Activate and Setup ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
+
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
 		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**
-	 * Test that no Landing Page option is displayedin the Plugin Settings when
+	 * Test that no Landing Page option is displayed in the Plugin Settings when
 	 * creating and viewing a new WordPress Post, and that no attempt to check
 	 * for a Landing Page is made when viewing a Post.
 	 *

--- a/tests/acceptance/landing-pages/PostLandingPageCest.php
+++ b/tests/acceptance/landing-pages/PostLandingPageCest.php
@@ -18,6 +18,7 @@ class PostLandingPageCest
 		// Activate and Setup ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**

--- a/tests/acceptance/products/PageBlockProductCest.php
+++ b/tests/acceptance/products/PageBlockProductCest.php
@@ -16,7 +16,9 @@ class PageBlockProductCest
 	public function _before(AcceptanceTester $I)
 	{
 		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
+
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
 		$I->setupConvertKitPluginResources($I);
 	}
 

--- a/tests/acceptance/products/PageBlockProductCest.php
+++ b/tests/acceptance/products/PageBlockProductCest.php
@@ -17,6 +17,7 @@ class PageBlockProductCest
 	{
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**

--- a/tests/acceptance/products/PageBlockProductCest.php
+++ b/tests/acceptance/products/PageBlockProductCest.php
@@ -17,7 +17,6 @@ class PageBlockProductCest
 	{
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 	}
 
 	/**

--- a/tests/acceptance/products/PageLinkProductCest.php
+++ b/tests/acceptance/products/PageLinkProductCest.php
@@ -18,7 +18,6 @@ class PageLinkProductCest
 	{
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 	}
 
 	/**

--- a/tests/acceptance/products/PageLinkProductCest.php
+++ b/tests/acceptance/products/PageLinkProductCest.php
@@ -18,6 +18,7 @@ class PageLinkProductCest
 	{
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**

--- a/tests/acceptance/products/PageLinkProductCest.php
+++ b/tests/acceptance/products/PageLinkProductCest.php
@@ -17,8 +17,12 @@ class PageLinkProductCest
 	public function _before(AcceptanceTester $I)
 	{
 		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
-		$I->setupConvertKitPluginResources($I);
+
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+
+		// We don't call $I->setupConvertKitPluginResources($I), as we want the Plugin to populate the Products
+		// resource, which will also create the Product Custom Posts used for the linking functionality.
 	}
 
 	/**

--- a/tests/acceptance/products/PageShortcodeProductCest.php
+++ b/tests/acceptance/products/PageShortcodeProductCest.php
@@ -17,7 +17,6 @@ class PageShortcodeProductCest
 	{
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 	}
 
 	/**

--- a/tests/acceptance/products/PageShortcodeProductCest.php
+++ b/tests/acceptance/products/PageShortcodeProductCest.php
@@ -16,7 +16,9 @@ class PageShortcodeProductCest
 	public function _before(AcceptanceTester $I)
 	{
 		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
+
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
 		$I->setupConvertKitPluginResources($I);
 	}
 

--- a/tests/acceptance/products/PageShortcodeProductCest.php
+++ b/tests/acceptance/products/PageShortcodeProductCest.php
@@ -17,6 +17,7 @@ class PageShortcodeProductCest
 	{
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**

--- a/tests/acceptance/tags/PageShortcodeCustomContentCest.php
+++ b/tests/acceptance/tags/PageShortcodeCustomContentCest.php
@@ -17,7 +17,6 @@ class PageShortcodeCustomContentCest
 	{
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 	}
 
 	/**

--- a/tests/acceptance/tags/PageShortcodeCustomContentCest.php
+++ b/tests/acceptance/tags/PageShortcodeCustomContentCest.php
@@ -16,7 +16,9 @@ class PageShortcodeCustomContentCest
 	public function _before(AcceptanceTester $I)
 	{
 		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
+
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
 		$I->setupConvertKitPluginResources($I);
 	}
 

--- a/tests/acceptance/tags/PageShortcodeCustomContentCest.php
+++ b/tests/acceptance/tags/PageShortcodeCustomContentCest.php
@@ -17,6 +17,7 @@ class PageShortcodeCustomContentCest
 	{
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**

--- a/tests/acceptance/tags/PageTagCest.php
+++ b/tests/acceptance/tags/PageTagCest.php
@@ -18,6 +18,7 @@ class PageTagCest
 		// Activate and Setup ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**

--- a/tests/acceptance/tags/PageTagCest.php
+++ b/tests/acceptance/tags/PageTagCest.php
@@ -18,7 +18,6 @@ class PageTagCest
 		// Activate and Setup ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
-		$I->enableDebugLog($I);
 	}
 
 	/**

--- a/tests/acceptance/tags/PageTagCest.php
+++ b/tests/acceptance/tags/PageTagCest.php
@@ -17,7 +17,9 @@ class PageTagCest
 	{
 		// Activate and Setup ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
+
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
 		$I->setupConvertKitPluginResources($I);
 	}
 


### PR DESCRIPTION
## Summary

Improves test performance by performing the following before each test:
- programmatically defining the API Key, Secret and default forms,
- writing resources (ConvertKit forms, landing pages, posts, products and tags) directly to the database cache, instead of querying the API for them, effectively mocking the API for reading resources

This improves performance and prevents API rate limits being hit (due to test run in parallel), as`Settings > ConvertKit` is only accessed when explicitly required (i.e. for `PluginSettingsGeneralCest`).  Previously, this screen would always be accessed for every test, resulting in the API being queried every time to fetch forms, landing pages, posts, products and tags.

For performance comparison, see before:
![Screenshot 2023-01-09 at 17 20 00](https://user-images.githubusercontent.com/1462305/211389156-02b6a921-66f4-4776-b5a1-6031e3e19513.png)

After:
![Screenshot 2023-01-09 at 17 20 05](https://user-images.githubusercontent.com/1462305/211389186-7fd33631-298f-4b8c-b6c9-9f96022f8d74.png)

Other API functions are not mocked (e.g. tagging a subscriber), and WPUnit test coverage remains, to ensure that resource classes correctly work when querying the API.

## Testing

Tests should pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)