### PR TITLE
Merge `test-performance` into `main`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "1.2.3"
+        "convertkit/convertkit-wordpress-libraries": "1.3.0"
     },
     "require-dev": {
         "lucatume/wp-browser": "^3.0",


### PR DESCRIPTION
[Original PR](https://github.com/ConvertKit/convertkit-wordpress/pull/419) incorrectly set `wp-libs-1.3.0` to base off this `test-performance` branch instead of `main`.