### PR TITLE
Block Formatters: Don't register when no forms / products in ConvertKit

### DIFF
--- a/includes/block-formatters/class-convertkit-block-formatter-form-link.php
+++ b/includes/block-formatters/class-convertkit-block-formatter-form-link.php
@@ -39,8 +39,12 @@ class ConvertKit_Block_Formatter_Form_Link extends ConvertKit_Block_Formatter {
 	 */
 	public function __construct() {
 
-		// Register this as a Gutenberg block formatter in the ConvertKit Plugin.
-		add_filter( 'convertkit_get_block_formatters', array( $this, 'register' ) );
+		// Register this as a Gutenberg block formatter in the ConvertKit Plugin,
+		// if forms exist on ConvertKit.
+		$this->forms = new ConvertKit_Resource_Forms( 'block_formatter_register' );
+		if ( $this->forms->exist() ) {
+			add_filter( 'convertkit_get_block_formatters', array( $this, 'register' ) );
+		}
 
 		// Enqueue JS in footer if links exist in the content that have the formatter applied.
 		add_filter( 'the_content', array( $this, 'maybe_enqueue_scripts' ) );
@@ -114,11 +118,10 @@ class ConvertKit_Block_Formatter_Form_Link extends ConvertKit_Block_Formatter {
 		}
 
 		// Get ConvertKit Forms.
-		$forms            = array();
-		$forms_data       = array();
-		$convertkit_forms = new ConvertKit_Resource_Forms( 'block_edit' );
-		if ( $convertkit_forms->exist() ) {
-			foreach ( $convertkit_forms->get() as $form ) {
+		$forms      = array();
+		$forms_data = array();
+		if ( $this->forms->exist() ) {
+			foreach ( $this->forms->get() as $form ) {
 				// Ignore inline forms; this formatter is only for modal, slide in and sticky bar forms.
 				if ( ! array_key_exists( 'format', $form ) ) {
 					continue;
@@ -173,9 +176,6 @@ class ConvertKit_Block_Formatter_Form_Link extends ConvertKit_Block_Formatter {
 		if ( strpos( $content, 'data-formkit-toggle' ) === false ) {
 			return $content;
 		}
-
-		// Get Forms.
-		$this->forms = new ConvertKit_Resource_Forms();
 
 		// Return content, unedited, if no Forms exist.
 		if ( ! $this->forms->exist() ) {

--- a/includes/block-formatters/class-convertkit-block-formatter-product-link.php
+++ b/includes/block-formatters/class-convertkit-block-formatter-product-link.php
@@ -39,8 +39,12 @@ class ConvertKit_Block_Formatter_Product_Link extends ConvertKit_Block_Formatter
 	 */
 	public function __construct() {
 
-		// Register this as a Gutenberg block formatter in the ConvertKit Plugin.
-		add_filter( 'convertkit_get_block_formatters', array( $this, 'register' ) );
+		// Register this as a Gutenberg block formatter in the ConvertKit Plugin,
+		// if forms exist on ConvertKit.
+		$this->products = new ConvertKit_Resource_Products( 'block_formatter_register' );
+		if ( $this->products->exist() ) {
+			add_filter( 'convertkit_get_block_formatters', array( $this, 'register' ) );
+		}
 
 	}
 
@@ -111,11 +115,10 @@ class ConvertKit_Block_Formatter_Product_Link extends ConvertKit_Block_Formatter
 		}
 
 		// Get ConvertKit Products.
-		$products            = array();
-		$products_data       = array();
-		$convertkit_products = new ConvertKit_Resource_Products();
-		if ( $convertkit_products->exist() ) {
-			foreach ( $convertkit_products->get() as $product ) {
+		$products      = array();
+		$products_data = array();
+		if ( $this->products->exist() ) {
+			foreach ( $this->products->get() as $product ) {
 				$products[ absint( $product['id'] ) ]      = sanitize_text_field( $product['name'] );
 				$products_data[ absint( $product['id'] ) ] = array(
 					'data-id'       => sanitize_text_field( $product['id'] ),

--- a/tests/_support/Helper/Acceptance/WPGutenberg.php
+++ b/tests/_support/Helper/Acceptance/WPGutenberg.php
@@ -252,6 +252,27 @@ class WPGutenberg extends \Codeception\Module
 	}
 
 	/**
+	 * Asserts that the given block formatter is not registered.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   AcceptanceTester $I                      Acceptance Tester.
+	 * @param   string           $formatterName          Formatter Name (e.g. 'ConvertKit Form Trigger').
+	 */
+	public function dontSeeGutenbergFormatter($I, $formatterName)
+	{
+		// Click More button in block toolbar.
+		$I->waitForElementVisible('.block-editor-block-toolbar button[aria-label="More"]');
+		$I->click('.block-editor-block-toolbar button[aria-label="More"]');
+
+		// Click Block Formatter button.
+		$I->waitForElementVisible('.components-dropdown-menu__popover');
+
+		// Confirm the Block Formatter is not registered.
+		$I->dontSee($formatterName, '.components-dropdown-menu__popover');
+	}
+
+	/**
 	 * Check that the given block did not output any errors when rendered in the
 	 * Gutenberg editor.
 	 *

--- a/tests/acceptance/forms/PageBlockFormatterFormTriggerCest.php
+++ b/tests/acceptance/forms/PageBlockFormatterFormTriggerCest.php
@@ -16,10 +16,6 @@ class PageBlockFormatterFormTriggerCest
 	public function _before(AcceptanceTester $I)
 	{
 		$I->activateConvertKitPlugin($I);
-
-		// Setup ConvertKit Plugin with no default form specified.
-		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
-		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**
@@ -31,6 +27,10 @@ class PageBlockFormatterFormTriggerCest
 	 */
 	public function testFormTriggerFormatterWithModalForm(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form Trigger Formatter: Modal Form');
 
@@ -81,6 +81,10 @@ class PageBlockFormatterFormTriggerCest
 	 */
 	public function testFormTriggerFormatterToggleFormSelection(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form Trigger Formatter: Modal Form Toggle');
 
@@ -137,6 +141,10 @@ class PageBlockFormatterFormTriggerCest
 	 */
 	public function testFormTriggerFormatterWithNoForm(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form Trigger Formatter: No Form');
 
@@ -171,6 +179,31 @@ class PageBlockFormatterFormTriggerCest
 
 		// Confirm that the link does not display, as no form was selected.
 		$I->dontSeeFormTriggerLinkOutput($I);
+	}
+
+	/**
+	 * Test the Form Trigger formatter is not available when no forms exist in ConvertKit.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFormTriggerFormatterNotRegisteredWhenNoFormsExist(AcceptanceTester $I)
+	{
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form Trigger Formatter: No Forms Exist');
+
+		// Add paragraph to Page.
+		$I->addGutenbergParagraphBlock($I, 'Subscribe');
+
+		// Select text.
+		$I->selectAllText($I, '.wp-block-post-content p[data-empty="false"]');
+
+		// Confirm the formatter is not registered.
+		$I->dontSeeGutenbergFormatter($I, 'ConvertKit Form Trigger');
+
+		// Publish the page, to avoid an alert when navigating away.
+		$I->publishGutenbergPage($I);
 	}
 
 	/**

--- a/tests/acceptance/products/PageBlockFormatterProductLinkCest.php
+++ b/tests/acceptance/products/PageBlockFormatterProductLinkCest.php
@@ -16,10 +16,6 @@ class PageBlockFormatterProductLinkCest
 	public function _before(AcceptanceTester $I)
 	{
 		$I->activateConvertKitPlugin($I);
-
-		// Setup ConvertKit Plugin with no default form specified.
-		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
-		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**
@@ -31,6 +27,10 @@ class PageBlockFormatterProductLinkCest
 	 */
 	public function testProductLinkFormatter(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product Link Formatter');
 
@@ -77,6 +77,10 @@ class PageBlockFormatterProductLinkCest
 	 */
 	public function testProductLinkFormatterToggleProductSelection(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product Link Formatter: Product Toggle');
 
@@ -131,8 +135,12 @@ class PageBlockFormatterProductLinkCest
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testFormLinkFormatterWithNoForm(AcceptanceTester $I)
+	public function testProductLinkFormatterWithNoProduct(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product Link Formatter: No Product');
 
@@ -167,6 +175,31 @@ class PageBlockFormatterProductLinkCest
 
 		// Confirm that the link does not display, as no product was selected.
 		$I->dontSeeElementInDOM('a[data-commerce]');
+	}
+
+	/**
+	 * Test the Product Link formatter is not available when no products exist in ConvertKit.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testProductLinkFormatterNotRegisteredWhenNoProductsExist(AcceptanceTester $I)
+	{
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product Link Formatter: No Products Exist');
+
+		// Add paragraph to Page.
+		$I->addGutenbergParagraphBlock($I, 'Subscribe');
+
+		// Select text.
+		$I->selectAllText($I, '.wp-block-post-content p[data-empty="false"]');
+
+		// Confirm the formatter is not registered.
+		$I->dontSeeGutenbergFormatter($I, 'ConvertKit Product Trigger');
+
+		// Publish the page, to avoid an alert when navigating away.
+		$I->publishGutenbergPage($I);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Only register a block formatter in Gutenberg to link text to a form / product when forms / products exist in ConvertKit,
- Use `$forms` and `$products` class properties.

## Testing

- `PageBlockFormatterFormTriggerCest:testFormTriggerFormatterNotRegisteredWhenNoFormsExist`: Confirm no block formatter to link text to a ConvertKit Form is registered when no Forms exist in ConvertKit.
- `PageBlockFormatterProductLinkCest:testProductLinkFormatterNotRegisteredWhenNoProductsExist`: Confirm no block formatter to link text to a ConvertKit Product is registered when no Products exist in ConvertKit.

## Checklist

* [ ] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](TESTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)