### PR TITLE
Remove all PHPStan ignores

### DIFF
--- a/includes/class-convertkit-output-restrict-content.php
+++ b/includes/class-convertkit-output-restrict-content.php
@@ -21,7 +21,7 @@ class ConvertKit_Output_Restrict_Content {
 	 *
 	 * @var     bool|string
 	 */
-	private $success = false; // @phpstan-ignore-line.
+	private $success = false;
 
 	/**
 	 * Holds the WP_Error object if an API call / authentication failed,
@@ -31,7 +31,7 @@ class ConvertKit_Output_Restrict_Content {
 	 *
 	 * @var     bool|WP_Error
 	 */
-	private $error = false; // @phpstan-ignore-line.
+	private $error = false;
 
 	/**
 	 * Holds the ConvertKit Plugin Settings class
@@ -719,6 +719,10 @@ class ConvertKit_Output_Restrict_Content {
 	 * @return  string                  HTML
 	 */
 	private function get_call_to_action( $post_id, $resource_type, $resource_id ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
+
+		// Read success and error notices from this class.
+		$success = $this->success;
+		$error = $this->error;
 
 		// This is deliberately a switch statement, because we will likely add in support
 		// for restrict by tag and form later.

--- a/includes/class-convertkit-output-restrict-content.php
+++ b/includes/class-convertkit-output-restrict-content.php
@@ -722,7 +722,7 @@ class ConvertKit_Output_Restrict_Content {
 
 		// Read success and error notices from this class.
 		$success = $this->success;
-		$error = $this->error;
+		$error   = $this->error;
 
 		// This is deliberately a switch statement, because we will likely add in support
 		// for restrict by tag and form later.

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -21,7 +21,7 @@ class WP_ConvertKit {
 	 *
 	 * @var     object
 	 */
-	public static $instance;
+	private static $instance;
 
 	/**
 	 * Holds singleton initialized classes that include
@@ -362,7 +362,7 @@ class WP_ConvertKit {
 	 */
 	public function load_language_files() {
 
-		load_plugin_textdomain( 'convertkit', false, basename( dirname( CONVERTKIT_PLUGIN_FILE ) ) . '/languages/' );  // @phpstan-ignore-line.
+		load_plugin_textdomain( 'convertkit', false, 'convertkit/languages' );
 
 	}
 
@@ -419,9 +419,9 @@ class WP_ConvertKit {
 	 */
 	public static function get_instance() {
 
-		if ( ! isset( self::$instance ) && ! ( self::$instance instanceof self ) ) {  // @phpstan-ignore-line.
-			self::$instance = new self();
-		}
+		if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
 
 		return self::$instance;
 

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -356,12 +356,15 @@ class WP_ConvertKit {
 	}
 
 	/**
-	 * Loads plugin textdomain
+	 * Loads the plugin's translated strings, if available.
 	 *
 	 * @since   1.0.0
 	 */
 	public function load_language_files() {
 
+		// If the .mo file for a given language is available in WP_LANG_DIR/convertkit
+		// i.e. it's available as a translation at https://translate.wordpress.org/projects/wp-plugins/convertkit/,
+		// it will be used instead of the .mo file in convertkit/languages.
 		load_plugin_textdomain( 'convertkit', false, 'convertkit/languages' );
 
 	}
@@ -420,8 +423,8 @@ class WP_ConvertKit {
 	public static function get_instance() {
 
 		if ( null === self::$instance ) {
-            self::$instance = new self();
-        }
+			self::$instance = new self();
+		}
 
 		return self::$instance;
 

--- a/includes/integrations/contactform7/class-convertkit-contactform7-settings.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-settings.php
@@ -72,9 +72,6 @@ class ConvertKit_ContactForm7_Settings {
 		if ( empty( $this->get() ) ) {
 			return false;
 		}
-		if ( count( $this->get() ) === 0 ) { // @phpstan-ignore-line.
-			return false;
-		}
 
 		return true;
 

--- a/includes/integrations/wishlist/class-convertkit-wishlist-settings.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist-settings.php
@@ -72,9 +72,6 @@ class ConvertKit_Wishlist_Settings {
 		if ( empty( $this->get() ) ) {
 			return false;
 		}
-		if ( count( $this->get() ) === 0 ) { // @phpstan-ignore-line.
-			return false;
-		}
 
 		return true;
 

--- a/views/frontend/restrict-content/notices.php
+++ b/views/frontend/restrict-content/notices.php
@@ -7,19 +7,19 @@
  */
 
 // If a success message exists, show it now.
-if ( $this->success !== false ) {
+if ( $success !== false ) {
 	?>
 	<div class="convertkit-restrict-content-notice convertkit-restrict-content-notice-success">
-		<?php echo esc_html( $this->success ); ?>
+		<?php echo esc_html( $success ); ?>
 	</div>
 	<?php
 }
 
 // If an error occured, show it now.
-if ( is_wp_error( $this->error ) ) {
+if ( is_wp_error( $error ) ) {
 	?>
 	<div class="convertkit-restrict-content-notice convertkit-restrict-content-notice-error">
-		<?php echo esc_html( $this->error->get_error_message() ); ?>
+		<?php echo esc_html( $error->get_error_message() ); ?>
 	</div>
 	<?php
 }


### PR DESCRIPTION
## Summary

Removes the few remaining PHPStan ignore directives in our code by making the applicable improvements to pass PHPStan static analysis.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)