### PR TITLE
WP_List_Table: cast `total_pages` as an integer

### DIFF
--- a/admin/class-multi-value-field-table.php
+++ b/admin/class-multi-value-field-table.php
@@ -180,7 +180,7 @@ class Multi_Value_Field_Table extends WP_List_Table {
 
 		$this->set_pagination_args(
 			array(
-				'total_items' => $total_items,
+				'total_items' => (int) $total_items,
 				'per_page'    => $per_page,
 				'total_pages' => ceil( $total_items / $per_page ),
 			)

--- a/admin/class-multi-value-field-table.php
+++ b/admin/class-multi-value-field-table.php
@@ -180,9 +180,9 @@ class Multi_Value_Field_Table extends WP_List_Table {
 
 		$this->set_pagination_args(
 			array(
-				'total_items' => (int) $total_items,
+				'total_items' => $total_items,
 				'per_page'    => $per_page,
-				'total_pages' => ceil( $total_items / $per_page ),
+				'total_pages' => (int) ceil( $total_items / $per_page ),
 			)
 		);
 


### PR DESCRIPTION
## Summary

Sets `total_pages` as an integer, as required by `WP_List_Table::set_pagination_args()`

![Screenshot 2023-05-30 at 14 01 56](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/b4011559-1465-4f62-b806-cf8d3e06cc0d)

## Testing

Not sure how to perform testing, or perhaps didn't include a test in this PR? Walk through the following in order for a beginner-friendly guide:
- [Setup](SETUP.md) - setting up your local environment for development and testing
- [Development](DEVELOPMENT.md) - best practices for development
- [Testing](TESTING.md) - how to write and run tests

## Checklist

* [ ] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](TESTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)