### PR TITLE
Restrict Content: Tests for common Caching Plugins

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -196,6 +196,8 @@ jobs:
         run: |
           sudo chmod g+w ${{ env.ROOT_DIR }}/wp-config.php
           sudo chown www-data:www-data ${{ env.ROOT_DIR }}/wp-config.php
+          sudo chmod g+w ${{ env.ROOT_DIR }}/wp-content
+          sudo chown www-data:www-data ${{ env.ROOT_DIR }}/wp-content
 
       # This ensures the wp-content/uploads folder can be written to by WordPress and third party Plugins.
       - name: Set Permissions for Uploads Directory

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         wp-versions: [ 'latest' ] #[ '6.1.1', 'latest' ]
-        php-versions: [ '7.4' ] #[ '7.4', '8.0', '8.1' ]
+        php-versions: [ '7.4', '8.0', '8.1', '8.2' ] #[ '7.4', '8.0', '8.1' ]
 
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -188,6 +188,17 @@ jobs:
         working-directory: ${{ env.PLUGIN_DIR }}
         run: composer dump-autoload
 
+      # This ensures that applicable files and folders can be written to by cache plugins.
+      # We only do this on Restrict Content tests, as doing so on wpunit tests results in WordPress
+      # bizarrely attempting to use FTP to write files.
+      - name: Set Permissions for Caching Plugins
+        if: ${{ matrix.test-groups == 'acceptance/restrict-content' }}
+        run: |
+          sudo chmod g+w ${{ env.ROOT_DIR }}/wp-config.php
+          sudo chown www-data:www-data ${{ env.ROOT_DIR }}/wp-config.php
+          sudo chmod g+w ${{ env.ROOT_DIR }}/wp-content
+          sudo chown www-data:www-data ${{ env.ROOT_DIR }}/wp-content
+
       # This ensures the wp-content/uploads folder can be written to by WordPress and third party Plugins.
       - name: Set Permissions for Uploads Directory
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,15 @@ jobs:
 
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
-          'acceptance/restrict-content'
+          'acceptance/broadcasts',
+          'acceptance/forms',
+          'acceptance/general',
+          'acceptance/integrations',
+          'acceptance/landing-pages',
+          'acceptance/products',
+          'acceptance/restrict-content',
+          'acceptance/tags',
+          'acceptance/wlm'
         ]
 
     # Steps to install, configure and run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,15 +50,7 @@ jobs:
 
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
-          'acceptance/broadcasts',
-          'acceptance/forms',
-          'acceptance/general',
-          'acceptance/integrations',
-          'acceptance/landing-pages',
-          'acceptance/products',
-          'acceptance/restrict-content',
-          'acceptance/tags',
-          'acceptance/wlm'
+          'acceptance/restrict-content'
         ]
 
     # Steps to install, configure and run tests
@@ -196,12 +188,18 @@ jobs:
         working-directory: ${{ env.PLUGIN_DIR }}
         run: composer dump-autoload
 
-      # This ensures that applicable files and folders can be written to by the WP Super Cache Plugin.
+      # This ensures that applicable files and folders can be written to by cache plugins.
       # We only do this on Restrict Content tests, as doing so on wpunit tests results in WordPress
       # bizarrely attempting to use FTP to write files.
       - name: Set Permissions for WP Super Cache
         if: ${{ matrix.test-groups == 'acceptance/restrict-content' }}
         run: |
+          sudo touch ${{ env.ROOT_DIR }}/wp-cache-config.php
+          sudo chmod g+w ${{ env.ROOT_DIR }}/wp-cache-config.php
+          sudo chown www-data:www-data ${{ env.ROOT_DIR }}/wp-cache-config.php
+          sudo touch ${{ env.ROOT_DIR }}/advanced-cache.php
+          sudo chmod g+w ${{ env.ROOT_DIR }}/advanced-cache.php
+          sudo chown www-data:www-data ${{ env.ROOT_DIR }}/advanced-cache.php
           sudo chmod g+w ${{ env.ROOT_DIR }}/wp-config.php
           sudo chown www-data:www-data ${{ env.ROOT_DIR }}/wp-config.php
           sudo chmod g+w ${{ env.ROOT_DIR }}/wp-content

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -196,8 +196,6 @@ jobs:
         run: |
           sudo chmod g+w ${{ env.ROOT_DIR }}/wp-config.php
           sudo chown www-data:www-data ${{ env.ROOT_DIR }}/wp-config.php
-          sudo chmod g+w ${{ env.ROOT_DIR }}/wp-content
-          sudo chown www-data:www-data ${{ env.ROOT_DIR }}/wp-content
 
       # This ensures the wp-content/uploads folder can be written to by WordPress and third party Plugins.
       - name: Set Permissions for Uploads Directory

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -194,8 +194,6 @@ jobs:
       - name: Set Permissions for Caching Plugins
         if: ${{ matrix.test-groups == 'acceptance/restrict-content' }}
         run: |
-         sudo chmod g+w ${{ env.ROOT_DIR }}/nginx.conf
-          sudo chown www-data:www-data ${{ env.ROOT_DIR }}/nginx.conf
           sudo chmod g+w ${{ env.ROOT_DIR }}/wp-config.php
           sudo chown www-data:www-data ${{ env.ROOT_DIR }}/wp-config.php
           sudo chmod g+w ${{ env.ROOT_DIR }}/wp-content

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         wp-versions: [ 'latest' ] #[ '6.1.1', 'latest' ]
-        php-versions: [ '7.4', '8.0', '8.1', '8.2' ] #[ '7.4', '8.0', '8.1' ]
+        php-versions: [ '7.4' ] #[ '7.4', '8.0', '8.1' ]
 
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       DB_USER: root
       DB_PASS: root
       DB_HOST: localhost
-      INSTALL_PLUGINS: "contact-form-7 convertkit-for-woocommerce classic-editor disable-welcome-messages-and-tips elementor integrate-convertkit-wpforms woocommerce wordpress-seo wpforms-lite" # Don't include this repository's Plugin here.
+      INSTALL_PLUGINS: "contact-form-7 convertkit-for-woocommerce classic-editor disable-welcome-messages-and-tips elementor integrate-convertkit-wpforms woocommerce wordpress-seo wpforms-lite litespeed-cache wp-super-cache w3-total-cache wp-fastest-cache wp-optimize" # Don't include this repository's Plugin here.
       CONVERTKIT_API_KEY: ${{ secrets.CONVERTKIT_API_KEY }} # ConvertKit API Key, stored in the repository's Settings > Secrets
       CONVERTKIT_API_SECRET: ${{ secrets.CONVERTKIT_API_SECRET }} # ConvertKit API Secret, stored in the repository's Settings > Secrets
       CONVERTKIT_API_KEY_NO_DATA: ${{ secrets.CONVERTKIT_API_KEY_NO_DATA }} # ConvertKit API Key for ConvertKit account with no data, stored in the repository's Settings > Secrets

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -194,6 +194,8 @@ jobs:
       - name: Set Permissions for Caching Plugins
         if: ${{ matrix.test-groups == 'acceptance/restrict-content' }}
         run: |
+         sudo chmod g+w ${{ env.ROOT_DIR }}/nginx.conf
+          sudo chown www-data:www-data ${{ env.ROOT_DIR }}/nginx.conf
           sudo chmod g+w ${{ env.ROOT_DIR }}/wp-config.php
           sudo chown www-data:www-data ${{ env.ROOT_DIR }}/wp-config.php
           sudo chmod g+w ${{ env.ROOT_DIR }}/wp-content

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -188,23 +188,6 @@ jobs:
         working-directory: ${{ env.PLUGIN_DIR }}
         run: composer dump-autoload
 
-      # This ensures that applicable files and folders can be written to by cache plugins.
-      # We only do this on Restrict Content tests, as doing so on wpunit tests results in WordPress
-      # bizarrely attempting to use FTP to write files.
-      - name: Set Permissions for WP Super Cache
-        if: ${{ matrix.test-groups == 'acceptance/restrict-content' }}
-        run: |
-          sudo touch ${{ env.ROOT_DIR }}/wp-cache-config.php
-          sudo chmod g+w ${{ env.ROOT_DIR }}/wp-cache-config.php
-          sudo chown www-data:www-data ${{ env.ROOT_DIR }}/wp-cache-config.php
-          sudo touch ${{ env.ROOT_DIR }}/advanced-cache.php
-          sudo chmod g+w ${{ env.ROOT_DIR }}/advanced-cache.php
-          sudo chown www-data:www-data ${{ env.ROOT_DIR }}/advanced-cache.php
-          sudo chmod g+w ${{ env.ROOT_DIR }}/wp-config.php
-          sudo chown www-data:www-data ${{ env.ROOT_DIR }}/wp-config.php
-          sudo chmod g+w ${{ env.ROOT_DIR }}/wp-content
-          sudo chown www-data:www-data ${{ env.ROOT_DIR }}/wp-content
-
       # This ensures the wp-content/uploads folder can be written to by WordPress and third party Plugins.
       - name: Set Permissions for Uploads Directory
         run: |

--- a/tests/_support/Helper/Acceptance/WPCachePlugins.php
+++ b/tests/_support/Helper/Acceptance/WPCachePlugins.php
@@ -1,0 +1,211 @@
+<?php
+namespace Helper\Acceptance;
+
+/**
+ * Helper methods and actions related to WordPress Caching Plugins,
+ * which are then available using $I->{yourFunctionName}.
+ *
+ * @since   2.2.2
+ */
+class WPCachePlugins extends \Codeception\Module
+{
+	/**
+	 * Helper method to enable caching in the LiteSpeed Plugin.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   AcceptanceTester $I      Acceptance Tester.
+	 */
+	public function enableCachingLiteSpeedCachePlugin($I)
+	{
+		// Navigate to its settings screen.
+		$I->amOnAdminPage('admin.php?page=litespeed-cache');
+
+		// Enable.
+		$I->click('label[for="input_radio_cache_1"]');
+
+		// Save.
+		$I->click('Save Changes');
+	}
+
+	/**
+	 * Helper method to exclude caching when a cookie is present
+	 * in the LiteSpeed Cache Plugin.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   AcceptanceTester $I             Acceptance Tester.
+	 * @param   string           $cookieName    Cookie Name to exclude from caching.
+	 */
+	public function excludeCachingLiteSpeedCachePlugin($I, $cookieName = 'ck_subscriber_id')
+	{
+		// Navigate to its settings screen.
+		$I->amOnAdminPage('admin.php?page=litespeed-cache');
+
+		// Click Excludes tab.
+		$I->click('a[litespeed-accesskey="4"]');
+
+		// Add cookie to "Do Not Cache Cookies" setting.
+		$I->fillField('cache-exc_cookies', $cookieName);
+
+		// Save.
+		$I->scrollTo('#litespeed-submit-0');
+		$I->click('#litespeed-submit-0');
+	}
+
+	/**
+	 * Helper method to enable caching in the W3 Total Cache Plugin.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   AcceptanceTester $I      Acceptance Tester.
+	 */
+	public function enableCachingW3TotalCachePlugin($I)
+	{
+		// Navigate to its settings screen.
+		$I->amOnAdminPage('admin.php?page=w3tc_general');
+
+		// Skip Setup Guide.
+		$I->click('#w3tc-wizard-skip');
+
+		// Navigate to its settings screen.
+		$I->waitForElementVisible('input.w3tc-gopro-button');
+		$I->amOnAdminPage('admin.php?page=w3tc_general');
+
+		// Enable.
+		$I->checkOption('#pgcache__enabled');
+
+		// Save.
+		$I->click('Save all settings');
+	}
+
+	/**
+	 * Helper method to exclude caching when a cookie is present
+	 * in the W3 Total Cache Plugin.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   AcceptanceTester $I             Acceptance Tester.
+	 * @param   string           $cookieName    Cookie Name to exclude from caching.
+	 */
+	public function excludeCachingW3TotalCachePlugin($I, $cookieName = 'ck_subscriber_id')
+	{
+		// Navigate to its settings screen.
+		$I->amOnAdminPage('admin.php?page=w3tc_pgcache');
+
+		// Add cookie to "Rejected Cookies" setting.
+		$I->scrollTo('#pgcache_reject_cookie');
+		$I->fillField('#pgcache_reject_cookie', $cookieName);
+
+		// Save.
+		$I->scrollTo('#notes');
+		$I->click('#w3tc_save_options_pagecache_advanced');
+	}
+
+	/**
+	 * Helper method to enable caching in the WP Fastest Cache Plugin.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   AcceptanceTester $I      Acceptance Tester.
+	 */
+	public function enableCachingWPFastestCachePlugin($I)
+	{
+		// Navigate to its settings screen.
+		$I->amOnAdminPage('admin.php?page=wpfastestcacheoptions');
+
+		// Enable.
+		$I->checkOption('input[name="wpFastestCacheStatus"]');
+
+		// Save.
+		$I->click('Submit');
+
+		// The ConvertKit Plugin will now automatically add an exclusion rule
+		// to WP Fastest Cache. Check this rule does exist in the settings.
+		$I->amOnAdminPage('admin.php?page=wpfastestcacheoptions');
+		$I->click('label[for="wpfc-exclude"]');
+		$I->see('Contains: ck_subscriber_id');
+	}
+
+	/**
+	 * Helper method to enable caching in the WP Optimize Plugin.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   AcceptanceTester $I      Acceptance Tester.
+	 */
+	public function enableCachingWPOptimizePlugin($I)
+	{
+		// Navigate to its settings screen.
+		$I->amOnAdminPage('admin.php?page=wpo_cache');
+
+		// Dismiss notice.
+		$I->click('Dismiss');
+
+		// Enable.
+		$I->click('div.cache-options label.switch');
+
+		// Save.
+		$I->waitForElementVisible('#wp-optimize-purge-cache');
+		$I->click('#wp-optimize-save-cache-settings');
+	}
+
+	/**
+	 * Helper method to enable caching in the WP Super Cache Plugin.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   AcceptanceTester $I      Acceptance Tester.
+	 */
+	public function enableCachingWPSuperCachePlugin($I)
+	{
+		// Navigate to its settings screen.
+		$I->amOnAdminPage('options-general.php?page=wpsupercache');
+
+		// Enable.
+		$I->selectOption('input[name="wp_cache_easy_on"]', '1');
+
+		// Save.
+		$I->click('Update Status');
+	}
+
+	/**
+	 * Helper method to exclude caching when a cookie is present
+	 * in the WP Super Cache Plugin.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   AcceptanceTester $I             Acceptance Tester.
+	 * @param   string           $cookieName    Cookie Name to exclude from caching.
+	 */
+	public function excludeCachingWPSuperCachePlugin($I, $cookieName = 'ck_subscriber_id')
+	{
+		// Navigate to its settings screen.
+		$I->amOnAdminPage('options-general.php?page=wpsupercache&tab=settings');
+
+		// Add cookie to "Rejected Cookies" setting.
+		$I->fillField('wp_rejected_cookies', $cookieName);
+
+		// Save.
+		$I->click('form[name="wp_edit_rejected_cookies"] input.button-primary');
+	}
+
+	/**
+	 * Helper method to delete the files at wp-content/advanced-cache.php
+	 * and wp-content/wp-cache-config.php, which may have been created by a
+	 * previous caching plugin that was enabled in a previous test.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   AcceptanceTester $I      Acceptance Tester.
+	 */
+	public function deleteWPCacheConfigFiles($I)
+	{
+		if (file_exists($_ENV['WP_ROOT_FOLDER'] . '/wp-content/advanced-cache.php')) {
+			$I->deleteFile($_ENV['WP_ROOT_FOLDER'] . '/wp-content/advanced-cache.php');
+		}
+		if (file_exists($_ENV['WP_ROOT_FOLDER'] . '/wp-content/wp-cache-config.php')) {
+			$I->deleteFile($_ENV['WP_ROOT_FOLDER'] . '/wp-content/wp-cache-config.php');
+		}
+	}
+}

--- a/tests/_support/Helper/Acceptance/WPCachePlugins.php
+++ b/tests/_support/Helper/Acceptance/WPCachePlugins.php
@@ -201,6 +201,9 @@ class WPCachePlugins extends \Codeception\Module
 	 */
 	public function deleteWPCacheConfigFiles($I)
 	{
+		if (file_exists($_ENV['WP_ROOT_FOLDER'] . '/wp-content/advanced-cache.php')) {
+			$I->deleteFile($_ENV['WP_ROOT_FOLDER'] . '/wp-content/advanced-cache.php');
+		}
 		if (file_exists($_ENV['WP_ROOT_FOLDER'] . '/wp-content/wp-cache-config.php')) {
 			$I->deleteFile($_ENV['WP_ROOT_FOLDER'] . '/wp-content/wp-cache-config.php');
 		}

--- a/tests/_support/Helper/Acceptance/WPCachePlugins.php
+++ b/tests/_support/Helper/Acceptance/WPCachePlugins.php
@@ -201,9 +201,6 @@ class WPCachePlugins extends \Codeception\Module
 	 */
 	public function deleteWPCacheConfigFiles($I)
 	{
-		if (file_exists($_ENV['WP_ROOT_FOLDER'] . '/wp-content/advanced-cache.php')) {
-			$I->deleteFile($_ENV['WP_ROOT_FOLDER'] . '/wp-content/advanced-cache.php');
-		}
 		if (file_exists($_ENV['WP_ROOT_FOLDER'] . '/wp-content/wp-cache-config.php')) {
 			$I->deleteFile($_ENV['WP_ROOT_FOLDER'] . '/wp-content/wp-cache-config.php');
 		}

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -26,6 +26,7 @@ modules:
         - \Helper\Acceptance\Select2
         - \Helper\Acceptance\ThirdPartyPlugin
         - \Helper\Acceptance\WPBulkEdit
+        - \Helper\Acceptance\WPCachePlugins
         - \Helper\Acceptance\WPClassicEditor
         - \Helper\Acceptance\WPGutenberg
         - \Helper\Acceptance\WPMetabox

--- a/tests/acceptance/restrict-content/RestrictContentCacheCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentCacheCest.php
@@ -90,6 +90,9 @@ class RestrictContentCacheCest
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// to confirm caching does not show the incorrect content.
 		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID, $this->visibleContent, $this->memberContent);
+
+		// Deactivate Litespeed Cache Plugin.
+		$I->deactivateThirdPartyPlugin($I, 'litespeed-cache');
 	}
 
 	/**
@@ -131,6 +134,9 @@ class RestrictContentCacheCest
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// to confirm caching does not show the incorrect content.
 		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID, $this->visibleContent, $this->memberContent);
+
+		// Deactivate W3 Total Cache Plugin.
+		$I->deactivateThirdPartyPlugin($I, 'w3-total-cache');
 	}
 
 	/**
@@ -172,6 +178,9 @@ class RestrictContentCacheCest
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// to confirm caching does not show the incorrect content.
 		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID, $this->visibleContent, $this->memberContent);
+
+		// Deactivate WP Fastest Cache Plugin.
+		$I->deactivateThirdPartyPlugin($I, 'wp-fastest-cache');
 	}
 
 	/**
@@ -184,7 +193,7 @@ class RestrictContentCacheCest
 	 */
 	public function testRestrictContentWPOptimize(AcceptanceTester $I)
 	{
-		// Activate and enable WP Super Cache Plugin.
+		// Activate and enable WP Optimize Cache Plugin.
 		$I->activateThirdPartyPlugin($I, 'wp-optimize');
 		$I->enableCachingWPOptimizePlugin($I);
 
@@ -213,6 +222,9 @@ class RestrictContentCacheCest
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// to confirm caching does not show the incorrect content.
 		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID, $this->visibleContent, $this->memberContent);
+
+		// Deactivate WP-Optimize Cache Plugin.
+		$I->deactivateThirdPartyPlugin($I, 'wp-optimize');
 	}
 
 	/**
@@ -254,6 +266,9 @@ class RestrictContentCacheCest
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// to confirm caching does not show the incorrect content.
 		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID, $this->visibleContent, $this->memberContent);
+
+		// Deactivate WP Super Cache Plugin.
+		$I->deactivateThirdPartyPlugin($I, 'wp-super-cache');
 	}
 
 	/**

--- a/tests/acceptance/restrict-content/RestrictContentCacheCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentCacheCest.php
@@ -52,6 +52,50 @@ class RestrictContentCacheCest
 	}
 
 	/**
+	 * Tests that the WP Super Cache Plugin does not interfere with Restrict Content
+	 * output when a ck_subscriber_id cookie is present.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentWPSuperCache(AcceptanceTester $I)
+	{
+		// Activate and enable WP Super Cache Plugin.
+		$I->activateThirdPartyPlugin($I, 'wp-super-cache');
+		$I->enableCachingWPSuperCachePlugin($I);
+
+		// Configure WP Super Cache Plugin to exclude caching when the ck_subscriber_id cookie is set.
+		$I->excludeCachingWPSuperCachePlugin($I);
+
+		// Create Restricted Content Page.
+		$pageID = $I->createRestrictedContentPage(
+			$I,
+			'ConvertKit: Restrict Content: Product: WP Super Cache',
+			$this->visibleContent,
+			$this->memberContent,
+			'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+		);
+
+		// Log out, so that caching is honored.
+		$I->logOut();
+
+		// Navigate to the page.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Test that the restricted content CTA displays when no valid signed subscriber ID is used,
+		// to confirm caching does not show member only content.
+		$I->testRestrictContentHidesContentWithCTA($I, $this->visibleContent, $this->memberContent);
+
+		// Test that the restricted content displays when a valid signed subscriber ID is used,
+		// to confirm caching does not show the incorrect content.
+		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID, $this->visibleContent, $this->memberContent);
+
+		// Deactivate WP Super Cache Plugin.
+		$I->deactivateThirdPartyPlugin($I, 'wp-super-cache');
+	}
+
+	/**
 	 * Tests that the LiteSpeed Cache Plugin does not interfere with Restrict Content
 	 * output when a ck_subscriber_id cookie is present.
 	 *
@@ -225,50 +269,6 @@ class RestrictContentCacheCest
 
 		// Deactivate WP-Optimize Cache Plugin.
 		$I->deactivateThirdPartyPlugin($I, 'wp-optimize');
-	}
-
-	/**
-	 * Tests that the WP Super Cache Plugin does not interfere with Restrict Content
-	 * output when a ck_subscriber_id cookie is present.
-	 *
-	 * @since   2.2.2
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 */
-	public function testRestrictContentWPSuperCache(AcceptanceTester $I)
-	{
-		// Activate and enable WP Super Cache Plugin.
-		$I->activateThirdPartyPlugin($I, 'wp-super-cache');
-		$I->enableCachingWPSuperCachePlugin($I);
-
-		// Configure WP Super Cache Plugin to exclude caching when the ck_subscriber_id cookie is set.
-		$I->excludeCachingWPSuperCachePlugin($I);
-
-		// Create Restricted Content Page.
-		$pageID = $I->createRestrictedContentPage(
-			$I,
-			'ConvertKit: Restrict Content: Product: WP Super Cache',
-			$this->visibleContent,
-			$this->memberContent,
-			'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
-		);
-
-		// Log out, so that caching is honored.
-		$I->logOut();
-
-		// Navigate to the page.
-		$I->amOnPage('?p=' . $pageID);
-
-		// Test that the restricted content CTA displays when no valid signed subscriber ID is used,
-		// to confirm caching does not show member only content.
-		$I->testRestrictContentHidesContentWithCTA($I, $this->visibleContent, $this->memberContent);
-
-		// Test that the restricted content displays when a valid signed subscriber ID is used,
-		// to confirm caching does not show the incorrect content.
-		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID, $this->visibleContent, $this->memberContent);
-
-		// Deactivate WP Super Cache Plugin.
-		$I->deactivateThirdPartyPlugin($I, 'wp-super-cache');
 	}
 
 	/**

--- a/tests/acceptance/restrict-content/RestrictContentCacheCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentCacheCest.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * Tests that common caching plugins do not interfere with Restrict Content
+ * output when configured correctly.
+ *
+ * @since   2.2.2
+ */
+class RestrictContentCacheCest
+{
+	/**
+	 * The visible content to all users.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @var     string
+	 */
+	public $visibleContent = 'Visible content';
+
+	/**
+	 * The content only available to authorized users.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @var     string
+	 */
+	public $memberContent = 'Member only content.';
+
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		// Activate and Setup ConvertKit plugin.
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+
+		// Enable Restricted Content.
+		$I->setupConvertKitPluginRestrictContent(
+			$I,
+			[
+				'enabled' => true,
+			]
+		);
+
+		// Clear up any cache configuration files that might exist from previous tests.
+		$I->deleteWPCacheConfigFiles($I);
+		$I->resetCookie('ck_subscriber_id');
+	}
+
+	/**
+	 * Tests that the LiteSpeed Cache Plugin does not interfere with Restrict Content
+	 * output when a ck_subscriber_id cookie is present.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentLiteSpeedCache(AcceptanceTester $I)
+	{
+		// Activate and enable LiteSpeed Cache Plugin.
+		$I->activateThirdPartyPlugin($I, 'litespeed-cache');
+		$I->enableCachingLiteSpeedCachePlugin($I);
+
+		// Configure LiteSpeed Cache Plugin to exclude caching when the ck_subscriber_id cookie is set.
+		$I->excludeCachingLiteSpeedCachePlugin($I);
+
+		// Create Restricted Content Page.
+		$pageID = $I->createRestrictedContentPage(
+			$I,
+			'ConvertKit: Restrict Content: Product: LiteSpeed Cache',
+			$this->visibleContent,
+			$this->memberContent,
+			'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+		);
+
+		// Log out, so that caching is honored.
+		$I->logOut();
+
+		// Navigate to the page.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Test that the restricted content CTA displays when no valid signed subscriber ID is used,
+		// to confirm caching does not show member only content.
+		$I->testRestrictContentHidesContentWithCTA($I, $this->visibleContent, $this->memberContent);
+
+		// Test that the restricted content displays when a valid signed subscriber ID is used,
+		// to confirm caching does not show the incorrect content.
+		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID, $this->visibleContent, $this->memberContent);
+	}
+
+	/**
+	 * Tests that the W3 Total Cache Plugin does not interfere with Restrict Content
+	 * output when a ck_subscriber_id cookie is present.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentW3TotalCache(AcceptanceTester $I)
+	{
+		// Activate and enable W3 Total Cache Plugin.
+		$I->activateThirdPartyPlugin($I, 'w3-total-cache');
+		$I->enableCachingW3TotalCachePlugin($I);
+
+		// Configure W3 Total Cache Plugin to exclude caching when the ck_subscriber_id cookie is set.
+		$I->excludeCachingW3TotalCachePlugin($I);
+
+		// Create Restricted Content Page.
+		$pageID = $I->createRestrictedContentPage(
+			$I,
+			'ConvertKit: Restrict Content: Product: W3 Total Cache',
+			$this->visibleContent,
+			$this->memberContent,
+			'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+		);
+
+		// Log out, so that caching is honored.
+		$I->logOut();
+
+		// Navigate to the page.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Test that the restricted content CTA displays when no valid signed subscriber ID is used,
+		// to confirm caching does not show member only content.
+		$I->testRestrictContentHidesContentWithCTA($I, $this->visibleContent, $this->memberContent);
+
+		// Test that the restricted content displays when a valid signed subscriber ID is used,
+		// to confirm caching does not show the incorrect content.
+		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID, $this->visibleContent, $this->memberContent);
+	}
+
+	/**
+	 * Tests that the WP Fatest Cache Plugin does not interfere with Restrict Content
+	 * output when a ck_subscriber_id cookie is present.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentWPFastestCache(AcceptanceTester $I)
+	{
+		// Activate and enable WP Fastest Cache Plugin.
+		$I->activateThirdPartyPlugin($I, 'wp-fastest-cache');
+		$I->enableCachingWPFastestCachePlugin($I);
+
+		// No need to configure WP-Optimize to exclude caching when the ck_subscriber_id cookie is set,
+		// as this is automatically performed by the ConvertKit Plugin.
+
+		// Create Restricted Content Page.
+		$pageID = $I->createRestrictedContentPage(
+			$I,
+			'ConvertKit: Restrict Content: Product: WP Fastest Cache',
+			$this->visibleContent,
+			$this->memberContent,
+			'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+		);
+
+		// Log out, so that caching is honored.
+		$I->logOut();
+
+		// Navigate to the page.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Test that the restricted content CTA displays when no valid signed subscriber ID is used,
+		// to confirm caching does not show member only content.
+		$I->testRestrictContentHidesContentWithCTA($I, $this->visibleContent, $this->memberContent);
+
+		// Test that the restricted content displays when a valid signed subscriber ID is used,
+		// to confirm caching does not show the incorrect content.
+		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID, $this->visibleContent, $this->memberContent);
+	}
+
+	/**
+	 * Tests that the WP-Optimize Plugin does not interfere with Restrict Content
+	 * output when a ck_subscriber_id cookie is present.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentWPOptimize(AcceptanceTester $I)
+	{
+		// Activate and enable WP Super Cache Plugin.
+		$I->activateThirdPartyPlugin($I, 'wp-optimize');
+		$I->enableCachingWPOptimizePlugin($I);
+
+		// No need to configure WP-Optimize to exclude caching when the ck_subscriber_id cookie is set,
+		// as this is automatically performed by the ConvertKit Plugin.
+
+		// Create Restricted Content Page.
+		$pageID = $I->createRestrictedContentPage(
+			$I,
+			'ConvertKit: Restrict Content: Product: WP-Optimize',
+			$this->visibleContent,
+			$this->memberContent,
+			'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+		);
+
+		// Log out, so that caching is honored.
+		$I->logOut();
+
+		// Navigate to the page.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Test that the restricted content CTA displays when no valid signed subscriber ID is used,
+		// to confirm caching does not show member only content.
+		$I->testRestrictContentHidesContentWithCTA($I, $this->visibleContent, $this->memberContent);
+
+		// Test that the restricted content displays when a valid signed subscriber ID is used,
+		// to confirm caching does not show the incorrect content.
+		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID, $this->visibleContent, $this->memberContent);
+	}
+
+	/**
+	 * Tests that the WP Super Cache Plugin does not interfere with Restrict Content
+	 * output when a ck_subscriber_id cookie is present.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentWPSuperCache(AcceptanceTester $I)
+	{
+		// Activate and enable WP Super Cache Plugin.
+		$I->activateThirdPartyPlugin($I, 'wp-super-cache');
+		$I->enableCachingWPSuperCachePlugin($I);
+
+		// Configure WP Super Cache Plugin to exclude caching when the ck_subscriber_id cookie is set.
+		$I->excludeCachingWPSuperCachePlugin($I);
+
+		// Create Restricted Content Page.
+		$pageID = $I->createRestrictedContentPage(
+			$I,
+			'ConvertKit: Restrict Content: Product: WP Super Cache',
+			$this->visibleContent,
+			$this->memberContent,
+			'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+		);
+
+		// Log out, so that caching is honored.
+		$I->logOut();
+
+		// Navigate to the page.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Test that the restricted content CTA displays when no valid signed subscriber ID is used,
+		// to confirm caching does not show member only content.
+		$I->testRestrictContentHidesContentWithCTA($I, $this->visibleContent, $this->memberContent);
+
+		// Test that the restricted content displays when a valid signed subscriber ID is used,
+		// to confirm caching does not show the incorrect content.
+		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID, $this->visibleContent, $this->memberContent);
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deleteWPCacheConfigFiles($I);
+		$I->resetCookie('ck_subscriber_id');
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
+	}
+}

--- a/tests/acceptance/restrict-content/RestrictContentCacheCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentCacheCest.php
@@ -52,50 +52,6 @@ class RestrictContentCacheCest
 	}
 
 	/**
-	 * Tests that the WP Super Cache Plugin does not interfere with Restrict Content
-	 * output when a ck_subscriber_id cookie is present.
-	 *
-	 * @since   2.2.2
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 */
-	public function testRestrictContentWPSuperCache(AcceptanceTester $I)
-	{
-		// Activate and enable WP Super Cache Plugin.
-		$I->activateThirdPartyPlugin($I, 'wp-super-cache');
-		$I->enableCachingWPSuperCachePlugin($I);
-
-		// Configure WP Super Cache Plugin to exclude caching when the ck_subscriber_id cookie is set.
-		$I->excludeCachingWPSuperCachePlugin($I);
-
-		// Create Restricted Content Page.
-		$pageID = $I->createRestrictedContentPage(
-			$I,
-			'ConvertKit: Restrict Content: Product: WP Super Cache',
-			$this->visibleContent,
-			$this->memberContent,
-			'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
-		);
-
-		// Log out, so that caching is honored.
-		$I->logOut();
-
-		// Navigate to the page.
-		$I->amOnPage('?p=' . $pageID);
-
-		// Test that the restricted content CTA displays when no valid signed subscriber ID is used,
-		// to confirm caching does not show member only content.
-		$I->testRestrictContentHidesContentWithCTA($I, $this->visibleContent, $this->memberContent);
-
-		// Test that the restricted content displays when a valid signed subscriber ID is used,
-		// to confirm caching does not show the incorrect content.
-		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID, $this->visibleContent, $this->memberContent);
-
-		// Deactivate WP Super Cache Plugin.
-		$I->deactivateThirdPartyPlugin($I, 'wp-super-cache');
-	}
-
-	/**
 	 * Tests that the LiteSpeed Cache Plugin does not interfere with Restrict Content
 	 * output when a ck_subscriber_id cookie is present.
 	 *
@@ -137,6 +93,9 @@ class RestrictContentCacheCest
 
 		// Deactivate Litespeed Cache Plugin.
 		$I->deactivateThirdPartyPlugin($I, 'litespeed-cache');
+
+		// Delete any cache configuration files.
+		$I->deleteWPCacheConfigFiles($I);
 	}
 
 	/**
@@ -181,6 +140,9 @@ class RestrictContentCacheCest
 
 		// Deactivate W3 Total Cache Plugin.
 		$I->deactivateThirdPartyPlugin($I, 'w3-total-cache');
+
+		// Delete any cache configuration files.
+		$I->deleteWPCacheConfigFiles($I);
 	}
 
 	/**
@@ -225,6 +187,9 @@ class RestrictContentCacheCest
 
 		// Deactivate WP Fastest Cache Plugin.
 		$I->deactivateThirdPartyPlugin($I, 'wp-fastest-cache');
+
+		// Delete any cache configuration files.
+		$I->deleteWPCacheConfigFiles($I);
 	}
 
 	/**
@@ -269,6 +234,53 @@ class RestrictContentCacheCest
 
 		// Deactivate WP-Optimize Cache Plugin.
 		$I->deactivateThirdPartyPlugin($I, 'wp-optimize');
+
+		// Delete any cache configuration files.
+		$I->deleteWPCacheConfigFiles($I);
+	}
+
+	/**
+	 * Tests that the WP Super Cache Plugin does not interfere with Restrict Content
+	 * output when a ck_subscriber_id cookie is present.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentWPSuperCache(AcceptanceTester $I)
+	{
+		// Activate and enable WP Super Cache Plugin.
+		$I->activateThirdPartyPlugin($I, 'wp-super-cache');
+		$I->enableCachingWPSuperCachePlugin($I);
+
+		// Configure WP Super Cache Plugin to exclude caching when the ck_subscriber_id cookie is set.
+		$I->excludeCachingWPSuperCachePlugin($I);
+
+		// Create Restricted Content Page.
+		$pageID = $I->createRestrictedContentPage(
+			$I,
+			'ConvertKit: Restrict Content: Product: WP Super Cache',
+			$this->visibleContent,
+			$this->memberContent,
+			'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+		);
+
+		// Log out, so that caching is honored.
+		$I->logOut();
+
+		// Navigate to the page.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Test that the restricted content CTA displays when no valid signed subscriber ID is used,
+		// to confirm caching does not show member only content.
+		$I->testRestrictContentHidesContentWithCTA($I, $this->visibleContent, $this->memberContent);
+
+		// Test that the restricted content displays when a valid signed subscriber ID is used,
+		// to confirm caching does not show the incorrect content.
+		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID, $this->visibleContent, $this->memberContent);
+
+		// Deactivate WP Super Cache Plugin.
+		$I->deactivateThirdPartyPlugin($I, 'wp-super-cache');
 	}
 
 	/**
@@ -282,7 +294,6 @@ class RestrictContentCacheCest
 	 */
 	public function _passed(AcceptanceTester $I)
 	{
-		$I->deleteWPCacheConfigFiles($I);
 		$I->resetCookie('ck_subscriber_id');
 		$I->deactivateConvertKitPlugin($I);
 		$I->resetConvertKitPlugin($I);

--- a/tests/acceptance/restrict-content/RestrictContentCacheCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentCacheCest.php
@@ -109,7 +109,9 @@ class RestrictContentCacheCest
 	public function testRestrictContentW3TotalCache(AcceptanceTester $I)
 	{
 		// Activate and enable W3 Total Cache Plugin.
-		$I->activateThirdPartyPlugin($I, 'w3-total-cache');
+		// Don't use activateThirdPartyPlugin(), as W3 Total Cache returns a PHP Deprecated notice in 8.1+.
+		$I->amOnPluginsPage();
+		$I->activatePlugin('w3-total-cache');
 		$I->enableCachingW3TotalCachePlugin($I);
 
 		// Configure W3 Total Cache Plugin to exclude caching when the ck_subscriber_id cookie is set.


### PR DESCRIPTION
## Summary

Adds tests for common WordPress Caching Plugins when using Member Content, to confirm that the correct content is displayed when a valid `ck_subscriber_id` cookie exists.

## Testing

- `RestrictContentCacheCest`: Tests to confirm that Member Content functionality works when common WordPress Caching Plugins are correctly configured to exclude caching when the `ck_subscriber_id` cookie exists.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)