### PR TITLE
Restrict Content: Add caching warning notice

### DIFF
--- a/admin/class-convertkit-admin-settings-restrict-content.php
+++ b/admin/class-convertkit-admin-settings-restrict-content.php
@@ -156,7 +156,7 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 		<p class="description"><?php esc_html_e( 'Defines the text and button labels to display when a Page, Post or Custom Post has its Member Content setting set to a Product, and the visitor has not authenticated/subscribed.', 'convertkit' ); ?></p>
 		<div class="notice notice-warning">
 			<p>
-				<?php 
+				<?php
 				echo sprintf(
 					'%s %s %s',
 					esc_html__( 'If you have server side or a caching plugin enabled, you must configure it to disable caching when the', 'convertkit' ),

--- a/admin/class-convertkit-admin-settings-restrict-content.php
+++ b/admin/class-convertkit-admin-settings-restrict-content.php
@@ -154,6 +154,18 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 		?>
 		<span class="convertkit-beta-label"><?php esc_html_e( 'Beta', 'convertkit' ); ?></span>
 		<p class="description"><?php esc_html_e( 'Defines the text and button labels to display when a Page, Post or Custom Post has its Member Content setting set to a Product, and the visitor has not authenticated/subscribed.', 'convertkit' ); ?></p>
+		<div class="notice notice-warning">
+			<p>
+				<?php 
+				echo sprintf(
+					'%s %s %s',
+					esc_html__( 'If you have server side or a caching plugin enabled, you must configure it to disable caching when the', 'convertkit' ),
+					'<code>ck_subscriber_id</code>',
+					esc_html__( 'cookie is present. Failing to do so will result in incorrect working functionality.', 'convertkit' )
+				);
+				?>
+			</p>
+		</div>
 		<?php
 
 	}

--- a/admin/class-convertkit-admin-settings-restrict-content.php
+++ b/admin/class-convertkit-admin-settings-restrict-content.php
@@ -159,9 +159,9 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 				<?php
 				echo sprintf(
 					'%s %s %s',
-					esc_html__( 'If you have server side or a caching plugin enabled, you must configure it to disable caching when the', 'convertkit' ),
+					esc_html__( 'If your web host has caching configured (or you are using a caching plugin), you must configure it to disable caching when the', 'convertkit' ),
 					'<code>ck_subscriber_id</code>',
-					esc_html__( 'cookie is present. Failing to do so will result in incorrect working functionality.', 'convertkit' )
+					esc_html__( 'cookie is present. Failing to do so will result in errors.', 'convertkit' )
 				);
 				?>
 			</p>


### PR DESCRIPTION
## Summary

Adds a notice to the Member Content settings screen at `Settings > ConvertKit > Member Content (beta)`, advising that  any server side or plugin level caching system must be configured to disable caching when the `ck_subscriber_id` cookie is present.

![Screenshot 2023-05-04 at 12 55 42](https://user-images.githubusercontent.com/1462305/236196832-1ad91028-92dd-45e4-9272-d284d3259f03.png)

Whilst we forcibly exclude caching by [appending a query parameter](https://github.com/ConvertKit/convertkit-wordpress/pull/464) as part of the authentication flow, two scenarios still exist where cached (incorrect) content can be served by the server or a third party caching plugin:
1. If a subscriber subsequently leaves the WordPress Page, and then accesses it days later (e.g. through a link on the web site, perhaps in the site navigation menu, which will not include a query parameter)
2. A different visitor accesses the same page; some caching plugins may take the member content output from an authenticated subscriber, cache it, and therefore serve it to all visitors.

Most third party caching plugins provide a setting to disable caching when a cookie is present - for example, but not limited to:

**W3 Total Cache**

![Screenshot 2023-05-03 at 14 52 34](https://user-images.githubusercontent.com/1462305/235936524-153817d3-0936-4d56-abe6-fe8fefb6e990.png)

**WP Fastest Cache**

![Screenshot 2023-05-03 at 14 52 57](https://user-images.githubusercontent.com/1462305/235936528-7deb3207-5b55-4aec-a85a-a5d55ad6afe3.png)

**WP Super Cache**

![Screenshot 2023-05-03 at 14 53 21](https://user-images.githubusercontent.com/1462305/235936530-6a51ab2c-6ba6-4c31-a28e-9e92aeddc6ca.png)

It may be possible to automatically add this exclusion rule to third party caching plugins from the ConvertKit Plugin, but given the range of caching solutions available, we can't cover every single one, and this would involve some technical work - so the notice is a good starting point.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)