### PR TITLE
Escape Settings Tab URLs

### DIFF
--- a/admin/class-convertkit-admin-settings.php
+++ b/admin/class-convertkit-admin-settings.php
@@ -226,7 +226,7 @@ class ConvertKit_Admin_Settings {
 			foreach ( $this->sections as $section ) {
 				printf(
 					'<li><a href="%s" class="convertkit-tab %s">%s%s</a></li>',
-					esc_attr(
+					esc_url(
 						add_query_arg(
 							array(
 								'page' => self::SETTINGS_PAGE_SLUG,

--- a/admin/class-convertkit-admin-settings.php
+++ b/admin/class-convertkit-admin-settings.php
@@ -227,10 +227,13 @@ class ConvertKit_Admin_Settings {
 				printf(
 					'<li><a href="%s" class="convertkit-tab %s">%s%s</a></li>',
 					esc_attr(
-						add_query_arg( array(
-							'page' => self::SETTINGS_PAGE_SLUG,
-							'tab' => $section->name,
-						), admin_url( 'options-general.php' ) )
+						add_query_arg(
+							array(
+								'page' => self::SETTINGS_PAGE_SLUG,
+								'tab'  => $section->name,
+							),
+							admin_url( 'options-general.php' )
+						)
 					),
 					( $active_section === $section->name ? 'convertkit-tab-active' : '' ),
 					esc_html( $section->tab_text ),

--- a/admin/class-convertkit-admin-settings.php
+++ b/admin/class-convertkit-admin-settings.php
@@ -225,10 +225,14 @@ class ConvertKit_Admin_Settings {
 			<?php
 			foreach ( $this->sections as $section ) {
 				printf(
-					'<li><a href="?page=%s&tab=%s" class="convertkit-tab %s">%s%s</a></li>',
-					sanitize_text_field( $_REQUEST['page'] ), // phpcs:ignore WordPress.Security.NonceVerification
-					esc_html( $section->name ),
-					$active_section === $section->name ? 'convertkit-tab-active' : '',
+					'<li><a href="%s" class="convertkit-tab %s">%s%s</a></li>',
+					esc_attr(
+						add_query_arg( array(
+							'page' => self::SETTINGS_PAGE_SLUG,
+							'tab' => $section->name,
+						), admin_url( 'options-general.php' ) )
+					),
+					( $active_section === $section->name ? 'convertkit-tab-active' : '' ),
 					esc_html( $section->tab_text ),
 					$section->is_beta ? $this->get_beta_tab() : '' // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				);

--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -132,7 +132,7 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource {
 		}
 
 		// If here, return Form <script> embed now, as we want the inline form to display at this specific point of the content.
-		return '<script async data-uid="' . esc_attr( $this->resources[ $id ]['uid'] ) . '" src="' . esc_attr( $this->resources[ $id ]['embed_js'] ) . '"></script>';
+		return '<script async data-uid="' . esc_attr( $this->resources[ $id ]['uid'] ) . '" src="' . esc_url( $this->resources[ $id ]['embed_js'] ) . '"></script>';
 
 	}
 

--- a/tests/acceptance/general/PluginSettingsToolsCest.php
+++ b/tests/acceptance/general/PluginSettingsToolsCest.php
@@ -324,8 +324,8 @@ class PluginSettingsToolsCest
 		// Click the submit button.
 		$I->click('Submit');
 
-		// Check that no alert is displayed, which confirms XSS isn't possible as the query parameter is correctly escaped.
-		$I->see('xxxxxxxx');
+		// Check that document.write did not work, which confirms XSS isn't possible as the query parameter is correctly escaped.
+		$I->dontSee('/XSS/');
 	}
 
 	/**

--- a/tests/acceptance/general/PluginSettingsToolsCest.php
+++ b/tests/acceptance/general/PluginSettingsToolsCest.php
@@ -311,8 +311,8 @@ class PluginSettingsToolsCest
 				'post_content' => '<form action="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/options-general.php?page=_wp_convertkit_settings&tab=tools" method="POST">
       <input type="hidden" name="page" value=\'"style=animation-name:rotation onanimationstart=document.write(/XSS/)//\' />
       <input type="submit" value="Submit" />
-    </form>'
-    		]
+    </form>',
+			]
 		);
 
 		// Load the Page on the frontend site.

--- a/views/backend/setup-wizard/convertkit-restrict-content-setup/content-1.php
+++ b/views/backend/setup-wizard/convertkit-restrict-content-setup/content-1.php
@@ -29,7 +29,7 @@
 
 <div class="convertkit-setup-wizard-grid">
 	<div>
-		<a href="<?php echo esc_attr( $this->download_url ); ?>" class="button button-primary button-hero">
+		<a href="<?php echo esc_url( $this->download_url ); ?>" class="button button-primary button-hero">
 			<?php esc_html_e( 'Download', 'convertkit' ); ?>
 		</a>
 		<span class="description">
@@ -38,7 +38,7 @@
 	</div>
 
 	<div>
-		<a href="<?php echo esc_attr( $this->course_url ); ?>" class="button button-primary button-hero">
+		<a href="<?php echo esc_url( $this->course_url ); ?>" class="button button-primary button-hero">
 			<?php esc_html_e( 'Course', 'convertkit' ); ?>
 		</a>
 		<span class="description">

--- a/views/backend/setup-wizard/convertkit-setup/content-1.php
+++ b/views/backend/setup-wizard/convertkit-setup/content-1.php
@@ -16,7 +16,7 @@
 <div class="convertkit-setup-wizard-grid">
 	<div>
 		<h2><?php esc_html_e( 'I don\'t have a ConvertKit account.', 'convertkit' ); ?></h2>
-		<a href="<?php echo esc_attr( convertkit_get_registration_url() ); ?>" class="button button-primary button-hero convertkit-redirect" data-convertkit-redirect-url="<?php echo esc_attr( $this->next_step_url ); ?>" target="_blank">
+		<a href="<?php echo esc_url( convertkit_get_registration_url() ); ?>" class="button button-primary button-hero convertkit-redirect" data-convertkit-redirect-url="<?php echo esc_attr( $this->next_step_url ); ?>" target="_blank">
 			<?php esc_html_e( 'Register', 'convertkit' ); ?>
 		</a>
 		<span class="description"><?php esc_html_e( 'Sign up to ConvertKit and register your account. It\'s free.', 'convertkit' ); ?></span>
@@ -24,7 +24,7 @@
 
 	<div>
 		<h2><?php esc_html_e( 'I have a ConvertKit account.', 'convertkit' ); ?></h2>
-		<a href="<?php echo esc_attr( $this->next_step_url ); ?>" class="button button-primary button-hero">
+		<a href="<?php echo esc_url( $this->next_step_url ); ?>" class="button button-primary button-hero">
 			<?php esc_html_e( 'Connect', 'convertkit' ); ?>
 		</a>
 		<span class="description"><?php esc_html_e( 'Great! Click the Connect button to get started.', 'convertkit' ); ?></span>

--- a/views/backend/setup-wizard/convertkit-setup/content-4.php
+++ b/views/backend/setup-wizard/convertkit-setup/content-4.php
@@ -15,14 +15,14 @@
 
 <div class="convertkit-setup-wizard-grid">
 	<div>
-		<a href="<?php echo esc_attr( admin_url( 'index.php' ) ); ?>" class="button button-primary button-hero">
+		<a href="<?php echo esc_url( admin_url( 'index.php' ) ); ?>" class="button button-primary button-hero">
 			<?php esc_html_e( 'Dashboard', 'convertkit' ); ?>
 		</a>
 		<span class="description"><?php esc_html_e( 'Exit the wizard and load the WordPress Dashboard screen.', 'convertkit' ); ?></span>
 	</div>
 
 	<div>
-		<a href="<?php echo esc_attr( convertkit_get_settings_link() ); ?>" class="button button-primary button-hero">
+		<a href="<?php echo esc_url( convertkit_get_settings_link() ); ?>" class="button button-primary button-hero">
 			<?php esc_html_e( 'Plugin Settings', 'convertkit' ); ?>
 		</a>
 		<span class="description"><?php esc_html_e( 'Exit the wizard and load the Plugin\'s settings screen.', 'convertkit' ); ?></span>

--- a/views/backend/setup-wizard/footer.php
+++ b/views/backend/setup-wizard/footer.php
@@ -15,7 +15,7 @@
 						if ( $this->previous_step_url ) {
 							?>
 							<div class="left">
-								<a href="<?php echo esc_attr( $this->previous_step_url ); ?>" class="button button-hero">
+								<a href="<?php echo esc_url( $this->previous_step_url ); ?>" class="button button-hero">
 									<?php echo esc_html_e( 'Back', 'convertkit' ); ?>
 								</a>
 							</div>
@@ -30,7 +30,7 @@
 								if ( isset( $this->steps[ $this->step ]['next_button']['link'] ) ) {
 									// Link.
 									?>
-									<a href="<?php echo esc_attr( $this->steps[ $this->step ]['next_button']['link'] ); ?>" class="button button-primary button-hero"><?php echo esc_html( $this->steps[ $this->step ]['next_button']['label'] ); ?></a>
+									<a href="<?php echo esc_url( $this->steps[ $this->step ]['next_button']['link'] ); ?>" class="button button-primary button-hero"><?php echo esc_html( $this->steps[ $this->step ]['next_button']['label'] ); ?></a>
 									<?php
 								} else {
 									// Submit button.
@@ -53,7 +53,7 @@
 			if ( $this->step < count( $this->steps ) ) {
 				?>
 				<div id="convertkit-setup-wizard-exit-link">
-					<a href="<?php echo esc_attr( $this->exit_url ); ?>" class="convertkit-confirm" title="<?php esc_html_e( 'Exit wizard', 'convertkit' ); ?>" data-message="<?php esc_html_e( 'Are you sure you want to exit the wizard? Setup is incomplete.', 'convertkit' ); ?>">
+					<a href="<?php echo esc_url( $this->exit_url ); ?>" class="convertkit-confirm" title="<?php esc_html_e( 'Exit wizard', 'convertkit' ); ?>" data-message="<?php esc_html_e( 'Are you sure you want to exit the wizard? Setup is incomplete.', 'convertkit' ); ?>">
 						<?php esc_html_e( 'Exit wizard', 'convertkit' ); ?>
 					</a>
 				</div>


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://convertkit.atlassian.net/browse/T3-325), where an unescaped `page` parameter could result in XSS, by:
- using `add_query_arg()` to build each setting tab URL,
- use `self::SETTINGS_PAGE_SLUG` instead of `$_REQUEST['page']`, as all tabs' `page` parameter will be the same settings slug,
- use `esc_url()` on each settings tab URL, to ensure that it is is escaped.

This PR also replaces `esc_attr()` with `esc_url()` when used for `href` and `src` attributes, for best practice.  `esc_attr()` works, but isn't the best function to use in these cases.

## Testing

- `PluginSettingsToolsCest:testTabParameterEscaping`: Test that the request `page` parameter is escaped correctly, to prevent XSS.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)