### PR TITLE
Remove blanket phpcs:ignore rules

### DIFF
--- a/admin/section/class-convertkit-settings-tools.php
+++ b/admin/section/class-convertkit-settings-tools.php
@@ -177,7 +177,7 @@ class ConvertKit_Settings_Tools extends ConvertKit_Settings_Base {
 		header( 'Content-Disposition: attachment; filename=convertkit-export.json' );
 		header( 'Pragma: no-cache' );
 		header( 'Expires: 0' );
-		echo $json; /* phpcs:ignore */
+		echo $json; // phpcs:ignore WordPress.Security.EscapeOutput
 		exit();
 
 	}

--- a/includes/block-formatters/class-convertkit-block-formatter-form-link.php
+++ b/includes/block-formatters/class-convertkit-block-formatter-form-link.php
@@ -75,7 +75,7 @@ class ConvertKit_Block_Formatter_Form_Link extends ConvertKit_Block_Formatter {
 			'icon'           => 'resources/backend/images/block-icon-formtrigger.png',
 
 			// Gutenberg: Block Icon in Editor.
-			'gutenberg_icon'    => file_get_contents( CONVERTKIT_PLUGIN_PATH . '/resources/backend/images/block-icon-formtrigger.svg' ), /* phpcs:ignore */
+			'gutenberg_icon' => $this->get_file_contents( CONVERTKIT_PLUGIN_PATH . '/resources/backend/images/block-icon-formtrigger.svg' ),
 		);
 
 	}

--- a/includes/block-formatters/class-convertkit-block-formatter-product-link.php
+++ b/includes/block-formatters/class-convertkit-block-formatter-product-link.php
@@ -72,7 +72,7 @@ class ConvertKit_Block_Formatter_Product_Link extends ConvertKit_Block_Formatter
 			'icon'           => 'resources/backend/images/block-icon-product.png',
 
 			// Gutenberg: Block Icon in Editor.
-			'gutenberg_icon'    => file_get_contents( CONVERTKIT_PLUGIN_PATH . '/resources/backend/images/block-icon-product.svg' ), /* phpcs:ignore */
+			'gutenberg_icon' => $this->get_file_contents( CONVERTKIT_PLUGIN_PATH . '/resources/backend/images/block-icon-product.svg' ),
 		);
 
 	}

--- a/includes/block-formatters/class-convertkit-block-formatter.php
+++ b/includes/block-formatters/class-convertkit-block-formatter.php
@@ -106,4 +106,30 @@ class ConvertKit_Block_Formatter {
 
 	}
 
+	/**
+	 * Return the contents of the given local file.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   string $local_file     Local file, including path.
+	 * @return  string                  File contents.
+	 */
+	public function get_file_contents( $local_file ) {
+
+		// Call globals.
+		global $wp_filesystem;
+
+		// Initiate.
+		WP_Filesystem();
+
+		// Bail if the file doesn't exist.
+		if ( ! $wp_filesystem->exists( $local_file ) ) {
+			return '';
+		}
+
+		// Return file's contents.
+		return $wp_filesystem->get_contents( $local_file );
+
+	}
+
 }

--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -139,7 +139,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 			'shortcode_include_closing_tag'     => false,
 
 			// Gutenberg: Block Icon in Editor.
-			'gutenberg_icon'                		=> file_get_contents( CONVERTKIT_PLUGIN_PATH . '/resources/backend/images/block-icon-broadcasts.svg' ), /* phpcs:ignore */
+			'gutenberg_icon'                    => $this->get_file_contents( CONVERTKIT_PLUGIN_PATH . '/resources/backend/images/block-icon-broadcasts.svg' ),
 
 			// Gutenberg: Example image showing how this block looks when choosing it in Gutenberg.
 			'gutenberg_example_image'           => CONVERTKIT_PLUGIN_URL . 'resources/backend/images/block-example-broadcasts.png',

--- a/includes/blocks/class-convertkit-block-form-trigger.php
+++ b/includes/blocks/class-convertkit-block-form-trigger.php
@@ -103,7 +103,7 @@ class ConvertKit_Block_Form_Trigger extends ConvertKit_Block {
 			'shortcode_include_closing_tag'     => false,
 
 			// Gutenberg: Block Icon in Editor.
-			'gutenberg_icon'                => file_get_contents( CONVERTKIT_PLUGIN_PATH . '/resources/backend/images/block-icon-formtrigger.svg' ), /* phpcs:ignore */
+			'gutenberg_icon'                    => $this->get_file_contents( CONVERTKIT_PLUGIN_PATH . '/resources/backend/images/block-icon-formtrigger.svg' ),
 
 			// Gutenberg: Example image showing how this block looks when choosing it in Gutenberg.
 			'gutenberg_example_image'           => CONVERTKIT_PLUGIN_URL . 'resources/backend/images/block-example-formtrigger.png',

--- a/includes/blocks/class-convertkit-block-form.php
+++ b/includes/blocks/class-convertkit-block-form.php
@@ -108,7 +108,7 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 			'shortcode_include_closing_tag'     => false,
 
 			// Gutenberg: Block Icon in Editor.
-			'gutenberg_icon'                    => file_get_contents( CONVERTKIT_PLUGIN_PATH . '/resources/backend/images/block-icon-form.svg' ), /* phpcs:ignore */
+			'gutenberg_icon'                    => $this->get_file_contents( CONVERTKIT_PLUGIN_PATH . '/resources/backend/images/block-icon-form.svg' ),
 
 			// Gutenberg: Example image showing how this block looks when choosing it in Gutenberg.
 			'gutenberg_example_image'           => CONVERTKIT_PLUGIN_URL . 'resources/backend/images/block-example-form.png',

--- a/includes/blocks/class-convertkit-block-product.php
+++ b/includes/blocks/class-convertkit-block-product.php
@@ -125,7 +125,7 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 			'shortcode_include_closing_tag'     => false,
 
 			// Gutenberg: Block Icon in Editor.
-			'gutenberg_icon'                => file_get_contents( CONVERTKIT_PLUGIN_PATH . '/resources/backend/images/block-icon-product.svg' ), /* phpcs:ignore */
+			'gutenberg_icon'                    => $this->get_file_contents( CONVERTKIT_PLUGIN_PATH . '/resources/backend/images/block-icon-product.svg' ),
 
 			// Gutenberg: Example image showing how this block looks when choosing it in Gutenberg.
 			'gutenberg_example_image'           => CONVERTKIT_PLUGIN_URL . 'resources/backend/images/block-example-product.png',

--- a/includes/blocks/class-convertkit-block.php
+++ b/includes/blocks/class-convertkit-block.php
@@ -379,4 +379,30 @@ class ConvertKit_Block {
 
 	}
 
+	/**
+	 * Return the contents of the given local file.
+	 *
+	 * @since   2.2.2
+	 *
+	 * @param   string $local_file     Local file, including path.
+	 * @return  string                  File contents.
+	 */
+	public function get_file_contents( $local_file ) {
+
+		// Call globals.
+		global $wp_filesystem;
+
+		// Initiate.
+		WP_Filesystem();
+
+		// Bail if the file doesn't exist.
+		if ( ! $wp_filesystem->exists( $local_file ) ) {
+			return '';
+		}
+
+		// Return file's contents.
+		return $wp_filesystem->get_contents( $local_file );
+
+	}
+
 }

--- a/views/backend/post/meta-box.php
+++ b/views/backend/post/meta-box.php
@@ -39,15 +39,12 @@
 						<span class="dashicons dashicons-update"></span>
 					</button>
 					<p class="description">
-						<?php
-						printf(
-							/* translators: settings url */
-							__( '<code>Default</code>: Uses the form specified on the <a href="%s" target="_blank">settings page</a>.', 'convertkit' ), /* phpcs:ignore */
-							esc_attr( esc_url( $settings_link ) )
-						);
-						?>
+						<code><?php esc_html_e( 'Default', 'convertkit' ); ?></code>
+						<?php esc_html_e( ': Uses the form specified on the', 'convertkit' ); ?>
+						<a href="<?php echo esc_url( $settings_link ); ?>"><?php esc_html_e( 'settings page', 'convertkit' ); ?></a>
 						<br />
-						<?php _e( '<code>None</code>: do not display a form.', 'convertkit' ); /* phpcs:ignore */ ?>
+						<code><?php esc_html_e( 'None', 'convertkit' ); ?></code>
+						<?php esc_html_e( ': do not display a form.', 'convertkit' ); ?>
 						<br />
 						<?php esc_html_e( 'Any other option will display that form after the main content.', 'convertkit' ); ?>
 						<br />

--- a/views/backend/term/fields-add.php
+++ b/views/backend/term/fields-add.php
@@ -31,7 +31,8 @@
 			<span class="dashicons dashicons-update"></span>
 		</button>
 		<p class="description">
-			<?php _e( '<code>Default</code>: Display a form based on the Post\'s settings.', 'convertkit' ); /* phpcs:ignore */ ?>
+			<code><?php esc_html_e( 'Default', 'convertkit' ); ?></code>
+			<?php esc_html_e( ': Display a form based on the Post\'s settings.', 'convertkit' ); ?>
 			<br />
 			<?php
 			echo sprintf(

--- a/views/backend/term/fields-edit.php
+++ b/views/backend/term/fields-edit.php
@@ -33,7 +33,8 @@
 				<span class="dashicons dashicons-update"></span>
 			</button>
 			<p class="description">
-				<?php _e( '<code>Default</code>: Display a form based on the Post\'s settings.', 'convertkit' ); /* phpcs:ignore */ ?>
+				<code><?php esc_html_e( 'Default', 'convertkit' ); ?></code>
+				<?php esc_html_e( ': Display a form based on the Post\'s settings.', 'convertkit' ); ?>
 				<br />
 				<?php
 				echo sprintf(


### PR DESCRIPTION
## Summary

Improve output of HTML, removing the need to use blanket `/* phpcs:ignore */` directives.

Uses the `WP_Filesystem` class for reading contents of SVG icons per WordPress Coding Standards.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)