### PR TITLE
Replace mixed type in docblocks

### DIFF
--- a/.scripts/class-read-actions-filters.php
+++ b/.scripts/class-read-actions-filters.php
@@ -21,14 +21,14 @@ class Read_Actions_Filters {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param   mixed $folders                        WordPress Plugin/Theme Folder Path(s) (e.g. /path/to/your/wp/wp-content/plugins/plugin-name).
-	 * @param   bool  $extract_filters                Extract apply_filters() calls.
-	 * @param   bool  $extract_actions                Extract do_action() calls.
-	 * @param   bool  $return_format                  Return Format (html|array).
-	 * @param   mixed $prefix_required                Optional prefix string required on filters and actions for inclusion in resultset (false = don't filter any found filters/actions).
-	 * @param   mixed $prefix_required_replacement    Optional prefix string replacement, to use if $prefix_required is found (e.g. $this->base->plugin->name --> convertkit_).
-	 * @param   bool  $by_file                        Denote filters and actions by filename (false = group filters and actions if they appear across multiple files).
-	 * @return  mixed                                  Output
+	 * @param   array 		$folders                        WordPress Plugin/Theme Folder Path(s) (e.g. /path/to/your/wp/wp-content/plugins/plugin-name).
+	 * @param   bool  		$extract_filters                Extract apply_filters() calls.
+	 * @param   bool  		$extract_actions                Extract do_action() calls.
+	 * @param   bool  		$return_format                  Return Format (html|array).
+	 * @param   bool|string $prefix_required                Optional prefix string required on filters and actions for inclusion in resultset (false = don't filter any found filters/actions).
+	 * @param   bool|string $prefix_required_replacement    Optional prefix string replacement, to use if $prefix_required is found (e.g. $this->base->plugin->name --> convertkit_).
+	 * @param   bool  		$by_file                        Denote filters and actions by filename (false = group filters and actions if they appear across multiple files).
+	 * @return  bool|string                                 Output
 	 */
 	public function run( $folders, $extract_filters = true, $extract_actions = true, $return_format = 'html', $prefix_required = false, $prefix_required_replacement = false, $by_file = false ) {
 
@@ -124,14 +124,14 @@ class Read_Actions_Filters {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param   string $function_to_search             Function to search (apply_filters|do_action).
-	 * @param   string $results                        Existing Results.
-	 * @param   string $contents                       File Contents.
-	 * @param   string $file_only                      Filename (excluding full path).
-	 * @param   string $prefix_required                Optional prefix string required on filters and actions for inclusion in resultset (false = don't filter any found filters/actions).
-	 * @param   mixed  $prefix_required_replacement    Optional prefix string replacement, to use if $prefix_required is found (e.g. $this->base->plugin->name --> convertkit_).
-	 * @param   bool   $by_file                        Deliminate array results by file.
-	 * @return  array       Matches
+	 * @param   string 			$function_to_search             Function to search (apply_filters|do_action).
+	 * @param   string 			$results                        Existing Results.
+	 * @param   string 			$contents                       File Contents.
+	 * @param   string 			$file_only                      Filename (excluding full path).
+	 * @param   bool|string 	$prefix_required                Optional prefix string required on filters and actions for inclusion in resultset (false = don't filter any found filters/actions).
+	 * @param   bool|string  	$prefix_required_replacement    Optional prefix string replacement, to use if $prefix_required is found (e.g. $this->base->plugin->name --> convertkit_).
+	 * @param   bool   			$by_file                        Deliminate array results by file.
+	 * @return  array       									Matches
 	 */
 	private function find_matches( $function_to_search, $results, $contents, $file_only, $prefix_required, $prefix_required_replacement = false, $by_file ) {
 

--- a/.scripts/class-read-actions-filters.php
+++ b/.scripts/class-read-actions-filters.php
@@ -21,13 +21,13 @@ class Read_Actions_Filters {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param   array 		$folders                        WordPress Plugin/Theme Folder Path(s) (e.g. /path/to/your/wp/wp-content/plugins/plugin-name).
-	 * @param   bool  		$extract_filters                Extract apply_filters() calls.
-	 * @param   bool  		$extract_actions                Extract do_action() calls.
-	 * @param   bool  		$return_format                  Return Format (html|array).
+	 * @param   array       $folders                        WordPress Plugin/Theme Folder Path(s) (e.g. /path/to/your/wp/wp-content/plugins/plugin-name).
+	 * @param   bool        $extract_filters                Extract apply_filters() calls.
+	 * @param   bool        $extract_actions                Extract do_action() calls.
+	 * @param   bool        $return_format                  Return Format (html|array).
 	 * @param   bool|string $prefix_required                Optional prefix string required on filters and actions for inclusion in resultset (false = don't filter any found filters/actions).
 	 * @param   bool|string $prefix_required_replacement    Optional prefix string replacement, to use if $prefix_required is found (e.g. $this->base->plugin->name --> convertkit_).
-	 * @param   bool  		$by_file                        Denote filters and actions by filename (false = group filters and actions if they appear across multiple files).
+	 * @param   bool        $by_file                        Denote filters and actions by filename (false = group filters and actions if they appear across multiple files).
 	 * @return  bool|string                                 Output
 	 */
 	public function run( $folders, $extract_filters = true, $extract_actions = true, $return_format = 'html', $prefix_required = false, $prefix_required_replacement = false, $by_file = false ) {
@@ -124,14 +124,14 @@ class Read_Actions_Filters {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param   string 			$function_to_search             Function to search (apply_filters|do_action).
-	 * @param   string 			$results                        Existing Results.
-	 * @param   string 			$contents                       File Contents.
-	 * @param   string 			$file_only                      Filename (excluding full path).
-	 * @param   bool|string 	$prefix_required                Optional prefix string required on filters and actions for inclusion in resultset (false = don't filter any found filters/actions).
-	 * @param   bool|string  	$prefix_required_replacement    Optional prefix string replacement, to use if $prefix_required is found (e.g. $this->base->plugin->name --> convertkit_).
-	 * @param   bool   			$by_file                        Deliminate array results by file.
-	 * @return  array       									Matches
+	 * @param   string      $function_to_search             Function to search (apply_filters|do_action).
+	 * @param   string      $results                        Existing Results.
+	 * @param   string      $contents                       File Contents.
+	 * @param   string      $file_only                      Filename (excluding full path).
+	 * @param   bool|string $prefix_required                Optional prefix string required on filters and actions for inclusion in resultset (false = don't filter any found filters/actions).
+	 * @param   bool|string $prefix_required_replacement    Optional prefix string replacement, to use if $prefix_required is found (e.g. $this->base->plugin->name --> convertkit_).
+	 * @param   bool        $by_file                        Deliminate array results by file.
+	 * @return  array                                           Matches
 	 */
 	private function find_matches( $function_to_search, $results, $contents, $file_only, $prefix_required, $prefix_required_replacement = false, $by_file ) {
 

--- a/admin/section/class-convertkit-settings-base.php
+++ b/admin/section/class-convertkit-settings-base.php
@@ -207,9 +207,9 @@ abstract class ConvertKit_Settings_Base {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @param   string $value          Value.
-	 * @param   mixed  $description    Description (false|string).
-	 * @return  string                  Masked Value
+	 * @param   string 		$value          Value.
+	 * @param   bool|string $description    Description.
+	 * @return  string                  	Masked Value
 	 */
 	public function get_masked_value( $value, $description = false ) {
 
@@ -231,10 +231,10 @@ abstract class ConvertKit_Settings_Base {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @param   string $name           Name.
-	 * @param   string $value          Value.
-	 * @param   mixed  $description    Description (false|string|array).
-	 * @return  string                  HTML Field
+	 * @param   string 				$name           Name.
+	 * @param   string 				$value          Value.
+	 * @param   bool|string|array  	$description    Description.
+	 * @return  string                  			HTML Field
 	 */
 	public function get_text_field( $name, $value = '', $description = false ) {
 
@@ -255,13 +255,13 @@ abstract class ConvertKit_Settings_Base {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @param   string $name            Name.
-	 * @param   string $value           Value.
-	 * @param   array  $options         Options / Choices.
-	 * @param   mixed  $description     Description (false|string).
-	 * @param   mixed  $css_classes     <select> CSS class(es) (false|array).
-	 * @param   mixed  $attributes      <select> attributes (false|array).
-	 * @return  string                  HTML Select Field
+	 * @param   string 			$name            Name.
+	 * @param   string 			$value           Value.
+	 * @param   array  			$options         Options / Choices.
+	 * @param   bool|string  	$description     Description.
+	 * @param   bool|array  	$css_classes     <select> CSS class(es).
+	 * @param   bool|array  	$attributes      <select> attributes.
+	 * @return  string                  		 HTML Select Field
 	 */
 	public function get_select_field( $name, $value = '', $options = array(), $description = false, $css_classes = false, $attributes = false ) {
 
@@ -303,12 +303,12 @@ abstract class ConvertKit_Settings_Base {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @param   string $name           Name.
-	 * @param   string $value          Value.
-	 * @param   bool   $checked        Should checkbox be checked/ticked.
-	 * @param   mixed  $label          Label (false|string).
-	 * @param   mixed  $description    Description (false|string).
-	 * @return  string                  HTML Checkbox
+	 * @param   string 		$name           Name.
+	 * @param   string 		$value          Value.
+	 * @param   bool   		$checked        Should checkbox be checked/ticked.
+	 * @param   bool|string $label          Label.
+	 * @param   bool|string $description    Description.
+	 * @return  string                  	HTML Checkbox
 	 */
 	public function get_checkbox_field( $name, $value, $checked = false, $label = '', $description = '' ) {
 
@@ -346,8 +346,8 @@ abstract class ConvertKit_Settings_Base {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @param   mixed $description    Description (false|string|array).
-	 * @return  string                  HTML Description
+	 * @param   bool|string|array 	$description 	Description.
+	 * @return  string                  			HTML Description
 	 */
 	private function get_description( $description ) {
 

--- a/admin/section/class-convertkit-settings-base.php
+++ b/admin/section/class-convertkit-settings-base.php
@@ -207,9 +207,9 @@ abstract class ConvertKit_Settings_Base {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @param   string 		$value          Value.
+	 * @param   string      $value          Value.
 	 * @param   bool|string $description    Description.
-	 * @return  string                  	Masked Value
+	 * @return  string                      Masked Value
 	 */
 	public function get_masked_value( $value, $description = false ) {
 
@@ -231,10 +231,10 @@ abstract class ConvertKit_Settings_Base {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @param   string 				$name           Name.
-	 * @param   string 				$value          Value.
-	 * @param   bool|string|array  	$description    Description.
-	 * @return  string                  			HTML Field
+	 * @param   string            $name           Name.
+	 * @param   string            $value          Value.
+	 * @param   bool|string|array $description    Description.
+	 * @return  string                              HTML Field
 	 */
 	public function get_text_field( $name, $value = '', $description = false ) {
 
@@ -255,13 +255,13 @@ abstract class ConvertKit_Settings_Base {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @param   string 			$name            Name.
-	 * @param   string 			$value           Value.
-	 * @param   array  			$options         Options / Choices.
-	 * @param   bool|string  	$description     Description.
-	 * @param   bool|array  	$css_classes     <select> CSS class(es).
-	 * @param   bool|array  	$attributes      <select> attributes.
-	 * @return  string                  		 HTML Select Field
+	 * @param   string      $name            Name.
+	 * @param   string      $value           Value.
+	 * @param   array       $options         Options / Choices.
+	 * @param   bool|string $description     Description.
+	 * @param   bool|array  $css_classes     <select> CSS class(es).
+	 * @param   bool|array  $attributes      <select> attributes.
+	 * @return  string                           HTML Select Field
 	 */
 	public function get_select_field( $name, $value = '', $options = array(), $description = false, $css_classes = false, $attributes = false ) {
 
@@ -303,12 +303,12 @@ abstract class ConvertKit_Settings_Base {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @param   string 		$name           Name.
-	 * @param   string 		$value          Value.
-	 * @param   bool   		$checked        Should checkbox be checked/ticked.
+	 * @param   string      $name           Name.
+	 * @param   string      $value          Value.
+	 * @param   bool        $checked        Should checkbox be checked/ticked.
 	 * @param   bool|string $label          Label.
 	 * @param   bool|string $description    Description.
-	 * @return  string                  	HTML Checkbox
+	 * @return  string                      HTML Checkbox
 	 */
 	public function get_checkbox_field( $name, $value, $checked = false, $label = '', $description = '' ) {
 
@@ -346,8 +346,8 @@ abstract class ConvertKit_Settings_Base {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @param   bool|string|array 	$description 	Description.
-	 * @return  string                  			HTML Description
+	 * @param   bool|string|array $description    Description.
+	 * @return  string                              HTML Description
 	 */
 	private function get_description( $description ) {
 

--- a/includes/blocks/class-convertkit-block-content.php
+++ b/includes/blocks/class-convertkit-block-content.php
@@ -99,7 +99,7 @@ class ConvertKit_Block_Content extends ConvertKit_Block {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  mixed   bool | array
+	 * @return  bool|array
 	 */
 	public function get_fields() {
 
@@ -132,7 +132,7 @@ class ConvertKit_Block_Content extends ConvertKit_Block {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  mixed   bool | array
+	 * @return  bool|array
 	 */
 	public function get_panels() {
 

--- a/includes/blocks/class-convertkit-block-form.php
+++ b/includes/blocks/class-convertkit-block-form.php
@@ -163,7 +163,7 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  mixed   bool | array
+	 * @return  bool|array
 	 */
 	public function get_fields() {
 
@@ -203,7 +203,7 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  mixed   bool | array
+	 * @return  bool|array
 	 */
 	public function get_panels() {
 

--- a/includes/class-convertkit-resource-landing-pages.php
+++ b/includes/class-convertkit-resource-landing-pages.php
@@ -58,7 +58,7 @@ class ConvertKit_Resource_Landing_Pages extends ConvertKit_Resource {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @param   mixed $id     Landing Page ID | Legacy Landing Page URL.
+	 * @param   int|string 		$id     Landing Page ID or Legacy Landing Page URL.
 	 * @return  WP_Error|string
 	 */
 	public function get_html( $id ) {

--- a/includes/class-convertkit-resource-landing-pages.php
+++ b/includes/class-convertkit-resource-landing-pages.php
@@ -58,7 +58,7 @@ class ConvertKit_Resource_Landing_Pages extends ConvertKit_Resource {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @param   int|string 		$id     Landing Page ID or Legacy Landing Page URL.
+	 * @param   int|string $id     Landing Page ID or Legacy Landing Page URL.
 	 * @return  WP_Error|string
 	 */
 	public function get_html( $id ) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -47,7 +47,7 @@ function convertkit_plugin_activate( $network_wide ) {
  *
  * @since   1.9.7.4
  *
- * @param   mixed $site_or_blog_id    WP_Site or Blog ID.
+ * @param   int $site_or_blog_id    WP_Site or Blog ID.
  */
 function convertkit_plugin_activate_new_site( $site_or_blog_id ) {
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -47,7 +47,7 @@ function convertkit_plugin_activate( $network_wide ) {
  *
  * @since   1.9.7.4
  *
- * @param   int $site_or_blog_id    WP_Site or Blog ID.
+ * @param   WP_Site|int $site_or_blog_id    WP_Site or Blog ID.
  */
 function convertkit_plugin_activate_new_site( $site_or_blog_id ) {
 

--- a/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php
@@ -179,7 +179,7 @@ class ConvertKit_Wishlist_Admin_Settings extends ConvertKit_Settings_Base {
 	/**
 	 * Gets membership levels from WishList Member API
 	 *
-	 * @return mixed bool|array
+	 * @return bool|array
 	 */
 	public function get_wlm_levels() {
 


### PR DESCRIPTION
## Summary

Replaces the vague `mixed` parameter on docblocks with accurate definitions of accepted variable types, for improved PHPStan analysis.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)