### PR TITLE
Use `esc_url()` instead of `esc_attr()` for link href attributes

### DIFF
--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -399,7 +399,7 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 					esc_html__( 'Select a form above to automatically output below all %s.', 'convertkit' ),
 					$args['post_type_object']->label
 				),
-				'<a href="' . esc_attr( $preview_url ) . '" id="convertkit-preview-form-' . esc_attr( $args['post_type'] ) . '" target="_blank">' . esc_html__( 'Click here', 'convertkit' ) . '</a>',
+				'<a href="' . esc_url( $preview_url ) . '" id="convertkit-preview-form-' . esc_attr( $args['post_type'] ) . '" target="_blank">' . esc_html__( 'Click here', 'convertkit' ) . '</a>',
 				esc_html__( 'to preview how this will display.', 'convertkit' )
 			);
 		} else {

--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -508,7 +508,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 			// Add broadcast as list item.
 			$html .= '<li class="convertkit-broadcast">
 				<time datetime="' . esc_attr( date_i18n( 'Y-m-d', $date_timestamp ) ) . '">' . esc_html( date_i18n( $atts['date_format'], $date_timestamp ) ) . '</time>
-				<a href="' . esc_attr( $url ) . '" target="_blank" rel="nofollow noopener"' . $this->get_link_style_tag( $atts ) . '>' . esc_html( $broadcast['title'] ) . '</a>
+				<a href="' . esc_url( $url ) . '" target="_blank" rel="nofollow noopener"' . $this->get_link_style_tag( $atts ) . '>' . esc_html( $broadcast['title'] ) . '</a>
 			</li>';
 		}
 
@@ -563,7 +563,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 	 */
 	private function get_pagination_link_prev_html( $atts, $nonce ) {
 
-		return '<a href="' . esc_attr( $this->get_pagination_link( $atts['page'] - 1, $nonce ) ) . '" title="' . esc_attr( $atts['paginate_label_prev'] ) . '" data-page="' . esc_attr( (string) ( $atts['page'] - 1 ) ) . '" data-nonce="' . esc_attr( $nonce ) . '"' . $this->get_link_style_tag( $atts ) . '>
+		return '<a href="' . esc_url( $this->get_pagination_link( $atts['page'] - 1, $nonce ) ) . '" title="' . esc_attr( $atts['paginate_label_prev'] ) . '" data-page="' . esc_attr( (string) ( $atts['page'] - 1 ) ) . '" data-nonce="' . esc_attr( $nonce ) . '"' . $this->get_link_style_tag( $atts ) . '>
 			' . esc_html( $atts['paginate_label_prev'] ) . '
 		</a>';
 
@@ -581,7 +581,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 	 */
 	private function get_pagination_link_next_html( $atts, $nonce ) {
 
-		return '<a href="' . esc_attr( $this->get_pagination_link( $atts['page'] + 1, $nonce ) ) . '" title="' . esc_attr( $atts['paginate_label_next'] ) . '" data-page="' . esc_attr( (string) ( $atts['page'] + 1 ) ) . '" data-nonce="' . esc_attr( $nonce ) . '"' . $this->get_link_style_tag( $atts ) . '>
+		return '<a href="' . esc_url( $this->get_pagination_link( $atts['page'] + 1, $nonce ) ) . '" title="' . esc_attr( $atts['paginate_label_next'] ) . '" data-page="' . esc_attr( (string) ( $atts['page'] + 1 ) ) . '" data-nonce="' . esc_attr( $nonce ) . '"' . $this->get_link_style_tag( $atts ) . '>
 			' . esc_html( $atts['paginate_label_next'] ) . '
 		</a>';
 

--- a/includes/blocks/class-convertkit-block-form-trigger.php
+++ b/includes/blocks/class-convertkit-block-form-trigger.php
@@ -445,7 +445,7 @@ class ConvertKit_Block_Form_Trigger extends ConvertKit_Block {
 		if ( $return_as_span ) {
 			$html .= '<span';
 		} else {
-			$html .= '<a data-formkit-toggle="' . esc_attr( $form['uid'] ) . '" href="' . esc_attr( $form['embed_url'] ) . '"';
+			$html .= '<a data-formkit-toggle="' . esc_attr( $form['uid'] ) . '" href="' . esc_url( $form['embed_url'] ) . '"';
 		}
 
 		$html .= ' class="wp-block-button__link ' . implode( ' ', map_deep( $css_classes, 'sanitize_html_class' ) ) . '" style="' . implode( ';', map_deep( $css_styles, 'esc_attr' ) ) . '">';

--- a/includes/class-convertkit-resource-products.php
+++ b/includes/class-convertkit-resource-products.php
@@ -129,7 +129,7 @@ class ConvertKit_Resource_Products extends ConvertKit_Resource {
 		if ( $return_as_span ) {
 			$html .= '<span';
 		} else {
-			$html .= '<a href="' . esc_attr( $this->resources[ $id ]['url'] ) . '"';
+			$html .= '<a href="' . esc_url( $this->resources[ $id ]['url'] ) . '"';
 		}
 
 		$html .= ' class="wp-block-button__link ' . implode( ' ', map_deep( $css_classes, 'sanitize_html_class' ) ) . '" style="' . implode( ';', map_deep( $css_styles, 'esc_attr' ) ) . '" data-commerce>';

--- a/views/backend/post/no-api-key.php
+++ b/views/backend/post/no-api-key.php
@@ -14,7 +14,7 @@
 		/* translators: %1$s: Post Type Singular Name, %2$s: Link to Plugin Settings */
 		esc_html__( 'To configure the ConvertKit Form / Landing Page to display on this %1$s, enter your ConvertKit API credentials in the %2$s', 'convertkit' ),
 		esc_attr( $post_type->labels->singular_name ),
-		'<a href="' . esc_attr( convertkit_get_settings_link() ) . '">' . esc_html__( 'Plugin Settings', 'convertkit' ) . '</a>'
+		'<a href="' . esc_url( convertkit_get_settings_link() ) . '">' . esc_html__( 'Plugin Settings', 'convertkit' ) . '</a>'
 	);
 	?>
 </p>

--- a/views/backend/setup-wizard/convertkit-setup/content-3.php
+++ b/views/backend/setup-wizard/convertkit-setup/content-3.php
@@ -70,7 +70,7 @@ if ( ! $this->forms->exist() ) {
 				echo sprintf(
 					'%s %s %s',
 					esc_html__( 'Select a form above.', 'convertkit' ),
-					'<a href="' . esc_attr( $this->preview_post_url ) . '" id="convertkit-preview-form-post" target="_blank">' . esc_html__( 'Click here', 'convertkit' ) . '</a>',
+					'<a href="' . esc_url( $this->preview_post_url ) . '" id="convertkit-preview-form-post" target="_blank">' . esc_html__( 'Click here', 'convertkit' ) . '</a>',
 					esc_html__( 'to preview how this will look on individual posts.', 'convertkit' )
 				);
 			} else {
@@ -105,7 +105,7 @@ if ( ! $this->forms->exist() ) {
 				echo sprintf(
 					'%s %s %s',
 					esc_html__( 'Select a form above.', 'convertkit' ),
-					'<a href="' . esc_attr( $this->preview_page_url ) . '" id="convertkit-preview-form-page" target="_blank">' . esc_html__( 'Click here', 'convertkit' ) . '</a>',
+					'<a href="' . esc_url( $this->preview_page_url ) . '" id="convertkit-preview-form-page" target="_blank">' . esc_html__( 'Click here', 'convertkit' ) . '</a>',
 					esc_html__( 'to preview how this will look on individual pages.', 'convertkit' )
 				);
 			} else {


### PR DESCRIPTION
## Summary

Uses `[esc_url()](https://developer.wordpress.org/reference/functions/esc_url/)` instead of `esc_attr()` for link `href` attributes, for best practices.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)