### PR TITLE
Restrict Content: Fix error on Plugin Deactivation

### DIFF
--- a/includes/class-convertkit-post-type-product.php
+++ b/includes/class-convertkit-post-type-product.php
@@ -139,6 +139,11 @@ class ConvertKit_Post_Type_Product {
 		// Delete all Products in the Custom Post Type.
 		$this->delete_all();
 
+		// Bail if the Post Type isn't registered.
+		if ( ! post_type_exists( $this->post_type_name ) ) {
+			return;
+		}
+
 		// If no Products exist, bail.
 		if ( ! $products ) {
 			return;

--- a/includes/class-convertkit-post-type-product.php
+++ b/includes/class-convertkit-post-type-product.php
@@ -36,7 +36,7 @@ class ConvertKit_Post_Type_Product {
 	public function __construct() {
 
 		// Register Custom Post Type.
-		add_action( 'init', array( $this, 'register' ), 1 );
+		add_action( 'init', array( $this, 'register' ) );
 
 		// Register commerce.js.
 		add_action( 'init', array( $this, 'register_commerce_script' ) );

--- a/includes/class-convertkit-post-type-product.php
+++ b/includes/class-convertkit-post-type-product.php
@@ -36,7 +36,7 @@ class ConvertKit_Post_Type_Product {
 	public function __construct() {
 
 		// Register Custom Post Type.
-		add_action( 'init', array( $this, 'register' ) );
+		add_action( 'init', array( $this, 'register' ), 1 );
 
 		// Register commerce.js.
 		add_action( 'init', array( $this, 'register_commerce_script' ) );

--- a/tests/_data/dump.sql
+++ b/tests/_data/dump.sql
@@ -216,7 +216,7 @@ INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`
 (86,  'site_icon',  '0',  'yes'),
 (87,  'medium_large_size_w',  '768',  'yes'),
 (88,  'medium_large_size_h',  '0',  'yes'),
-(89,  'wp_page_for_privacy_policy', '3',  'yes'),
+(89,  'wp_page_for_privacy_policy', '',  'yes'),
 (90,  'show_comments_cookies_opt_in', '1',  'yes'),
 (92,  'disallowed_keys',  '', 'no'),
 (93,  'comment_previously_approved',  '1',  'yes'),

--- a/tests/acceptance/general/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/general/RefreshResourcesButtonCest.php
@@ -19,6 +19,14 @@ class RefreshResourcesButtonCest
 		// Activate and Setup ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPluginResources($I);
+
+		// Enable Restrict Content, so the Products refresh button can be tested.
+		$I->setupConvertKitPluginRestrictContent(
+			$I,
+			[
+				'enabled' => true,
+			]
+		);
 	}
 
 	/**

--- a/tests/acceptance/products/PageLinkProductCest.php
+++ b/tests/acceptance/products/PageLinkProductCest.php
@@ -18,11 +18,15 @@ class PageLinkProductCest
 	{
 		$I->activateConvertKitPlugin($I);
 
-		// Setup ConvertKit Plugin with no default form specified.
-		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsGeneralScreen($I);
 
-		// We don't call $I->setupConvertKitPluginResources($I), as we want the Plugin to populate the Products
-		// resource, which will also create the Product Custom Posts used for the linking functionality.
+		// Complete API Fields.
+		$I->fillField('_wp_convertkit_settings[api_key]', $_ENV['CONVERTKIT_API_KEY']);
+		$I->fillField('_wp_convertkit_settings[api_secret]', $_ENV['CONVERTKIT_API_SECRET']);
+
+		// Click the Save Changes button.
+		$I->click('Save Changes');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes this error on Plugin deactivation, due to the Products Custom Post Type no longer being registered.
![RestrictContentFilterCest testNoFilterDisplayedWhenRestrictContentDisabled fail](https://user-images.githubusercontent.com/1462305/212340044-1a2c2784-015a-43fc-9aa4-a1e43a2b18a7.png)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)