### PR TITLE
Add UTM parameters to "Edit form in ConvertKit" link

### DIFF
--- a/includes/class-convertkit-preview-output.php
+++ b/includes/class-convertkit-preview-output.php
@@ -176,7 +176,7 @@ class ConvertKit_Preview_Output {
 
 		// Append a link to edit the Form on ConvertKit.
 		$form_html .= sprintf(
-			'<div style="margin:0;padding:5px;text-align:right;font-size:13px;"><a href="https://app.convertkit.com/forms/designers/%s/edit" target="_blank">%s</a></div>',
+			'<div style="margin:0;padding:5px;text-align:right;font-size:13px;"><a href="https://app.convertkit.com/forms/designers/%s/edit/?utm_source=wordpress&utm_content=convertkit" target="_blank">%s</a></div>',
 			esc_attr( (string) $form_id ),
 			esc_html__( 'Edit form in ConvertKit', 'convertkit' )
 		);

--- a/tests/acceptance/forms/EditFormLinkCest.php
+++ b/tests/acceptance/forms/EditFormLinkCest.php
@@ -55,7 +55,7 @@ class EditFormLinkCest
 		$I->amOnUrl($_ENV['TEST_SITE_WP_URL'] . $I->grabFromCurrentUrl() . '?preview=true');
 
 		// Confirm that the Edit Form link is displayed.
-		$I->seeInSource('<a href="https://app.convertkit.com/forms/designers/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/edit" target="_blank">Edit form in ConvertKit</a>');
+		$I->seeInSource('<a href="https://app.convertkit.com/forms/designers/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/edit/?utm_source=wordpress&utm_content=convertkit" target="_blank">Edit form in ConvertKit</a>');
 	}
 
 	/**
@@ -182,7 +182,7 @@ class EditFormLinkCest
 		$I->amOnUrl($_ENV['TEST_SITE_WP_URL'] . $I->grabFromCurrentUrl() . '?preview=true');
 
 		// Confirm that the Edit Form link is displayed.
-		$I->seeInSource('<a href="https://app.convertkit.com/forms/designers/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/edit" target="_blank">Edit form in ConvertKit</a>');
+		$I->seeInSource('<a href="https://app.convertkit.com/forms/designers/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/edit/?utm_source=wordpress&utm_content=convertkit" target="_blank">Edit form in ConvertKit</a>');
 	}
 
 	/**
@@ -266,7 +266,7 @@ class EditFormLinkCest
 		$I->amOnUrl($_ENV['TEST_SITE_WP_URL'] . $I->grabFromCurrentUrl() . '?preview=true');
 
 		// Confirm that the Edit Form link is displayed.
-		$I->seeInSource('<a href="https://app.convertkit.com/forms/designers/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/edit" target="_blank">Edit form in ConvertKit</a>');
+		$I->seeInSource('<a href="https://app.convertkit.com/forms/designers/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/edit/?utm_source=wordpress&utm_content=convertkit" target="_blank">Edit form in ConvertKit</a>');
 	}
 
 	/**

--- a/tests/acceptance/forms/EditFormLinkCest.php
+++ b/tests/acceptance/forms/EditFormLinkCest.php
@@ -55,7 +55,7 @@ class EditFormLinkCest
 		$I->amOnUrl($_ENV['TEST_SITE_WP_URL'] . $I->grabFromCurrentUrl() . '?preview=true');
 
 		// Confirm that the Edit Form link is displayed.
-		$I->seeInSource('<a href="https://app.convertkit.com/forms/designers/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/edit/?utm_source=wordpress&utm_content=convertkit" target="_blank">Edit form in ConvertKit</a>');
+		$I->seeInSource('<a href="https://app.convertkit.com/forms/designers/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/edit/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">Edit form in ConvertKit</a>');
 	}
 
 	/**
@@ -182,7 +182,7 @@ class EditFormLinkCest
 		$I->amOnUrl($_ENV['TEST_SITE_WP_URL'] . $I->grabFromCurrentUrl() . '?preview=true');
 
 		// Confirm that the Edit Form link is displayed.
-		$I->seeInSource('<a href="https://app.convertkit.com/forms/designers/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/edit/?utm_source=wordpress&utm_content=convertkit" target="_blank">Edit form in ConvertKit</a>');
+		$I->seeInSource('<a href="https://app.convertkit.com/forms/designers/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/edit/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">Edit form in ConvertKit</a>');
 	}
 
 	/**
@@ -266,7 +266,7 @@ class EditFormLinkCest
 		$I->amOnUrl($_ENV['TEST_SITE_WP_URL'] . $I->grabFromCurrentUrl() . '?preview=true');
 
 		// Confirm that the Edit Form link is displayed.
-		$I->seeInSource('<a href="https://app.convertkit.com/forms/designers/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/edit/?utm_source=wordpress&utm_content=convertkit" target="_blank">Edit form in ConvertKit</a>');
+		$I->seeInSource('<a href="https://app.convertkit.com/forms/designers/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/edit/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">Edit form in ConvertKit</a>');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Adds `utm_source` and `utm_content` parameters to the Edit form in ConvertKit link, to match UTM parameters added to other ConvertKit links.

## Testing

- `EditFormLinkCest`: Modified tests to include detection of UTM parameters.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)