### PR TITLE
Tests: Use Chromedriver v109

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -157,6 +157,8 @@ jobs:
         
       - name: Install chromedriver
         uses: nanasess/setup-chromedriver@master
+        with:
+          chromedriver-version: '109.0.5414.74'
 
       - name: Start chromedriver
         run: |


### PR DESCRIPTION
## Summary

Forces tests to run using Chromedriver v109, due to numerous [reported issues](https://groups.google.com/g/chromedriver-users) with v110.

Specifically:
- tests where downloading and inspecting a file's content
- tests to check an iframe exists

![Screenshot 2023-02-21 at 16 03 17](https://user-images.githubusercontent.com/1462305/220405360-93d7b596-6095-422d-b3de-deb02349e06c.png)

This will need to be reviewed periodically and a later version of Chromedriver used when they resolve.

## Testing

Existing tests pass

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)