### PR TITLE
Fix button padding in WordPress 5.x

### DIFF
--- a/resources/backend/css/settings.css
+++ b/resources/backend/css/settings.css
@@ -110,6 +110,11 @@ body.settings_page__wp_convertkit_settings .wrap .postbox .button {
 	margin:  0 5px 0 0;
 	padding: 4px 12px;
 	font-size: 14px;
+
+	/* Required for WordPress 5.x styling */
+	height: auto;
+	text-shadow: none;
+	box-shadow: none;
 }
 body.settings_page__wp_convertkit_settings .wrap .postbox .button-primary {
 	background: #fb6970;

--- a/resources/backend/css/setup-wizard.css
+++ b/resources/backend/css/setup-wizard.css
@@ -120,7 +120,6 @@
 #convertkit-setup-wizard-content button,
 #convertkit-setup-wizard-footer a.button,
 #convertkit-setup-wizard-footer button {
-	padding: 5px 20px;
 	font-weight: 500;
 	font-size: 16px;
 }

--- a/views/backend/setup-wizard/convertkit-restrict-content-setup/content-1.php
+++ b/views/backend/setup-wizard/convertkit-restrict-content-setup/content-1.php
@@ -29,7 +29,7 @@
 
 <div class="convertkit-setup-wizard-grid">
 	<div>
-		<a href="<?php echo esc_attr( $this->download_url ); ?>" class="button button-primary">
+		<a href="<?php echo esc_attr( $this->download_url ); ?>" class="button button-primary button-hero">
 			<?php esc_html_e( 'Download', 'convertkit' ); ?>
 		</a>
 		<span class="description">
@@ -38,7 +38,7 @@
 	</div>
 
 	<div>
-		<a href="<?php echo esc_attr( $this->course_url ); ?>" class="button button-primary">
+		<a href="<?php echo esc_attr( $this->course_url ); ?>" class="button button-primary button-hero">
 			<?php esc_html_e( 'Course', 'convertkit' ); ?>
 		</a>
 		<span class="description">

--- a/views/backend/setup-wizard/convertkit-setup/content-1.php
+++ b/views/backend/setup-wizard/convertkit-setup/content-1.php
@@ -16,7 +16,7 @@
 <div class="convertkit-setup-wizard-grid">
 	<div>
 		<h2><?php esc_html_e( 'I don\'t have a ConvertKit account.', 'convertkit' ); ?></h2>
-		<a href="<?php echo esc_attr( convertkit_get_registration_url() ); ?>" class="button button-primary convertkit-redirect" data-convertkit-redirect-url="<?php echo esc_attr( $this->next_step_url ); ?>" target="_blank">
+		<a href="<?php echo esc_attr( convertkit_get_registration_url() ); ?>" class="button button-primary button-hero convertkit-redirect" data-convertkit-redirect-url="<?php echo esc_attr( $this->next_step_url ); ?>" target="_blank">
 			<?php esc_html_e( 'Register', 'convertkit' ); ?>
 		</a>
 		<span class="description"><?php esc_html_e( 'Sign up to ConvertKit and register your account. It\'s free.', 'convertkit' ); ?></span>
@@ -24,7 +24,7 @@
 
 	<div>
 		<h2><?php esc_html_e( 'I have a ConvertKit account.', 'convertkit' ); ?></h2>
-		<a href="<?php echo esc_attr( $this->next_step_url ); ?>" class="button button-primary">
+		<a href="<?php echo esc_attr( $this->next_step_url ); ?>" class="button button-primary button-hero">
 			<?php esc_html_e( 'Connect', 'convertkit' ); ?>
 		</a>
 		<span class="description"><?php esc_html_e( 'Great! Click the Connect button to get started.', 'convertkit' ); ?></span>

--- a/views/backend/setup-wizard/convertkit-setup/content-3.php
+++ b/views/backend/setup-wizard/convertkit-setup/content-3.php
@@ -19,7 +19,7 @@ if ( ! $this->forms->exist() ) {
 
 	<hr />
 
-	<a href="https://app.convertkit.com/forms/new?format=inline" target="_blank" class="button button-primary">
+	<a href="https://app.convertkit.com/forms/new?format=inline" target="_blank" class="button button-primary button-hero">
 		<?php esc_html_e( 'Create form', 'convertkit' ); ?>
 	</a>
 

--- a/views/backend/setup-wizard/convertkit-setup/content-4.php
+++ b/views/backend/setup-wizard/convertkit-setup/content-4.php
@@ -15,14 +15,14 @@
 
 <div class="convertkit-setup-wizard-grid">
 	<div>
-		<a href="<?php echo esc_attr( admin_url( 'index.php' ) ); ?>" class="button button-primary">
+		<a href="<?php echo esc_attr( admin_url( 'index.php' ) ); ?>" class="button button-primary button-hero">
 			<?php esc_html_e( 'Dashboard', 'convertkit' ); ?>
 		</a>
 		<span class="description"><?php esc_html_e( 'Exit the wizard and load the WordPress Dashboard screen.', 'convertkit' ); ?></span>
 	</div>
 
 	<div>
-		<a href="<?php echo esc_attr( convertkit_get_settings_link() ); ?>" class="button button-primary">
+		<a href="<?php echo esc_attr( convertkit_get_settings_link() ); ?>" class="button button-primary button-hero">
 			<?php esc_html_e( 'Plugin Settings', 'convertkit' ); ?>
 		</a>
 		<span class="description"><?php esc_html_e( 'Exit the wizard and load the Plugin\'s settings screen.', 'convertkit' ); ?></span>

--- a/views/backend/setup-wizard/footer.php
+++ b/views/backend/setup-wizard/footer.php
@@ -15,7 +15,7 @@
 						if ( $this->previous_step_url ) {
 							?>
 							<div class="left">
-								<a href="<?php echo esc_attr( $this->previous_step_url ); ?>" class="button">
+								<a href="<?php echo esc_attr( $this->previous_step_url ); ?>" class="button button-hero">
 									<?php echo esc_html_e( 'Back', 'convertkit' ); ?>
 								</a>
 							</div>
@@ -30,13 +30,13 @@
 								if ( isset( $this->steps[ $this->step ]['next_button']['link'] ) ) {
 									// Link.
 									?>
-									<a href="<?php echo esc_attr( $this->steps[ $this->step ]['next_button']['link'] ); ?>" class="button button-primary"><?php echo esc_html( $this->steps[ $this->step ]['next_button']['label'] ); ?></a>
+									<a href="<?php echo esc_attr( $this->steps[ $this->step ]['next_button']['link'] ); ?>" class="button button-primary button-hero"><?php echo esc_html( $this->steps[ $this->step ]['next_button']['label'] ); ?></a>
 									<?php
 								} else {
 									// Submit button.
 									wp_nonce_field( $this->page_name );
 									?>
-									<button class="button button-primary button-large"><?php echo esc_html( $this->steps[ $this->step ]['next_button']['label'] ); ?></button>
+									<button class="button button-primary button-hero"><?php echo esc_html( $this->steps[ $this->step ]['next_button']['label'] ); ?></button>
 									<?php
 								}
 								?>


### PR DESCRIPTION
## Summary

Improves UI compatibility with WordPress 5.x, and follows better practices by using WordPress' built in `button-hero` CSS class instead of applying padding to specific buttons we want to display larger than the default on setup wizards and the Plugin's settings screens.

Below examples are from a site running WordPress 5.1.15, as buttons previously rendered correctly in WordPress 6.x.

Setup Wizard Before:
![setup-wizard-before](https://user-images.githubusercontent.com/1462305/230114798-fa3d9ecc-238c-4e5e-9e0d-dfeaf546e7fe.png)

Setup Wizard After:
![setup-wizard-after](https://user-images.githubusercontent.com/1462305/230114822-c13b8198-8424-4eeb-a53f-062d4cab7020.png)

Settings Before:
![settings-before](https://user-images.githubusercontent.com/1462305/230114955-1e43533f-2623-4198-9fdd-996b9664e3a5.png)

Settings After:
![settings-after](https://user-images.githubusercontent.com/1462305/230114993-62d88adf-34a5-481f-9bba-952d76b5f94d.png)

## Testing

Existing tests pass.

## Checklist

* [ ] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](TESTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)