### PR TITLE
Use WordPress Libraries 1.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "1.2.3"
+        "convertkit/convertkit-wordpress-libraries": "1.3.0"
     },
     "require-dev": {
         "lucatume/wp-browser": "^3.0",


### PR DESCRIPTION
## Summary

Updates the Plugin to use the latest version of our ConvertKit WordPress Libraries, [1.3.0](https://github.com/ConvertKit/convertkit-wordpress-libraries/releases/tag/1.3.0), which contains the necessary API functions for the Restrict Content functionality.

Adding this prior to Restrict Content so we avoid a repeat of [this issue](https://github.com/ConvertKit/convertkit-wordpress/pull/382).

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)