### PR TITLE
Elementor 3.9.0 Compatibility

### DIFF
--- a/includes/integrations/elementor/class-convertkit-elementor.php
+++ b/includes/integrations/elementor/class-convertkit-elementor.php
@@ -103,10 +103,17 @@ class ConvertKit_Elementor {
 
 			// Load widget class for this block.
 			require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/elementor/class-convertkit-elementor-widget-' . $block . '.php';
-
-			// Register Widget.
 			$class_name = 'ConvertKit_Elementor_Widget_' . str_replace( '-', '_', $block );
-			$widgets_manager->register_widget_type( new $class_name() );
+
+			// Register Widget, using applicable function depending on the Elementor version.
+			if ( method_exists( $widgets_manager, 'register' ) ) {
+				// Use register() function, available in Elementor 3.5.0.
+				// Required per https://developers.elementor.com/docs/managers/registering-widgets/
+				$widgets_manager->register( new $class_name() );	
+			} else {
+				// Fallback to register_widget_type(), available in Elementor < 3.5.0.
+				$widgets_manager->register_widget_type( new $class_name() );
+			}
 		}
 
 	}

--- a/includes/integrations/elementor/class-convertkit-elementor.php
+++ b/includes/integrations/elementor/class-convertkit-elementor.php
@@ -108,8 +108,8 @@ class ConvertKit_Elementor {
 			// Register Widget, using applicable function depending on the Elementor version.
 			if ( method_exists( $widgets_manager, 'register' ) ) {
 				// Use register() function, available in Elementor 3.5.0.
-				// Required per https://developers.elementor.com/docs/managers/registering-widgets/
-				$widgets_manager->register( new $class_name() );	
+				// Required per https://developers.elementor.com/docs/managers/registering-widgets/.
+				$widgets_manager->register( new $class_name() );
 			} else {
 				// Fallback to register_widget_type(), available in Elementor < 3.5.0.
 				$widgets_manager->register_widget_type( new $class_name() );


### PR DESCRIPTION
## Summary

Starting in Elementor 3.5.0, widgets should be registered using the [`register()` function](https://developers.elementor.com/docs/managers/registering-widgets/).

This has become a [hard deprecation in Elementor 3.9.0](https://developers.elementor.com/v3-5-planned-deprecations/), which results in a PHP Deprecated notice displaying if WP_DEBUG is enabled:
![ElementorBroadcastsCest testBroadcastsWidgetWithValidParameters fail](https://user-images.githubusercontent.com/1462305/211391708-4ae3d614-6ddb-401c-a56f-d569b01a5c49.png)

This PR resolves by using the applicable Elementor function to register our blocks as Elementor widgets, depending on the Elementor version.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)