### PR TITLE
Restrict Content: Align CTA

### DIFF
--- a/resources/frontend/css/restrict-content.css
+++ b/resources/frontend/css/restrict-content.css
@@ -1,8 +1,9 @@
 #convertkit-restrict-content {
+	max-width: 610px;
 	background: #f6f8fa;
 	box-shadow: 0 2px 5px #0000000d;
 	color: #373f45;
-	margin: 30px 0;
+	margin: 30px auto;
 	padding: 40px 30px 30px 30px;
 	border: 1px solid #EDF2F4;
 	text-align: center;
@@ -32,6 +33,7 @@
 }
 #convertkit-restrict-content .convertkit-restrict-content-actions .convertkit-product a {
 	display: inline-block;
+	text-decoration: none;
 }
 
 #convertkit-restrict-content .convertkit-restrict-content-notice {


### PR DESCRIPTION
## Summary

- Centers the call to action for themes that don't provide the styles to do this automatically.
- Removes text decoration on button links, that might be applied by some themes.

Before:
![Screenshot 2023-02-13 at 15 06 31](https://user-images.githubusercontent.com/1462305/218495683-c7be09a3-2d7c-4f17-8560-61886205103c.png)

After:
![Screenshot 2023-02-13 at 15 06 25](https://user-images.githubusercontent.com/1462305/218495706-c22e8fdd-4079-4e0b-93ef-d19a7b67fbfa.png)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)