### PR TITLE
Run tests against WordPress 6.2 Beta 1

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -35,7 +35,7 @@ jobs:
     # Defines the WordPress and PHP Versions matrix to run tests on.
     strategy:
       matrix:
-        wp-versions: [ 'latest' ] #[ '6.1.1', 'latest' ]
+        wp-versions: [ '6.2-beta1' ] #[ '6.1.1', 'latest' ]
         php-versions: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ] #[ '7.3', '7.4', '8.0', '8.1' ]
 
     # Steps to install, configure and run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
     # For PHP, make sure that an nginx configuration file exists for the required PHP version in this repository at tests/nginx/php-x.x.conf
     strategy:
       matrix:
-        wp-versions: [ 'latest' ] #[ '6.1.1', 'latest' ]
+        wp-versions: [ '6.2-beta1' ] #[ '6.1.1', 'latest' ]
         php-versions: [ '7.4', '8.0', '8.1', '8.2' ] #[ '7.4', '8.0', '8.1' ]
         
         # Folder names within the 'tests' folder to run tests in parallel.

--- a/includes/widgets/class-ck-widget-form.php
+++ b/includes/widgets/class-ck-widget-form.php
@@ -32,7 +32,7 @@ class CK_Widget_Form extends WP_Widget {
 
 		parent::__construct(
 			'convertkit_form',
-			__( 'ConvertKit Form', 'convertkit' ),
+			__( 'ConvertKit Form (Legacy Widget)', 'convertkit' ),
 			array(
 				'classname'                   => 'convertkit widget_convertkit_form',
 				'description'                 => __( 'Display a ConvertKit form.', 'convertkit' ),

--- a/resources/backend/js/gutenberg-block-broadcasts.js
+++ b/resources/backend/js/gutenberg-block-broadcasts.js
@@ -30,7 +30,7 @@ function convertKitGutenbergBroadcastsBlockRenderPreview( block, props ) {
 	// A Product is specified.
 	// Use the block's PHP's render() function by calling the ServerSideRender component.
 	return wp.element.createElement(
-		wp.components.ServerSideRender,
+		wp.serverSideRender,
 		{
 			block: 'convertkit/' + block.name,
 			attributes: props.attributes,

--- a/resources/backend/js/gutenberg-block-form.js
+++ b/resources/backend/js/gutenberg-block-form.js
@@ -81,7 +81,7 @@ function convertKitGutenbergFormBlockRenderPreview( block, props ) {
 	// This is a Legacy Form.
 	// Use the block's PHP's render() function by calling the ServerSideRender component.
 	return wp.element.createElement(
-		wp.components.ServerSideRender,
+		wp.serverSideRender,
 		{
 			block: 'convertkit/' + block.name,
 			attributes: props.attributes,

--- a/resources/backend/js/gutenberg-block-product.js
+++ b/resources/backend/js/gutenberg-block-product.js
@@ -31,7 +31,7 @@ function convertKitGutenbergProductBlockRenderPreview( block, props ) {
 	// A Product is specified.
 	// Use the block's PHP's render() function by calling the ServerSideRender component.
 	return wp.element.createElement(
-		wp.components.ServerSideRender,
+		wp.serverSideRender,
 		{
 			block: 'convertkit/' + block.name,
 			attributes: props.attributes,

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -30,13 +30,13 @@ if ( typeof wp !== 'undefined' &&
 function convertKitGutenbergRegisterBlock( block ) {
 
 	// Register Block.
-	( function( wp, block ) {
+	( function( blocks, editor, element, components, block ) {
 
 		// Define some constants for the various items we'll use.
-		const el                              = wp.element.createElement;
-		const { registerBlockType }           = wp.blocks;
-		const { RichText, InspectorControls } = wp.editor;
-		const { Fragment } 		  			  = wp.element;
+		const el                              = element.createElement;
+		const { registerBlockType }           = blocks;
+		const { RichText, InspectorControls } = editor;
+		const { Fragment } 		  			  = element;
 		const {
 			TextControl,
 			CheckboxControl,
@@ -50,15 +50,14 @@ function convertKitGutenbergRegisterBlock( block ) {
 			PanelBody,
 			PanelRow,
 			SandBox
-		}                                     = wp.components;
-		const { serverSideRender }			  = wp;
+		}                                     = components;
 
 		// Build Icon, if it's an object.
 		var icon = 'dashicons-tablet';
 		if ( typeof block.gutenberg_icon !== 'undefined' ) {
 			if ( block.gutenberg_icon.search( 'svg' ) >= 0 ) {
 				// SVG.
-				icon = wp.element.RawHTML(
+				icon = element.RawHTML(
 					{
 						children: block.gutenberg_icon
 					}
@@ -262,14 +261,16 @@ function convertKitGutenbergRegisterBlock( block ) {
 					// Generate Block Preview.
 					var preview = '';
 					if ( typeof block.gutenberg_preview_render_callback !== 'undefined' ) {
+						console.log( 'custom callback' );
 						// Use a custom callback function to render this block's preview in the Gutenberg Editor.
 						// This doesn't affect the output for this block on the frontend site, which will always
 						// use the block's PHP's render() function.
 						preview = window[ block.gutenberg_preview_render_callback ]( block, props );
 					} else {
+						// @TODO Is this code ever used?
 						// Use the block's PHP's render() function by calling the ServerSideRender component.
 						preview = el(
-							serverSideRender,
+							ServerSideRender,
 							{
 								block: 'convertkit/' + block.name,
 								attributes: props.attributes,
@@ -308,7 +309,10 @@ function convertKitGutenbergRegisterBlock( block ) {
 		);
 
 	} (
-		window.wp,
+		window.wp.blocks,
+		window.wp.blockEditor,
+		window.wp.element,
+		window.wp.components,
 		block
 	) );
 

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -30,13 +30,13 @@ if ( typeof wp !== 'undefined' &&
 function convertKitGutenbergRegisterBlock( block ) {
 
 	// Register Block.
-	( function( blocks, editor, element, components, block ) {
+	( function( wp, block ) {
 
 		// Define some constants for the various items we'll use.
-		const el                              = element.createElement;
-		const { registerBlockType }           = blocks;
-		const { RichText, InspectorControls } = editor;
-		const { Fragment } 		  			  = element;
+		const el                              = wp.element.createElement;
+		const { registerBlockType }           = wp.blocks;
+		const { RichText, InspectorControls } = wp.editor;
+		const { Fragment } 		  			  = wp.element;
 		const {
 			TextControl,
 			CheckboxControl,
@@ -49,16 +49,16 @@ function convertKitGutenbergRegisterBlock( block ) {
 			Panel,
 			PanelBody,
 			PanelRow,
-			SandBox,
-			ServerSideRender
-		}                                     = components;
+			SandBox
+		}                                     = wp.components;
+		const { serverSideRender }			  = wp;
 
 		// Build Icon, if it's an object.
 		var icon = 'dashicons-tablet';
 		if ( typeof block.gutenberg_icon !== 'undefined' ) {
 			if ( block.gutenberg_icon.search( 'svg' ) >= 0 ) {
 				// SVG.
-				icon = element.RawHTML(
+				icon = wp.element.RawHTML(
 					{
 						children: block.gutenberg_icon
 					}
@@ -269,7 +269,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 					} else {
 						// Use the block's PHP's render() function by calling the ServerSideRender component.
 						preview = el(
-							ServerSideRender,
+							serverSideRender,
 							{
 								block: 'convertkit/' + block.name,
 								attributes: props.attributes,
@@ -308,10 +308,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 		);
 
 	} (
-		window.wp.blocks,
-		window.wp.blockEditor,
-		window.wp.element,
-		window.wp.components,
+		window.wp,
 		block
 	) );
 

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -261,22 +261,10 @@ function convertKitGutenbergRegisterBlock( block ) {
 					// Generate Block Preview.
 					var preview = '';
 					if ( typeof block.gutenberg_preview_render_callback !== 'undefined' ) {
-						console.log( 'custom callback' );
 						// Use a custom callback function to render this block's preview in the Gutenberg Editor.
 						// This doesn't affect the output for this block on the frontend site, which will always
 						// use the block's PHP's render() function.
 						preview = window[ block.gutenberg_preview_render_callback ]( block, props );
-					} else {
-						// @TODO Is this code ever used?
-						// Use the block's PHP's render() function by calling the ServerSideRender component.
-						preview = el(
-							ServerSideRender,
-							{
-								block: 'convertkit/' + block.name,
-								attributes: props.attributes,
-								className: 'convertkit-' + block.name
-							}
-						);
 					}
 
 					// Return.

--- a/tests/_support/Helper/Acceptance/WPGutenberg.php
+++ b/tests/_support/Helper/Acceptance/WPGutenberg.php
@@ -113,8 +113,8 @@ class WPGutenberg extends \Codeception\Module
 	 */
 	public function addGutenbergParagraphBlock($I, $text)
 	{
-		$I->click('.is-root-container');
-		$I->fillField('.is-root-container p', $text);
+		$I->click('.wp-block-post-content');
+		$I->fillField('.wp-block-post-content p', $text);
 	}
 
 	/**
@@ -130,14 +130,14 @@ class WPGutenberg extends \Codeception\Module
 	{
 		// Focus away from paragraph and then back to the paragraph, so that the block toolbar displays.
 		$I->click('div.edit-post-visual-editor__post-title-wrapper h1');
-		$I->click('.is-root-container p');
-		$I->waitForElementVisible('.is-root-container p.is-selected');
+		$I->click('.wp-block-post-content p');
+		$I->waitForElementVisible('.wp-block-post-content p.is-selected');
 
 		// Insert link via block toolbar.
 		$this->insertGutenbergLink($I, $name);
 
 		// Confirm that the Product text exists in the paragraph.
-		$I->see($name, '.is-root-container p.is-selected');
+		$I->see($name, '.wp-block-post-content p.is-selected');
 	}
 
 	/**
@@ -152,18 +152,18 @@ class WPGutenberg extends \Codeception\Module
 	public function addGutenbergLinkToButton($I, $name)
 	{
 		// Enter text.
-		$I->fillField('.is-root-container .wp-block-button .block-editor-rich-text__editable', $name);
+		$I->fillField('.wp-block-post-content .wp-block-button .block-editor-rich-text__editable', $name);
 
 		// Focus away from button and then back to the button, so that the block toolbar displays.
 		$I->click('div.edit-post-visual-editor__post-title-wrapper h1');
-		$I->click('.is-root-container .wp-block-button');
-		$I->waitForElementVisible('.is-root-container div.is-selected');
+		$I->click('.wp-block-post-content .wp-block-button');
+		$I->waitForElementVisible('.wp-block-post-content div.is-selected');
 
 		// Insert link via block toolbar.
 		$this->insertGutenbergLink($I, $name);
 
 		// Confirm that the Product text exists in the button.
-		$I->see($name, '.is-root-container .wp-block-button');
+		$I->see($name, '.wp-block-post-content .wp-block-button');
 	}
 
 	/**

--- a/tests/_support/Helper/Acceptance/WPGutenberg.php
+++ b/tests/_support/Helper/Acceptance/WPGutenberg.php
@@ -75,7 +75,7 @@ class WPGutenberg extends \Codeception\Module
 		// When the Blocks sidebar appears, search for the block.
 		$I->waitForElementVisible('.interface-interface-skeleton__secondary-sidebar[aria-label="Block Library"]');
 		$I->fillField('.block-editor-inserter__menu input[type=search]', $blockName);
-		$I->seeElementInDOM('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
+		$I->waitForElementVisible('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
 		$I->click('.block-editor-inserter__panel-content button.editor-block-list-item-' . $blockProgrammaticName);
 
 		// If a Block configuration is specified, apply it to the Block now.

--- a/tests/_support/Helper/Acceptance/WPWidget.php
+++ b/tests/_support/Helper/Acceptance/WPWidget.php
@@ -37,8 +37,9 @@ class WPWidget extends \Codeception\Module
 		// First matching item will be the legacy widget; any blocks will follow.
 		// We can't target using the CSS selector button.editor-block-list-item-legacy-widget/{name}, as Codeception
 		// fails stating this is malformed CSS.
-		$I->seeElementInDOM('.block-editor-inserter__panel-content .block-editor-block-types-list__list-item button[tabindex="0"]');
-		$I->click('.block-editor-inserter__panel-content .block-editor-block-types-list__list-item button[tabindex="0"]');
+		$I->wait(2);
+		$I->waitForElementVisible('.block-editor-inserter__panel-content button');
+		$I->click('.block-editor-inserter__panel-content button');
 
 		// If a Block configuration is specified, apply it to the Block now.
 		if ($blockConfiguration) {

--- a/tests/acceptance/forms/WidgetFormCest.php
+++ b/tests/acceptance/forms/WidgetFormCest.php
@@ -45,7 +45,7 @@ class WidgetFormCest
 		// Add legacy widget, setting the Form setting to the value specified in the .env file.
 		$I->addLegacyWidget(
 			$I,
-			'ConvertKit Form',
+			'ConvertKit Form (Legacy Widget)',
 			'convertkit-form',
 			[
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
@@ -72,7 +72,7 @@ class WidgetFormCest
 		// Add legacy widget, setting the Form setting to the value specified in the .env file.
 		$I->addLegacyWidget(
 			$I,
-			'ConvertKit Form',
+			'ConvertKit Form (Legacy Widget)',
 			'convertkit-form',
 			[
 				'form' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],


### PR DESCRIPTION
## Summary

Run tests against WordPress 6.2 Beta 1, fixing:

- Use `wp.serverSideRender` instead of deprecated `wp.components.ServerSideRender`, which is removed in WordPress 6.2
![Screenshot 2023-02-09 at 15 59 06](https://user-images.githubusercontent.com/1462305/217870598-8350f670-15b5-4ae6-a463-3a23fc38a5d8.png)
- Rename the ConvertKit Form widget to a Legacy Widget; users should use the Form block, but we need to retain the existing WordPress widget for backward compatibility for those already using it

## Testing



## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)