### PR TITLE
Restrict Content: Honor `Disable CSS` setting

### DIFF
--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -467,7 +467,7 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 			'no_css',
 			'on',
 			$this->settings->css_disabled(), // phpcs:ignore WordPress.Security.EscapeOutput
-			esc_html__( 'Prevent plugin from loading CSS files. This will disable styling on the broadcasts shortcode and block. Use with caution!', 'convertkit' )
+			esc_html__( 'Prevent plugin from loading CSS files. This will disable styling on broadcasts, product buttons and member\'s content. Use with caution!', 'convertkit' )
 		);
 
 	}

--- a/includes/blocks/class-convertkit-block-product.php
+++ b/includes/blocks/class-convertkit-block-product.php
@@ -75,7 +75,7 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 	 */
 	public function enqueue_styles() {
 
-		wp_enqueue_style( 'convertkit-gutenberg-block-product-frontend', CONVERTKIT_PLUGIN_URL . 'resources/frontend/css/product.css', array(), CONVERTKIT_PLUGIN_VERSION );
+		wp_enqueue_style( 'convertkit-product', CONVERTKIT_PLUGIN_URL . 'resources/frontend/css/product.css', array(), CONVERTKIT_PLUGIN_VERSION );
 
 	}
 

--- a/includes/class-convertkit-output-restrict-content.php
+++ b/includes/class-convertkit-output-restrict-content.php
@@ -713,8 +713,11 @@ class ConvertKit_Output_Restrict_Content {
 		// for restrict by tag and form later.
 		switch ( $resource_type ) {
 			case 'product':
-				// Enqueue styles.
-				wp_enqueue_style( 'convertkit-restrict-content', CONVERTKIT_PLUGIN_URL . 'resources/frontend/css/restrict-content.css', array(), CONVERTKIT_PLUGIN_VERSION );
+				// Only load styles if the Disable CSS option is off.
+				if ( ! $this->settings->css_disabled() ) {
+					// Enqueue styles.
+					wp_enqueue_style( 'convertkit-restrict-content', CONVERTKIT_PLUGIN_URL . 'resources/frontend/css/restrict-content.css', array(), CONVERTKIT_PLUGIN_VERSION );
+				}
 
 				// Output product code form if this request is after the user entered their email address,
 				// which means we're going through the authentication flow.

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -843,7 +843,7 @@ class Plugin extends \Codeception\Module
 
 		// Confirm Restrict Content CSS is output.
 		$I->seeInSource('<link rel="stylesheet" id="convertkit-restrict-content-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/restrict-content.css');
-	
+
 		// Check content is / is not displayed, and CTA displays with expected text.
 		$this->testRestrictContentHidesContentWithCTA($I, $visibleContent, $memberContent, $textItems);
 

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -841,6 +841,9 @@ class Plugin extends \Codeception\Module
 			$I->amOnUrl($urlOrPageID);
 		}
 
+		// Confirm Restrict Content CSS is output.
+		$I->seeInSource('<link rel="stylesheet" id="convertkit-restrict-content-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/restrict-content.css');
+	
 		// Check content is / is not displayed, and CTA displays with expected text.
 		$this->testRestrictContentHidesContentWithCTA($I, $visibleContent, $memberContent, $textItems);
 

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -992,7 +992,7 @@ class Plugin extends \Codeception\Module
 	public function seeProductOutput($I, $productURL, $text = false, $textColor = false, $backgroundColor = false)
 	{
 		// Confirm that the product stylesheet loaded.
-		$I->seeInSource('<link rel="stylesheet" id="convertkit-gutenberg-block-product-frontend-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/product.css');
+		$I->seeInSource('<link rel="stylesheet" id="convertkit-product-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/product.css');
 
 		// Confirm that the block displays.
 		$I->seeElementInDOM('a.convertkit-product.wp-block-button__link');

--- a/tests/acceptance/general/PluginSettingsGeneralCest.php
+++ b/tests/acceptance/general/PluginSettingsGeneralCest.php
@@ -412,6 +412,7 @@ class PluginSettingsGeneralCest
 
 		// Confirm no CSS is output by the Plugin.
 		$I->dontSeeInSource('broadcasts.css');
+		$I->dontSeeInSource('product.css');
 
 		// Go to the Plugin's Settings Screen.
 		$I->loadConvertKitSettingsGeneralScreen($I);
@@ -433,6 +434,7 @@ class PluginSettingsGeneralCest
 
 		// Confirm CSS is output by the Plugin.
 		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
+		$I->seeInSource('<link rel="stylesheet" id="convertkit-product-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/product.css');
 	}
 
 	/**

--- a/tests/acceptance/restrict-content/RestrictContentSettingsCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentSettingsCest.php
@@ -187,6 +187,41 @@ class RestrictContentSettingsCest
 	}
 
 	/**
+	 * Tests that disabling CSS results in restrict-content.css not being output.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testDisableCSSSetting(AcceptanceTester $I)
+	{
+		// Enable Restrict Content.
+		$I->setupConvertKitPluginRestrictContent(
+			$I,
+			[
+				'enabled' => true,
+			]
+		);
+
+		// Disable CSS.
+		$I->loadConvertKitSettingsGeneralScreen($I);
+		$I->checkOption('#no_css');
+		$I->click('Save Changes');
+
+		// Create Restricted Content Page.
+		$pageID = $I->createRestrictedContentPage(
+			$I,
+			'ConvertKit: Restrict Content: Settings: Custom',
+			'Visible content.',
+			'Member only content.',
+			'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+		);
+
+		// Confirm no CSS is output by the Plugin.
+		$I->dontSeeInSource('restrict-content.css');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.


### PR DESCRIPTION
## Summary

- Honors the `Disable CSS` setting at `Settings > ConvertKit`
- Updated the description for the `Disable CSS` setting to reflect which sections are affected
- Product CSS: Set ID to match format of other CSS e.g. Broadcasts

## Testing

- `RestrictContentSettingsCest:testDisableCSSSetting`: Test that the `Disable CSS` setting is honored when enabled

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)