### PR TITLE
Fix Form and Product block / shortcode field definitions

### DIFF
--- a/includes/blocks/class-convertkit-block-form.php
+++ b/includes/blocks/class-convertkit-block-form.php
@@ -181,17 +181,15 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 			}
 		}
 
-		// Get Settings.
-		$settings = new ConvertKit_Settings();
-
 		return array(
 			'form' => array(
 				'label'  => __( 'Form', 'convertkit' ),
 				'type'   => 'select',
 				'values' => $forms,
 				'data'   => array(
-					'forms'   => $convertkit_forms->get(),
-					'api_key' => $settings->get_api_key(),
+					// Used by resources/backend/js/gutenberg-block-form.js to determine whether the selected form's format
+					// (modal, slide in, sticky bar) and output a message in the block editor for the preview.
+					'forms'   => ( $convertkit_forms->exist() ? $convertkit_forms->get() : array() ),
 				),
 			),
 		);

--- a/includes/blocks/class-convertkit-block-form.php
+++ b/includes/blocks/class-convertkit-block-form.php
@@ -187,9 +187,10 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 				'type'   => 'select',
 				'values' => $forms,
 				'data'   => array(
-					// Used by resources/backend/js/gutenberg-block-form.js to determine whether the selected form's format
-					// (modal, slide in, sticky bar) and output a message in the block editor for the preview.
-					'forms'   => ( $convertkit_forms->exist() ? $convertkit_forms->get() : array() ),
+					// Used by resources/backend/js/gutenberg-block-form.js to determine the selected form's format
+					// (modal, slide in, sticky bar) and output a message in the block editor for the preview to explain
+					// why some formats cannot be previewed.
+					'forms' => ( $convertkit_forms->exist() ? $convertkit_forms->get() : array() ),
 				),
 			),
 		);

--- a/includes/blocks/class-convertkit-block-product.php
+++ b/includes/blocks/class-convertkit-block-product.php
@@ -256,9 +256,6 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 			}
 		}
 
-		// Get Settings.
-		$settings = new ConvertKit_Settings();
-
 		// Gutenberg's built-in fields (such as styling, padding etc) don't need to be defined here, as they'll be included
 		// automatically by Gutenberg.
 		return array(
@@ -266,10 +263,6 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 				'label'  => __( 'Product', 'convertkit' ),
 				'type'   => 'select',
 				'values' => $products,
-				'data'   => array(
-					'products' => $convertkit_products->get(),
-					'api_key'  => $settings->get_api_key(),
-				),
 			),
 			'text'             => array(
 				'label'       => __( 'Button Text', 'convertkit' ),

--- a/resources/backend/js/gutenberg-block-product.js
+++ b/resources/backend/js/gutenberg-block-product.js
@@ -14,11 +14,9 @@
  */
 function convertKitGutenbergProductBlockRenderPreview( block, props ) {
 
-	var product = block.fields.product.data.products[ props.attributes.product ];
-
 	// If no Product has been selected for display, return a prompt to tell the editor
 	// what to do.
-	if ( typeof product === 'undefined' ) {
+	if ( props.attributes.product === '' ) {
 		return wp.element.createElement(
 			'div',
 			{

--- a/views/backend/tinymce/modal-field.php
+++ b/views/backend/tinymce/modal-field.php
@@ -6,22 +6,6 @@
  * @author ConvertKit
  */
 
-// Build a string of data- attributes.
-$data_attributes                   = '';
-$data_attributes_shortcode_defined = false;
-if ( isset( $field['data'] ) ) {
-	foreach ( $field['data'] as $data_attribute => $data_attribute_value ) {
-		$data_attributes .= ' data-' . $data_attribute . '="' . $data_attribute_value . '"';
-
-		if ( $data_attribute === 'shortcode' ) {
-			$data_attributes_shortcode_defined = true;
-		}
-	}
-}
-if ( ! $data_attributes_shortcode_defined ) {
-	$data_attributes .= ' data-shortcode="' . $field_name . '"';
-}
-
 switch ( $field['type'] ) {
 
 	/**
@@ -33,7 +17,7 @@ switch ( $field['type'] ) {
 				id="tinymce_modal_<?php echo esc_attr( $field_name ); ?>"
 				name="<?php echo esc_attr( $field_name ); ?>"
 				value="<?php echo esc_attr( isset( $shortcode['attributes'][ $field_name ]['default'] ) ? $shortcode['attributes'][ $field_name ]['default'] : '' ); ?>" 
-				<?php echo $data_attributes; // phpcs:ignore ?>
+				data-shortcode="<?php echo esc_attr( $field_name ); ?>"
 				placeholder="<?php echo esc_attr( isset( $field['placeholder'] ) ? $field['placeholder'] : '' ); ?>"
 				class="widefat" />
 		<?php
@@ -48,7 +32,7 @@ switch ( $field['type'] ) {
 				id="tinymce_modal_<?php echo esc_attr( $field_name ); ?>"
 				name="<?php echo esc_attr( $field_name ); ?>" 
 				value="<?php echo esc_attr( isset( $shortcode['attributes'][ $field_name ]['default'] ) ? $shortcode['attributes'][ $field_name ]['default'] : '' ); ?>" 
-				<?php echo $data_attributes; // phpcs:ignore ?>
+				data-shortcode="<?php echo esc_attr( $field_name ); ?>"
 				min="<?php echo esc_attr( $field['min'] ); ?>" 
 				max="<?php echo esc_attr( $field['max'] ); ?>" 
 				step="<?php echo esc_attr( $field['step'] ); ?>"
@@ -63,7 +47,7 @@ switch ( $field['type'] ) {
 		?>
 		<select name="<?php echo esc_attr( $field_name ); ?>"
 				id="tinymce_modal_<?php echo esc_attr( $field_name ); ?>"
-				<?php echo $data_attributes; // phpcs:ignore ?>
+				data-shortcode="<?php echo esc_attr( $field_name ); ?>"
 				size="1"
 				class="widefat">
 			<?php
@@ -87,7 +71,7 @@ switch ( $field['type'] ) {
 		?>
 		<select name="<?php echo esc_attr( $field_name ); ?>"
 				id="tinymce_modal_<?php echo esc_attr( $field_name ); ?>"
-				<?php echo $data_attributes; // phpcs:ignore ?>
+				data-shortcode="<?php echo esc_attr( $field_name ); ?>"
 				size="1"
 				class="widefat">
 			<?php
@@ -108,7 +92,7 @@ switch ( $field['type'] ) {
 				id="tinymce_modal_<?php echo esc_attr( $field_name ); ?>"
 				name="<?php echo esc_attr( $field_name ); ?>"
 				value="<?php echo esc_attr( isset( $shortcode['attributes'][ $field_name ]['default'] ) ? $shortcode['attributes'][ $field_name ]['default'] : '' ); ?>" 
-				<?php echo $data_attributes; // phpcs:ignore ?>
+				data-shortcode="<?php echo esc_attr( $field_name ); ?>"
 				placeholder="<?php echo esc_attr( isset( $field['placeholder'] ) ? $field['placeholder'] : '' ); ?>"
 				class="widefat convertkit-color-picker" />
 		<?php


### PR DESCRIPTION
## Summary

Form block / shortcode:
- Removes an unused API Key and settings class
- Explains why a data attribute comprising of forms exists
- Check that Forms exist before attempting to `get()` Forms to populate the data attribute

Product block / shortcode:
- Removes unused data attributes and settings class
- Performs a simpler check when previewing a block to determine if a Product was specified in the Block's settings

Classic Editor:
- Removes unnecessary code to build unused data-attributes when the insert shortcode modal is displayed in the Classic Editor for Forms, Products and Broadcasts
- Always defines the data-shortcode attribute, correctly escaped, to determine the shortcode name to insert into the Classic Editor

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)