### PR TITLE
Improve reliability of tests that use `see()`

### DIFF
--- a/tests/_support/Helper/Acceptance/WPBulkEdit.php
+++ b/tests/_support/Helper/Acceptance/WPBulkEdit.php
@@ -49,8 +49,11 @@ class WPBulkEdit extends \Codeception\Module
 		// Click Update.
 		$I->click('Update');
 
+		// Wait for the WP_List_Table of Pages to load.
+		$I->waitForElementVisible('tbody#the-list');
+
 		// Confirm that Bulk Editing saved with no errors.
-		$I->seeInSource(count($postIDs) . ' ' . $postType . 's updated');
+		$I->see(count($postIDs) . ' ' . $postType . 's updated.');
 	}
 
 	/**

--- a/tests/acceptance/forms/CategoryFormCest.php
+++ b/tests/acceptance/forms/CategoryFormCest.php
@@ -126,6 +126,9 @@ class CategoryFormCest
 		// Click Update.
 		$I->click('Update');
 
+		// Wait for the page to load.
+		$I->waitForElementVisible('#wpfooter');
+
 		// Check that the update succeeded.
 		$I->seeElementInDOM('div.notice-success');
 

--- a/tests/acceptance/general/PageCest.php
+++ b/tests/acceptance/general/PageCest.php
@@ -44,7 +44,7 @@ class PageCest
 		$I->dontSeeElementInDOM('#wp-convertkit-form');
 
 		// Check that an expected message is displayed.
-		$I->seeInSource('To configure the ConvertKit Form / Landing Page to display on this Page, enter your ConvertKit API credentials');
+		$I->see('To configure the ConvertKit Form / Landing Page to display on this Page, enter your ConvertKit API credentials');
 
 		// Check that a link to the Plugin Settings exists.
 		$I->seeInSource('<a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/options-general.php?page=_wp_convertkit_settings">Plugin Settings</a>');

--- a/tests/acceptance/general/PluginSettingsGeneralCest.php
+++ b/tests/acceptance/general/PluginSettingsGeneralCest.php
@@ -87,7 +87,7 @@ class PluginSettingsGeneralCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check that 'No Forms exist in ConvertKit' is displayed.
-		$I->seeInSource('No Forms exist in ConvertKit.');
+		$I->see('No Forms exist in ConvertKit.');
 	}
 
 	/**

--- a/tests/acceptance/general/PluginSettingsToolsCest.php
+++ b/tests/acceptance/general/PluginSettingsToolsCest.php
@@ -261,6 +261,9 @@ class PluginSettingsToolsCest
 		// Select the invalid configuration file at tests/_data/convertkit-export-invalid.json to import.
 		$I->attachFile('input[name=import]', 'convertkit-export-invalid.json');
 
+		// Wait for page to load.
+		$I->waitForElementVisible('#wpfooter');
+
 		// Click the Import button.
 		$I->click('input#convertkit-import');
 
@@ -289,6 +292,9 @@ class PluginSettingsToolsCest
 
 		// Click the Import button.
 		$I->click('input#convertkit-import');
+
+		// Wait for page to load.
+		$I->waitForElementVisible('#wpfooter');
 
 		// Confirm error message displays.
 		$I->see('The uploaded configuration file isn\'t valid.');

--- a/tests/acceptance/general/PluginSettingsToolsCest.php
+++ b/tests/acceptance/general/PluginSettingsToolsCest.php
@@ -194,7 +194,7 @@ class PluginSettingsToolsCest
 		$I->click('input#convertkit-import');
 
 		// Confirm success message displays.
-		$I->seeInSource('Configuration imported successfully.');
+		$I->see('Configuration imported successfully.');
 
 		// Go to the Plugin's Settings Screen.
 		$I->loadConvertKitSettingsGeneralScreen($I);
@@ -239,7 +239,7 @@ class PluginSettingsToolsCest
 		$I->click('input#convertkit-import');
 
 		// Confirm error message displays.
-		$I->seeInSource('An error occured uploading the configuration file.');
+		$I->see('An error occured uploading the configuration file.');
 	}
 
 	/**
@@ -265,7 +265,7 @@ class PluginSettingsToolsCest
 		$I->click('input#convertkit-import');
 
 		// Confirm error message displays.
-		$I->seeInSource('The uploaded configuration file contains no settings.');
+		$I->see('The uploaded configuration file contains no settings.');
 	}
 
 	/**
@@ -291,7 +291,7 @@ class PluginSettingsToolsCest
 		$I->click('input#convertkit-import');
 
 		// Confirm error message displays.
-		$I->seeInSource('The uploaded configuration file isn\'t valid.');
+		$I->see('The uploaded configuration file isn\'t valid.');
 	}
 
 	/**

--- a/tests/acceptance/general/PostCest.php
+++ b/tests/acceptance/general/PostCest.php
@@ -44,7 +44,7 @@ class PostCest
 		$I->dontSeeElementInDOM('#wp-convertkit-form');
 
 		// Check that an expected message is displayed.
-		$I->seeInSource('To configure the ConvertKit Form / Landing Page to display on this Post, enter your ConvertKit API credentials');
+		$I->see('To configure the ConvertKit Form / Landing Page to display on this Post, enter your ConvertKit API credentials');
 
 		// Check that a link to the Plugin Settings exists.
 		$I->seeInSource('<a href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/options-general.php?page=_wp_convertkit_settings">Plugin Settings</a>');

--- a/tests/acceptance/integrations/ContactForm7FormCest.php
+++ b/tests/acceptance/integrations/ContactForm7FormCest.php
@@ -84,7 +84,7 @@ class ContactForm7FormCest
 		$I->performOn(
 			'form.sent',
 			function($I) {
-				$I->seeInSource('Thank you for your message. It has been sent.');
+				$I->see('Thank you for your message. It has been sent.');
 			}
 		);
 

--- a/tests/acceptance/restrict-content/RestrictContentFilterCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentFilterCest.php
@@ -122,6 +122,9 @@ class RestrictContentFilterCest
 		// Navigate to Pages.
 		$I->amOnAdminPage('edit.php?post_type=page');
 
+		// Wait for the WP_List_Table of Pages to load.
+		$I->waitForElementVisible('tbody#the-list');
+
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
@@ -132,6 +135,9 @@ class RestrictContentFilterCest
 		// Filter by Product.
 		$I->selectOption('#wp-convertkit-restrict-content-filter', $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
 		$I->click('Filter');
+
+		// Wait for the WP_List_Table of Pages to load.
+		$I->waitForElementVisible('tbody#the-list');
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);

--- a/tests/acceptance/restrict-content/RestrictContentSetupCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentSetupCest.php
@@ -105,6 +105,9 @@ class RestrictContentSetupCest
 		// Confirm exit.
 		$I->acceptPopup();
 
+		// Wait for the WP_List_Table of Pages to load.
+		$I->waitForElementVisible('tbody#the-list');
+
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
@@ -143,6 +146,9 @@ class RestrictContentSetupCest
 
 		// Click submit button.
 		$I->click('Submit');
+
+		// Wait for the WP_List_Table of Pages to load.
+		$I->waitForElementVisible('tbody#the-list');
 
 		// Confirm that one Page is listed in the WP_List_Table.
 		$I->see('ConvertKit: Member Content: Download');
@@ -192,6 +198,9 @@ class RestrictContentSetupCest
 		// Click submit button.
 		$I->click('Submit');
 
+		// Wait for the WP_List_Table of Pages to load.
+		$I->waitForElementVisible('tbody#the-list');
+
 		// Confirm that four Pages are listed in the WP_List_Table.
 		$I->see('ConvertKit: Member Content: Course');
 		$I->see('— ConvertKit: Member Content: Course: 1/3');
@@ -224,21 +233,25 @@ class RestrictContentSetupCest
 
 		// Test Next / Previous links.
 		$I->click('Next Lesson');
+		$I->waitForElementVisible('body.page-template-default');
 		$I->see('ConvertKit: Member Content: Course: 2/3');
 		$I->see('Some introductory text about lesson 2');
 		$I->see('Lesson 2 content (that is available when the visitor has paid for the ConvertKit product) goes here');
 
 		$I->click('Next Lesson');
+		$I->waitForElementVisible('body.page-template-default');
 		$I->see('ConvertKit: Member Content: Course: 3/3');
 		$I->see('Some introductory text about lesson 3');
 		$I->see('Lesson 3 content (that is available when the visitor has paid for the ConvertKit product) goes here');
 
 		$I->click('Previous Lesson');
+		$I->waitForElementVisible('body.page-template-default');
 		$I->see('ConvertKit: Member Content: Course: 2/3');
 		$I->see('Some introductory text about lesson 2');
 		$I->see('Lesson 2 content (that is available when the visitor has paid for the ConvertKit product) goes here');
 
 		$I->click('Previous Lesson');
+		$I->waitForElementVisible('body.page-template-default');
 		$I->see('ConvertKit: Member Content: Course: 1/3');
 		$I->see('Some introductory text about lesson 1');
 		$I->see('Lesson 1 content (that is available when the visitor has paid for the ConvertKit product) goes here');

--- a/tests/acceptance/tags/PageShortcodeCustomContentCest.php
+++ b/tests/acceptance/tags/PageShortcodeCustomContentCest.php
@@ -99,7 +99,7 @@ class PageShortcodeCustomContentCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the Custom Content is not yet displayed.
-		$I->dontSeeInSource('ConvertKitCustomContent');
+		$I->dontSee('ConvertKitCustomContent');
 
 		// Reload the page, this time with an invalid subscriber ID .
 		$I->amOnPage('/convertkit-custom-content-shortcode-valid-tag-param-and-invalid-subscriber-id?ck_subscriber_id=1');
@@ -108,7 +108,7 @@ class PageShortcodeCustomContentCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the Custom Content is not yet displayed.
-		$I->dontSeeInSource('ConvertKitCustomContent');
+		$I->dontSee('ConvertKitCustomContent');
 	}
 
 	/**
@@ -136,7 +136,7 @@ class PageShortcodeCustomContentCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the Custom Content is not yet displayed.
-		$I->dontSeeInSource('ConvertKitCustomContent');
+		$I->dontSee('ConvertKitCustomContent');
 
 		// Reload the page, this time with a subscriber ID who is already subscribed to the tag.
 		$I->amOnPage('/convertkit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id?ck_subscriber_id=' . $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']);
@@ -145,7 +145,7 @@ class PageShortcodeCustomContentCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the Custom Content is now displayed.
-		$I->seeInSource('ConvertKitCustomContent');
+		$I->see('ConvertKitCustomContent');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Wait for an expected DOM element to be visible before asserting whether expected text is on the screen, immediately after loading a given URL.

Use `see()` in place of `seeInSource()` when asserting if text is displayed; `seeInSource()` is best for determining if raw HTML exists.

Prevents tests failing despite the output being valid:

![Screenshot 2023-05-15 at 16 08 56](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/ed309d55-31a1-4996-bb28-19decee42bdd)

![Screenshot 2023-05-15 at 16 09 21](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/a78c4154-ccf1-48d4-b97e-f9b7a336a8cd)

Ensures tests run and pass first time:
https://github.com/ConvertKit/convertkit-wordpress/actions/runs/4982297086

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)