### PR TITLE
Add Setup Wizard link on Plugins screen

### DIFF
--- a/admin/class-convertkit-admin-settings.php
+++ b/admin/class-convertkit-admin-settings.php
@@ -190,20 +190,29 @@ class ConvertKit_Admin_Settings {
 	 * @param   array $links      Links.
 	 * @return  array               Links
 	 */
-	public static function add_settings_page_link( $links ) {
+	public function add_settings_page_link( $links ) {
 
-		return array_merge(
-			array(
-				'settings' => sprintf(
-					'<a href="%s">%s</a>',
-					convertkit_get_settings_link(),
-					__( 'Settings', 'convertkit' )
-				),
-			),
-			$links
+		// Add link to Plugin settings screen.
+		$links['settings'] = sprintf(
+			'<a href="%s">%s</a>',
+			convertkit_get_settings_link(),
+			__( 'Settings', 'convertkit' )
 		);
 
+		/**
+		 * Define links to display below the Plugin Name on the WP_List_Table at Plugins > Installed Plugins.
+		 *
+		 * @since   2.1.2
+		 *
+		 * @param   array   $links  HTML Links.
+		 */
+		$links = apply_filters( 'convertkit_plugin_screen_action_links', $links );
+
+		// Return.
+		return $links;
+
 	}
+
 	/**
 	 * Output tabs, one for each registered settings section.
 	 *

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php
@@ -103,12 +103,43 @@ class ConvertKit_Admin_Setup_Wizard_Plugin extends ConvertKit_Admin_Setup_Wizard
 			),
 		);
 
+		// Register link to Setup Wizard below Plugin Name at Plugins > Installed Plugins.
+		add_filter( 'convertkit_plugin_screen_action_links', array( $this, 'add_setup_wizard_link_on_plugins_screen' ) );
+
 		add_action( 'admin_init', array( $this, 'maybe_redirect_to_setup_screen' ), 9999 );
 		add_action( 'convertkit_admin_setup_wizard_process_form_convertkit-setup', array( $this, 'process_form' ) );
 		add_action( 'convertkit_admin_setup_wizard_load_screen_data_convertkit-setup', array( $this, 'load_screen_data' ) );
 
 		// Call parent class constructor.
 		parent::__construct();
+
+	}
+
+	/**
+	 * Add a link to the Setup Wizard below the Plugin Name on the WP_List_Table at Plugins > Installed Plugins.
+	 *
+	 * @since   2.1.2
+	 *
+	 * @param   array $links  HTML Links.
+	 * @return  array           HTML Links
+	 */
+	public function add_setup_wizard_link_on_plugins_screen( $links ) {
+
+		return array_merge(
+			$links,
+			array(
+				'setup_wizard' => sprintf(
+					'<a href="%s">%s</a>',
+					add_query_arg(
+						array(
+							'page' => $this->page_name,
+						),
+						admin_url( 'index.php' )
+					),
+					__( 'Setup Wizard', 'convertkit' )
+				),
+			)
+		);
 
 	}
 

--- a/tests/acceptance/general/PluginSetupWizardCest.php
+++ b/tests/acceptance/general/PluginSetupWizardCest.php
@@ -378,6 +378,30 @@ class PluginSetupWizardCest
 	}
 
 	/**
+	 * Tests that a link to the Setup Wizard exists on the Plugins screen, and works when clicked.
+	 *
+	 * @since   2.1.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSetupWizardLinkOnPluginsScreen(AcceptanceTester $I)
+	{
+		// Activate and Setup ConvertKit plugin.
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Navigate to Plugins screen.
+		$I->amOnPluginsPage();
+
+		// Click Setup Wizard link underneath the Plugin in the WP_List_Table.
+		$I->click('tr[data-slug="convertkit"] td div.row-actions span.setup_wizard a');
+
+		// Confirm expected setup wizard screen is displayed.
+		$this->_seeExpectedSetupWizardScreen($I, 1, 'Welcome to the ConvertKit Setup Wizard');
+	}
+
+	/**
 	 * Activate the Plugin, without checking it is activated, so that its Setup Wizard
 	 * screen loads.
 	 *


### PR DESCRIPTION
## Summary

Adds a link to the Setup Wizard from the `Plugins > Installed Plugins` screen, to provide users a simpler UI method of configuring the Plugin vs. the settings screen.

![Screenshot 2023-03-28 at 15 13 55](https://user-images.githubusercontent.com/1462305/228266794-00e2bd64-d1b4-48e7-bf36-5f3d7d8adcac.png)

This can be used at any time, not just for new installations, and walks the user through the existing Setup Wizard where they:
- register a ConvertKit account,
- enter API keys,
- select a default form to display on Pages and/or Posts, with preview functionality

## Testing

- `PluginSetupWizardCest:testSetupWizardLinkOnPluginsScreen`: Tests that the link displays on the Plugins screen, and loads the expected Setup Wizard screen when clicked.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)