### PR TITLE
Fix PHPStan fatal error on GitHub Action

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
         "wp-coding-standards/wpcs": "*",
         "phpstan/phpstan": "^1.7",
-        "szepeviktor/phpstan-wordpress": "^1.0"
+        "szepeviktor/phpstan-wordpress": "^1.0",
+        "wp-cli/wp-cli": "2.7.1"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
## Summary

GitHub Actions for PHPStan started failing yesterday, due to WP-CLI 2.8.0 being released, which results in both `wp-cli/wp-cli` and `szepeviktor/phpstan-wordpress` packages attempting to declare the same `WpOrg\Requests\Autoload` class.

![Screenshot 2023-06-01 at 13 58 12](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/c6cf03af-7ff4-4a7e-8236-94142a79231b)

Forces WP-CLI to 2.7.1, which resolves.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)