### PR TITLE
Add locale to `utm_term`

### DIFF
--- a/admin/class-convertkit-admin-settings.php
+++ b/admin/class-convertkit-admin-settings.php
@@ -330,6 +330,7 @@ class ConvertKit_Admin_Settings {
 		return add_query_arg(
 			array(
 				'utm_source'  => 'wordpress',
+				'utm_term'	  => get_locale(),
 				'utm_content' => 'convertkit',
 			),
 			$this->sections[ $active_section ]->documentation_url()

--- a/admin/class-convertkit-admin-settings.php
+++ b/admin/class-convertkit-admin-settings.php
@@ -330,7 +330,7 @@ class ConvertKit_Admin_Settings {
 		return add_query_arg(
 			array(
 				'utm_source'  => 'wordpress',
-				'utm_term'	  => get_locale(),
+				'utm_term'    => get_locale(),
 				'utm_content' => 'convertkit',
 			),
 			$this->sections[ $active_section ]->documentation_url()

--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -499,7 +499,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 			$url = add_query_arg(
 				array(
 					'utm_source'  => 'wordpress',
-					'utm_term'	  => get_locale(),
+					'utm_term'    => get_locale(),
 					'utm_content' => 'convertkit',
 				),
 				$broadcast['url']

--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -499,6 +499,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 			$url = add_query_arg(
 				array(
 					'utm_source'  => 'wordpress',
+					'utm_term'	  => get_locale(),
 					'utm_content' => 'convertkit',
 				),
 				$broadcast['url']

--- a/includes/class-convertkit-preview-output.php
+++ b/includes/class-convertkit-preview-output.php
@@ -181,7 +181,7 @@ class ConvertKit_Preview_Output {
 			$link = add_query_arg(
 				array(
 					'utm_source'  => 'wordpress',
-					'utm_term'	  => get_locale(),
+					'utm_term'    => get_locale(),
 					'utm_content' => 'convertkit',
 				),
 				sprintf(
@@ -193,7 +193,7 @@ class ConvertKit_Preview_Output {
 			$link = add_query_arg(
 				array(
 					'utm_source'  => 'wordpress',
-					'utm_term'	  => get_locale(),
+					'utm_term'    => get_locale(),
 					'utm_content' => 'convertkit',
 				),
 				sprintf(

--- a/includes/class-convertkit-preview-output.php
+++ b/includes/class-convertkit-preview-output.php
@@ -178,14 +178,28 @@ class ConvertKit_Preview_Output {
 		// If no format array key is specified, this is a Legacy Form, which has a different edit URL on ConvertKit.
 		if ( ! array_key_exists( 'format', $form ) ) {
 			// Legacy Form.
-			$link = sprintf(
-				'https://app.convertkit.com/landing_pages/%s/edit/?utm_source=wordpress&utm_content=convertkit',
-				esc_attr( (string) $form_id )
+			$link = add_query_arg(
+				array(
+					'utm_source'  => 'wordpress',
+					'utm_term'	  => get_locale(),
+					'utm_content' => 'convertkit',
+				),
+				sprintf(
+					'https://app.convertkit.com/landing_pages/%s/edit/',
+					esc_attr( (string) $form_id )
+				)
 			);
 		} else {
-			$link = sprintf(
-				'https://app.convertkit.com/forms/designers/%s/edit/?utm_source=wordpress&utm_content=convertkit',
-				esc_attr( (string) $form_id )
+			$link = add_query_arg(
+				array(
+					'utm_source'  => 'wordpress',
+					'utm_term'	  => get_locale(),
+					'utm_content' => 'convertkit',
+				),
+				sprintf(
+					'https://app.convertkit.com/forms/designers/%s/edit/',
+					esc_attr( (string) $form_id )
+				)
 			);
 		}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -256,7 +256,7 @@ function convertkit_get_registration_url() {
 	return add_query_arg(
 		array(
 			'utm_source'  => 'wordpress',
-			'utm_term'	  => get_locale(),
+			'utm_term'    => get_locale(),
 			'utm_content' => 'convertkit',
 		),
 		'https://app.convertkit.com/users/signup'
@@ -276,7 +276,7 @@ function convertkit_get_sign_in_url() {
 	return add_query_arg(
 		array(
 			'utm_source'  => 'wordpress',
-			'utm_term'	  => get_locale(),
+			'utm_term'    => get_locale(),
 			'utm_content' => 'convertkit',
 		),
 		'https://app.convertkit.com/'
@@ -296,7 +296,7 @@ function convertkit_get_api_key_url() {
 	return add_query_arg(
 		array(
 			'utm_source'  => 'wordpress',
-			'utm_term'	  => get_locale(),
+			'utm_term'    => get_locale(),
 			'utm_content' => 'convertkit',
 		),
 		'https://app.convertkit.com/account_settings/advanced_settings/'

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -253,7 +253,14 @@ function convertkit_get_settings_link( $query_args = array() ) {
  */
 function convertkit_get_registration_url() {
 
-	return 'https://app.convertkit.com/users/signup?utm_source=wordpress&utm_content=convertkit';
+	return add_query_arg(
+		array(
+			'utm_source'  => 'wordpress',
+			'utm_term'	  => get_locale(),
+			'utm_content' => 'convertkit',
+		),
+		'https://app.convertkit.com/users/signup'
+	);
 
 }
 
@@ -266,7 +273,14 @@ function convertkit_get_registration_url() {
  */
 function convertkit_get_sign_in_url() {
 
-	return 'https://app.convertkit.com/?utm_source=wordpress&utm_content=convertkit';
+	return add_query_arg(
+		array(
+			'utm_source'  => 'wordpress',
+			'utm_term'	  => get_locale(),
+			'utm_content' => 'convertkit',
+		),
+		'https://app.convertkit.com/'
+	);
 
 }
 
@@ -279,7 +293,14 @@ function convertkit_get_sign_in_url() {
  */
 function convertkit_get_api_key_url() {
 
-	return 'https://app.convertkit.com/account_settings/advanced_settings/?utm_source=wordpress&utm_content=convertkit';
+	return add_query_arg(
+		array(
+			'utm_source'  => 'wordpress',
+			'utm_term'	  => get_locale(),
+			'utm_content' => 'convertkit',
+		),
+		'https://app.convertkit.com/account_settings/advanced_settings/'
+	);
 
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -13,17 +13,17 @@ ConvertKit is an email marketing and email newsletter platform for capturing ema
 
 == Description ==
 
-[ConvertKit](https://convertkit.com?utm_source=wordpress&utm_content=readme) makes it easy to grow your email subscribers lists, sell more products and send targeted email newsletters - all by easily embedding email marketing / email subscriber forms anywhere on your WordPress web site.
+[ConvertKit](https://convertkit.com?utm_source=wordpress&utm_term=en_US&utm_content=readme) makes it easy to grow your email subscribers lists, sell more products and send targeted email newsletters - all by easily embedding email marketing / email subscriber forms anywhere on your WordPress web site.
 
 = Email Marketing and Email Newsletter Features =
 
-- Design [subscription forms](https://convertkit.com/features/forms?utm_source=wordpress&utm_content=readme) in ConvertKit, automatically appending them to any WordPress post or page, or displaying forms within your WordPress content using the supplied Gutenberg block and shortcode options. Perfect for building your email subscriber lists.
-- Build [landing pages](https://convertkit.com/features/landing-pages?utm_source=wordpress&utm_content=readme) in ConvertKit, and display them on a WordPress page to capture email subscribers
-- List past [email newsletters](https://convertkit.com/features/email-marketing?utm_source=wordpress&utm_content=readme) on your WordPress site
+- Design [subscription forms](https://convertkit.com/features/forms?utm_source=wordpress&utm_term=en_US&utm_content=readme) in ConvertKit, automatically appending them to any WordPress post or page, or displaying forms within your WordPress content using the supplied Gutenberg block and shortcode options. Perfect for building your email subscriber lists.
+- Build [landing pages](https://convertkit.com/features/landing-pages?utm_source=wordpress&utm_term=en_US&utm_content=readme) in ConvertKit, and display them on a WordPress page to capture email subscribers
+- List past [email newsletters](https://convertkit.com/features/email-marketing?utm_source=wordpress&utm_term=en_US&utm_content=readme) on your WordPress site
 
 = Forms =
 
-Design [forms](https://convertkit.com/features/forms?utm_source=wordpress&utm_content=readme) in ConvertKit, choosing from a variety of designs, customisable to your branding.
+Design [forms](https://convertkit.com/features/forms?utm_source=wordpress&utm_term=en_US&utm_content=readme) in ConvertKit, choosing from a variety of designs, customisable to your branding.
 
 Sign up forms can be configured to:
 
@@ -46,13 +46,13 @@ Start collecting email subscribers today!
 
 = Landing Pages =
 
-Embed [landing pages](https://convertkit.com/features/landing-pages?utm_source=wordpress&utm_content=readme), designed in ConvertKit, on your WordPress web site, choosing from a variety of designs, customisable to your branding and ideal for building your email marketing list or selling a product.
+Embed [landing pages](https://convertkit.com/features/landing-pages?utm_source=wordpress&utm_term=en_US&utm_content=readme), designed in ConvertKit, on your WordPress web site, choosing from a variety of designs, customisable to your branding and ideal for building your email marketing list or selling a product.
 
 Create or edit a WordPress Page, choose the ConvertKit landing page from the ConvertKit meta box settings to display, and you're all set to begin growing your email subscribers list.
 
 = Email Newsletter Broadcasts =
 
-Use ConvertKit's [email marketing](https://convertkit.com/features/email-marketing?utm_source=wordpress&utm_content=readme) feature to send email newsletters to your subscribers and leads.
+Use ConvertKit's [email marketing](https://convertkit.com/features/email-marketing?utm_source=wordpress&utm_term=en_US&utm_content=readme) feature to send email newsletters to your subscribers and leads.
 
 Embed existing email newsletters on your WordPress web site, ensuring visitors never miss your email marketing content, by:
 
@@ -88,11 +88,11 @@ ConvertKit is the go-to marketing hub for creators that helps you grow and monet
 
 **Sell your digital products:** Market and sell your digital products and subscriptions with ConvertKit to drive higher conversions and save big on fees.
 
-If you are not yet using ConvertKit, [creating an account](https://app.convertkit.com/users/signup?plan=1k&utm_source=wordpress&utm_content=readme) is 100% free and only takes you about 30 seconds.
+If you are not yet using ConvertKit, [creating an account](https://app.convertkit.com/users/signup?plan=1k&utm_source=wordpress&utm_term=en_US&utm_content=readme) is 100% free and only takes you about 30 seconds.
 
 = Documentation =
 
-Full Plugin documentation can be found [here](https://help.convertkit.com/en/articles/2502591-the-convertkit-wordpress-plugin?utm_source=wordpress&utm_content=readme).
+Full Plugin documentation can be found [here](https://help.convertkit.com/en/articles/2502591-the-convertkit-wordpress-plugin?utm_source=wordpress&utm_term=en_US&utm_content=readme).
 
 == Installation ==
 
@@ -101,7 +101,7 @@ Full Plugin documentation can be found [here](https://help.convertkit.com/en/art
 
 == Configuration ==
 
-1. Configure the plugin by navigating to Settings > ConvertKit in the WordPress Administration Menu, entering your [API Key](https://app.convertkit.com/account_settings/advanced_settings?utm_source=wordpress&utm_content=readme) and defining the default forms to display on Pages, Posts and/or Custom Post Types
+1. Configure the plugin by navigating to Settings > ConvertKit in the WordPress Administration Menu, entering your [API Key](https://app.convertkit.com/account_settings/advanced_settings?utm_source=wordpress&utm_term=en_US&utm_content=readme) and defining the default forms to display on Pages, Posts and/or Custom Post Types
 2. (Optional) choose a specific Form to display when editing a Page, Post or Custom Post Type in the Page/Post/Custom Post Type's ConvertKit settings
 3. (Optional) use the ConvertKit Form Shortcode or Block to insert Forms into your Page, Post or Custom Post Type content
 
@@ -109,7 +109,7 @@ Full Plugin documentation can be found [here](https://help.convertkit.com/en/art
 
 = Does this plugin require a paid service? =
 
-No. You must first have an account on [convertkit.com](https://convertkit.com?utm_source=wordpress&utm_content=readme), but you do not have to use a paid plan!
+No. You must first have an account on [convertkit.com](https://convertkit.com?utm_source=wordpress&utm_term=en_US&utm_content=readme), but you do not have to use a paid plan!
 
 = How do I refresh my available Forms, Landing Pages and Tags? =
 

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -644,7 +644,7 @@ class Plugin extends \Codeception\Module
 
 		// Confirm that UTM parameters exist on a broadcast link.
 		$I->assertStringContainsString(
-			'utm_source=wordpress&utm_content=convertkit',
+			'utm_source=wordpress&utm_term=en_US&utm_content=convertkit',
 			$I->grabAttributeFrom('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast a', 'href')
 		);
 
@@ -691,7 +691,7 @@ class Plugin extends \Codeception\Module
 		$I->seeBroadcastsOutput($I, 1, $previousLabel, false);
 
 		// Confirm that the expected Broadcast name is displayed and links to the expected URL, with UTM parameters.
-		$I->seeInSource('<a href="' . $_ENV['CONVERTKIT_API_BROADCAST_SECOND_URL'] . '?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener"');
+		$I->seeInSource('<a href="' . $_ENV['CONVERTKIT_API_BROADCAST_SECOND_URL'] . '?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener"');
 		$I->seeInSource($_ENV['CONVERTKIT_API_BROADCAST_SECOND_TITLE']);
 
 		// Click the Newer Posts link.
@@ -705,7 +705,7 @@ class Plugin extends \Codeception\Module
 		$I->seeBroadcastsOutput($I, 1, false, $nextLabel);
 
 		// Confirm that the expected Broadcast name is displayed and links to the expected URL, with UTM parameters.
-		$I->seeInSource('<a href="' . $_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener"');
+		$I->seeInSource('<a href="' . $_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener"');
 		$I->seeInSource($_ENV['CONVERTKIT_API_BROADCAST_FIRST_TITLE']);
 	}
 

--- a/tests/_support/Helper/Acceptance/WPGutenberg.php
+++ b/tests/_support/Helper/Acceptance/WPGutenberg.php
@@ -224,6 +224,7 @@ class WPGutenberg extends \Codeception\Module
 		$I->click('.block-editor-block-toolbar button[aria-label="More"]');
 
 		// Click Block Formatter button.
+		$I->waitForElementVisible('.components-dropdown-menu__popover');
 		$I->click($formatterName, '.components-dropdown-menu__popover');
 
 		// Apply formatter configuration.

--- a/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
@@ -86,7 +86,7 @@ class PageBlockBroadcastsCest
 		// Confirm that the expected Broadcast name is displayed first links to the expected URL, with UTM parameters.
 		$I->assertEquals(
 			$I->grabAttributeFrom('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast:first-child a', 'href'),
-			$_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&utm_content=convertkit'
+			$_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&utm_term=en_US&utm_content=convertkit'
 		);
 	}
 
@@ -131,7 +131,7 @@ class PageBlockBroadcastsCest
 		// Confirm that the expected Broadcast name is displayed first links to the expected URL, with UTM parameters.
 		$I->assertEquals(
 			$I->grabAttributeFrom('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast:first-child a', 'href'),
-			$_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&utm_content=convertkit'
+			$_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&utm_term=en_US&utm_content=convertkit'
 		);
 	}
 
@@ -173,7 +173,7 @@ class PageBlockBroadcastsCest
 		// Confirm that the expected Broadcast name is displayed first links to the expected URL, with UTM parameters.
 		$I->assertEquals(
 			$I->grabAttributeFrom('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast:first-child a', 'href'),
-			$_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&utm_content=convertkit'
+			$_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&utm_term=en_US&utm_content=convertkit'
 		);
 	}
 
@@ -216,7 +216,7 @@ class PageBlockBroadcastsCest
 		// Confirm that the expected Broadcast name is displayed first links to the expected URL, with UTM parameters.
 		$I->assertEquals(
 			$I->grabAttributeFrom('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast:first-child a', 'href'),
-			$_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&utm_content=convertkit'
+			$_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&utm_term=en_US&utm_content=convertkit'
 		);
 	}
 

--- a/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
@@ -56,7 +56,7 @@ class PageShortcodeBroadcastsCest
 		// Confirm that the expected Broadcast name is displayed first links to the expected URL, with UTM parameters.
 		$I->assertEquals(
 			$I->grabAttributeFrom('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast:first-child a', 'href'),
-			$_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&utm_content=convertkit'
+			$_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&utm_term=en_US&utm_content=convertkit'
 		);
 	}
 
@@ -98,7 +98,7 @@ class PageShortcodeBroadcastsCest
 		// Confirm that the expected Broadcast name is displayed first links to the expected URL, with UTM parameters.
 		$I->assertEquals(
 			$I->grabAttributeFrom('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast:first-child a', 'href'),
-			$_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&utm_content=convertkit'
+			$_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&utm_term=en_US&utm_content=convertkit'
 		);
 	}
 
@@ -140,7 +140,7 @@ class PageShortcodeBroadcastsCest
 		// Confirm that the expected Broadcast name is displayed first links to the expected URL, with UTM parameters.
 		$I->assertEquals(
 			$I->grabAttributeFrom('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast:first-child a', 'href'),
-			$_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&utm_content=convertkit'
+			$_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&utm_term=en_US&utm_content=convertkit'
 		);
 	}
 
@@ -284,13 +284,13 @@ class PageShortcodeBroadcastsCest
 
 		// Confirm that the chosen colors are applied as CSS styles.
 		$I->seeInSource('<div class="convertkit-broadcasts has-text-color has-background" style="color:' . $textColor . ';background-color:' . $backgroundColor . '"');
-		$I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:' . $linkColor . '"');
+		$I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:' . $linkColor . '"');
 
 		// Test pagination.
 		$I->testBroadcastsPagination($I, 'Older', 'Newer');
 
 		// Confirm that link styles are still applied to refreshed data.
-		$I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:' . $linkColor . '"');
+		$I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:' . $linkColor . '"');
 	}
 
 	/**

--- a/tests/acceptance/forms/EditFormLinkCest.php
+++ b/tests/acceptance/forms/EditFormLinkCest.php
@@ -58,7 +58,7 @@ class EditFormLinkCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the Edit Form link is displayed.
-		$I->seeInSource('<a href="https://app.convertkit.com/forms/designers/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/edit/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">Edit form in ConvertKit</a>');
+		$I->seeInSource('<a href="https://app.convertkit.com/forms/designers/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/edit/?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit" target="_blank">Edit form in ConvertKit</a>');
 	}
 
 	/**
@@ -184,7 +184,7 @@ class EditFormLinkCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the Edit Form link is displayed.
-		$I->seeInSource('<a href="https://app.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/edit/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">Edit form in ConvertKit</a>');
+		$I->seeInSource('<a href="https://app.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/edit/?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit" target="_blank">Edit form in ConvertKit</a>');
 	}
 
 	/**
@@ -232,7 +232,7 @@ class EditFormLinkCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the Edit Form link is displayed.
-		$I->seeInSource('<a href="https://app.convertkit.com/forms/designers/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/edit/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">Edit form in ConvertKit</a>');
+		$I->seeInSource('<a href="https://app.convertkit.com/forms/designers/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/edit/?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit" target="_blank">Edit form in ConvertKit</a>');
 	}
 
 	/**
@@ -322,7 +322,7 @@ class EditFormLinkCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the Edit Form link is displayed.
-		$I->seeInSource('<a href="https://app.convertkit.com/forms/designers/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/edit/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">Edit form in ConvertKit</a>');
+		$I->seeInSource('<a href="https://app.convertkit.com/forms/designers/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/edit/?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit" target="_blank">Edit form in ConvertKit</a>');
 	}
 
 	/**

--- a/tests/acceptance/forms/PageNoFormCest.php
+++ b/tests/acceptance/forms/PageNoFormCest.php
@@ -47,7 +47,7 @@ class PageNoFormCest
 		$I->seeElementInDOM('#wp-convertkit-meta-box');
 
 		// Confirm that UTM parameters exist for the 'sign in to ConvertKit' link.
-		$I->seeInSource('<a href="https://app.convertkit.com/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">sign in to ConvertKit</a>');
+		$I->seeInSource('<a href="https://app.convertkit.com/?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit" target="_blank">sign in to ConvertKit</a>');
 	}
 
 	/**

--- a/tests/acceptance/general/PluginSettingsGeneralCest.php
+++ b/tests/acceptance/general/PluginSettingsGeneralCest.php
@@ -54,17 +54,17 @@ class PluginSettingsGeneralCest
 		$I->loadConvertKitSettingsGeneralScreen($I);
 
 		// Confirm that UTM parameters exist for the 'Get your ConvertKit API Key' link.
-		$I->seeInSource('<a href="https://app.convertkit.com/account_settings/advanced_settings/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">Get your ConvertKit API Key.</a>');
+		$I->seeInSource('<a href="https://app.convertkit.com/account_settings/advanced_settings/?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit" target="_blank">Get your ConvertKit API Key.</a>');
 
 		// Confirm that UTM parameters exist for the 'Get your ConvertKit API Secret' link.
-		$I->seeInSource('<a href="https://app.convertkit.com/account_settings/advanced_settings/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">Get your ConvertKit API Secret.</a>');
+		$I->seeInSource('<a href="https://app.convertkit.com/account_settings/advanced_settings/?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit" target="_blank">Get your ConvertKit API Secret.</a>');
 
 		// Confirm that UTM parameters exist for the 'sign in to ConvertKit' link.
-		$I->seeInSource('<a href="https://app.convertkit.com/?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">sign in to ConvertKit</a>');
+		$I->seeInSource('<a href="https://app.convertkit.com/?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit" target="_blank">sign in to ConvertKit</a>');
 
 		// Confirm that the UTM parameters exist for the documentation links.
-		$I->seeInSource('<a href="https://help.convertkit.com/en/articles/2502591-the-convertkit-wordpress-plugin?utm_source=wordpress&amp;utm_content=convertkit" class="convertkit-tab" target="_blank">Documentation <span class="dashicons dashicons-external"></span></a>');
-		$I->seeInSource('<a href="https://help.convertkit.com/en/articles/2502591-the-convertkit-wordpress-plugin?utm_source=wordpress&amp;utm_content=convertkit" target="_blank">plugin documentation</a>');
+		$I->seeInSource('<a href="https://help.convertkit.com/en/articles/2502591-the-convertkit-wordpress-plugin?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit" class="convertkit-tab" target="_blank">Documentation <span class="dashicons dashicons-external"></span></a>');
+		$I->seeInSource('<a href="https://help.convertkit.com/en/articles/2502591-the-convertkit-wordpress-plugin?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit" target="_blank">plugin documentation</a>');
 	}
 
 	/**

--- a/tests/acceptance/general/PluginSetupWizardCest.php
+++ b/tests/acceptance/general/PluginSetupWizardCest.php
@@ -90,7 +90,7 @@ class PluginSetupWizardCest
 		$I->click('Register');
 		$I->wait(2); // Required, otherwise switchToNextTab fails.
 		$I->switchToNextTab();
-		$I->seeInCurrentUrl('users/signup?utm_source=wordpress&utm_content=convertkit');
+		$I->seeInCurrentUrl('users/signup?utm_source=wordpress&utm_term=en_US&utm_content=convertkit');
 
 		// Close newly opened tab from above button.
 		$I->closeTab();

--- a/tests/acceptance/integrations/ElementorBroadcastsCest.php
+++ b/tests/acceptance/integrations/ElementorBroadcastsCest.php
@@ -81,7 +81,7 @@ class ElementorBroadcastsCest
 		// Confirm that the expected Broadcast name is displayed first links to the expected URL, with UTM parameters.
 		$I->assertEquals(
 			$I->grabAttributeFrom('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast:first-child a', 'href'),
-			$_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&utm_content=convertkit'
+			$_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&utm_term=en_US&utm_content=convertkit'
 		);
 	}
 
@@ -122,7 +122,7 @@ class ElementorBroadcastsCest
 		// Confirm that the expected Broadcast name is displayed first links to the expected URL, with UTM parameters.
 		$I->assertEquals(
 			$I->grabAttributeFrom('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast:first-child a', 'href'),
-			$_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&utm_content=convertkit'
+			$_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&utm_term=en_US&utm_content=convertkit'
 		);
 	}
 
@@ -160,7 +160,7 @@ class ElementorBroadcastsCest
 		// Confirm that the expected Broadcast name is displayed first links to the expected URL, with UTM parameters.
 		$I->assertEquals(
 			$I->grabAttributeFrom('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast:first-child a', 'href'),
-			$_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&utm_content=convertkit'
+			$_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&utm_term=en_US&utm_content=convertkit'
 		);
 	}
 
@@ -273,13 +273,13 @@ class ElementorBroadcastsCest
 
 		// Confirm that the chosen colors are applied as CSS styles.
 		$I->seeInSource('<div class="convertkit-broadcasts has-text-color has-background" style="color:' . $textColor . ';background-color:' . $backgroundColor . '"');
-		$I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:' . $linkColor . '"');
+		$I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:' . $linkColor . '"');
 
 		// Test pagination.
 		$I->testBroadcastsPagination($I, 'Older', 'Newer');
 
 		// Confirm that link styles are still applied to refreshed data.
-		$I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:' . $linkColor . '"');
+		$I->seeInSource('<a href="https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit" target="_blank" rel="nofollow noopener" style="color:' . $linkColor . '"');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

As discussed with @brendancarney, adds the WordPress locale (e.g. `en_US`) to the `utm_term` in links to ConvertKit, so we can determine the most common languages used and prioritize which languages to translate the Plugin to.

## Testing

- Existing tests updated to check for `utm_term`.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)