### PR TITLE
Elementor: Form Trigger Button Widget

### DIFF
--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -163,7 +163,7 @@ class WP_ConvertKit {
 		$this->classes['ajax']                           = new ConvertKit_AJAX();
 		$this->classes['blocks_convertkit_broadcasts']   = new ConvertKit_Block_Broadcasts();
 		$this->classes['blocks_convertkit_content']      = new ConvertKit_Block_Content();
-		$this->classes['blocks_convertkit_form_trigger'] = new ConvertKit_Block_Form_Trigger();
+		$this->classes['blocks_convertkit_formtrigger']  = new ConvertKit_Block_Form_Trigger();
 		$this->classes['blocks_convertkit_form']         = new ConvertKit_Block_Form();
 		$this->classes['blocks_convertkit_product']      = new ConvertKit_Block_Product();
 		$this->classes['block_formatter_form_link']      = new ConvertKit_Block_Formatter_Form_Link();

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -160,21 +160,21 @@ class WP_ConvertKit {
 	 */
 	private function initialize_global() {
 
-		$this->classes['ajax']                           = new ConvertKit_AJAX();
-		$this->classes['blocks_convertkit_broadcasts']   = new ConvertKit_Block_Broadcasts();
-		$this->classes['blocks_convertkit_content']      = new ConvertKit_Block_Content();
-		$this->classes['blocks_convertkit_formtrigger']  = new ConvertKit_Block_Form_Trigger();
-		$this->classes['blocks_convertkit_form']         = new ConvertKit_Block_Form();
-		$this->classes['blocks_convertkit_product']      = new ConvertKit_Block_Product();
-		$this->classes['block_formatter_form_link']      = new ConvertKit_Block_Formatter_Form_Link();
-		$this->classes['block_formatter_product_link']   = new ConvertKit_Block_Formatter_Product_Link();
-		$this->classes['elementor']                      = new ConvertKit_Elementor();
-		$this->classes['gutenberg']                      = new ConvertKit_Gutenberg();
-		$this->classes['review_request']                 = new ConvertKit_Review_Request( 'ConvertKit', 'convertkit', CONVERTKIT_PLUGIN_PATH );
-		$this->classes['preview_output']                 = new ConvertKit_Preview_Output();
-		$this->classes['setup']                          = new ConvertKit_Setup();
-		$this->classes['shortcodes']                     = new ConvertKit_Shortcodes();
-		$this->classes['widgets']                        = new ConvertKit_Widgets();
+		$this->classes['ajax']                          = new ConvertKit_AJAX();
+		$this->classes['blocks_convertkit_broadcasts']  = new ConvertKit_Block_Broadcasts();
+		$this->classes['blocks_convertkit_content']     = new ConvertKit_Block_Content();
+		$this->classes['blocks_convertkit_formtrigger'] = new ConvertKit_Block_Form_Trigger();
+		$this->classes['blocks_convertkit_form']        = new ConvertKit_Block_Form();
+		$this->classes['blocks_convertkit_product']     = new ConvertKit_Block_Product();
+		$this->classes['block_formatter_form_link']     = new ConvertKit_Block_Formatter_Form_Link();
+		$this->classes['block_formatter_product_link']  = new ConvertKit_Block_Formatter_Product_Link();
+		$this->classes['elementor']                     = new ConvertKit_Elementor();
+		$this->classes['gutenberg']                     = new ConvertKit_Gutenberg();
+		$this->classes['review_request']                = new ConvertKit_Review_Request( 'ConvertKit', 'convertkit', CONVERTKIT_PLUGIN_PATH );
+		$this->classes['preview_output']                = new ConvertKit_Preview_Output();
+		$this->classes['setup']                         = new ConvertKit_Setup();
+		$this->classes['shortcodes']                    = new ConvertKit_Shortcodes();
+		$this->classes['widgets']                       = new ConvertKit_Widgets();
 
 		// Run the setup's update process on WordPress' init hook.
 		// Doing this sooner may result in errors with WordPress functions that are not yet

--- a/includes/integrations/elementor/class-convertkit-elementor-widget-formtrigger.php
+++ b/includes/integrations/elementor/class-convertkit-elementor-widget-formtrigger.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Elementor Widget: Form Trigger Button.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Registers the ConvertKit Form Trigger Button Block as an Elementor Widget.
+ *
+ * @package ConvertKit
+ * @author  ConvertKit
+ */
+class ConvertKit_Elementor_Widget_FormTrigger extends ConvertKit_Elementor_Widget {
+
+	/**
+	 * The module's slug. Must be different from the block's name i.e. cannot be convertkit-product.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @var     string
+	 */
+	public $slug = 'convertkit-elementor-formtrigger';
+
+}

--- a/tests/acceptance/integrations/ElementorFormTriggerCest.php
+++ b/tests/acceptance/integrations/ElementorFormTriggerCest.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Tests for the ConvertKit Form Trigger Button Elementor Widget.
+ *
+ * @since   2.2.2
+ */
+class ElementorFormTriggerCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'elementor');
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+	}
+
+	/**
+	 * Test the Form Trigger widget is registered in Elementor.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFormTriggerWidgetIsRegistered(AcceptanceTester $I)
+	{
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form Trigger: Elementor: Registered');
+
+		// Click Edit with Elementor button.
+		$I->click('#elementor-switch-mode-button');
+
+		// When Elementor loads, search for the ConvertKit Form Trigger block.
+		$I->waitForElementVisible('#elementor-panel-elements-search-input');
+		$I->fillField('#elementor-panel-elements-search-input', 'ConvertKit Form Trigger');
+
+		// Confirm that the Form Trigger widget is displayed as an option.
+		$I->seeElementInDOM('#elementor-panel-elements .elementor-element');
+	}
+
+	/**
+	 * Test the Form Trigger widget works when using valid parameters.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFormTriggerWidgetWithValidParameters(AcceptanceTester $I)
+	{
+		// Create Page with Form Trigger widget in Elementor.
+		$pageID = $this->_createPageWithFormTriggerWidget(
+			$I,
+			'ConvertKit: Page: Form Trigger: Elementor Widget: Valid Params',
+			[
+				'form' => $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'],
+				'text' => 'Subscribe',
+			]
+		);
+
+		// Load Page.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the form trigger button displays.
+		$I->seeFormTriggerOutput($I, $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_URL'], 'Subscribe');
+	}
+
+	/**
+	 * Test the Form Trigger widget's hex colors work when defined.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFormTriggerWidgetWithHexColorParameters(AcceptanceTester $I)
+	{
+		// Define colors.
+		$backgroundColor = '#ee1616';
+		$textColor       = '#1212c0';
+
+		// Create Page with Form Trigger widget in Elementor.
+		$pageID = $this->_createPageWithFormTriggerWidget(
+			$I,
+			'ConvertKit: Page: Form Trigger: Elementor Widget: Hex Colors',
+			[
+				'form'             => $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'],
+				'text'             => 'Subscribe',
+				'background_color' => $backgroundColor,
+				'text_color'       => $textColor,
+			]
+		);
+
+		// Load Page.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the form trigger button displays.
+		$I->seeFormTriggerOutput($I, $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_URL'], 'Subscribe', $textColor, $backgroundColor);
+	}
+
+	/**
+	 * Create a Page in the database comprising of Elementor Page Builder data
+	 * containing a ConvertKit Form widget.
+	 *
+	 * Codeception's dragAndDrop() method doesn't support dropping an element into an iframe, which is
+	 * how Elementor works for adding widgets to a Page.
+	 *
+	 * Therefore, we directly create a Page in the database, with Elementor's data structure
+	 * as if we added the Form Trigger widget to a Page edited in Elementor.
+	 *
+	 * testFormTriggerWidgetIsRegistered() above is a sanity check that the Form Trigger Widget is registered
+	 * and available to users in Elementor.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   AcceptanceTester $I          Tester.
+	 * @param   string           $title      Page Title.
+	 * @param   array            $settings   Widget settings.
+	 * @return  int                             Page ID
+	 */
+	private function _createPageWithFormTriggerWidget(AcceptanceTester $I, $title, $settings)
+	{
+		return $I->havePostInDatabase(
+			[
+				'post_title'  => $title,
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'meta_input'  => [
+					// Elementor.
+					'_elementor_data'          => [
+						0 => [
+							'id'       => '39bb59e',
+							'elType'   => 'section',
+							'settings' => [],
+							'elements' => [
+								[
+									'id'       => 'b7e0e58',
+									'elType'   => 'column',
+									'settings' => [
+										'_column_size' => 100,
+										'_inline_size' => null,
+									],
+									'elements' => [
+										[
+											'id'         => 'a73a906',
+											'elType'     => 'widget',
+											'settings'   => $settings,
+											'widgetType' => 'convertkit-elementor-formtrigger',
+										],
+									],
+								],
+							],
+						],
+					],
+					'_elementor_version'       => '3.6.1',
+					'_elementor_edit_mode'     => 'builder',
+					'_elementor_template_type' => 'wp-page',
+
+					// Configure ConvertKit Plugin to not display a default Form,
+					// as we are testing for the Form in Elementor.
+					'_wp_convertkit_post_meta' => [
+						'form'         => '0',
+						'landing_page' => '',
+						'tag'          => '',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateThirdPartyPlugin($I, 'elementor');
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
+	}
+}


### PR DESCRIPTION
## Summary

Registers the [Form Trigger button](https://github.com/ConvertKit/convertkit-wordpress/pull/456) as an Elementor widget

![Screenshot 2023-05-16 at 15 08 01](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/2bfb60c1-3b00-4655-9c30-7fccf1778b83)

## Testing

- `ElementorFormTriggerCest`: Add tests to confirm the Form Trigger button registers as an Elementor widget and works when configured.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)