### PR TITLE
Broadcasts Block / Shortcode: Add grid, image, description and read more support

### DIFF
--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -269,7 +269,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 			'display_grid'        => array(
 				'label'       => __( 'Display as grid', 'convertkit' ),
 				'type'        => 'toggle',
-				'description' => __( 'If enabled, displays broadcasts in a three column grid, instead of a list.', 'convertkit' ),
+				'description' => __( 'If enabled, displays broadcasts in a grid, instead of a list.', 'convertkit' ),
 			),
 			'date_format'         => array(
 				'label'  => __( 'Date format', 'convertkit' ),
@@ -282,15 +282,15 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 				),
 			),
 			'display_image'       => array(
-				'label' => __( 'Display image', 'convertkit' ),
+				'label' => __( 'Display images', 'convertkit' ),
 				'type'  => 'toggle',
 			),
 			'display_description' => array(
-				'label' => __( 'Display description', 'convertkit' ),
+				'label' => __( 'Display descriptions', 'convertkit' ),
 				'type'  => 'toggle',
 			),
 			'display_read_more'   => array(
-				'label' => __( 'Display read more link', 'convertkit' ),
+				'label' => __( 'Display read more links', 'convertkit' ),
 				'type'  => 'toggle',
 			),
 			'read_more_label'     => array(
@@ -634,7 +634,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 		$html = '<li class="convertkit-broadcast">';
 
 		// Display date.
-		$html .= '<time datetime="' . esc_attr( date_i18n( 'Y-m-d', $date_timestamp ) ) . '" class="convertkit-broadcast-date">' . esc_html( date_i18n( $atts['date_format'], $date_timestamp ) ) . '</time>';
+		$html .= '<time datetime="' . esc_attr( date_i18n( 'Y-m-d', $date_timestamp ) ) . '">' . esc_html( date_i18n( $atts['date_format'], $date_timestamp ) ) . '</time>';
 
 		// Display linked title.
 		$html .= '<a href="' . esc_attr( $url ) . '" target="_blank" rel="nofollow noopener"' . $this->get_link_style_tag( $atts ) . ' class="convertkit-broadcast-title">' . esc_html( $broadcast['title'] ) . '</a>';
@@ -656,7 +656,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 			// We check for description, as these were added to the API in https://github.com/ConvertKit/convertkit/pull/23938,
 			// and might not immediately be available until the resources are refreshed.
 			if ( $atts['display_description'] && array_key_exists( 'description', $broadcast ) && ! is_null( $broadcast['description'] ) ) {
-				$html .= esc_html( $broadcast['description'] );
+				$html .= '<span class="convertkit-broadcast-description">' . esc_html( $broadcast['description'] ) . '</span>';
 			}
 
 			// Display read more link.

--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -613,7 +613,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 	private function build_html_list_item( $broadcast, $atts ) {
 
 		// @TODO Remove debugging.
-		$broadcast['description'] = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce aliquam dui sed mattis aliquam. Aliquam fringilla lobortis diam nec posuere. Phasellus auctor et lacus eget consectetur.';
+		$broadcast['description']   = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce aliquam dui sed mattis aliquam. Aliquam fringilla lobortis diam nec posuere. Phasellus auctor et lacus eget consectetur.';
 		$broadcast['thumbnail_url'] = 'https://placehold.co/600x400';
 		$broadcast['thumbnail_alt'] = 'Broadcast image alt text';
 

--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -356,7 +356,6 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 			'general' => array(
 				'label'  => __( 'General', 'convertkit' ),
 				'fields' => array(
-					// 'layout',
 					'display_date',
 					'date_format',
 					'display_image',
@@ -386,7 +385,6 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 	public function get_default_values() {
 
 		return array(
-			'layout'              => 'list',
 			'display_date'        => true,
 			'date_format'         => 'F j, Y',
 			'display_image'       => false,
@@ -478,13 +476,13 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 
 		// Build attributes array.
 		$atts = array(
-			'display_date'        => stripslashes( sanitize_text_field( $_REQUEST['display_date'] ) ),
+			'display_date'        => absint( $_REQUEST['display_date'] ),
 			'date_format'         => stripslashes( sanitize_text_field( $_REQUEST['date_format'] ) ),
-			'display_image'       => stripslashes( sanitize_text_field( $_REQUEST['display_image'] ) ),
-			'display_description' => stripslashes( sanitize_text_field( $_REQUEST['display_description'] ) ),
-			'display_read_more'   => stripslashes( sanitize_text_field( $_REQUEST['display_read_more'] ) ),
+			'display_image'       => absint( $_REQUEST['display_image'] ),
+			'display_description' => absint( $_REQUEST['display_description'] ),
+			'display_read_more'   => absint( $_REQUEST['display_read_more'] ),
 			'read_more_label'     => stripslashes( sanitize_text_field( $_REQUEST['read_more_label'] ) ),
-			'limit'               => stripslashes( sanitize_text_field( $_REQUEST['limit'] ) ),
+			'limit'               => absint( $_REQUEST['limit'] ),
 			'page'                => absint( $_REQUEST['page'] ),
 			'paginate'            => absint( $_REQUEST['paginate'] ),
 			'paginate_label_next' => stripslashes( sanitize_text_field( $_REQUEST['paginate_label_next'] ) ),
@@ -542,7 +540,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 
 		// Include container, if required.
 		if ( $include_container ) {
-			$html = '<div class="' . implode( ' ', map_deep( $atts['_css_classes'], 'sanitize_html_class' ) ) . '" style="' . implode( ';', map_deep( $atts['_css_styles'], 'esc_attr' ) ) . '" ' . $this->get_atts_as_html_data_attributes( $atts ) . '>';
+			$html .= '<div class="' . implode( ' ', map_deep( $atts['_css_classes'], 'sanitize_html_class' ) ) . '" style="' . implode( ';', map_deep( $atts['_css_styles'], 'esc_attr' ) ) . '" ' . $this->get_atts_as_html_data_attributes( $atts ) . '>';
 		}
 
 		// Start list.
@@ -596,7 +594,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 		 * @param   string  $html       ConvertKit Broadcasts HTML.
 		 * @param   array   $atts       Block Attributes.
 		 */
-		$html = apply_filters( 'convertkit_block_broadcasts_render', $form, $atts );
+		$html = apply_filters( 'convertkit_block_broadcasts_render', $html, $atts );
 
 		// Return.
 		return $html;
@@ -613,6 +611,11 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 	 * @return  string              HTML
 	 */
 	private function build_html_list_item( $broadcast, $atts ) {
+
+		// @TODO Remove debugging.
+		$broadcast['description'] = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce aliquam dui sed mattis aliquam. Aliquam fringilla lobortis diam nec posuere. Phasellus auctor et lacus eget consectetur.';
+		$broadcast['thumbnail_url'] = 'https://placehold.co/600x400';
+		$broadcast['thumbnail_alt'] = 'Broadcast image alt text';
 
 		// Convert UTC date to timestamp.
 		$date_timestamp = strtotime( $broadcast['published_at'] );
@@ -632,17 +635,19 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 
 		// Display date, if enabled.
 		if ( $atts['display_date'] ) {
-			$html .= '<time datetime="' . esc_attr( date_i18n( 'Y-m-d', $date_timestamp ) ) . '">' . esc_html( date_i18n( $atts['date_format'], $date_timestamp ) ) . '</time>';
+			$html .= '<time datetime="' . esc_attr( date_i18n( 'Y-m-d', $date_timestamp ) ) . '" class="convertkit-broadcast-date">' . esc_html( date_i18n( $atts['date_format'], $date_timestamp ) ) . '</time>';
 		}
 
 		// Display linked title.
-		$html .= '<a href="' . esc_attr( $url ) . '" target="_blank" rel="nofollow noopener"' . $this->get_link_style_tag( $atts ) . '>' . esc_html( $broadcast['title'] ) . '</a>';
+		$html .= '<a href="' . esc_attr( $url ) . '" target="_blank" rel="nofollow noopener"' . $this->get_link_style_tag( $atts ) . ' class="convertkit-broadcast-title">' . esc_html( $broadcast['title'] ) . '</a>';
 
 		// Display image.
 		// We check for thumbnail_url, as these were added to the API in https://github.com/ConvertKit/convertkit/pull/23938,
 		// and might not immediately be available until the resources are refreshed.
 		if ( $atts['display_image'] && array_key_exists( 'thumbnail_url', $broadcast ) && ! is_null( $broadcast['thumbnail_url'] ) ) {
-			$html .= '<img class="convertkit-broadcast-image" src="' . esc_url( $broadcast['thumbnail_url'] ) . '" alt="' . esc_attr( $broadcast['thumbnail_alt'] ) . '" />';
+			$html .= '<a href="' . esc_attr( $url ) . '" target="_blank" rel="nofollow noopener" class="convertkit-broadcast-image">
+				<img src="' . esc_url( $broadcast['thumbnail_url'] ) . '" alt="' . esc_attr( $broadcast['thumbnail_alt'] ) . '" />
+			</a>';
 		}
 
 		// Display description.

--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -131,7 +131,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 
 			// Shortcode: TinyMCE / QuickTags Modal Width and Height.
 			'modal'                             => array(
-				'width'  => 500,
+				'width'  => 650,
 				'height' => 580,
 			),
 
@@ -267,8 +267,8 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 
 		return array(
 			'display_grid'        => array(
-				'label' => __( 'Display as grid', 'convertkit' ),
-				'type'  => 'toggle',
+				'label'       => __( 'Display as grid', 'convertkit' ),
+				'type'        => 'toggle',
 				'description' => __( 'If enabled, displays broadcasts in a three column grid, instead of a list.', 'convertkit' ),
 			),
 			'date_format'         => array(
@@ -386,7 +386,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 	public function get_default_values() {
 
 		return array(
-			'display_grid'		  => false,
+			'display_grid'        => false,
 			'date_format'         => 'F j, Y',
 			'display_image'       => false,
 			'display_description' => false,

--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -166,9 +166,9 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 
 		return array(
 			// Block attributes.
-			'display_date'         => array(
+			'display_grid'         => array(
 				'type'    => 'boolean',
-				'default' => $this->get_default_value( 'display_date' ),
+				'default' => $this->get_default_value( 'display_grid' ),
 			),
 			'date_format'          => array(
 				'type'    => 'string',
@@ -266,9 +266,10 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 		}
 
 		return array(
-			'display_date'        => array(
-				'label' => __( 'Display date', 'convertkit' ),
+			'display_grid'        => array(
+				'label' => __( 'Display as grid', 'convertkit' ),
 				'type'  => 'toggle',
+				'description' => __( 'If enabled, displays broadcasts in a three column grid, instead of a list.', 'convertkit' ),
 			),
 			'date_format'         => array(
 				'label'  => __( 'Date format', 'convertkit' ),
@@ -356,7 +357,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 			'general' => array(
 				'label'  => __( 'General', 'convertkit' ),
 				'fields' => array(
-					'display_date',
+					'display_grid',
 					'date_format',
 					'display_image',
 					'display_description',
@@ -385,7 +386,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 	public function get_default_values() {
 
 		return array(
-			'display_date'        => true,
+			'display_grid'		  => false,
 			'date_format'         => 'F j, Y',
 			'display_image'       => false,
 			'display_description' => false,
@@ -476,7 +477,6 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 
 		// Build attributes array.
 		$atts = array(
-			'display_date'        => absint( $_REQUEST['display_date'] ),
 			'date_format'         => stripslashes( sanitize_text_field( $_REQUEST['date_format'] ) ),
 			'display_image'       => absint( $_REQUEST['display_image'] ),
 			'display_description' => absint( $_REQUEST['display_description'] ),
@@ -633,10 +633,8 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 		// Build HTML.
 		$html = '<li class="convertkit-broadcast">';
 
-		// Display date, if enabled.
-		if ( $atts['display_date'] ) {
-			$html .= '<time datetime="' . esc_attr( date_i18n( 'Y-m-d', $date_timestamp ) ) . '" class="convertkit-broadcast-date">' . esc_html( date_i18n( $atts['date_format'], $date_timestamp ) ) . '</time>';
-		}
+		// Display date.
+		$html .= '<time datetime="' . esc_attr( date_i18n( 'Y-m-d', $date_timestamp ) ) . '" class="convertkit-broadcast-date">' . esc_html( date_i18n( $atts['date_format'], $date_timestamp ) ) . '</time>';
 
 		// Display linked title.
 		$html .= '<a href="' . esc_attr( $url ) . '" target="_blank" rel="nofollow noopener"' . $this->get_link_style_tag( $atts ) . ' class="convertkit-broadcast-title">' . esc_html( $broadcast['title'] ) . '</a>';
@@ -650,16 +648,23 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 			</a>';
 		}
 
-		// Display description.
-		// We check for description, as these were added to the API in https://github.com/ConvertKit/convertkit/pull/23938,
-		// and might not immediately be available until the resources are refreshed.
-		if ( $atts['display_description'] && array_key_exists( 'description', $broadcast ) && ! is_null( $broadcast['description'] ) ) {
-			$html .= '<span class="convertkit-broadcast-description">' . esc_html( $broadcast['description'] ) . '</span>';
-		}
+		// Display description / read more.
+		if ( $atts['display_description'] || $atts['display_read_more'] ) {
+			$html .= '<span class="convertkit-broadcast-text">';
 
-		// Display read more link.
-		if ( $atts['display_read_more'] ) {
-			$html .= '<a href="' . esc_attr( $url ) . '" target="_blank" rel="nofollow noopener" class="convertkit-broadcast-read-more">' . esc_html( $atts['read_more_label'] ) . '</a>';
+			// Display description.
+			// We check for description, as these were added to the API in https://github.com/ConvertKit/convertkit/pull/23938,
+			// and might not immediately be available until the resources are refreshed.
+			if ( $atts['display_description'] && array_key_exists( 'description', $broadcast ) && ! is_null( $broadcast['description'] ) ) {
+				$html .= esc_html( $broadcast['description'] );
+			}
+
+			// Display read more link.
+			if ( $atts['display_read_more'] ) {
+				$html .= '<a href="' . esc_attr( $url ) . '" target="_blank" rel="nofollow noopener" class="convertkit-broadcast-read-more">' . esc_html( $atts['read_more_label'] ) . '</a>';
+			}
+
+			$html .= '</span>';
 		}
 
 		// Close list item.

--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -675,7 +675,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 		 * @param   array   $atts       Block attributes.
 		 * @return  string              HTML
 		 */
-		$html = apply_filters( 'convertkit_block_broadcasts_build_html_list_item', $html, $broadcast );
+		$html = apply_filters( 'convertkit_block_broadcasts_build_html_list_item', $html, $broadcast, $atts );
 
 		return $html;
 

--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -612,11 +612,6 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 	 */
 	private function build_html_list_item( $broadcast, $atts ) {
 
-		// @TODO Remove debugging.
-		$broadcast['description']   = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce aliquam dui sed mattis aliquam. Aliquam fringilla lobortis diam nec posuere. Phasellus auctor et lacus eget consectetur.';
-		$broadcast['thumbnail_url'] = 'https://placehold.co/600x400';
-		$broadcast['thumbnail_alt'] = 'Broadcast image alt text';
-
 		// Convert UTC date to timestamp.
 		$date_timestamp = strtotime( $broadcast['published_at'] );
 

--- a/includes/blocks/class-convertkit-block-content.php
+++ b/includes/blocks/class-convertkit-block-content.php
@@ -66,7 +66,7 @@ class ConvertKit_Block_Content extends ConvertKit_Block {
 			// TinyMCE / QuickTags Modal Width and Height.
 			'modal'                         => array(
 				'width'  => 500,
-				'height' => 100,
+				'height' => 106,
 			),
 
 			'shortcode_include_closing_tag' => true,

--- a/includes/blocks/class-convertkit-block-form-trigger.php
+++ b/includes/blocks/class-convertkit-block-form-trigger.php
@@ -96,7 +96,7 @@ class ConvertKit_Block_Form_Trigger extends ConvertKit_Block {
 			// Shortcode: TinyMCE / QuickTags Modal Width and Height.
 			'modal'                             => array(
 				'width'  => 500,
-				'height' => 290,
+				'height' => 352,
 			),
 
 			// Shortcode: Include a closing [/shortcode] tag when using TinyMCE or QuickTag Modals.

--- a/includes/blocks/class-convertkit-block-form.php
+++ b/includes/blocks/class-convertkit-block-form.php
@@ -101,7 +101,7 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 			// Shortcode: TinyMCE / QuickTags Modal Width and Height.
 			'modal'                             => array(
 				'width'  => 500,
-				'height' => 100,
+				'height' => 106,
 			),
 
 			// Shortcode: Include a closing [/shortcode] tag when using TinyMCE or QuickTag Modals.

--- a/includes/blocks/class-convertkit-block-product.php
+++ b/includes/blocks/class-convertkit-block-product.php
@@ -118,7 +118,7 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 			// Shortcode: TinyMCE / QuickTags Modal Width and Height.
 			'modal'                             => array(
 				'width'  => 500,
-				'height' => 290,
+				'height' => 295,
 			),
 
 			// Shortcode: Include a closing [/shortcode] tag when using TinyMCE or QuickTag Modals.

--- a/resources/backend/css/tinymce.css
+++ b/resources/backend/css/tinymce.css
@@ -4,7 +4,7 @@
 .convertkit-option {
 	display: grid;
 	grid-template-areas: "left right";
-	grid-template-columns: 120px auto;
+	grid-template-columns: 150px auto;
 	grid-column-gap: 5px;
 	grid-row-gap: 5px;
 	justify-items: start;

--- a/resources/backend/css/tinymce.css
+++ b/resources/backend/css/tinymce.css
@@ -1,6 +1,10 @@
 /**
  * TinyMCE and QuickTag Modals
  */
+#convertkit-modal-body #convertkit-modal-body-body {
+	/* Scroll inner contents so that modal height doesn't need to exceed screen resolution. */
+	overflow-y: auto;
+}
 .convertkit-option {
 	display: grid;
 	grid-template-areas: "left right";

--- a/resources/backend/js/quicktags.js
+++ b/resources/backend/js/quicktags.js
@@ -62,7 +62,7 @@ function convertKitQuickTagRegister( block ) {
 						if ( height > 580 ) {
 							height = 580;
 						}
-						
+
 						$( 'div.convertkit-quicktags-modal div.media-modal.wp-core-ui' ).css(
 							{
 								height: ( $( 'div.convertkit-quicktags-modal div.media-frame-title h1' ).outerHeight() + height + 6 ) + 'px' // Additional 6px prevents a vertical scroll bar due to larger title vs. TinyMCE.

--- a/resources/backend/js/quicktags.js
+++ b/resources/backend/js/quicktags.js
@@ -54,10 +54,18 @@ function convertKitQuickTagRegister( block ) {
 						// Initialize color pickers.
 						$( '.convertkit-color-picker' ).wpColorPicker();
 
-						// Resize Modal height to prevent whitespace below form.
+						// Resize Modal height up to a maximum of 580px.
+						// This ensures shortcodes with fewer options don't display whitespace below form fields,
+						// and shortcodes with many options won't result in the modal exceeding the size of the screen.
+						// Content will overflow-y to show a scrollbar where necessary.
+						let height = $( 'div.convertkit-quicktags-modal form.convertkit-tinymce-popup' ).height();
+						if ( height > 580 ) {
+							height = 580;
+						}
+						
 						$( 'div.convertkit-quicktags-modal div.media-modal.wp-core-ui' ).css(
 							{
-								height: ( $( 'div.convertkit-quicktags-modal div.media-frame-title h1' ).outerHeight() + $( 'div.convertkit-quicktags-modal form.convertkit-tinymce-popup' ).height() + 6 ) + 'px' // Additional 6px prevents a vertical scroll bar.
+								height: ( $( 'div.convertkit-quicktags-modal div.media-frame-title h1' ).outerHeight() + height + 6 ) + 'px' // Additional 6px prevents a vertical scroll bar due to larger title vs. TinyMCE.
 							}
 						);
 

--- a/resources/backend/js/tinymce.js
+++ b/resources/backend/js/tinymce.js
@@ -44,7 +44,10 @@ function convertKitTinyMCERegisterPlugin( block ) {
 								id: 	'convertkit-modal-body',
 								title: 	block.title,
 								width: 	block.modal.width,
-								height: block.modal.height,
+								
+								// Set modal height up to a maximum of 580px.
+								// Content will overflow-y to show a scrollbar where necessary.
+								height: ( block.modal.height < 580 ? block.modal.height : 580 ),
 								inline: 1,
 								buttons:[],
 							}

--- a/resources/backend/js/tinymce.js
+++ b/resources/backend/js/tinymce.js
@@ -44,7 +44,7 @@ function convertKitTinyMCERegisterPlugin( block ) {
 								id: 	'convertkit-modal-body',
 								title: 	block.title,
 								width: 	block.modal.width,
-								
+
 								// Set modal height up to a maximum of 580px.
 								// Content will overflow-y to show a scrollbar where necessary.
 								height: ( block.modal.height < 580 ? block.modal.height : 580 ),

--- a/resources/frontend/css/broadcasts.css
+++ b/resources/frontend/css/broadcasts.css
@@ -17,21 +17,58 @@
 	margin: 0;
 	padding: 0;
 }
+
+/**
+ * List View
+ */
 .convertkit-broadcasts-list li {
 	display: grid;
-	grid-template-areas: "date subject";
+	grid-template-areas: 
+		"date title"
+		"image description"
+		"blank read-more";
 	grid-template-columns: 150px auto;
 	grid-column-gap: 20px;
+}
+
+/**
+ * Grid View - TODO.
+ */
+
+
+/**
+ * Broadcast Item
+ */
+.convertkit-broadcasts-list li {
 	list-style: none;
 	margin: 0;
 	padding: 5px 0;
 }
-.convertkit-broadcasts-list li time {
+.convertkit-broadcasts-list li .convertkit-broadcast-date {
 	grid-area: date;
 }
-.convertkit-broadcasts-list li a {
-	grid-area: subject;
+.convertkit-broadcasts-list li .convertkit-broadcast-title {
+	grid-area: title;
 }
+.convertkit-broadcasts-list li .convertkit-broadcast-image {
+	grid-area: image;
+}
+.convertkit-broadcasts-list li .convertkit-broadcast-image img {
+	max-width: 100%;
+	height: auto;
+}
+.convertkit-broadcasts-list li .convertkit-broadcast-description {
+	grid-area: description;
+	font-size: 16px;
+	font-style: italic;
+}
+.convertkit-broadcasts-list li .convertkit-broadcast-read-more {
+	grid-area: read-more;
+}
+
+/**
+ * Pagination
+ */
 .convertkit-broadcasts-pagination {
 	display: grid;
 	grid-template-areas: "prev next";

--- a/resources/frontend/css/broadcasts.css
+++ b/resources/frontend/css/broadcasts.css
@@ -23,7 +23,7 @@
  */
 .convertkit-broadcasts-list li {
 	display: grid;
-	grid-template-areas: 
+	grid-template-areas:
 		"date title"
 		"image description"
 		"blank read-more";

--- a/resources/frontend/css/broadcasts.css
+++ b/resources/frontend/css/broadcasts.css
@@ -61,7 +61,7 @@
 	margin: 0;
 	padding: 5px 0;
 }
-.convertkit-broadcasts-list li .convertkit-broadcast-date {
+.convertkit-broadcasts-list li time {
 	display: inline-block;
 	grid-area: date;
 }

--- a/resources/frontend/css/broadcasts.css
+++ b/resources/frontend/css/broadcasts.css
@@ -38,6 +38,7 @@
 	grid-template-columns: repeat(3, 1fr);
 	grid-column-gap: 20px;
 	grid-row-gap: 20px;
+	align-items: start;
 }
 .convertkit-broadcasts[data-display-grid="1"] .convertkit-broadcasts-list li {
 	grid-template-areas:

--- a/resources/frontend/css/broadcasts.css
+++ b/resources/frontend/css/broadcasts.css
@@ -25,16 +25,32 @@
 	display: grid;
 	grid-template-areas:
 		"date title"
-		"image description"
-		"blank read-more";
+		"image text";
 	grid-template-columns: 150px auto;
 	grid-column-gap: 20px;
 }
 
 /**
- * Grid View - TODO.
+ * Grid View.
  */
-
+.convertkit-broadcasts[data-display-grid="1"] .convertkit-broadcasts-list {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	grid-column-gap: 20px;
+	grid-row-gap: 20px;
+}
+.convertkit-broadcasts[data-display-grid="1"] .convertkit-broadcasts-list li {
+	grid-template-areas:
+		"image"
+		"date"
+		"title"
+		"text";
+	grid-template-columns: none;
+	grid-row-gap: 10px;
+}
+.convertkit-broadcasts[data-display-grid="1"] .convertkit-broadcasts-list li .convertkit-broadcast-read-more {
+	margin: 10px 0 0 0;
+}
 
 /**
  * Broadcast Item
@@ -45,25 +61,28 @@
 	padding: 5px 0;
 }
 .convertkit-broadcasts-list li .convertkit-broadcast-date {
+	display: inline-block;
 	grid-area: date;
 }
 .convertkit-broadcasts-list li .convertkit-broadcast-title {
+	display: inline-block;
 	grid-area: title;
 }
 .convertkit-broadcasts-list li .convertkit-broadcast-image {
+	display: inline-block;
 	grid-area: image;
 }
 .convertkit-broadcasts-list li .convertkit-broadcast-image img {
 	max-width: 100%;
 	height: auto;
 }
-.convertkit-broadcasts-list li .convertkit-broadcast-description {
-	grid-area: description;
+.convertkit-broadcasts-list li .convertkit-broadcast-text {
+	display: inline-block;
+	grid-area: text;
 	font-size: 16px;
-	font-style: italic;
 }
 .convertkit-broadcasts-list li .convertkit-broadcast-read-more {
-	grid-area: read-more;
+	display: block;
 }
 
 /**

--- a/resources/frontend/js/broadcasts.js
+++ b/resources/frontend/js/broadcasts.js
@@ -21,17 +21,21 @@ jQuery( document ).ready(
 				e.preventDefault();
 
 				// Get block container and build object of data-* attributes.
-				var blockContainer = $( this ).closest( 'div.convertkit-broadcasts' ),
-					atts           = {
-						date_format: $( blockContainer ).data( 'date-format' ),
-						limit: $( blockContainer ).data( 'limit' ),
-						paginate: $( blockContainer ).data( 'paginate' ),
-						paginate_label_prev: $( blockContainer ).data( 'paginate-label-prev' ),
-						paginate_label_next: $( blockContainer ).data( 'paginate-label-next' ),
-						link_color: $( blockContainer ).data( 'link-color' ),
-
-						page: $( this ).data( 'page' ), // Page is supplied as a data- attribute on the link clicked, not the container.
-						nonce: $( this ).data( 'nonce' ) // Nonce is supplied as a data- attribute on the link clicked, not the container.
+				let blockContainer = $( this ).closest( 'div.convertkit-broadcasts' );
+				let atts           = {
+					display_date: $( blockContainer ).data( 'display-date' ),
+					date_format: $( blockContainer ).data( 'date-format' ),
+					display_image: $( blockContainer ).data( 'display-image' ),
+					display_description: $( blockContainer ).data( 'display-description' ),
+					display_read_more: $( blockContainer ).data( 'display-read-more' ),
+					read_more_label: $( blockContainer ).data( 'read-more-label' ),
+					limit: $( blockContainer ).data( 'limit' ),
+					paginate: $( blockContainer ).data( 'paginate' ),
+					paginate_label_prev: $( blockContainer ).data( 'paginate-label-prev' ),
+					paginate_label_next: $( blockContainer ).data( 'paginate-label-next' ),
+					link_color: $( blockContainer ).data( 'link-color' ),
+					page: $( this ).data( 'page' ), // Page is supplied as a data- attribute on the link clicked, not the container.
+					nonce: $( this ).data( 'nonce' ) // Nonce is supplied as a data- attribute on the link clicked, not the container.
 				};
 
 				convertKitBroadcastsRender( blockContainer, atts );

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -232,25 +232,34 @@ class Plugin extends \Codeception\Module
 			'convertkit_posts',
 			[
 				224758 => [
-					'id'           => 224758,
-					'title'        => 'Test Subject',
-					'url'          => 'https://cheerful-architect-3237.ck.page/posts/test-subject',
-					'published_at' => '2022-01-24T00:00:00.000Z',
-					'is_paid'      => null,
+					'id'            => 224758,
+					'title'         => 'Test Subject',
+					'url'           => 'https://cheerful-architect-3237.ck.page/posts/test-subject',
+					'published_at'  => '2022-01-24T00:00:00.000Z',
+					'description'   => 'Description text for Test Subject',
+					'thumbnail_url' => 'https://placehold.co/600x400',
+					'thumbnail_alt' => 'Alt text for Test Subject',
+					'is_paid'       => null,
 				],
 				489480 => [
-					'id'           => 489480,
-					'title'        => 'Broadcast 2',
-					'url'          => 'https://cheerful-architect-3237.ck.page/posts/broadcast-2',
-					'published_at' => '2022-04-08T00:00:00.000Z',
-					'is_paid'      => null,
+					'id'            => 489480,
+					'title'         => 'Broadcast 2',
+					'url'           => 'https://cheerful-architect-3237.ck.page/posts/broadcast-2',
+					'published_at'  => '2022-04-08T00:00:00.000Z',
+					'description'   => 'Description text for Broadcast 2',
+					'thumbnail_url' => 'https://placehold.co/600x400',
+					'thumbnail_alt' => 'Alt text for Broadcast 2',
+					'is_paid'       => null,
 				],
 				572575 => [
-					'id'           => 572575,
-					'title'        => 'Paid Subscriber Broadcast',
-					'url'          => 'https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast',
-					'published_at' => '2022-05-03T00:00:00.000Z',
-					'is_paid'      => true,
+					'id'            => 572575,
+					'title'         => 'Paid Subscriber Broadcast',
+					'url'           => 'https://cheerful-architect-3237.ck.page/posts/paid-subscriber-broadcast',
+					'published_at'  => '2022-05-03T00:00:00.000Z',
+					'description'   => 'Description text for Paid Subscriber Broadcast',
+					'thumbnail_url' => 'https://placehold.co/600x400',
+					'thumbnail_alt' => 'Alt text for Paid Subscriber Broadcast',
+					'is_paid'       => true,
 				],
 			]
 		);
@@ -625,7 +634,7 @@ class Plugin extends \Codeception\Module
 
 	/**
 	 * Check that expected HTML exists in the DOM of the page we're viewing for
-	 * a Broadcasts block or shortcode.
+	 * a Broadcasts block or shortcode, based on its configuration.
 	 *
 	 * @since   1.9.7.5
 	 *
@@ -633,33 +642,73 @@ class Plugin extends \Codeception\Module
 	 * @param   bool|int         $numberOfPosts          Number of Broadcasts listed.
 	 * @param   bool|string      $seePrevPaginationLabel Test if the "previous" pagination link is output and matches expected label.
 	 * @param   bool|string      $seeNextPaginationLabel Test if the "next" pagination link is output and matches expected label.
+	 * @param 	bool 			 $seeGrid 				 Test if the broadcasts are displayed in grid view (false = list view).
+	 * @param 	bool 			 $seeImage 				 Test if the broadcasts display images.
+	 * @param 	bool 			 $seeDescription 		 Test if the broadcasts display descriptions.
+	 * @param 	bool|string 	 $seeReadMore 			 Test if the broadcasts display a read more link matching the given text.
 	 */
-	public function seeBroadcastsOutput($I, $numberOfPosts = false, $seePrevPaginationLabel = false, $seeNextPaginationLabel = false)
+	public function seeBroadcastsOutput($I, $numberOfPosts = false, $seePrevPaginationLabel = false, $seeNextPaginationLabel = false, $seeGrid = false, $seeImage = false, $seeDescription = false, $seeReadMore = false)
 	{
 		// Confirm that the block displays.
 		$I->seeElementInDOM('div.convertkit-broadcasts');
 		$I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-list');
 		$I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast');
-		$I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast a');
+		$I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast a.convertkit-broadcast-title');
 
 		// Confirm that UTM parameters exist on a broadcast link.
 		$I->assertStringContainsString(
 			'utm_source=wordpress&utm_term=en_US&utm_content=convertkit',
-			$I->grabAttributeFrom('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast a', 'href')
+			$I->grabAttributeFrom('a.convertkit-broadcast-title', 'href')
 		);
+
+		// If Display as grid is enabled, confirm the applicable HTML exists so that CSS can style this layout.
+		if ($seeGrid) {
+			$I->seeElementInDOM('div.convertkit-broadcasts[data-display-grid="1"]');
+		} else {
+			$I->dontSeeElementInDOM('div.convertkit-broadcasts[data-display-grid="1"]');
+		}
+
+		// If Display image is enabled, confirm the image is displayed.
+		if ($seeImage) {
+			$I->seeElementInDOM('a.convertkit-broadcast-image img');
+			$I->assertStringContainsString(
+				'utm_source=wordpress&utm_term=en_US&utm_content=convertkit',
+				$I->grabAttributeFrom('a.convertkit-broadcast-image', 'href')
+			);
+		} else {
+			$I->dontSeeElementInDOM('a.convertkit-broadcast-image img');
+		}
+
+		// If Display description is enabled, confirm the description is displayed.
+		if ($seeDescription) {
+			$I->seeElementInDOM('.convertkit-broadcast-text');
+		} else {
+			$I->dontSeeElementInDOM('.convertkit-broadcast-text');
+		}
+
+		// If Display read more link is enabled, confirm the read more link is displayed and matches the given text.
+		if ($seeReadMore) {
+			$I->seeElementInDOM('a.convertkit-broadcast-read-more');
+			$I->assertStringContainsString(
+				'utm_source=wordpress&utm_term=en_US&utm_content=convertkit',
+				$I->grabAttributeFrom('a.convertkit-broadcast-read-more', 'href')
+			);
+		} else {
+			$I->dontSeeElementInDOM('a.convertkit-broadcast-read-more');
+		}
 
 		// Confirm that the number of expected broadcasts displays.
 		if ($numberOfPosts !== false) {
 			$I->seeNumberOfElements('li.convertkit-broadcast', $numberOfPosts);
 		}
 
-		// Confirm that previous pagination displays.
+		// Confirm that previous pagination displays, if expected.
 		if ($seePrevPaginationLabel !== false) {
 			$I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-pagination li.convertkit-broadcasts-pagination-prev a');
 			$I->seeInSource($seePrevPaginationLabel);
 		}
 
-		// Confirm that next pagination displays.
+		// Confirm that next pagination displays, if expected.
 		if ($seeNextPaginationLabel !== false) {
 			$I->seeElementInDOM('div.convertkit-broadcasts ul.convertkit-broadcasts-pagination li.convertkit-broadcasts-pagination-next a');
 		}

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -642,10 +642,10 @@ class Plugin extends \Codeception\Module
 	 * @param   bool|int         $numberOfPosts          Number of Broadcasts listed.
 	 * @param   bool|string      $seePrevPaginationLabel Test if the "previous" pagination link is output and matches expected label.
 	 * @param   bool|string      $seeNextPaginationLabel Test if the "next" pagination link is output and matches expected label.
-	 * @param 	bool 			 $seeGrid 				 Test if the broadcasts are displayed in grid view (false = list view).
-	 * @param 	bool 			 $seeImage 				 Test if the broadcasts display images.
-	 * @param 	bool 			 $seeDescription 		 Test if the broadcasts display descriptions.
-	 * @param 	bool|string 	 $seeReadMore 			 Test if the broadcasts display a read more link matching the given text.
+	 * @param   bool             $seeGrid                Test if the broadcasts are displayed in grid view (false = list view).
+	 * @param   bool             $seeImage               Test if the broadcasts display images.
+	 * @param   bool             $seeDescription         Test if the broadcasts display descriptions.
+	 * @param   bool|string      $seeReadMore            Test if the broadcasts display a read more link matching the given text.
 	 */
 	public function seeBroadcastsOutput($I, $numberOfPosts = false, $seePrevPaginationLabel = false, $seeNextPaginationLabel = false, $seeGrid = false, $seeImage = false, $seeDescription = false, $seeReadMore = false)
 	{
@@ -681,9 +681,9 @@ class Plugin extends \Codeception\Module
 
 		// If Display description is enabled, confirm the description is displayed.
 		if ($seeDescription) {
-			$I->seeElementInDOM('.convertkit-broadcast-text');
+			$I->seeElementInDOM('.convertkit-broadcast-description');
 		} else {
-			$I->dontSeeElementInDOM('.convertkit-broadcast-text');
+			$I->dontSeeElementInDOM('.convertkit-broadcast-description');
 		}
 
 		// If Display read more link is enabled, confirm the read more link is displayed and matches the given text.

--- a/tests/_support/Helper/Acceptance/WPGutenberg.php
+++ b/tests/_support/Helper/Acceptance/WPGutenberg.php
@@ -103,7 +103,9 @@ class WPGutenberg extends \Codeception\Module
 						$I->selectOption($fieldID, $attributes[1]);
 						break;
 					case 'toggle':
-						$I->click($field);
+						if ( $attributes[1] ) {
+							$I->click($field);
+						}
 						break;
 					default:
 						$I->fillField($fieldID, $attributes[1]);

--- a/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
@@ -91,6 +91,46 @@ class PageBlockBroadcastsCest
 	}
 
 	/**
+	 * Test the Broadcasts block's "Display as grid" parameter works.
+	 *
+	 * @since   2.2.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsBlockWithDisplayGridParameter(AcceptanceTester $I)
+	{
+		// Setup Plugin and enable debug log.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Display as Grid');
+
+		// Add block to Page, setting the date format.
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			[
+				'#inspector-toggle-control-0' => [ 'toggle', true ],
+			]
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that the block displays correctly with the expected number of Broadcasts in the grid format.
+		$I->seeBroadcastsOutput(
+			$I, 
+			3, // Confirm 3 broadcasts are output.
+			false, // Don't check previous pagination label. 
+			false, // Don't check next pagination label.
+			true // Confirm grid mode is set.
+		);
+
+	}
+
+	/**
 	 * Test the Broadcasts block's date format parameter works.
 	 *
 	 * @since   1.9.7.4
@@ -119,20 +159,145 @@ class PageBlockBroadcastsCest
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
 
-		// Confirm that the block displays.
-		$I->seeBroadcastsOutput($I);
+		// Confirm that the block displays correctly with the expected number of Broadcasts.
+		$I->seeBroadcastsOutput($I, 3);
 
 		// Confirm that the date format is as expected.
 		$I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
-
-		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', [ 1, 10 ]);
 
 		// Confirm that the expected Broadcast name is displayed first links to the expected URL, with UTM parameters.
 		$I->assertEquals(
 			$I->grabAttributeFrom('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast:first-child a', 'href'),
 			$_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&utm_term=en_US&utm_content=convertkit'
 		);
+	}
+
+	/**
+	 * Test the Broadcasts block's "Display image" parameter works.
+	 *
+	 * @since   2.2.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsBlockWithDisplayImageParameter(AcceptanceTester $I)
+	{
+		// Setup Plugin and enable debug log.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Display image');
+
+		// Add block to Page, setting the date format.
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			[
+				'#inspector-toggle-control-0' => [ 'toggle', true ],
+				'#inspector-toggle-control-1' => [ 'toggle', true ],
+			]
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that the block displays correctly with the expected number of Broadcasts in the grid format.
+		$I->seeBroadcastsOutput(
+			$I, 
+			3, // Confirm 3 broadcasts are output.
+			false, // Don't check previous pagination label. 
+			false, // Don't check next pagination label.
+			true, // Confirm grid mode is set.
+			true // Confirm images are displayed.
+		);
+
+	}
+
+	/**
+	 * Test the Broadcasts block's "Display description" parameter works.
+	 *
+	 * @since   2.2.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsBlockWithDisplayDescriptionParameter(AcceptanceTester $I)
+	{
+		// Setup Plugin and enable debug log.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Display description');
+
+		// Add block to Page, setting the date format.
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			[
+				'#inspector-toggle-control-2' => [ 'toggle', true ],
+			]
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that the block displays correctly with the expected number of Broadcasts in the grid format.
+		$I->seeBroadcastsOutput(
+			$I, 
+			3, // Confirm 3 broadcasts are output.
+			false, // Don't check previous pagination label. 
+			false, // Don't check next pagination label.
+			false, // Confirm grid mode is not set.
+			false, // Confirm images are not displayed.
+			true // Confirm description is displayed.
+		);
+
+	}
+
+	/**
+	 * Test the Broadcasts block's "Display read more link" parameter works.
+	 *
+	 * @since   2.2.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsBlockWithDisplayReadMoreLinkParameter(AcceptanceTester $I)
+	{
+		// Setup Plugin and enable debug log.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Display read more link');
+
+		// Add block to Page, setting the date format.
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Broadcasts',
+			'convertkit-broadcasts',
+			[
+				'#inspector-toggle-control-3' => [ 'toggle', true ],
+				'read_more_label'     		  => [ 'input', 'Continue reading' ],
+			]
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that the block displays correctly with the expected number of Broadcasts in the grid format.
+		$I->seeBroadcastsOutput(
+			$I, 
+			3, // Confirm 3 broadcasts are output.
+			false, // Don't check previous pagination label. 
+			false, // Don't check next pagination label.
+			false, // Confirm grid mode is not set.
+			false, // Confirm images are not displayed.
+			false, // Confirm description is not displayed.
+			'Continue reading' // Confirm read more link is displayed with correct text.
+		);
+
 	}
 
 	/**
@@ -164,11 +329,8 @@ class PageBlockBroadcastsCest
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
 
-		// Confirm that the block displays.
-		$I->seeBroadcastsOutput($I);
-
-		// Confirm that the expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', 2);
+		// Confirm that the block displays correctly with the expected number of Broadcasts.
+		$I->seeBroadcastsOutput($I, 2);
 
 		// Confirm that the expected Broadcast name is displayed first links to the expected URL, with UTM parameters.
 		$I->assertEquals(
@@ -207,11 +369,8 @@ class PageBlockBroadcastsCest
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
 
-		// Confirm that the block displays.
-		$I->seeBroadcastsOutput($I);
-
-		// Confirm that the expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', [ 1, 10 ]);
+		// Confirm that the block displays correctly with the expected number of Broadcasts.
+		$I->seeBroadcastsOutput($I, 3);
 
 		// Confirm that the expected Broadcast name is displayed first links to the expected URL, with UTM parameters.
 		$I->assertEquals(
@@ -364,7 +523,7 @@ class PageBlockBroadcastsCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the block displays.
-		$I->seeBroadcastsOutput($I);
+		$I->seeBroadcastsOutput($I, 3);
 
 		// Confirm that our stylesheet loaded.
 		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
@@ -411,7 +570,7 @@ class PageBlockBroadcastsCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the block displays.
-		$I->seeBroadcastsOutput($I);
+		$I->seeBroadcastsOutput($I, 3);
 
 		// Confirm that our stylesheet loaded.
 		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');

--- a/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
@@ -121,9 +121,9 @@ class PageBlockBroadcastsCest
 
 		// Confirm that the block displays correctly with the expected number of Broadcasts in the grid format.
 		$I->seeBroadcastsOutput(
-			$I, 
+			$I,
 			3, // Confirm 3 broadcasts are output.
-			false, // Don't check previous pagination label. 
+			false, // Don't check previous pagination label.
 			false, // Don't check next pagination label.
 			true // Confirm grid mode is set.
 		);
@@ -204,9 +204,9 @@ class PageBlockBroadcastsCest
 
 		// Confirm that the block displays correctly with the expected number of Broadcasts in the grid format.
 		$I->seeBroadcastsOutput(
-			$I, 
+			$I,
 			3, // Confirm 3 broadcasts are output.
-			false, // Don't check previous pagination label. 
+			false, // Don't check previous pagination label.
 			false, // Don't check next pagination label.
 			true, // Confirm grid mode is set.
 			true // Confirm images are displayed.
@@ -245,9 +245,9 @@ class PageBlockBroadcastsCest
 
 		// Confirm that the block displays correctly with the expected number of Broadcasts in the grid format.
 		$I->seeBroadcastsOutput(
-			$I, 
+			$I,
 			3, // Confirm 3 broadcasts are output.
-			false, // Don't check previous pagination label. 
+			false, // Don't check previous pagination label.
 			false, // Don't check next pagination label.
 			false, // Confirm grid mode is not set.
 			false, // Confirm images are not displayed.
@@ -279,7 +279,7 @@ class PageBlockBroadcastsCest
 			'convertkit-broadcasts',
 			[
 				'#inspector-toggle-control-3' => [ 'toggle', true ],
-				'read_more_label'     		  => [ 'input', 'Continue reading' ],
+				'read_more_label'             => [ 'input', 'Continue reading' ],
 			]
 		);
 
@@ -288,9 +288,9 @@ class PageBlockBroadcastsCest
 
 		// Confirm that the block displays correctly with the expected number of Broadcasts in the grid format.
 		$I->seeBroadcastsOutput(
-			$I, 
+			$I,
 			3, // Confirm 3 broadcasts are output.
-			false, // Don't check previous pagination label. 
+			false, // Don't check previous pagination label.
 			false, // Don't check next pagination label.
 			false, // Confirm grid mode is not set.
 			false, // Confirm images are not displayed.
@@ -370,7 +370,7 @@ class PageBlockBroadcastsCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the block displays correctly with the expected number of Broadcasts.
-		$I->seeBroadcastsOutput($I, 3);
+		$I->seeBroadcastsOutput($I, 1);
 
 		// Confirm that the expected Broadcast name is displayed first links to the expected URL, with UTM parameters.
 		$I->assertEquals(
@@ -401,8 +401,8 @@ class PageBlockBroadcastsCest
 			'ConvertKit Broadcasts',
 			'convertkit-broadcasts',
 			[
-				'limit'                   => [ 'input', '1' ],
-				'.components-form-toggle' => [ 'toggle', true ],
+				'limit'                       => [ 'input', '1' ],
+				'#inspector-toggle-control-4' => [ 'toggle', true ],
 			]
 		);
 
@@ -435,10 +435,10 @@ class PageBlockBroadcastsCest
 			'ConvertKit Broadcasts',
 			'convertkit-broadcasts',
 			[
-				'limit'                   => [ 'input', '1' ],
-				'.components-form-toggle' => [ 'toggle', true ],
-				'paginate_label_prev'     => [ 'input', 'Newer' ],
-				'paginate_label_next'     => [ 'input', 'Older' ],
+				'limit'                       => [ 'input', '1' ],
+				'#inspector-toggle-control-4' => [ 'toggle', true ],
+				'paginate_label_prev'         => [ 'input', 'Newer' ],
+				'paginate_label_next'         => [ 'input', 'Older' ],
 			]
 		);
 
@@ -471,10 +471,10 @@ class PageBlockBroadcastsCest
 			'ConvertKit Broadcasts',
 			'convertkit-broadcasts',
 			[
-				'limit'                   => [ 'input', '1' ],
-				'.components-form-toggle' => [ 'toggle', true ],
-				'paginate_label_prev'     => [ 'input', '' ],
-				'paginate_label_next'     => [ 'input', '' ],
+				'limit'                       => [ 'input', '1' ],
+				'#inspector-toggle-control-4' => [ 'toggle', true ],
+				'paginate_label_prev'         => [ 'input', '' ],
+				'paginate_label_next'         => [ 'input', '' ],
 			]
 		);
 

--- a/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
@@ -74,14 +74,11 @@ class PageBlockBroadcastsCest
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
 
-		// Confirm that the block displays.
-		$I->seeBroadcastsOutput($I);
+		// Confirm that the block displays correctly with the expected number of Broadcasts.
+		$I->seeBroadcastsOutput($I, 3);
 
 		// Confirm that the default date format is as expected.
 		$I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
-
-		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', [ 1, 10 ]);
 
 		// Confirm that the expected Broadcast name is displayed first links to the expected URL, with UTM parameters.
 		$I->assertEquals(
@@ -522,7 +519,7 @@ class PageBlockBroadcastsCest
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the block displays.
+		// Confirm that the block displays correctly with the expected number of Broadcasts.
 		$I->seeBroadcastsOutput($I, 3);
 
 		// Confirm that our stylesheet loaded.
@@ -569,7 +566,7 @@ class PageBlockBroadcastsCest
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the block displays.
+		// Confirm that the block displays correctly with the expected number of Broadcasts.
 		$I->seeBroadcastsOutput($I, 3);
 
 		// Confirm that our stylesheet loaded.

--- a/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
@@ -38,7 +38,7 @@ class PageShortcodeBroadcastsCest
 			$I,
 			'ConvertKit Broadcasts',
 			false,
-			'[convertkit_broadcasts date_format="F j, Y" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -80,7 +80,7 @@ class PageShortcodeBroadcastsCest
 			[
 				'date_format' => [ 'select', date('Y-m-d') ],
 			],
-			'[convertkit_broadcasts date_format="Y-m-d" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			'[convertkit_broadcasts display_grid="0" date_format="Y-m-d" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -122,7 +122,7 @@ class PageShortcodeBroadcastsCest
 			[
 				'limit' => [ 'input', '2' ],
 			],
-			'[convertkit_broadcasts date_format="F j, Y" limit="2" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -165,7 +165,7 @@ class PageShortcodeBroadcastsCest
 				'limit'    => [ 'input', '1' ],
 				'paginate' => [ 'toggle', 'Yes' ],
 			],
-			'[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="1" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -198,7 +198,7 @@ class PageShortcodeBroadcastsCest
 				'paginate_label_prev' => [ 'input', 'Newer' ],
 				'paginate_label_next' => [ 'input', 'Older' ],
 			],
-			'[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older"]'
+			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="1" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -231,7 +231,7 @@ class PageShortcodeBroadcastsCest
 				'paginate_label_prev' => [ 'input', '' ],
 				'paginate_label_next' => [ 'input', '' ],
 			],
-			'[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1"]'
+			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="1" paginate="1"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -263,7 +263,7 @@ class PageShortcodeBroadcastsCest
 		$I->havePageInDatabase(
 			[
 				'post_name'    => 'convertkit-page-broadcasts-shortcode-hex-color-params',
-				'post_content' => '[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older" link_color="' . $linkColor . '" background_color="' . $backgroundColor . '" text_color="' . $textColor . '"]',
+				'post_content' => '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="1" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older" link_color="' . $linkColor . '" background_color="' . $backgroundColor . '" text_color="' . $textColor . '"]',
 			]
 		);
 
@@ -311,7 +311,7 @@ class PageShortcodeBroadcastsCest
 			$I,
 			'convertkit-broadcasts',
 			false,
-			'[convertkit_broadcasts date_format="F j, Y" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -347,7 +347,7 @@ class PageShortcodeBroadcastsCest
 			[
 				'date_format' => [ 'select', date('Y-m-d') ],
 			],
-			'[convertkit_broadcasts date_format="Y-m-d" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			'[convertkit_broadcasts display_grid="0" date_format="Y-m-d" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -383,7 +383,7 @@ class PageShortcodeBroadcastsCest
 			[
 				'limit' => [ 'input', '2' ],
 			],
-			'[convertkit_broadcasts date_format="F j, Y" limit="2" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="2" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -420,7 +420,7 @@ class PageShortcodeBroadcastsCest
 				'limit'    => [ 'input', '1' ],
 				'paginate' => [ 'toggle', 'Yes' ],
 			],
-			'[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
+			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="1" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -453,7 +453,7 @@ class PageShortcodeBroadcastsCest
 				'paginate_label_prev' => [ 'input', 'Newer' ],
 				'paginate_label_next' => [ 'input', 'Older' ],
 			],
-			'[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older"]'
+			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="1" paginate="1" paginate_label_prev="Newer" paginate_label_next="Older"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -477,7 +477,7 @@ class PageShortcodeBroadcastsCest
 		$I->havePageInDatabase(
 			[
 				'post_name'    => 'convertkit-page-broadcasts-shortcode-parameter-escaping',
-				'post_content' => '[convertkit_broadcasts date_format="F j, Y" limit="1" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next" link_color=\'red" onmouseover="alert(1)"\']',
+				'post_content' => '[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="1" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next" link_color=\'red" onmouseover="alert(1)"\']',
 			]
 		);
 

--- a/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
@@ -33,7 +33,7 @@ class PageShortcodeBroadcastsCest
 		// Add a Page using the Classic Editor.
 		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor');
 
-		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+		// Add shortcode to Page.
 		$I->addVisualEditorShortcode(
 			$I,
 			'ConvertKit Broadcasts',
@@ -44,19 +44,51 @@ class PageShortcodeBroadcastsCest
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewClassicEditorPage($I);
 
-		// Confirm that the shortcode output displays.
-		$I->seeBroadcastsOutput($I);
+		// Confirm that the shortcode displays correctly with the expected number of Broadcasts.
+		$I->seeBroadcastsOutput($I, 3);
 
 		// Confirm that the default date format is as expected.
 		$I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
-
-		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', [ 1, 10 ]);
 
 		// Confirm that the expected Broadcast name is displayed first links to the expected URL, with UTM parameters.
 		$I->assertEquals(
 			$I->grabAttributeFrom('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast:first-child a', 'href'),
 			$_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&utm_term=en_US&utm_content=convertkit'
+		);
+	}
+
+	/**
+	 * Test the [convertkit_broadcasts] shortcode's "Display as grid" parameter works.
+	 *
+	 * @since   2.2.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsShortcodeInVisualEditorWithDisplayGridParameter(AcceptanceTester $I)
+	{
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Display as Grid');
+
+		// Add shortcode to Page.
+		$I->addVisualEditorShortcode(
+			$I,
+			'ConvertKit Broadcasts',
+			[
+				'display_grid' => [ 'toggle', 'Yes' ],
+			],
+			'[convertkit_broadcasts display_grid="1" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage($I);
+
+		// Confirm that the shortcode displays correctly with the expected number of Broadcasts in the grid format.
+		$I->seeBroadcastsOutput(
+			$I,
+			3, // Confirm 3 broadcasts are output.
+			false, // Don't check previous pagination label.
+			false, // Don't check next pagination label.
+			true // Confirm grid mode is set.
 		);
 	}
 
@@ -73,7 +105,7 @@ class PageShortcodeBroadcastsCest
 		// Add a Page using the Classic Editor.
 		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Date Format');
 
-		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+		// Add shortcode to Page.
 		$I->addVisualEditorShortcode(
 			$I,
 			'ConvertKit Broadcasts',
@@ -86,19 +118,128 @@ class PageShortcodeBroadcastsCest
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewClassicEditorPage($I);
 
-		// Confirm that the shortcode output displays.
-		$I->seeBroadcastsOutput($I);
+		// Confirm that the shortcode displays correctly with the expected number of Broadcasts.
+		$I->seeBroadcastsOutput($I, 3);
 
 		// Confirm that the default date format is as expected.
 		$I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
-
-		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', [ 1, 10 ]);
 
 		// Confirm that the expected Broadcast name is displayed first links to the expected URL, with UTM parameters.
 		$I->assertEquals(
 			$I->grabAttributeFrom('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast:first-child a', 'href'),
 			$_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&utm_term=en_US&utm_content=convertkit'
+		);
+	}
+
+	/**
+	 * Test the [convertkit_broadcasts] shortcode's "Display image" parameter works.
+	 *
+	 * @since   2.2.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsShortcodeInVisualEditorWithDisplayImageParameter(AcceptanceTester $I)
+	{
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Display image');
+
+		// Add shortcode to Page.
+		$I->addVisualEditorShortcode(
+			$I,
+			'ConvertKit Broadcasts',
+			[
+				'display_image' => [ 'toggle', 'Yes' ],
+			],
+			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="1" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage($I);
+
+		// Confirm that the shortcode displays correctly with the expected number of Broadcasts in the grid format.
+		$I->seeBroadcastsOutput(
+			$I,
+			3, // Confirm 3 broadcasts are output.
+			false, // Don't check previous pagination label.
+			false, // Don't check next pagination label.
+			false, // Confirm grid mode is not set.
+			true // Confirm images are displayed.
+		);
+	}
+
+	/**
+	 * Test the [convertkit_broadcasts] shortcode's "Display description" parameter works.
+	 *
+	 * @since   2.2.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsShortcodeInVisualEditorWithDisplayDescriptionParameter(AcceptanceTester $I)
+	{
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Display description');
+
+		// Add shortcode to Page.
+		$I->addVisualEditorShortcode(
+			$I,
+			'ConvertKit Broadcasts',
+			[
+				'display_description' => [ 'toggle', 'Yes' ],
+			],
+			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="1" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage($I);
+
+		// Confirm that the shortcode displays correctly with the expected number of Broadcasts in the grid format.
+		$I->seeBroadcastsOutput(
+			$I,
+			3, // Confirm 3 broadcasts are output.
+			false, // Don't check previous pagination label.
+			false, // Don't check next pagination label.
+			false, // Confirm grid mode is not set.
+			false, // Confirm images are not displayed.
+			true // Confirm description is displayed.
+		);
+	}
+
+	/**
+	 * Test the [convertkit_broadcasts] shortcode's "Display read more link" parameter works.
+	 *
+	 * @since   2.2.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsShortcodeInVisualEditorWithDisplayReadMoreLinkParameter(AcceptanceTester $I)
+	{
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Display read more link');
+
+		// Add shortcode to Page.
+		$I->addVisualEditorShortcode(
+			$I,
+			'ConvertKit Broadcasts',
+			[
+				'display_read_more' => [ 'toggle', 'Yes' ],
+				'read_more_label'   => [ 'input', 'Continue reading' ],
+			],
+			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="1" read_more_label="Continue reading" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage($I);
+
+		// Confirm that the shortcode displays correctly with the expected number of Broadcasts in the grid format.
+		$I->seeBroadcastsOutput(
+			$I,
+			3, // Confirm 3 broadcasts are output.
+			false, // Don't check previous pagination label.
+			false, // Don't check next pagination label.
+			false, // Confirm grid mode is not set.
+			false, // Confirm images are not displayed.
+			false, // Confirm description is not displayed.
+			'Continue reading' // Confirm read more link is displayed with correct text.
 		);
 	}
 
@@ -115,7 +256,7 @@ class PageShortcodeBroadcastsCest
 		// Add a Page using the Classic Editor.
 		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Limit');
 
-		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+		// Add shortcode to Page.
 		$I->addVisualEditorShortcode(
 			$I,
 			'ConvertKit Broadcasts',
@@ -129,13 +270,7 @@ class PageShortcodeBroadcastsCest
 		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the shortcode output displays.
-		$I->seeBroadcastsOutput($I);
-
-		// Confirm that the default date format is as expected.
-		$I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
-
-		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', 2);
+		$I->seeBroadcastsOutput($I, 2);
 
 		// Confirm that the expected Broadcast name is displayed first links to the expected URL, with UTM parameters.
 		$I->assertEquals(
@@ -157,7 +292,7 @@ class PageShortcodeBroadcastsCest
 		// Add a Page using the Classic Editor.
 		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Pagination');
 
-		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+		// Add shortcode to Page.
 		$I->addVisualEditorShortcode(
 			$I,
 			'ConvertKit Broadcasts',
@@ -188,7 +323,7 @@ class PageShortcodeBroadcastsCest
 		// Add a Page using the Classic Editor.
 		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Pagination Labels');
 
-		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+		// Add shortcode to Page.
 		$I->addVisualEditorShortcode(
 			$I,
 			'ConvertKit Broadcasts',
@@ -221,7 +356,7 @@ class PageShortcodeBroadcastsCest
 		// Add a Page using the Classic Editor.
 		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Visual Editor: Blank Pagination Labels');
 
-		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+		// Add shortcode to Page.
 		$I->addVisualEditorShortcode(
 			$I,
 			'ConvertKit Broadcasts',
@@ -276,8 +411,8 @@ class PageShortcodeBroadcastsCest
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the block displays.
-		$I->seeBroadcastsOutput($I);
+		// Confirm that the shortcode displays correctly with the expected number of Broadcasts.
+		$I->seeBroadcastsOutput($I, 1);
 
 		// Confirm that our stylesheet loaded.
 		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
@@ -306,7 +441,7 @@ class PageShortcodeBroadcastsCest
 		// Add a Page using the Classic Editor.
 		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor');
 
-		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+		// Add shortcode to Page.
 		$I->addTextEditorShortcode(
 			$I,
 			'convertkit-broadcasts',
@@ -317,14 +452,50 @@ class PageShortcodeBroadcastsCest
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewClassicEditorPage($I);
 
-		// Confirm that the shortcode output displays.
-		$I->seeBroadcastsOutput($I);
+		// Confirm that the shortcode displays correctly with the expected number of Broadcasts.
+		$I->seeBroadcastsOutput($I, 3);
 
 		// Confirm that the default date format is as expected.
 		$I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
 
 		// Confirm that the default expected number of Broadcasts are displayed.
 		$I->seeNumberOfElements('li.convertkit-broadcast', [ 1, 10 ]);
+	}
+
+	/**
+	 * Test the [convertkit_broadcasts] shortcode's "Display as grid" parameter works
+	 * using the Text Editor.
+	 *
+	 * @since   2.2.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsShortcodeInTextEditorWithDisplayGridParameter(AcceptanceTester $I)
+	{
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor: Display as Grid');
+
+		// Add shortcode to Page.
+		$I->addTextEditorShortcode(
+			$I,
+			'convertkit-broadcasts',
+			[
+				'display_grid' => [ 'toggle', 'Yes' ],
+			],
+			'[convertkit_broadcasts display_grid="1" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage($I);
+
+		// Confirm that the shortcode displays correctly with the expected number of Broadcasts in the grid format.
+		$I->seeBroadcastsOutput(
+			$I,
+			3, // Confirm 3 broadcasts are output.
+			false, // Don't check previous pagination label.
+			false, // Don't check next pagination label.
+			true // Confirm grid mode is set.
+		);
 	}
 
 	/**
@@ -353,14 +524,126 @@ class PageShortcodeBroadcastsCest
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewClassicEditorPage($I);
 
-		// Confirm that the shortcode output displays.
-		$I->seeBroadcastsOutput($I);
+		// Confirm that the shortcode displays correctly with the expected number of Broadcasts.
+		$I->seeBroadcastsOutput($I, 3);
 
 		// Confirm that the default date format is as expected.
 		$I->seeInSource('<time datetime="2022-04-08">2022-04-08</time>');
+	}
 
-		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', [ 1, 10 ]);
+	/**
+	 * Test the [convertkit_broadcasts] shortcode's "Display image" parameter works
+	 * using the Text Editor.
+	 *
+	 * @since   2.2.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsShortcodeInTextEditorWithDisplayImageParameter(AcceptanceTester $I)
+	{
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor: Display image');
+
+		// Add shortcode to Page.
+		$I->addTextEditorShortcode(
+			$I,
+			'convertkit-broadcasts',
+			[
+				'display_image' => [ 'toggle', 'Yes' ],
+			],
+			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="1" display_description="0" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage($I);
+
+		// Confirm that the block displays correctly with the expected number of Broadcasts in the grid format.
+		$I->seeBroadcastsOutput(
+			$I,
+			3, // Confirm 3 broadcasts are output.
+			false, // Don't check previous pagination label.
+			false, // Don't check next pagination label.
+			false, // Confirm grid mode is not set.
+			true // Confirm images are displayed.
+		);
+	}
+
+	/**
+	 * Test the [convertkit_broadcasts] shortcode's "Display description" parameter works
+	 * using the Text Editor.
+	 *
+	 * @since   2.2.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsShortcodeInTextEditorWithDisplayDescriptionParameter(AcceptanceTester $I)
+	{
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor: Display description');
+
+		// Add shortcode to Page.
+		$I->addTextEditorShortcode(
+			$I,
+			'convertkit-broadcasts',
+			[
+				'display_description' => [ 'toggle', 'Yes' ],
+			],
+			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="1" display_read_more="0" read_more_label="Read more" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage($I);
+
+		// Confirm that the block displays correctly with the expected number of Broadcasts in the grid format.
+		$I->seeBroadcastsOutput(
+			$I,
+			3, // Confirm 3 broadcasts are output.
+			false, // Don't check previous pagination label.
+			false, // Don't check next pagination label.
+			false, // Confirm grid mode is not set.
+			false, // Confirm images are not displayed.
+			true // Confirm description is displayed.
+		);
+	}
+
+	/**
+	 * Test the [convertkit_broadcasts] shortcode's "Display read more link" parameter works
+	 * using the Text Editor.
+	 *
+	 * @since   2.2.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsShortcodeInTextEditorWithDisplayReadMoreLinkParameter(AcceptanceTester $I)
+	{
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Text Editor: Display read more link');
+
+		// Add shortcode to Page.
+		$I->addTextEditorShortcode(
+			$I,
+			'convertkit-broadcasts',
+			[
+				'display_read_more' => [ 'toggle', 'Yes' ],
+				'read_more_label'   => [ 'input', 'Continue reading' ],
+			],
+			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="1" read_more_label="Continue reading" limit="10" paginate="0" paginate_label_prev="Previous" paginate_label_next="Next"]'
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage($I);
+
+		// Confirm that the block displays correctly with the expected number of Broadcasts in the grid format.
+		$I->seeBroadcastsOutput(
+			$I,
+			3, // Confirm 3 broadcasts are output.
+			false, // Don't check previous pagination label.
+			false, // Don't check next pagination label.
+			false, // Confirm grid mode is not set.
+			false, // Confirm images are not displayed.
+			false, // Confirm description is not displayed.
+			'Continue reading' // Confirm read more link is displayed with correct text.
+		);
 	}
 
 	/**
@@ -389,14 +672,11 @@ class PageShortcodeBroadcastsCest
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewClassicEditorPage($I);
 
-		// Confirm that the shortcode output displays.
-		$I->seeBroadcastsOutput($I);
+		// Confirm that the shortcode displays correctly with the expected number of Broadcasts.
+		$I->seeBroadcastsOutput($I, 2);
 
 		// Confirm that the default date format is as expected.
 		$I->seeInSource('<time datetime="2022-04-08">April 8, 2022</time>');
-
-		// Confirm that the default expected number of Broadcasts are displayed.
-		$I->seeNumberOfElements('li.convertkit-broadcast', 2);
 	}
 
 	/**

--- a/tests/acceptance/broadcasts/WidgetBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/WidgetBroadcastsCest.php
@@ -138,8 +138,8 @@ class WidgetBroadcastsCest
 			'ConvertKit Broadcasts',
 			'convertkit-broadcasts',
 			[
-				'.components-form-toggle' => [ 'toggle', true ],
-				'limit'                   => [ 'input', '1' ],
+				'#inspector-toggle-control-4' => [ 'toggle', true ],
+				'limit'                       => [ 'input', '1' ],
 			]
 		);
 
@@ -165,10 +165,10 @@ class WidgetBroadcastsCest
 			'ConvertKit Broadcasts',
 			'convertkit-broadcasts',
 			[
-				'.components-form-toggle' => [ 'toggle', true ],
-				'limit'                   => [ 'input', '1' ],
-				'paginate_label_prev'     => [ 'input', 'Newer' ],
-				'paginate_label_next'     => [ 'input', 'Older' ],
+				'#inspector-toggle-control-4' => [ 'toggle', true ],
+				'limit'                       => [ 'input', '1' ],
+				'paginate_label_prev'         => [ 'input', 'Newer' ],
+				'paginate_label_next'         => [ 'input', 'Older' ],
 			]
 		);
 
@@ -194,10 +194,10 @@ class WidgetBroadcastsCest
 			'ConvertKit Broadcasts',
 			'convertkit-broadcasts',
 			[
-				'.components-form-toggle' => [ 'toggle', true ],
-				'limit'                   => [ 'input', '1' ],
-				'paginate_label_prev'     => [ 'input', '' ],
-				'paginate_label_next'     => [ 'input', '' ],
+				'#inspector-toggle-control-4' => [ 'toggle', true ],
+				'limit'                       => [ 'input', '1' ],
+				'paginate_label_prev'         => [ 'input', '' ],
+				'paginate_label_next'         => [ 'input', '' ],
 			]
 		);
 


### PR DESCRIPTION
## Summary

Adds options to the ConvertKit Broadcasts block and shortcode to display output as a grid, and optionally display each broadcasts' image, description and read more link.

<img width="1822" alt="Screenshot 2023-06-01 at 18 10 48" src="https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/fbf25f88-2b81-4f05-b862-6411afcd9f01">

Demo:

https://www.loom.com/share/0fb937fabe364d928ad0497b593177af

Requires [this PR](https://github.com/ConvertKit/convertkit/pull/23938) to merge into the WordPress API. Tests mock this expected data structure to confirm working functionality.

Responsive CSS for list and grid views on smaller screens to follow in separate PR.

## Testing

- `PageBlockBroadcastsCest`: Added tests for display as grid, images, descriptions, read more links and read more label.
- `PageShortcodeBroadcastsCest`: Added tests for display as grid, images, descriptions, read more links and read more label when using the [convertkit_broadcasts] shortcode.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)