### PR TITLE
Update readme file for 2.2.0

### DIFF
--- a/ACTIONS-FILTERS.md
+++ b/ACTIONS-FILTERS.md
@@ -35,6 +35,10 @@
 						<td><a href="#convertkit_blocks"><code>convertkit_blocks</code></a></td>
 						<td>Registers blocks for the ConvertKit Plugin.</td>
 					</tr><tr>
+						<td>&nbsp;</td>
+						<td><a href="#convertkit_get_block_formatters"><code>convertkit_get_block_formatters</code></a></td>
+						<td>Registers block formatters in Gutenberg for the ConvertKit Plugin.</td>
+					</tr><tr>
 						<td colspan="3">../includes/blocks/class-convertkit-block-content.php</td>
 					</tr><tr>
 						<td>&nbsp;</td>
@@ -63,17 +67,17 @@
 						<td><a href="#convertkit_block_form_render"><code>convertkit_block_form_render</code></a></td>
 						<td>Filter the block's content immediately before it is output.</td>
 					</tr><tr>
+						<td colspan="3">../includes/blocks/class-convertkit-block-form-trigger.php</td>
+					</tr><tr>
+						<td>&nbsp;</td>
+						<td><a href="#convertkit_block_form_trigger_render"><code>convertkit_block_form_trigger_render</code></a></td>
+						<td>Filter the block's content immediately before it is output.</td>
+					</tr><tr>
 						<td colspan="3">../includes/class-convertkit-post.php</td>
 					</tr><tr>
 						<td>&nbsp;</td>
 						<td><a href="#convertkit_post_get_default_settings"><code>convertkit_post_get_default_settings</code></a></td>
 						<td>The default settings, used to populate the Post's Settings when a Post has no Settings.</td>
-					</tr><tr>
-						<td colspan="3">../includes/class-convertkit-post-type-product.php</td>
-					</tr><tr>
-						<td>&nbsp;</td>
-						<td><a href="#convertkit_post_type_product_register"><code>convertkit_post_type_product_register</code></a></td>
-						<td>Filter the arguments for registering the Products Custom Post Type</td>
 					</tr><tr>
 						<td colspan="3">../includes/class-convertkit-term.php</td>
 					</tr><tr>
@@ -134,6 +138,10 @@
 						<td>&nbsp;</td>
 						<td><a href="#convertkit_frontend_append_form"><code>convertkit_frontend_append_form</code></a></td>
 						<td>Filter the Post's Content, which includes a ConvertKit Form, immediately before it is output.</td>
+					</tr><tr>
+						<td>&nbsp;</td>
+						<td><a href="#convertkit_output_scripts_footer"><code>convertkit_output_scripts_footer</code></a></td>
+						<td>Define an array of scripts to output in the footer of the WordPress site.</td>
 					</tr><tr>
 						<td colspan="3">../includes/class-convertkit-settings.php</td>
 					</tr><tr>
@@ -310,6 +318,33 @@ add_filter( 'convertkit_blocks', function( $blocks ) {
 	return $blocks;
 }, 10, 1 );
 </pre>
+<h3 id="convertkit_get_block_formatters">
+						convertkit_get_block_formatters
+						<code>includes/functions.php::219</code>
+					</h3><h4>Overview</h4>
+						<p>Registers block formatters in Gutenberg for the ConvertKit Plugin.</p><h4>Parameters</h4>
+					<table>
+						<thead>
+							<tr>
+								<th>Parameter</th>
+								<th>Type</th>
+								<th>Description</th>
+							</tr>
+						</thead>
+						<tbody><tr>
+							<td>$block_formatters</td>
+							<td>array</td>
+							<td>Block formatters.</td>
+						</tr>
+						</tbody>
+					</table><h4>Usage</h4>
+<pre>
+add_filter( 'convertkit_get_block_formatters', function( $block_formatters ) {
+	// ... your code here
+	// Return value
+	return $block_formatters;
+}, 10, 1 );
+</pre>
 <h3 id="convertkit_block_content_render">
 						convertkit_block_content_render
 						<code>includes/blocks/class-convertkit-block-content.php::275</code>
@@ -481,6 +516,37 @@ add_filter( 'convertkit_block_form_render', function( $form, $atts, $form_id ) {
 	return $form;
 }, 10, 3 );
 </pre>
+<h3 id="convertkit_block_form_trigger_render">
+						convertkit_block_form_trigger_render
+						<code>includes/blocks/class-convertkit-block-form-trigger.php::378</code>
+					</h3><h4>Overview</h4>
+						<p>Filter the block's content immediately before it is output.</p><h4>Parameters</h4>
+					<table>
+						<thead>
+							<tr>
+								<th>Parameter</th>
+								<th>Type</th>
+								<th>Description</th>
+							</tr>
+						</thead>
+						<tbody><tr>
+							<td>$html</td>
+							<td>string</td>
+							<td>ConvertKit Button HTML.</td>
+						</tr><tr>
+							<td>$atts</td>
+							<td>array</td>
+							<td>Block Attributes.</td>
+						</tr>
+						</tbody>
+					</table><h4>Usage</h4>
+<pre>
+add_filter( 'convertkit_block_form_trigger_render', function( $html, $atts ) {
+	// ... your code here
+	// Return value
+	return $html;
+}, 10, 2 );
+</pre>
 <h3 id="convertkit_post_get_default_settings">
 						convertkit_post_get_default_settings
 						<code>includes/class-convertkit-post.php::316</code>
@@ -506,33 +572,6 @@ add_filter( 'convertkit_post_get_default_settings', function( $defaults ) {
 	// ... your code here
 	// Return value
 	return $defaults;
-}, 10, 1 );
-</pre>
-<h3 id="convertkit_post_type_product_register">
-						convertkit_post_type_product_register
-						<code>includes/class-convertkit-post-type-product.php::98</code>
-					</h3><h4>Overview</h4>
-						<p>Filter the arguments for registering the Products Custom Post Type</p><h4>Parameters</h4>
-					<table>
-						<thead>
-							<tr>
-								<th>Parameter</th>
-								<th>Type</th>
-								<th>Description</th>
-							</tr>
-						</thead>
-						<tbody><tr>
-							<td>$args</td>
-							<td>array</td>
-							<td>register_post_type() compatible arguments.</td>
-						</tr>
-						</tbody>
-					</table><h4>Usage</h4>
-<pre>
-add_filter( 'convertkit_post_type_product_register', function( $args ) {
-	// ... your code here
-	// Return value
-	return $args;
 }, 10, 1 );
 </pre>
 <h3 id="convertkit_term_get_default_settings">
@@ -703,7 +742,7 @@ add_filter( 'convertkit_wishlist_settings_get_defaults', function( $defaults ) {
 </pre>
 <h3 id="convertkit_output_restrict_content_get_resource_type">
 						convertkit_output_restrict_content_get_resource_type
-						<code>includes/class-convertkit-output-restrict-content.php::520</code>
+						<code>includes/class-convertkit-output-restrict-content.php::531</code>
 					</h3><h4>Overview</h4>
 						<p>Define the ConvertKit Resource Type that the visitor must be subscribed against to access this content, overriding the Post setting. Return false or an empty string to not restrict content.</p><h4>Parameters</h4>
 					<table>
@@ -734,7 +773,7 @@ add_filter( 'convertkit_output_restrict_content_get_resource_type', function( $r
 </pre>
 <h3 id="convertkit_output_restrict_content_get_resource_id">
 						convertkit_output_restrict_content_get_resource_id
-						<code>includes/class-convertkit-output-restrict-content.php::556</code>
+						<code>includes/class-convertkit-output-restrict-content.php::567</code>
 					</h3><h4>Overview</h4>
 						<p>Define the ConvertKit Resource ID that the visitor must be subscribed against to access this content, overriding the Post setting. Return 0 to not restrict content.</p><h4>Parameters</h4>
 					<table>
@@ -765,7 +804,7 @@ add_filter( 'convertkit_output_restrict_content_get_resource_id', function( $res
 </pre>
 <h3 id="convertkit_output_page_takeover_landing_page_id">
 						convertkit_output_page_takeover_landing_page_id
-						<code>includes/class-convertkit-output.php::138</code>
+						<code>includes/class-convertkit-output.php::139</code>
 					</h3><h4>Overview</h4>
 						<p>Define the ConvertKit Landing Page ID to display for the given Post ID, overriding the Post settings. Return false to not display any ConvertKit Landing Page.</p><h4>Parameters</h4>
 					<table>
@@ -796,7 +835,7 @@ add_filter( 'convertkit_output_page_takeover_landing_page_id', function( $landin
 </pre>
 <h3 id="convertkit_output_append_form_to_content_form_id">
 						convertkit_output_append_form_to_content_form_id
-						<code>includes/class-convertkit-output.php::193</code>
+						<code>includes/class-convertkit-output.php::194</code>
 					</h3><h4>Overview</h4>
 						<p>Define the ConvertKit Form ID to display for the given Post ID, overriding the Post, Category or Plugin settings. Return false to not display any ConvertKit Form.</p><h4>Parameters</h4>
 					<table>
@@ -827,7 +866,7 @@ add_filter( 'convertkit_output_append_form_to_content_form_id', function( $form_
 </pre>
 <h3 id="convertkit_frontend_append_form">
 						convertkit_frontend_append_form
-						<code>includes/class-convertkit-output.php::257</code>
+						<code>includes/class-convertkit-output.php::258</code>
 					</h3><h4>Overview</h4>
 						<p>Filter the Post's Content, which includes a ConvertKit Form, immediately before it is output.</p><h4>Parameters</h4>
 					<table>
@@ -864,6 +903,33 @@ add_filter( 'convertkit_frontend_append_form', function( $content, $form, $post_
 	return $content;
 }, 10, 4 );
 </pre>
+<h3 id="convertkit_output_scripts_footer">
+						convertkit_output_scripts_footer
+						<code>includes/class-convertkit-output.php::427</code>
+					</h3><h4>Overview</h4>
+						<p>Define an array of scripts to output in the footer of the WordPress site.</p><h4>Parameters</h4>
+					<table>
+						<thead>
+							<tr>
+								<th>Parameter</th>
+								<th>Type</th>
+								<th>Description</th>
+							</tr>
+						</thead>
+						<tbody><tr>
+							<td>$scripts</td>
+							<td>array</td>
+							<td>Scripts.</td>
+						</tr>
+						</tbody>
+					</table><h4>Usage</h4>
+<pre>
+add_filter( 'convertkit_output_scripts_footer', function( $scripts ) {
+	// ... your code here
+	// Return value
+	return $scripts;
+}, 10, 1 );
+</pre>
 <h3 id="convertkit_settings_get_defaults">
 						convertkit_settings_get_defaults
 						<code>includes/class-convertkit-settings.php::274</code>
@@ -893,7 +959,7 @@ add_filter( 'convertkit_settings_get_defaults', function( $defaults ) {
 </pre>
 <h3 id="convertkit_is_admin_or_frontend_editor">
 						convertkit_is_admin_or_frontend_editor
-						<code>includes/class-wp-convertkit.php::306</code>
+						<code>includes/class-wp-convertkit.php::308</code>
 					</h3><h4>Overview</h4>
 						<p>Filters whether the current request is a WordPress Administration / Frontend Editor request or not. Page Builders can set this to true to allow ConvertKit to load its administration functionality.</p><h4>Parameters</h4>
 					<table>
@@ -1076,7 +1142,7 @@ do_action( 'convertkit_settings_base_render_after', function(  ) {
 </pre>
 <h3 id="convertkit_settings_base_render_before">
 						convertkit_settings_base_render_before
-						<code>admin/section/class-convertkit-settings-tools.php::327</code>
+						<code>admin/section/class-convertkit-settings-tools.php::339</code>
 					</h3><h4>Parameters</h4>
 					<table>
 						<thead>
@@ -1096,7 +1162,7 @@ do_action( 'convertkit_settings_base_render_before', function(  ) {
 </pre>
 <h3 id="convertkit_settings_base_render_after">
 						convertkit_settings_base_render_after
-						<code>admin/section/class-convertkit-settings-tools.php::341</code>
+						<code>admin/section/class-convertkit-settings-tools.php::353</code>
 					</h3><h4>Parameters</h4>
 					<table>
 						<thead>
@@ -1286,7 +1352,7 @@ do_action( 'convertkit_admin_setup_wizard_load_screen_data_  this-page_name', fu
 </pre>
 <h3 id="convertkit_gutenberg_enqueue_scripts">
 						convertkit_gutenberg_enqueue_scripts
-						<code>includes/class-convertkit-gutenberg.php::157</code>
+						<code>includes/class-convertkit-gutenberg.php::163</code>
 					</h3><h4>Overview</h4>
 						<p>Enqueue any additional scripts for Gutenberg blocks that have been registered.</p><h4>Parameters</h4>
 					<table>
@@ -1301,17 +1367,21 @@ do_action( 'convertkit_admin_setup_wizard_load_screen_data_  this-page_name', fu
 							<td>$blocks</td>
 							<td>array</td>
 							<td>ConvertKit Blocks.</td>
+						</tr><tr>
+							<td>$block_formatters</td>
+							<td>array</td>
+							<td>ConvertKit Block Formatters.</td>
 						</tr>
 						</tbody>
 					</table><h4>Usage</h4>
 <pre>
-do_action( 'convertkit_gutenberg_enqueue_scripts', function( $blocks ) {
+do_action( 'convertkit_gutenberg_enqueue_scripts', function( $blocks, $block_formatters ) {
 	// ... your code here
-}, 10, 1 );
+}, 10, 2 );
 </pre>
 <h3 id="convertkit_gutenberg_enqueue_styles">
 						convertkit_gutenberg_enqueue_styles
-						<code>includes/class-convertkit-gutenberg.php::181</code>
+						<code>includes/class-convertkit-gutenberg.php::187</code>
 					</h3><h4>Parameters</h4>
 					<table>
 						<thead>
@@ -1331,7 +1401,7 @@ do_action( 'convertkit_gutenberg_enqueue_styles', function(  ) {
 </pre>
 <h3 id="convertkit_gutenberg_enqueue_scripts_editor_and_frontend">
 						convertkit_gutenberg_enqueue_scripts_editor_and_frontend
-						<code>includes/class-convertkit-gutenberg.php::205</code>
+						<code>includes/class-convertkit-gutenberg.php::211</code>
 					</h3><h4>Parameters</h4>
 					<table>
 						<thead>
@@ -1351,7 +1421,7 @@ do_action( 'convertkit_gutenberg_enqueue_scripts_editor_and_frontend', function(
 </pre>
 <h3 id="convertkit_gutenberg_enqueue_styles_editor_and_frontend">
 						convertkit_gutenberg_enqueue_styles_editor_and_frontend
-						<code>includes/class-convertkit-gutenberg.php::229</code>
+						<code>includes/class-convertkit-gutenberg.php::235</code>
 					</h3><h4>Parameters</h4>
 					<table>
 						<thead>
@@ -1371,7 +1441,7 @@ do_action( 'convertkit_gutenberg_enqueue_styles_editor_and_frontend', function( 
 </pre>
 <h3 id="convertkit_output_output_form">
 						convertkit_output_output_form
-						<code>includes/class-convertkit-output.php::93</code>
+						<code>includes/class-convertkit-output.php::94</code>
 					</h3><h4>Parameters</h4>
 					<table>
 						<thead>
@@ -1471,7 +1541,7 @@ do_action( 'convertkit_initialize_frontend', function(  ) {
 </pre>
 <h3 id="convertkit_initialize_global">
 						convertkit_initialize_global
-						<code>includes/class-wp-convertkit.php::186</code>
+						<code>includes/class-wp-convertkit.php::188</code>
 					</h3><h4>Parameters</h4>
 					<table>
 						<thead>

--- a/languages/convertkit.pot
+++ b/languages/convertkit.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2023-04-06T14:18:27+00:00\n"
+"POT-Creation-Date: 2023-05-04T11:58:32+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.7.1\n"
 "X-Domain: convertkit\n"
@@ -22,6 +22,7 @@ msgstr ""
 #: admin/class-convertkit-admin-settings.php:131
 #: includes/blocks/class-convertkit-block-broadcasts.php:124
 #: includes/blocks/class-convertkit-block-content.php:62
+#: includes/blocks/class-convertkit-block-form-trigger.php:89
 #: includes/blocks/class-convertkit-block-form.php:94
 #: includes/blocks/class-convertkit-block-product.php:111
 #: includes/integrations/elementor/class-convertkit-elementor.php:70
@@ -130,6 +131,14 @@ msgstr ""
 msgid "Defines the text and button labels to display when a Page, Post or Custom Post has its Member Content setting set to a Product, and the visitor has not authenticated/subscribed."
 msgstr ""
 
+#: admin/class-convertkit-admin-settings-restrict-content.php:162
+msgid "If your web host has caching configured (or you are using a caching plugin), you must configure it to disable caching when the"
+msgstr ""
+
+#: admin/class-convertkit-admin-settings-restrict-content.php:164
+msgid "cookie is present. Failing to do so will result in errors."
+msgstr ""
+
 #: admin/class-convertkit-admin-settings.php:157
 msgid "If you need help setting up the plugin please refer to the"
 msgstr ""
@@ -157,6 +166,7 @@ msgstr ""
 #: admin/section/class-convertkit-settings-general.php:58
 #: includes/blocks/class-convertkit-block-broadcasts.php:316
 #: includes/blocks/class-convertkit-block-content.php:146
+#: includes/blocks/class-convertkit-block-form-trigger.php:297
 #: includes/blocks/class-convertkit-block-form.php:216
 #: includes/blocks/class-convertkit-block-product.php:305
 msgid "General"
@@ -314,27 +324,27 @@ msgstr ""
 msgid "Tools"
 msgstr ""
 
-#: admin/section/class-convertkit-settings-tools.php:298
+#: admin/section/class-convertkit-settings-tools.php:310
 msgid "An error occured uploading the configuration file."
 msgstr ""
 
-#: admin/section/class-convertkit-settings-tools.php:299
+#: admin/section/class-convertkit-settings-tools.php:311
 msgid "The uploaded configuration file isn't valid."
 msgstr ""
 
-#: admin/section/class-convertkit-settings-tools.php:300
+#: admin/section/class-convertkit-settings-tools.php:312
 msgid "The uploaded configuration file contains no settings."
 msgstr ""
 
-#: admin/section/class-convertkit-settings-tools.php:301
+#: admin/section/class-convertkit-settings-tools.php:313
 msgid "Configuration imported successfully."
 msgstr ""
 
-#: admin/section/class-convertkit-settings-tools.php:352
+#: admin/section/class-convertkit-settings-tools.php:364
 msgid "Tools to help you manage ConvertKit on your site."
 msgstr ""
 
-#: admin/section/class-convertkit-settings-tools.php:380
+#: admin/section/class-convertkit-settings-tools.php:392
 msgid "WordPress 5.2 or higher is required for system information report."
 msgstr ""
 
@@ -424,6 +434,49 @@ msgstr ""
 msgid "Start Course"
 msgstr ""
 
+#: includes/block-formatters/class-convertkit-block-formatter-form-link.php:73
+#: includes/blocks/class-convertkit-block-form-trigger.php:84
+msgid "ConvertKit Form Trigger"
+msgstr ""
+
+#: includes/block-formatters/class-convertkit-block-formatter-form-link.php:74
+msgid "Displays a modal, sticky bar or slide in form to display when the link is pressed."
+msgstr ""
+
+#: includes/block-formatters/class-convertkit-block-formatter-form-link.php:143
+#: includes/blocks/class-convertkit-block-form-trigger.php:90
+#: includes/blocks/class-convertkit-block-form-trigger.php:254
+#: includes/blocks/class-convertkit-block-form.php:95
+#: includes/blocks/class-convertkit-block-form.php:186
+#: includes/widgets/class-ck-widget-form.php:79
+#: views/backend/post/bulk-edit.php:14
+#: views/backend/post/meta-box.php:15
+#: views/backend/post/quick-edit.php:14
+msgid "Form"
+msgstr ""
+
+#: includes/block-formatters/class-convertkit-block-formatter-form-link.php:145
+msgid "The modal, sticky bar or slide in form to display when the text is clicked."
+msgstr ""
+
+#: includes/block-formatters/class-convertkit-block-formatter-product-link.php:70
+msgid "ConvertKit Product Trigger"
+msgstr ""
+
+#: includes/block-formatters/class-convertkit-block-formatter-product-link.php:71
+msgid "Displays the Product modal when the link is pressed."
+msgstr ""
+
+#: includes/block-formatters/class-convertkit-block-formatter-product-link.php:131
+#: includes/blocks/class-convertkit-block-product.php:112
+#: includes/blocks/class-convertkit-block-product.php:263
+msgid "Product"
+msgstr ""
+
+#: includes/block-formatters/class-convertkit-block-formatter-product-link.php:133
+msgid "The product modal to display when the text is clicked."
+msgstr ""
+
 #: includes/blocks/class-convertkit-block-broadcasts.php:119
 msgid "ConvertKit Broadcasts"
 msgstr ""
@@ -481,11 +534,13 @@ msgid "Link color"
 msgstr ""
 
 #: includes/blocks/class-convertkit-block-broadcasts.php:289
+#: includes/blocks/class-convertkit-block-form-trigger.php:268
 #: includes/blocks/class-convertkit-block-product.php:276
 msgid "Background color"
 msgstr ""
 
 #: includes/blocks/class-convertkit-block-broadcasts.php:293
+#: includes/blocks/class-convertkit-block-form-trigger.php:272
 #: includes/blocks/class-convertkit-block-product.php:280
 msgid "Text color"
 msgstr ""
@@ -520,6 +575,50 @@ msgstr ""
 msgid "Tag"
 msgstr ""
 
+#: includes/blocks/class-convertkit-block-form-trigger.php:85
+msgid "Displays a modal, sticky bar or slide in form to display when the button is pressed."
+msgstr ""
+
+#: includes/blocks/class-convertkit-block-form-trigger.php:112
+#: includes/blocks/class-convertkit-block-form.php:117
+msgid "Select a Form using the Form option in the Gutenberg sidebar."
+msgstr ""
+
+#: includes/blocks/class-convertkit-block-form-trigger.php:257
+msgid "The modal, sticky bar or slide in form to display when the button is pressed. To embed a form, use the ConvertKit Form block instead."
+msgstr ""
+
+#: includes/blocks/class-convertkit-block-form-trigger.php:260
+#: includes/blocks/class-convertkit-block-product.php:268
+msgid "Button Text"
+msgstr ""
+
+#: includes/blocks/class-convertkit-block-form-trigger.php:262
+#: includes/blocks/class-convertkit-block-product.php:270
+msgid "The text to display for the button."
+msgstr ""
+
+#: includes/blocks/class-convertkit-block-form-trigger.php:320
+#: includes/class-convertkit-settings-restrict-content.php:118
+msgid "Subscribe"
+msgstr ""
+
+#. translators: ConvertKit Form ID
+#: includes/blocks/class-convertkit-block-form-trigger.php:414
+#: includes/class-convertkit-resource-forms.php:83
+msgid "ConvertKit Form ID %s does not exist on ConvertKit."
+msgstr ""
+
+#. translators: ConvertKit Form ID
+#: includes/blocks/class-convertkit-block-form-trigger.php:426
+msgid "ConvertKit Form ID %s has no uid property."
+msgstr ""
+
+#. translators: ConvertKit Form ID
+#: includes/blocks/class-convertkit-block-form-trigger.php:436
+msgid "ConvertKit Form ID %s has no embed_js property."
+msgstr ""
+
 #: includes/blocks/class-convertkit-block-form.php:89
 #: includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php:131
 #: includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php:142
@@ -530,19 +629,6 @@ msgstr ""
 
 #: includes/blocks/class-convertkit-block-form.php:90
 msgid "Displays a ConvertKit Form."
-msgstr ""
-
-#: includes/blocks/class-convertkit-block-form.php:95
-#: includes/blocks/class-convertkit-block-form.php:186
-#: includes/widgets/class-ck-widget-form.php:79
-#: views/backend/post/bulk-edit.php:14
-#: views/backend/post/meta-box.php:15
-#: views/backend/post/quick-edit.php:14
-msgid "Form"
-msgstr ""
-
-#: includes/blocks/class-convertkit-block-form.php:117
-msgid "Select a Form using the Form option in the Gutenberg sidebar."
 msgstr ""
 
 #. translators: Form name in ConvertKit
@@ -561,7 +647,6 @@ msgid "Sticky bar form \"%s\" selected. View on the frontend site to see the sti
 msgstr ""
 
 #: includes/blocks/class-convertkit-block-product.php:106
-#: includes/class-convertkit-post-type-product.php:66
 msgid "ConvertKit Product"
 msgstr ""
 
@@ -569,21 +654,8 @@ msgstr ""
 msgid "Displays a button to purchase a ConvertKit product."
 msgstr ""
 
-#: includes/blocks/class-convertkit-block-product.php:112
-#: includes/blocks/class-convertkit-block-product.php:263
-msgid "Product"
-msgstr ""
-
 #: includes/blocks/class-convertkit-block-product.php:134
 msgid "Select a Product using the Product option in the Gutenberg sidebar."
-msgstr ""
-
-#: includes/blocks/class-convertkit-block-product.php:268
-msgid "Button Text"
-msgstr ""
-
-#: includes/blocks/class-convertkit-block-product.php:270
-msgid "The text to display for the button."
 msgstr ""
 
 #: includes/blocks/class-convertkit-block-product.php:328
@@ -628,51 +700,8 @@ msgstr ""
 msgid "Invalid nonce specified. Please try again."
 msgstr ""
 
-#: includes/class-convertkit-post-type-product.php:65
-#: includes/class-convertkit-post-type-product.php:67
-#: includes/class-convertkit-post-type-product.php:78
-msgid "ConvertKit Products"
-msgstr ""
-
-#: includes/class-convertkit-post-type-product.php:68
-msgid "Add New"
-msgstr ""
-
-#: includes/class-convertkit-post-type-product.php:69
-msgid "Add New ConvertKit Product"
-msgstr ""
-
-#: includes/class-convertkit-post-type-product.php:70
-msgid "Edit ConvertKit Product"
-msgstr ""
-
-#: includes/class-convertkit-post-type-product.php:71
-msgid "New ConvertKit Product"
-msgstr ""
-
-#: includes/class-convertkit-post-type-product.php:72
-msgid "View ConvertKit Product"
-msgstr ""
-
-#: includes/class-convertkit-post-type-product.php:73
-msgid "Search ConvertKit Products"
-msgstr ""
-
-#: includes/class-convertkit-post-type-product.php:74
-msgid "No ConvertKit Products found"
-msgstr ""
-
-#: includes/class-convertkit-post-type-product.php:75
-msgid "No ConvertKit Products found in Trash"
-msgstr ""
-
 #: includes/class-convertkit-preview-output.php:196
 msgid "Edit form in ConvertKit"
-msgstr ""
-
-#. translators: ConvertKit Form ID
-#: includes/class-convertkit-resource-forms.php:83
-msgid "ConvertKit Form ID %s does not exist on ConvertKit."
 msgstr ""
 
 #: includes/class-convertkit-resource-forms.php:99
@@ -691,10 +720,6 @@ msgstr ""
 
 #: includes/class-convertkit-settings-restrict-content.php:117
 msgid "This content is only available to premium subscribers"
-msgstr ""
-
-#: includes/class-convertkit-settings-restrict-content.php:118
-msgid "Subscribe"
 msgstr ""
 
 #: includes/class-convertkit-settings-restrict-content.php:119
@@ -719,11 +744,11 @@ msgid "API Key and Secret not configured in Plugin Settings."
 msgstr ""
 
 #. translators: %1$s: PHP class name
-#: includes/class-wp-convertkit.php:385
+#: includes/class-wp-convertkit.php:387
 msgid "ConvertKit Error: Could not load Plugin class <strong>%1$s</strong>"
 msgstr ""
 
-#: includes/class-wp-convertkit.php:395
+#: includes/class-wp-convertkit.php:397
 msgid "ConvertKit Error"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -143,7 +143,7 @@ Full Plugin documentation can be found [here](https://help.convertkit.com/en/art
 * Fix: Forms: Output non-inline scripts using the `wp_footer` hook, ensuring modal overlays fill the screen
 * Fix: Member Content: Append `ck-cache-bust` query parameter after entering code, to prevent plugin / host caching showing stale data
 * Fix: Settings: Tools: Import / Export: Include Member Content settings in import and export configuration
-* Fix: Settings: Member Content: Display warning notice that server caching / cache plugins must disable caching when the `ck_subscriber_id` cookie is present
+* Fix: Settings: Member Content: Display warning notice that web host caching / caching plugins must be configured to disable caching when the `ck_subscriber_id` cookie is present
 
 ### 2.1.3 2023-04-06
 * Fix: Improve UI compatibility for buttons in WordPress 5.x, using `button-hero` CSS class instead of custom padding 

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -9,7 +9,7 @@
  * Plugin Name: ConvertKit
  * Plugin URI: https://convertkit.com/
  * Description: Quickly and easily integrate ConvertKit forms into your site.
- * Version: 2.1.3
+ * Version: 2.2.0
  * Author: ConvertKit
  * Author URI: https://convertkit.com/
  * Text Domain: convertkit
@@ -25,7 +25,7 @@ define( 'CONVERTKIT_PLUGIN_NAME', 'ConvertKit' ); // Used for user-agent in API 
 define( 'CONVERTKIT_PLUGIN_FILE', plugin_basename( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_PATH', __DIR__ );
-define( 'CONVERTKIT_PLUGIN_VERSION', '2.1.3' );
+define( 'CONVERTKIT_PLUGIN_VERSION', '2.2.0' );
 
 // Load shared classes, if they have not been included by another ConvertKit Plugin.
 if ( ! class_exists( 'ConvertKit_API' ) ) {


### PR DESCRIPTION
## Summary

Updates the following for today's 2.2.0 release:
- readme file changelog for today's 2.2.0 release.
- plugin title to include the `subscribers` keyword. 
- action and filter hook developer documentation
- .pot translation file

## Testing

Existing tests pass

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)