### PR TITLE
Add description to Disable CSS setting

### DIFF
--- a/admin/section/class-convertkit-settings-base.php
+++ b/admin/section/class-convertkit-settings-base.php
@@ -314,12 +314,12 @@ abstract class ConvertKit_Settings_Base {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @param   string      $name           Name.
-	 * @param   string      $value          Value.
-	 * @param   bool        $checked        Should checkbox be checked/ticked.
-	 * @param   bool|string $label          Label.
-	 * @param   bool|string $description    Description.
-	 * @return  string                      HTML Checkbox
+	 * @param   string      	  $name           Name.
+	 * @param   string      	  $value          Value.
+	 * @param   bool        	  $checked        Should checkbox be checked/ticked.
+	 * @param   bool|string 	  $label          Label.
+	 * @param   bool|string|array $description    Description.
+	 * @return  string                      	  HTML Checkbox
 	 */
 	public function get_checkbox_field( $name, $value, $checked = false, $label = '', $description = '' ) {
 

--- a/admin/section/class-convertkit-settings-base.php
+++ b/admin/section/class-convertkit-settings-base.php
@@ -314,12 +314,12 @@ abstract class ConvertKit_Settings_Base {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @param   string      	  $name           Name.
-	 * @param   string      	  $value          Value.
-	 * @param   bool        	  $checked        Should checkbox be checked/ticked.
-	 * @param   bool|string 	  $label          Label.
+	 * @param   string            $name           Name.
+	 * @param   string            $value          Value.
+	 * @param   bool              $checked        Should checkbox be checked/ticked.
+	 * @param   bool|string       $label          Label.
 	 * @param   bool|string|array $description    Description.
-	 * @return  string                      	  HTML Checkbox
+	 * @return  string                            HTML Checkbox
 	 */
 	public function get_checkbox_field( $name, $value, $checked = false, $label = '', $description = '' ) {
 

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -492,7 +492,7 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 					esc_html__( 'For developers who require custom form designs through use of CSS, consider using the', 'convertkit' ),
 					esc_html__( 'or', 'convertkit' ),
 					esc_html__( 'integrations.', 'convertkit' )
-				)
+				),
 			)
 		);
 

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -479,7 +479,21 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 			'no_css',
 			'on',
 			$this->settings->css_disabled(), // phpcs:ignore WordPress.Security.EscapeOutput
-			esc_html__( 'Prevent plugin from loading CSS files. This will disable styling on broadcasts, product buttons and member\'s content. Use with caution!', 'convertkit' )
+			esc_html__( 'Prevents loading plugin CSS files. This will disable styling on broadcasts, form trigger buttons, product buttons and member\'s content. Use with caution!', 'convertkit' ),
+			array(
+				sprintf(
+					'%s <a href="%s" target="_blank">%s</a>',
+					esc_html__( 'To customize forms and their styling, use the', 'convertkit' ),
+					esc_url( convertkit_get_form_editor_url() ),
+					esc_html__( 'ConvertKit form editor', 'convertkit' )
+				),
+				sprintf(
+					'%s <a href="https://wordpress.org/plugins/contact-form-7/" target="_blank">Contact Form 7</a>, <a href="https://wordpress.org/plugins/convertkit-gravity-forms/" target="_blank">Gravity Forms</a> %s <a href="https://wordpress.org/plugins/integrate-convertkit-wpforms/" target="_blank">WPForms</a> %s',
+					esc_html__( 'For developers who require custom form designs through use of CSS, consider using the', 'convertkit' ),
+					esc_html__( 'or', 'convertkit' ),
+					esc_html__( 'integrations.', 'convertkit' )
+				)
+			)
 		);
 
 	}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -305,6 +305,26 @@ function convertkit_get_api_key_url() {
 }
 
 /**
+ * Helper method to return the URL the user needs to visit to edit ConvertKit forms.
+ *
+ * @since   2.2.3
+ *
+ * @return  string  ConvertKit Form Editor URL.
+ */
+function convertkit_get_form_editor_url() {
+
+	return add_query_arg(
+		array(
+			'utm_source'  => 'wordpress',
+			'utm_term'    => get_locale(),
+			'utm_content' => 'convertkit',
+		),
+		'https://app.convertkit.com/forms'
+	);
+
+}
+
+/**
  * Helper method to enqueue Select2 scripts for use within the ConvertKit Plugin.
  *
  * @since   1.9.6.4

--- a/tests/acceptance/general/PluginSettingsGeneralCest.php
+++ b/tests/acceptance/general/PluginSettingsGeneralCest.php
@@ -435,7 +435,7 @@ class PluginSettingsGeneralCest
 
 		// Confirm no CSS is output by the Plugin.
 		$I->dontSeeInSource('broadcasts.css');
-		$I->dontSeeInSource('button.css');
+		$I->dontSeeInSource('button.css');		
 
 		// Go to the Plugin's Settings Screen.
 		$I->loadConvertKitSettingsGeneralScreen($I);


### PR DESCRIPTION
## Summary

Following this [review feedback](https://wordpress.org/support/topic/poor-ui-for-advanced-developer/), where the developer states that the `Disable CSS` checkbox did not work (as it rightly cannot control embedded forms), this PR adds a description below the `Disable CSS` setting with steps that can be taken to edit forms and their styling, and options for developers looking for complete form styling customisation through CSS (i.e. use of a WordPress forms plugin, with applicable ConvertKit plugin integration).

![Screenshot 2023-05-30 at 14 19 21](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/65c3f9f7-8fdd-4530-b723-ef48c60b2313)

Open to any suggestions to make the wording here as clear as possible.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)