### PR TITLE
Product Block: Display link to enter API Key or add Form in ConvertKit

### DIFF
--- a/includes/blocks/class-convertkit-block-form.php
+++ b/includes/blocks/class-convertkit-block-form.php
@@ -85,6 +85,9 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 	 */
 	public function get_overview() {
 
+		$convertkit_forms = new ConvertKit_Resource_Forms( 'block_edit' );
+		$settings = new ConvertKit_Settings();
+
 		return array(
 			'title'                             => __( 'ConvertKit Form', 'convertkit' ),
 			'description'                       => __( 'Displays a ConvertKit Form.', 'convertkit' ),
@@ -113,8 +116,18 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 			// Gutenberg: Example image showing how this block looks when choosing it in Gutenberg.
 			'gutenberg_example_image'           => CONVERTKIT_PLUGIN_URL . 'resources/backend/images/block-example-form.png',
 
-			// Gutenberg: Help description, displayed when no settings defined for a newly added Block.
-			'gutenberg_help_description'        => __( 'Select a Form using the Form option in the Gutenberg sidebar.', 'convertkit' ),
+			// Gutenberg: Help descriptions, displayed when no settings defined for a newly added Block, or API keys / forms don't exist.
+			'gutenberg_help_description_no_api_key' 	=> array(
+				'notice' 	=> __( 'No API Key specified.', 'convertkit' ),
+				'link' 		=> convertkit_get_settings_link(),
+				'link_text' => __( 'Click here to add your API Key.', 'convertkit' )
+			),
+			'gutenberg_help_description_no_resources' 	=> array(
+				'notice' 	=> __( 'No forms exist in ConvertKit.', 'convertkit' ),
+				'link' 		=> convertkit_get_new_form_url(),
+				'link_text' => __( 'Click here to create your first form.', 'convertkit' )
+			),
+			'gutenberg_help_description' 				=> __( 'Select a Form using the Form option in the Gutenberg sidebar.', 'convertkit' ),
 
 			// Gutenberg: JS function to call when rendering the block preview in the Gutenberg editor.
 			// If not defined, render_callback above will be used.
@@ -131,6 +144,11 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 				/* translators: Form name in ConvertKit */
 				'gutenberg_form_sticky_bar' => __( 'Sticky bar form "%s" selected. View on the frontend site to see the sticky bar form.', 'convertkit' ),
 			),
+
+			// Whether an API Key exists in the Plugin, and are the required resources (forms) available.
+			// If no API Key is specified in the Plugin's settings, render the "No API Key" output.
+			'has_api_key' 	=> $settings->has_api_key_and_secret(),
+			'has_resources' => $convertit_forms->exist(),
 		);
 
 	}

--- a/includes/blocks/class-convertkit-block-form.php
+++ b/includes/blocks/class-convertkit-block-form.php
@@ -86,55 +86,55 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 	public function get_overview() {
 
 		$convertkit_forms = new ConvertKit_Resource_Forms( 'block_edit' );
-		$settings = new ConvertKit_Settings();
+		$settings         = new ConvertKit_Settings();
 
 		return array(
-			'title'                             => __( 'ConvertKit Form', 'convertkit' ),
-			'description'                       => __( 'Displays a ConvertKit Form.', 'convertkit' ),
-			'icon'                              => 'resources/backend/images/block-icon-form.png',
-			'category'                          => 'convertkit',
-			'keywords'                          => array(
+			'title'                                   => __( 'ConvertKit Form', 'convertkit' ),
+			'description'                             => __( 'Displays a ConvertKit Form.', 'convertkit' ),
+			'icon'                                    => 'resources/backend/images/block-icon-form.png',
+			'category'                                => 'convertkit',
+			'keywords'                                => array(
 				__( 'ConvertKit', 'convertkit' ),
 				__( 'Form', 'convertkit' ),
 			),
 
 			// Function to call when rendering as a block or a shortcode on the frontend web site.
-			'render_callback'                   => array( $this, 'render' ),
+			'render_callback'                         => array( $this, 'render' ),
 
 			// Shortcode: TinyMCE / QuickTags Modal Width and Height.
-			'modal'                             => array(
+			'modal'                                   => array(
 				'width'  => 500,
 				'height' => 100,
 			),
 
 			// Shortcode: Include a closing [/shortcode] tag when using TinyMCE or QuickTag Modals.
-			'shortcode_include_closing_tag'     => false,
+			'shortcode_include_closing_tag'           => false,
 
 			// Gutenberg: Block Icon in Editor.
-			'gutenberg_icon'                    => convertkit_get_file_contents( CONVERTKIT_PLUGIN_PATH . '/resources/backend/images/block-icon-form.svg' ),
+			'gutenberg_icon'                          => convertkit_get_file_contents( CONVERTKIT_PLUGIN_PATH . '/resources/backend/images/block-icon-form.svg' ),
 
 			// Gutenberg: Example image showing how this block looks when choosing it in Gutenberg.
-			'gutenberg_example_image'           => CONVERTKIT_PLUGIN_URL . 'resources/backend/images/block-example-form.png',
+			'gutenberg_example_image'                 => CONVERTKIT_PLUGIN_URL . 'resources/backend/images/block-example-form.png',
 
 			// Gutenberg: Help descriptions, displayed when no settings defined for a newly added Block, or API keys / forms don't exist.
-			'gutenberg_help_description_no_api_key' 	=> array(
-				'notice' 	=> __( 'No API Key specified.', 'convertkit' ),
-				'link' 		=> convertkit_get_settings_link(),
-				'link_text' => __( 'Click here to add your API Key.', 'convertkit' )
+			'gutenberg_help_description_no_api_key'   => array(
+				'notice'    => __( 'No API Key specified.', 'convertkit' ),
+				'link'      => convertkit_get_settings_link(),
+				'link_text' => __( 'Click here to add your API Key.', 'convertkit' ),
 			),
-			'gutenberg_help_description_no_resources' 	=> array(
-				'notice' 	=> __( 'No forms exist in ConvertKit.', 'convertkit' ),
-				'link' 		=> convertkit_get_new_form_url(),
-				'link_text' => __( 'Click here to create your first form.', 'convertkit' )
+			'gutenberg_help_description_no_resources' => array(
+				'notice'    => __( 'No forms exist in ConvertKit.', 'convertkit' ),
+				'link'      => convertkit_get_new_form_url(),
+				'link_text' => __( 'Click here to create your first form.', 'convertkit' ),
 			),
-			'gutenberg_help_description' 				=> __( 'Select a Form using the Form option in the Gutenberg sidebar.', 'convertkit' ),
+			'gutenberg_help_description'              => __( 'Select a Form using the Form option in the Gutenberg sidebar.', 'convertkit' ),
 
 			// Gutenberg: JS function to call when rendering the block preview in the Gutenberg editor.
 			// If not defined, render_callback above will be used.
-			'gutenberg_preview_render_callback' => 'convertKitGutenbergFormBlockRenderPreview',
+			'gutenberg_preview_render_callback'       => 'convertKitGutenbergFormBlockRenderPreview',
 
 			// General: Any other strings for use in JS that need to support translation / i18n.
-			'i18n'                              => array(
+			'i18n'                                    => array(
 				/* translators: Form name in ConvertKit */
 				'gutenberg_form_modal'      => __( 'Modal form "%s" selected. View on the frontend site to see the modal form.', 'convertkit' ),
 
@@ -147,8 +147,8 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 
 			// Whether an API Key exists in the Plugin, and are the required resources (forms) available.
 			// If no API Key is specified in the Plugin's settings, render the "No API Key" output.
-			'has_api_key' 	=> $settings->has_api_key_and_secret(),
-			'has_resources' => $convertit_forms->exist(),
+			'has_api_key'                             => $settings->has_api_key_and_secret(),
+			'has_resources'                           => $convertkit_forms->exist(),
 		);
 
 	}

--- a/includes/blocks/class-convertkit-block-product.php
+++ b/includes/blocks/class-convertkit-block-product.php
@@ -102,40 +102,58 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 	 */
 	public function get_overview() {
 
+		$convertkit_products = new ConvertKit_Resource_Products( 'block_edit' );
+		$settings            = new ConvertKit_Settings();
+
 		return array(
-			'title'                             => __( 'ConvertKit Product', 'convertkit' ),
-			'description'                       => __( 'Displays a button to purchase a ConvertKit product.', 'convertkit' ),
-			'icon'                              => 'resources/backend/images/block-icon-product.png',
-			'category'                          => 'convertkit',
-			'keywords'                          => array(
+			'title'                                   => __( 'ConvertKit Product', 'convertkit' ),
+			'description'                             => __( 'Displays a button to purchase a ConvertKit product.', 'convertkit' ),
+			'icon'                                    => 'resources/backend/images/block-icon-product.png',
+			'category'                                => 'convertkit',
+			'keywords'                                => array(
 				__( 'ConvertKit', 'convertkit' ),
 				__( 'Product', 'convertkit' ),
 			),
 
 			// Function to call when rendering as a block or a shortcode on the frontend web site.
-			'render_callback'                   => array( $this, 'render' ),
+			'render_callback'                         => array( $this, 'render' ),
 
 			// Shortcode: TinyMCE / QuickTags Modal Width and Height.
-			'modal'                             => array(
+			'modal'                                   => array(
 				'width'  => 500,
 				'height' => 290,
 			),
 
 			// Shortcode: Include a closing [/shortcode] tag when using TinyMCE or QuickTag Modals.
-			'shortcode_include_closing_tag'     => false,
+			'shortcode_include_closing_tag'           => false,
 
 			// Gutenberg: Block Icon in Editor.
-			'gutenberg_icon'                    => convertkit_get_file_contents( CONVERTKIT_PLUGIN_PATH . '/resources/backend/images/block-icon-product.svg' ),
+			'gutenberg_icon'                          => convertkit_get_file_contents( CONVERTKIT_PLUGIN_PATH . '/resources/backend/images/block-icon-product.svg' ),
 
 			// Gutenberg: Example image showing how this block looks when choosing it in Gutenberg.
-			'gutenberg_example_image'           => CONVERTKIT_PLUGIN_URL . 'resources/backend/images/block-example-product.png',
+			'gutenberg_example_image'                 => CONVERTKIT_PLUGIN_URL . 'resources/backend/images/block-example-product.png',
 
-			// Gutenberg: Help description, displayed when no settings defined for a newly added Block.
-			'gutenberg_help_description'        => __( 'Select a Product using the Product option in the Gutenberg sidebar.', 'convertkit' ),
+			// Gutenberg: Help descriptions, displayed when no settings defined for a newly added Block, or API keys / products don't exist.
+			'gutenberg_help_description_no_api_key'   => array(
+				'notice'    => __( 'No API Key specified.', 'convertkit' ),
+				'link'      => convertkit_get_settings_link(),
+				'link_text' => __( 'Click here to add your API Key.', 'convertkit' ),
+			),
+			'gutenberg_help_description_no_resources' => array(
+				'notice'    => __( 'No products exist in ConvertKit.', 'convertkit' ),
+				'link'      => convertkit_get_new_product_url(),
+				'link_text' => __( 'Click here to create your first product.', 'convertkit' ),
+			),
+			'gutenberg_help_description'              => __( 'Select a Product using the Product option in the Gutenberg sidebar.', 'convertkit' ),
 
 			// Gutenberg: JS function to call when rendering the block preview in the Gutenberg editor.
 			// If not defined, render_callback above will be used.
-			'gutenberg_preview_render_callback' => 'convertKitGutenbergProductBlockRenderPreview',
+			'gutenberg_preview_render_callback'       => 'convertKitGutenbergProductBlockRenderPreview',
+
+			// Whether an API Key exists in the Plugin, and are the required resources (products) available.
+			// If no API Key is specified in the Plugin's settings, render the "No API Key" output.
+			'has_api_key'                             => $settings->has_api_key_and_secret(),
+			'has_resources'                           => $convertkit_products->exist(),
 		);
 
 	}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -306,10 +306,10 @@ function convertkit_get_api_key_url() {
 
 /**
  * Helper method to return the URL the user needs to visit on the ConvertKit app to create a new Form or Landing Page.
- * 
- * @since 	2.2.3
- * 
- * @return 	string 	ConvertKit App URL.
+ *
+ * @since   2.2.3
+ *
+ * @return  string  ConvertKit App URL.
  */
 function convertkit_get_new_form_url() {
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -305,6 +305,26 @@ function convertkit_get_api_key_url() {
 }
 
 /**
+ * Helper method to return the URL the user needs to visit on the ConvertKit app to create a new Form or Landing Page.
+ * 
+ * @since 	2.2.3
+ * 
+ * @return 	string 	ConvertKit App URL.
+ */
+function convertkit_get_new_form_url() {
+
+	return add_query_arg(
+		array(
+			'utm_source'  => 'wordpress',
+			'utm_term'    => get_locale(),
+			'utm_content' => 'convertkit',
+		),
+		'https://app.convertkit.com/forms/designers/new/'
+	);
+
+}
+
+/**
  * Helper method to enqueue Select2 scripts for use within the ConvertKit Plugin.
  *
  * @since   1.9.6.4

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -345,6 +345,26 @@ function convertkit_get_form_editor_url() {
 }
 
 /**
+ * Helper method to return the URL the user needs to visit on the ConvertKit app to create a new Product.
+ *
+ * @since   2.2.3
+ *
+ * @return  string  ConvertKit App URL.
+ */
+function convertkit_get_new_product_url() {
+
+	return add_query_arg(
+		array(
+			'utm_source'  => 'wordpress',
+			'utm_term'    => get_locale(),
+			'utm_content' => 'convertkit',
+		),
+		'https://app.convertkit.com/products/new/'
+	);
+
+}
+
+/**
  * Helper method to enqueue Select2 scripts for use within the ConvertKit Plugin.
  *
  * @since   1.9.6.4

--- a/resources/backend/js/gutenberg-block-form.js
+++ b/resources/backend/js/gutenberg-block-form.js
@@ -11,7 +11,7 @@
  * Custom callback function to render the ConvertKit Form Block preview in the Gutenberg Editor.
  *
  * @since 	1.9.6.5
- * 
+ *
  * @param 	object 	block 	Block
  * @param 	obejct  props 	Block properties
  */
@@ -20,7 +20,7 @@ function convertKitGutenbergFormBlockRenderPreview( block, props ) {
 	// If no API Key has been defined in the Plugin, return a prompt to tell the editor
 	// what to do.
 	if ( ! block.has_api_key ) {
-		return convertKitGutenbergDisplayBlockNoticeWithLink( 
+		return convertKitGutenbergDisplayBlockNoticeWithLink(
 			block.name,
 			block.gutenberg_help_description_no_api_key.notice,
 			block.gutenberg_help_description_no_api_key.link,
@@ -31,7 +31,7 @@ function convertKitGutenbergFormBlockRenderPreview( block, props ) {
 	// If no Forms exist in ConvertKit, return a prompt to tell the editor
 	// what to do.
 	if ( ! block.has_resources ) {
-		return convertKitGutenbergDisplayBlockNoticeWithLink( 
+		return convertKitGutenbergDisplayBlockNoticeWithLink(
 			block.name,
 			block.gutenberg_help_description_no_resources.notice,
 			block.gutenberg_help_description_no_resources.link,

--- a/resources/backend/js/gutenberg-block-form.js
+++ b/resources/backend/js/gutenberg-block-form.js
@@ -11,23 +11,41 @@
  * Custom callback function to render the ConvertKit Form Block preview in the Gutenberg Editor.
  *
  * @since 	1.9.6.5
+ * 
+ * @param 	object 	block 	Block
+ * @param 	obejct  props 	Block properties
  */
 function convertKitGutenbergFormBlockRenderPreview( block, props ) {
 
+	// If no API Key has been defined in the Plugin, return a prompt to tell the editor
+	// what to do.
+	if ( ! block.has_api_key ) {
+		return convertKitGutenbergDisplayBlockNoticeWithLink( 
+			block.name,
+			block.gutenberg_help_description_no_api_key.notice,
+			block.gutenberg_help_description_no_api_key.link,
+			block.gutenberg_help_description_no_api_key.link_text
+		);
+	}
+
+	// If no Forms exist in ConvertKit, return a prompt to tell the editor
+	// what to do.
+	if ( ! block.has_resources ) {
+		return convertKitGutenbergDisplayBlockNoticeWithLink( 
+			block.name,
+			block.gutenberg_help_description_no_resources.notice,
+			block.gutenberg_help_description_no_resources.link,
+			block.gutenberg_help_description_no_resources.link_text
+		);
+	}
+
+	// Get selected form.
 	var form = block.fields.form.data.forms[ props.attributes.form ];
 
 	// If no Form has been selected for display, return a prompt to tell the editor
 	// what to do.
 	if ( typeof form === 'undefined' ) {
-		return wp.element.createElement(
-			'div',
-			{
-				// convertkit-no-content class allows resources/backend/css/gutenberg.css
-				// to apply styling/branding to the block.
-				className: 'convertkit-' + block.name + ' convertkit-no-content'
-			},
-			block.gutenberg_help_description
-		);
+		return convertKitGutenbergDisplayBlockNotice( block.name, block.gutenberg_help_description );
 	}
 
 	// If the Form is a <script> embed, use the SandBox because the Gutenberg editor

--- a/resources/backend/js/gutenberg-block-product.js
+++ b/resources/backend/js/gutenberg-block-product.js
@@ -14,18 +14,32 @@
  */
 function convertKitGutenbergProductBlockRenderPreview( block, props ) {
 
+	// If no API Key has been defined in the Plugin, return a prompt to tell the editor
+	// what to do.
+	if ( ! block.has_api_key ) {
+		return convertKitGutenbergDisplayBlockNoticeWithLink(
+			block.name,
+			block.gutenberg_help_description_no_api_key.notice,
+			block.gutenberg_help_description_no_api_key.link,
+			block.gutenberg_help_description_no_api_key.link_text
+		);
+	}
+
+	// If no Forms exist in ConvertKit, return a prompt to tell the editor
+	// what to do.
+	if ( ! block.has_resources ) {
+		return convertKitGutenbergDisplayBlockNoticeWithLink(
+			block.name,
+			block.gutenberg_help_description_no_resources.notice,
+			block.gutenberg_help_description_no_resources.link,
+			block.gutenberg_help_description_no_resources.link_text
+		);
+	}
+
 	// If no Product has been selected for display, return a prompt to tell the editor
 	// what to do.
 	if ( props.attributes.product === '' ) {
-		return wp.element.createElement(
-			'div',
-			{
-				// convertkit-no-content class allows resources/backend/css/gutenberg.css
-				// to apply styling/branding to the block.
-				className: 'convertkit-' + block.name + ' convertkit-no-content'
-			},
-			block.gutenberg_help_description
-		);
+		return convertKitGutenbergDisplayBlockNotice( block.name, block.gutenberg_help_description );
 	}
 
 	// A Product is specified.

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -368,3 +368,67 @@ function convertKitGutenbergRegisterBlock( block ) {
 	) );
 
 }
+
+/**
+ * Outputs a notice for the block.  Typically used when a block's settings
+ * have not been defined, no API key exists in the Plugin or no resources
+ * (forms, products) exist in ConvertKit, and the user adds an e.g.
+ * Form / Product block.
+ * 
+ * @since 	2.2.3
+ * 
+ * @param 	string 	block_name 	Block Name.
+ * @param 	string 	notice 		Notice to display.
+ * @return 	object 				HTMLElement
+ */
+function convertKitGutenbergDisplayBlockNotice( block_name, notice ) {
+
+	return wp.element.createElement(
+		'div',
+		{
+			// convertkit-no-content class allows resources/backend/css/gutenberg.css
+			// to apply styling/branding to the block.
+			className: 'convertkit-' + block_name + ' convertkit-no-content'
+		},
+		notice
+	);
+
+}
+
+/**
+ * Outputs a notice for the block with a clickable link.  Typically used when a block's settings
+ * have not been defined, no API key exists in the Plugin or no resources
+ * (forms, products) exist in ConvertKit, and the user adds an e.g.
+ * Form / Product block.
+ * 
+ * @since 	2.2.3
+ * 
+ * @param 	string 	block_name 	Block Name.
+ * @param 	string 	notice 		Notice to display.
+ * @param 	string  link 		URL.
+ * @param 	string  link_text 	Link text for URL.
+ * @return 	object 				HTMLElement
+ */
+function convertKitGutenbergDisplayBlockNoticeWithLink( block_name, notice, link, link_text ) {
+
+	return wp.element.createElement(
+		'div',
+		{
+			// convertkit-no-content class allows resources/backend/css/gutenberg.css
+			// to apply styling/branding to the block.
+			className: 'convertkit-' + block_name + ' convertkit-no-content'
+		},
+		[
+			notice + ' ',
+			wp.element.createElement(
+				'a',
+				{
+					href: link,
+					target: '_blank'
+				},
+				link_text
+			)
+		]
+	);
+
+}

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -374,9 +374,9 @@ function convertKitGutenbergRegisterBlock( block ) {
  * have not been defined, no API key exists in the Plugin or no resources
  * (forms, products) exist in ConvertKit, and the user adds an e.g.
  * Form / Product block.
- * 
+ *
  * @since 	2.2.3
- * 
+ *
  * @param 	string 	block_name 	Block Name.
  * @param 	string 	notice 		Notice to display.
  * @return 	object 				HTMLElement
@@ -400,9 +400,9 @@ function convertKitGutenbergDisplayBlockNotice( block_name, notice ) {
  * have not been defined, no API key exists in the Plugin or no resources
  * (forms, products) exist in ConvertKit, and the user adds an e.g.
  * Form / Product block.
- * 
+ *
  * @since 	2.2.3
- * 
+ *
  * @param 	string 	block_name 	Block Name.
  * @param 	string 	notice 		Notice to display.
  * @param 	string  link 		URL.

--- a/tests/acceptance/forms/PageBlockFormCest.php
+++ b/tests/acceptance/forms/PageBlockFormCest.php
@@ -16,8 +16,6 @@ class PageBlockFormCest
 	public function _before(AcceptanceTester $I)
 	{
 		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
-		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**
@@ -29,6 +27,10 @@ class PageBlockFormCest
 	 */
 	public function testFormBlockWithValidFormParameter(AcceptanceTester $I)
 	{
+		// Setup Plugin and Resources.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Form Param');
 
@@ -68,6 +70,10 @@ class PageBlockFormCest
 	 */
 	public function testFormBlockWithValidLegacyFormParameter(AcceptanceTester $I)
 	{
+		// Setup Plugin and Resources.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Legacy Form: Block: Valid Form Param');
 
@@ -107,6 +113,10 @@ class PageBlockFormCest
 	 */
 	public function testFormBlockWithValidModalFormParameter(AcceptanceTester $I)
 	{
+		// Setup Plugin and Resources.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Modal Form Param');
 
@@ -157,6 +167,10 @@ class PageBlockFormCest
 	 */
 	public function testFormBlocksWithValidModalFormParameter(AcceptanceTester $I)
 	{
+		// Setup Plugin and Resources.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Modal Form Param');
 
@@ -217,6 +231,10 @@ class PageBlockFormCest
 	 */
 	public function testFormBlockWithValidSlideInFormParameter(AcceptanceTester $I)
 	{
+		// Setup Plugin and Resources.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Slide In Form Param');
 
@@ -267,6 +285,10 @@ class PageBlockFormCest
 	 */
 	public function testFormBlocksWithValidSlideInFormParameter(AcceptanceTester $I)
 	{
+		// Setup Plugin and Resources.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Slide In Form Param');
 
@@ -327,6 +349,10 @@ class PageBlockFormCest
 	 */
 	public function testFormBlockWithValidStickyBarFormParameter(AcceptanceTester $I)
 	{
+		// Setup Plugin and Resources.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Sticky Bar Form Param');
 
@@ -377,6 +403,10 @@ class PageBlockFormCest
 	 */
 	public function testFormBlocksWithValidStickyBarFormParameter(AcceptanceTester $I)
 	{
+		// Setup Plugin and Resources.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Sticky Bar Form Param');
 
@@ -436,6 +466,10 @@ class PageBlockFormCest
 	 */
 	public function testFormBlockWithNoFormParameter(AcceptanceTester $I)
 	{
+		// Setup Plugin and Resources.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Valid Sticky Bar Form Param');
 
@@ -464,6 +498,101 @@ class PageBlockFormCest
 
 		// Confirm that no ConvertKit Form is displayed.
 		$I->dontSeeElementInDOM('form[data-sv-form]');
+	}
+
+	/**
+	 * Test the Form block displays a message with a link to the Plugin's
+	 * settings screen, when the Plugin has no API key specified.
+	 *
+	 * @since   2.2.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFormBlockWhenNoAPIKey(AcceptanceTester $I)
+	{
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: No API Key');
+
+		// Add block to Page.
+		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form');
+
+		// Confirm that the Form block displays instructions to the user on how to enter their API Key.
+		$I->see(
+			'No API Key specified.',
+			[
+				'css' => '.convertkit-no-content',
+			]
+		);
+
+		// Click the link to confirm it loads the Plugin's settings screen.
+		$I->click(
+			'Click here to add your API Key.',
+			[
+				'css' => '.convertkit-no-content',
+			]
+		);
+
+		// Switch to next browser tab, as the link opens in a new tab.
+		$I->switchToNextTab();
+
+		// Confirm the Plugin's settings screen is displayed.
+		$I->seeElementInDOM('input[name="_wp_convertkit_settings[api_key]"]');
+		$I->seeElementInDOM('input[name="_wp_convertkit_settings[api_secret]"]');
+
+		// Close tab.
+		$I->closeTab();
+
+		// Save page to avoid alert box when _passed() runs to deactivate the Plugin.
+		$I->publishGutenbergPage($I);
+	}
+
+	/**
+	 * Test the Form block displays a message with a link to the Plugin's
+	 * settings screen, when the ConvertKit account has no forms.
+	 *
+	 * @since   2.2.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFormBlockWhenNoForms(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA'], '', '', '');
+		$I->setupConvertKitPluginResourcesNoData($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: No Forms');
+
+		// Add block to Page.
+		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form');
+
+		// Confirm that the Form block displays instructions to the user on how to add a Form in ConvertKit.
+		$I->see(
+			'No forms exist in ConvertKit.',
+			[
+				'css' => '.convertkit-no-content',
+			]
+		);
+
+		// Click the link to confirm it loads ConvertKit.
+		$I->click(
+			'Click here to create your first form.',
+			[
+				'css' => '.convertkit-no-content',
+			]
+		);
+
+		// Switch to next browser tab, as the link opens in a new tab.
+		$I->switchToNextTab();
+
+		// Confirm the ConvertKit login screen loaded.
+		$I->seeElementInDOM('input[name="user[email]"]');
+
+		// Close tab.
+		$I->closeTab();
+
+		// Save page to avoid alert box when _passed() runs to deactivate the Plugin.
+		$I->publishGutenbergPage($I);
 	}
 
 	/**

--- a/tests/acceptance/products/PageBlockProductCest.php
+++ b/tests/acceptance/products/PageBlockProductCest.php
@@ -16,10 +16,6 @@ class PageBlockProductCest
 	public function _before(AcceptanceTester $I)
 	{
 		$I->activateConvertKitPlugin($I);
-
-		// Setup ConvertKit Plugin with no default form specified.
-		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
-		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**
@@ -31,6 +27,10 @@ class PageBlockProductCest
 	 */
 	public function testProductBlockWithValidProductParameter(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Valid Product Param');
 
@@ -69,6 +69,10 @@ class PageBlockProductCest
 	 */
 	public function testProductBlockWithNoProductParameter(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: No Product Param');
 
@@ -108,6 +112,10 @@ class PageBlockProductCest
 	 */
 	public function testProductBlockWithTextParameter(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Text Param');
 
@@ -138,6 +146,10 @@ class PageBlockProductCest
 	 */
 	public function testProductBlockWithBlankTextParameter(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Blank Text Param');
 
@@ -168,6 +180,10 @@ class PageBlockProductCest
 	 */
 	public function testProductBlockWithThemeColorParameters(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Define colors.
 		$backgroundColor = 'white';
 		$textColor       = 'purple';
@@ -208,6 +224,10 @@ class PageBlockProductCest
 	 */
 	public function testProductBlockWithHexColorParameters(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Define colors.
 		$backgroundColor = '#ee1616';
 		$textColor       = '#1212c0';
@@ -237,6 +257,101 @@ class PageBlockProductCest
 	}
 
 	/**
+	 * Test the Product block displays a message with a link to the Plugin's
+	 * settings screen, when the Plugin has no API key specified.
+	 *
+	 * @since   2.2.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testProductBlockWhenNoAPIKey(AcceptanceTester $I)
+	{
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Block: No API Key');
+
+		// Add block to Page.
+		$I->addGutenbergBlock($I, 'ConvertKit Product', 'convertkit-product');
+
+		// Confirm that the Product block displays instructions to the user on how to enter their API Key.
+		$I->see(
+			'No API Key specified.',
+			[
+				'css' => '.convertkit-no-content',
+			]
+		);
+
+		// Click the link to confirm it loads the Plugin's settings screen.
+		$I->click(
+			'Click here to add your API Key.',
+			[
+				'css' => '.convertkit-no-content',
+			]
+		);
+
+		// Switch to next browser tab, as the link opens in a new tab.
+		$I->switchToNextTab();
+
+		// Confirm the Plugin's settings screen is displayed.
+		$I->seeElementInDOM('input[name="_wp_convertkit_settings[api_key]"]');
+		$I->seeElementInDOM('input[name="_wp_convertkit_settings[api_secret]"]');
+
+		// Close tab.
+		$I->closeTab();
+
+		// Save page to avoid alert box when _passed() runs to deactivate the Plugin.
+		$I->publishGutenbergPage($I);
+	}
+
+	/**
+	 * Test the Product block displays a message with a link to the Plugin's
+	 * settings screen, when the ConvertKit account has no products.
+	 *
+	 * @since   2.2.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testProductBlockWhenNoProducts(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA'], '', '', '');
+		$I->setupConvertKitPluginResourcesNoData($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Block: No Products');
+
+		// Add block to Page.
+		$I->addGutenbergBlock($I, 'ConvertKit Product', 'convertkit-product');
+
+		// Confirm that the Product block displays instructions to the user on how to add a Product in ConvertKit.
+		$I->see(
+			'No products exist in ConvertKit.',
+			[
+				'css' => '.convertkit-no-content',
+			]
+		);
+
+		// Click the link to confirm it loads ConvertKit.
+		$I->click(
+			'Click here to create your first product.',
+			[
+				'css' => '.convertkit-no-content',
+			]
+		);
+
+		// Switch to next browser tab, as the link opens in a new tab.
+		$I->switchToNextTab();
+
+		// Confirm the ConvertKit login screen loaded.
+		$I->seeElementInDOM('input[name="user[email]"]');
+
+		// Close tab.
+		$I->closeTab();
+
+		// Save page to avoid alert box when _passed() runs to deactivate the Plugin.
+		$I->publishGutenbergPage($I);
+	}
+
+	/**
 	 * Test the Product block's parameters are correctly escaped on output,
 	 * to prevent XSS.
 	 *
@@ -246,6 +361,10 @@ class PageBlockProductCest
 	 */
 	public function testProductBlockParameterEscaping(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Define a 'bad' block.  This is difficult to do in Gutenberg, but let's assume it's possible.
 		$I->havePageInDatabase(
 			[


### PR DESCRIPTION
## Summary

Similar to the [Form Block PR](https://github.com/ConvertKit/convertkit-wordpress/pull/481), when adding the ConvertKit Product Block, displays a notice if no API key is specified, or the ConvertKit account has no products specified, including a link to the settings screen / ConvertKit to resolve.

![Screenshot 2023-05-31 at 17 21 02](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/c6ca13d5-ace8-4010-be6a-285b81907ff6)
![Screenshot 2023-05-31 at 17 20 42](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/ad747ea8-3fad-4ba0-9e4f-8e450fef300c)



## Testing

- `PageBlockProductCest:testProductBlockWhenNoAPIKey`: Confirms that the expected message displays when no products exist in ConvertKit
- `PageBlockProductCest:testProductBlockWhenNoProducts`: Confirms that the expected message displays when no products exist in ConvertKit

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)