### PR TITLE
Refactor Gutenberg JavaScript

### DIFF
--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -32,10 +32,10 @@ function convertKitGutenbergRegisterBlock( block ) {
 	( function( blocks, editor, element, components ) {
 
 		// Define some constants for the various items we'll use.
-		const el                              = element.createElement;
-		const { registerBlockType }           = blocks;
+		const el                    = element.createElement;
+		const { registerBlockType } = blocks;
 		const { InspectorControls } = editor;
-		const { Fragment } 		  			  = element;
+		const { Fragment }          = element;
 		const {
 			TextControl,
 			SelectControl,
@@ -43,7 +43,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 			Panel,
 			PanelBody,
 			PanelRow
-		}                                     = components;
+		}                           = components;
 
 		/**
 		 * Returns the icon to display for this block, depending
@@ -122,12 +122,13 @@ function convertKitGutenbergRegisterBlock( block ) {
 
 				case 'select':
 					// Build options for <select> input.
-					let fieldOptions = [
+					let fieldOptions = [];
+					fieldOptions.push(
 						{
 							label: '(None)',
 							value: '',
-					}
-					];
+						}
+					);
 					for ( let value in field.values ) {
 						fieldOptions.push(
 							{
@@ -210,9 +211,9 @@ function convertKitGutenbergRegisterBlock( block ) {
 			let rows = [];
 			for ( let i in block.panels[ panel ].fields ) {
 				const attribute = block.panels[ panel ].fields[ i ], // e.g. 'term'.
-			  		  field     = block.fields[ attribute ]; // field array.
+					field       = block.fields[ attribute ]; // field array.
 
-			  	// If this field doesn't exist as an attribute in the block's get_attributes(),
+				// If this field doesn't exist as an attribute in the block's get_attributes(),
 				// this is a non-Gutenberg field (such as a color picker for shortcodes),
 				// which should be ignored.
 				if ( typeof block.attributes[ attribute ] === 'undefined' ) {
@@ -245,7 +246,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 */
 		const getPanels = function( props ) {
 
-			let panels = [],
+			let panels      = [],
 				initialOpen = true;
 
 			// Build Inspector Control Panels.
@@ -298,7 +299,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 			}
 
 			// Build Inspector Control Panels, which will appear in the Sidebar when editing the Block.
-			let panels  = getPanels( props );
+			let panels = getPanels( props );
 
 			// Generate Block Preview.
 			let preview = '';

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -94,7 +94,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 				help: 		field.description,
 				value: 		props.attributes[ attribute ],
 				onChange: 	function( value ) {
-					if ( field.type == 'number' ) {
+					if ( field.type === 'number' ) {
 						// If value is a blank string i.e. no attribute value was provided,
 						// cast it to the field's minimum number setting.
 						// This prevents WordPress' block renderer API returning a 400 error

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -29,43 +29,302 @@ if ( typeof wp !== 'undefined' &&
  */
 function convertKitGutenbergRegisterBlock( block ) {
 
-	// Register Block.
-	( function( blocks, editor, element, components, block ) {
+	( function( blocks, editor, element, components ) {
 
 		// Define some constants for the various items we'll use.
 		const el                              = element.createElement;
 		const { registerBlockType }           = blocks;
-		const { RichText, InspectorControls } = editor;
+		const { InspectorControls } = editor;
 		const { Fragment } 		  			  = element;
 		const {
 			TextControl,
-			CheckboxControl,
-			RadioControl,
 			SelectControl,
-			TextareaControl,
 			ToggleControl,
-			RangeControl,
-			FormTokenField,
 			Panel,
 			PanelBody,
-			PanelRow,
-			SandBox
+			PanelRow
 		}                                     = components;
 
-		// Build Icon, if it's an object.
-		var icon = 'dashicons-tablet';
-		if ( typeof block.gutenberg_icon !== 'undefined' ) {
+		/**
+		 * Returns the icon to display for this block, depending
+		 * on the supplied block's configuration.
+		 *
+		 * @since   2.2.0
+		 *
+		 * @return  element|string
+		 */
+		const getIcon = function() {
+
+			// Return a fallback default icon if none is specified for this block.
+			if ( typeof block.gutenberg_icon === 'undefined' ) {
+				return 'dashicons-tablet';
+			}
+
+			// Return HTML element if the icon is an SVG string.
 			if ( block.gutenberg_icon.search( 'svg' ) >= 0 ) {
-				// SVG.
-				icon = element.RawHTML(
+				return element.RawHTML(
 					{
 						children: block.gutenberg_icon
 					}
 				);
-			} else {
-				// Dashicon.
-				icon = block.gutenberg_icon;
 			}
+
+			// Just return the string, as it's a dashicon CSS class.
+			return block.gutenberg_icon;
+
+		}
+
+		/**
+		 * Return a field element for the block sidebar, which is displayed in a panel's row
+		 * when this block is being edited.
+		 *
+		 * @since   2.2.0
+		 *
+		 * @param   object  props           Block properties.
+		 * @param   object  field      		Field attributes.
+		 * @param 	string 	attribute 		Attribute name to store the field's data in.
+		 * @return  array                   Field element
+		 */
+		const getField = function( props, field, attribute ) {
+
+			// Define some field properties shared across all field types.
+			let fieldProperties = {
+				id:  		'convertkit_' + block.name + '_' + attribute,
+				label: 		field.label,
+				help: 		field.description,
+				value: 		props.attributes[ attribute ],
+				onChange: 	function( value ) {
+					if ( field.type == 'number' ) {
+						// If value is a blank string i.e. no attribute value was provided,
+						// cast it to the field's minimum number setting.
+						// This prevents WordPress' block renderer API returning a 400 error
+						// because a blank value will be passed as a string, when WordPress
+						// expects it to be a numerical value.
+						if ( value === '' ) {
+							value = field.min;
+						}
+
+						// Cast value to integer if a value exists.
+						if ( value.length > 0 ) {
+							value = Number( value );
+						}
+					}
+
+					let newValue          = {};
+					newValue[ attribute ] = value;
+					props.setAttributes( newValue );
+				}
+			};
+
+			// Define additional Field Properties and the Field Element,
+			// depending on the Field Type (select, textarea, text etc).
+			switch ( field.type ) {
+
+				case 'select':
+					// Build options for <select> input.
+					let fieldOptions = [
+						{
+							label: '(None)',
+							value: '',
+					}
+					];
+					for ( let value in field.values ) {
+						fieldOptions.push(
+							{
+								label: field.values[ value ],
+								value: value
+							}
+						);
+					}
+
+					// Sort field's options alphabetically by label.
+					fieldOptions.sort(
+						function ( x, y ) {
+
+							let a = x.label.toUpperCase(),
+							b     = y.label.toUpperCase();
+							return a.localeCompare( b );
+
+						}
+					);
+
+					// Assign options to field.
+					fieldProperties.options = fieldOptions;
+
+					// Return field element.
+					return el(
+						SelectControl,
+						fieldProperties
+					);
+					break;
+
+				case 'toggle':
+					// Define field properties.
+					fieldProperties.checked = props.attributes[ attribute ];
+
+					// Return field element.
+					return el(
+						ToggleControl,
+						fieldProperties
+					);
+					break;
+
+				case 'number':
+					// Define field properties.
+					fieldProperties.type = field.type;
+					fieldProperties.min  = field.min;
+					fieldProperties.max  = field.max;
+					fieldProperties.step = field.step;
+
+					// Return field element.
+					return el(
+						TextControl,
+						fieldProperties
+					);
+					break;
+
+				default:
+					// Return field element.
+					return el(
+						TextControl,
+						fieldProperties
+					);
+					break;
+			}
+
+		}
+
+		/**
+		 * Return an array of rows to display in the given block sidebar's panel when
+		 * this block is being edited.
+		 *
+		 * @since   2.2.0
+		 *
+		 * @param   object  props   Block properties.
+		 * @param   string  panel 	Panel name.
+		 * @return  array           Panel rows
+		 */
+		const getPanelRows = function( props, panel ) {
+
+			// Build Inspector Control Panel Rows, one for each Field.
+			let rows = [];
+			for ( let i in block.panels[ panel ].fields ) {
+				const attribute = block.panels[ panel ].fields[ i ], // e.g. 'term'.
+			  		  field     = block.fields[ attribute ]; // field array.
+
+			  	// If this field doesn't exist as an attribute in the block's get_attributes(),
+				// this is a non-Gutenberg field (such as a color picker for shortcodes),
+				// which should be ignored.
+				if ( typeof block.attributes[ attribute ] === 'undefined' ) {
+					continue;
+				}
+
+				rows.push(
+					el(
+						PanelRow,
+						{
+							key: attribute
+						},
+						getField( props, field, attribute )
+					)
+				);
+			}
+
+			return rows;
+
+		}
+
+		/**
+		 * Return an array of panels to display in the block's sidebar when the block
+		 * is being edited.
+		 *
+		 * @since   2.2.0
+		 *
+		 * @param   object  props 	Block formatter properties.
+		 * @return 	array 			Block sidebar panels.
+		 */
+		const getPanels = function( props ) {
+
+			let panels = [],
+				initialOpen = true;
+
+			// Build Inspector Control Panels.
+			for ( const panel in block.panels ) {
+				panels.push(
+					el(
+						PanelBody,
+						{
+							title: block.panels[ panel ].label,
+							key: panel,
+							initialOpen: initialOpen
+						},
+						getPanelRows( props, panel )
+					)
+				);
+
+				// Don't open any further panels.
+				initialOpen = false;
+			}
+
+			return panels;
+
+		}
+
+		/**
+		 * Display settings sidebar when the block is being edited, and save
+		 * changes that are made.
+		 *
+		 * @since   2.2.0
+		 *
+		 * @param   object  props   Block properties.
+		 * @return  object          Block settings sidebar elements
+		 */
+		const editBlock = function( props ) {
+
+			// If requesting an example of how this block looks (which is requested
+			// when the user adds a new block and hovers over this block's icon),
+			// show the preview image.
+			if ( props.attributes.is_gutenberg_example === true ) {
+				return (
+					Fragment,
+					{},
+					el(
+						'img',
+						{
+							src: block.gutenberg_example_image,
+						}
+					)
+				);
+			}
+
+			// Build Inspector Control Panels, which will appear in the Sidebar when editing the Block.
+			let panels  = getPanels( props );
+
+			// Generate Block Preview.
+			let preview = '';
+			if ( typeof block.gutenberg_preview_render_callback !== 'undefined' ) {
+				// Use a custom callback function to render this block's preview in the Gutenberg Editor.
+				// This doesn't affect the output for this block on the frontend site, which will always
+				// use the block's PHP's render() function.
+				preview = window[ block.gutenberg_preview_render_callback ]( block, props );
+			}
+
+			// Return settings sidebar panel with fields and the bloc preview.
+			return (
+				el(
+					// Sidebar Panel with Fields.
+					Fragment,
+					{},
+					el(
+						InspectorControls,
+						{},
+						panels
+					),
+					// Block Preview.
+					preview
+				)
+			);
+
 		}
 
 		// Register Block.
@@ -75,7 +334,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 				title:      block.title,
 				description:block.description,
 				category:   block.category,
-				icon:       icon,
+				icon:       getIcon,
 				keywords: 	block.keywords,
 				attributes: block.attributes,
 				supports: 	block.supports,
@@ -86,203 +345,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 				},
 
 				// Editor.
-				edit: function( props ) {
-
-					// If requesting an example of how this block looks (which is requested
-					// when the user adds a new block and hovers over this block's icon),
-					// show the preview image.
-					if ( props.attributes.is_gutenberg_example === true ) {
-						return (
-							Fragment,
-							{},
-							el(
-								'img',
-								{
-									src: block.gutenberg_example_image,
-								}
-							)
-						);
-					}
-
-					// Build Inspector Control Panels, which will appear in the Sidebar when editing the Block.
-					var panels  = [],
-					initialOpen = true;
-					for ( const panel in block.panels ) {
-
-						// Build Inspector Control Panel Rows, one for each Field.
-						var rows = [];
-						for ( var i in block.panels[ panel ].fields ) {
-							const attribute = block.panels[ panel ].fields[ i ], // e.g. 'term'.
-									field   = block.fields[ attribute ]; // field array.
-
-							// If this field doesn't exist as an attribute in the block's get_attributes(),
-							// this is a non-Gutenberg field (such as a color picker for shortcodes),
-							// which should be ignored.
-							if ( typeof block.attributes[ attribute ] === 'undefined' ) {
-								continue;
-							}
-
-							var fieldElement; // Holds the field element (select, textarea, text etc).
-
-							// Define Field's Properties.
-							var fieldProperties = {
-								id:  		'convertkit_' + block.name + '_' + attribute,
-								label: 		field.label,
-								help: 		field.description,
-								value: 		props.attributes[ attribute ],
-								onChange: 	function( value ) {
-									if ( field.type == 'number' ) {
-										// If value is a blank string i.e. no attribute value was provided,
-										// cast it to the field's minimum number setting.
-										// This prevents WordPress' block renderer API returning a 400 error
-										// because a blank value will be passed as a string, when WordPress
-										// expects it to be a numerical value.
-										if ( value === '' ) {
-											value = field.min;
-										}
-
-										// Cast value to integer if a value exists.
-										if ( value.length > 0 ) {
-											value = Number( value );
-										}
-									}
-
-									var newValue          = {};
-									newValue[ attribute ] = value;
-									props.setAttributes( newValue );
-								}
-							};
-
-							// Define additional Field Properties and the Field Element,
-							// depending on the Field Type (select, textarea, text etc).
-							switch ( field.type ) {
-
-								case 'select':
-									// Build options for <select> input.
-									var fieldOptions = [
-										{
-											label: '(None)',
-											value: '',
-									}
-									];
-									for ( var value in field.values ) {
-										fieldOptions.push(
-											{
-												label: field.values[ value ],
-												value: value
-											}
-										);
-									}
-
-									// Sort field's options alphabetically by label.
-									fieldOptions.sort(
-										function ( x, y ) {
-
-											let a = x.label.toUpperCase(),
-											b     = y.label.toUpperCase();
-											return a.localeCompare( b );
-
-										}
-									);
-
-									// Assign options to field.
-									fieldProperties.options = fieldOptions;
-
-									// Define field element.
-									fieldElement = el(
-										SelectControl,
-										fieldProperties
-									);
-									break;
-
-								case 'toggle':
-									// Define field properties.
-									fieldProperties.checked = props.attributes[ attribute ];
-
-									// Define field element.
-									fieldElement = el(
-										ToggleControl,
-										fieldProperties
-									);
-									break;
-
-								case 'number':
-									// Define field properties.
-									fieldProperties.type = field.type;
-									fieldProperties.min  = field.min;
-									fieldProperties.max  = field.max;
-									fieldProperties.step = field.step;
-
-									// Define field element.
-									fieldElement = el(
-										TextControl,
-										fieldProperties
-									);
-									break;
-
-								default:
-									// Define field element.
-									fieldElement = el(
-										TextControl,
-										fieldProperties
-									);
-									break;
-							}
-
-							// Add Field as a Row.
-							rows.push(
-								el(
-									PanelRow,
-									{
-										key: attribute
-									},
-									fieldElement
-								)
-							);
-						}
-
-						// Add the Panel Rows to a new Panel.
-						panels.push(
-							el(
-								PanelBody,
-								{
-									title: block.panels[ panel ].label,
-									key: panel,
-									initialOpen: initialOpen
-								},
-								rows
-							)
-						);
-
-						// Don't open any further panels.
-						initialOpen = false;
-					}
-
-					// Generate Block Preview.
-					var preview = '';
-					if ( typeof block.gutenberg_preview_render_callback !== 'undefined' ) {
-						// Use a custom callback function to render this block's preview in the Gutenberg Editor.
-						// This doesn't affect the output for this block on the frontend site, which will always
-						// use the block's PHP's render() function.
-						preview = window[ block.gutenberg_preview_render_callback ]( block, props );
-					}
-
-					// Return.
-					return (
-						el(
-							// Sidebar Panel with Fields.
-							Fragment,
-							{},
-							el(
-								InspectorControls,
-								{},
-								panels
-							),
-							// Block Preview.
-							preview
-						)
-					);
-				},
+				edit: editBlock,
 
 				// Output.
 				save: function( props ) {
@@ -300,8 +363,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 		window.wp.blocks,
 		window.wp.blockEditor,
 		window.wp.element,
-		window.wp.components,
-		block
+		window.wp.components
 	) );
 
 }


### PR DESCRIPTION
## Summary

Refactor Gutenberg JS, similar to the work done for the [block formatters](https://github.com/ConvertKit/convertkit-wordpress/pull/459).

Removes unused constants and elements.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)