### PR TITLE
Fix Preview with Legacy Form

### DIFF
--- a/includes/class-convertkit-preview-output.php
+++ b/includes/class-convertkit-preview-output.php
@@ -170,14 +170,29 @@ class ConvertKit_Preview_Output {
 
 		// Bail if the Form's format isn't an inline form - we don't want to show an edit link for
 		// e.g. a sticky bar form.
-		if ( $form['format'] !== 'inline' ) {
+		// Legacy Forms won't have a format array key.
+		if ( array_key_exists( 'format', $form ) && $form['format'] !== 'inline' ) {
 			return $form_html;
+		}
+
+		// If no format array key is specified, this is a Legacy Form, which has a different edit URL on ConvertKit.
+		if ( ! array_key_exists( 'format', $form ) ) {
+			// Legacy Form.
+			$link = sprintf(
+				'https://app.convertkit.com/landing_pages/%s/edit/?utm_source=wordpress&utm_content=convertkit',
+				esc_attr( (string) $form_id )
+			);
+		} else {
+			$link = sprintf(
+				'https://app.convertkit.com/forms/designers/%s/edit/?utm_source=wordpress&utm_content=convertkit',
+				esc_attr( (string) $form_id )
+			);
 		}
 
 		// Append a link to edit the Form on ConvertKit.
 		$form_html .= sprintf(
-			'<div style="margin:0;padding:5px;text-align:right;font-size:13px;"><a href="https://app.convertkit.com/forms/designers/%s/edit/?utm_source=wordpress&utm_content=convertkit" target="_blank">%s</a></div>',
-			esc_attr( (string) $form_id ),
+			'<div style="margin:0;padding:5px;text-align:right;font-size:13px;"><a href="%s" target="_blank">%s</a></div>',
+			esc_url( $link ),
 			esc_html__( 'Edit form in ConvertKit', 'convertkit' )
 		);
 

--- a/tests/acceptance/forms/EditFormLinkCest.php
+++ b/tests/acceptance/forms/EditFormLinkCest.php
@@ -54,6 +54,9 @@ class EditFormLinkCest
 		// View the Page as if we clicked Preview from the editor.
 		$I->amOnUrl($_ENV['TEST_SITE_WP_URL'] . $I->grabFromCurrentUrl() . '?preview=true');
 
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
 		// Confirm that the Edit Form link is displayed.
 		$I->seeInSource('<a href="https://app.convertkit.com/forms/designers/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/edit/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">Edit form in ConvertKit</a>');
 	}
@@ -88,6 +91,9 @@ class EditFormLinkCest
 
 		// View the Page as if we clicked Preview from the editor.
 		$I->amOnUrl($_ENV['TEST_SITE_WP_URL'] . $I->grabFromCurrentUrl() . '?preview=true');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that no Edit Form link is displayed, because there is no Form specified on this Page.
 		$I->dontSee('Edit form in ConvertKit');
@@ -136,8 +142,49 @@ class EditFormLinkCest
 		// View the Page as if we clicked Preview from the editor.
 		$I->amOnPage('/?p=' . $pageID . '&preview=true');
 
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
 		// Confirm that no Edit Form link is displayed, because the form Form specified on this Page is invalid.
 		$I->dontSee('Edit form in ConvertKit');
+	}
+
+	/**
+	 * Test that the 'Edit form on ConvertKit' link displays when a Legacy Form is specified
+	 * in the Page Settings, and the user previews the WordPress Page.
+	 *
+	 * @since   2.0.8
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testEditFormLinkOnPageWithLegacyForm(AcceptanceTester $I)
+	{
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Legacy: Edit Link');
+
+		// Configure metabox's Form setting = Legacy.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
+			]
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that no Edit Form link is displayed, because we did not preview the Page.
+		$I->dontSee('Edit form in ConvertKit');
+
+		// View the Page as if we clicked Preview from the editor.
+		$I->amOnUrl($_ENV['TEST_SITE_WP_URL'] . $I->grabFromCurrentUrl() . '?preview=true');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Edit Form link is displayed.
+		$I->seeInSource('<a href="https://app.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/edit/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">Edit form in ConvertKit</a>');
 	}
 
 	/**
@@ -180,6 +227,9 @@ class EditFormLinkCest
 
 		// View the Page as if we clicked Preview from the editor.
 		$I->amOnUrl($_ENV['TEST_SITE_WP_URL'] . $I->grabFromCurrentUrl() . '?preview=true');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the Edit Form link is displayed.
 		$I->seeInSource('<a href="https://app.convertkit.com/forms/designers/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/edit/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">Edit form in ConvertKit</a>');
@@ -227,6 +277,9 @@ class EditFormLinkCest
 		// View the Page as if we clicked Preview from the editor.
 		$I->amOnUrl($_ENV['TEST_SITE_WP_URL'] . $I->grabFromCurrentUrl() . '?preview=true');
 
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
 		// Confirm that no Edit Form link is displayed, because the form isn't an inline format.
 		$I->dontSee('Edit form in ConvertKit');
 	}
@@ -264,6 +317,9 @@ class EditFormLinkCest
 
 		// View the Page as if we clicked Preview from the editor.
 		$I->amOnUrl($_ENV['TEST_SITE_WP_URL'] . $I->grabFromCurrentUrl() . '?preview=true');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the Edit Form link is displayed.
 		$I->seeInSource('<a href="https://app.convertkit.com/forms/designers/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/edit/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">Edit form in ConvertKit</a>');
@@ -303,6 +359,9 @@ class EditFormLinkCest
 
 		// View the Page as if we clicked Preview from the editor.
 		$I->amOnUrl($_ENV['TEST_SITE_WP_URL'] . $I->grabFromCurrentUrl() . '?preview=true');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that no Edit Form link is displayed, because the form isn't an inline format.
 		$I->dontSee('Edit form in ConvertKit');


### PR DESCRIPTION
## Summary

Fixes an issue where a PHP warning would be output if a logged in WordPress user previews a Page, Post or Custom Post being edited that contains a Legacy Form, due to these forms not having a `format` property.

Before:
![Screenshot 2023-02-02 at 15 50 36](https://user-images.githubusercontent.com/1462305/216376175-14c565c1-8dd6-4e02-8ae0-075f44472aa9.png)

After:
![Screenshot 2023-02-02 at 15 59 07](https://user-images.githubusercontent.com/1462305/216376227-b4a238ce-fd80-4408-bdd6-095024cb1f7d.png)

## Testing

- EditFormLinkCest: Added test for legacy forms to confirm no errors and correct link to edit the legacy form on ConvertKit. Other tests include additional checks for PHP warnings/errors.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)