### PR TITLE
Form Trigger Block: Display link to enter API Key or add Form in ConvertKit

### DIFF
--- a/includes/blocks/class-convertkit-block-form-trigger.php
+++ b/includes/blocks/class-convertkit-block-form-trigger.php
@@ -80,40 +80,58 @@ class ConvertKit_Block_Form_Trigger extends ConvertKit_Block {
 	 */
 	public function get_overview() {
 
+		$convertkit_forms = new ConvertKit_Resource_Forms( 'block_edit' );
+		$settings         = new ConvertKit_Settings();
+
 		return array(
-			'title'                             => __( 'ConvertKit Form Trigger', 'convertkit' ),
-			'description'                       => __( 'Displays a modal, sticky bar or slide in form to display when the button is pressed.', 'convertkit' ),
-			'icon'                              => 'resources/backend/images/block-icon-formtrigger.png',
-			'category'                          => 'convertkit',
-			'keywords'                          => array(
+			'title'                                   => __( 'ConvertKit Form Trigger', 'convertkit' ),
+			'description'                             => __( 'Displays a modal, sticky bar or slide in form to display when the button is pressed.', 'convertkit' ),
+			'icon'                                    => 'resources/backend/images/block-icon-formtrigger.png',
+			'category'                                => 'convertkit',
+			'keywords'                                => array(
 				__( 'ConvertKit', 'convertkit' ),
 				__( 'Form', 'convertkit' ),
 			),
 
 			// Function to call when rendering as a block or a shortcode on the frontend web site.
-			'render_callback'                   => array( $this, 'render' ),
+			'render_callback'                         => array( $this, 'render' ),
 
 			// Shortcode: TinyMCE / QuickTags Modal Width and Height.
-			'modal'                             => array(
+			'modal'                                   => array(
 				'width'  => 500,
 				'height' => 352,
 			),
 
 			// Shortcode: Include a closing [/shortcode] tag when using TinyMCE or QuickTag Modals.
-			'shortcode_include_closing_tag'     => false,
+			'shortcode_include_closing_tag'           => false,
 
 			// Gutenberg: Block Icon in Editor.
-			'gutenberg_icon'                    => convertkit_get_file_contents( CONVERTKIT_PLUGIN_PATH . '/resources/backend/images/block-icon-formtrigger.svg' ),
+			'gutenberg_icon'                          => convertkit_get_file_contents( CONVERTKIT_PLUGIN_PATH . '/resources/backend/images/block-icon-formtrigger.svg' ),
 
 			// Gutenberg: Example image showing how this block looks when choosing it in Gutenberg.
-			'gutenberg_example_image'           => CONVERTKIT_PLUGIN_URL . 'resources/backend/images/block-example-formtrigger.png',
+			'gutenberg_example_image'                 => CONVERTKIT_PLUGIN_URL . 'resources/backend/images/block-example-formtrigger.png',
 
-			// Gutenberg: Help description, displayed when no settings defined for a newly added Block.
-			'gutenberg_help_description'        => __( 'Select a Form using the Form option in the Gutenberg sidebar.', 'convertkit' ),
+			// Gutenberg: Help descriptions, displayed when no settings defined for a newly added Block, or API keys / forms don't exist.
+			'gutenberg_help_description_no_api_key'   => array(
+				'notice'    => __( 'No API Key specified.', 'convertkit' ),
+				'link'      => convertkit_get_settings_link(),
+				'link_text' => __( 'Click here to add your API Key.', 'convertkit' ),
+			),
+			'gutenberg_help_description_no_resources' => array(
+				'notice'    => __( 'No forms exist in ConvertKit.', 'convertkit' ),
+				'link'      => convertkit_get_new_form_url(),
+				'link_text' => __( 'Click here to create your first form.', 'convertkit' ),
+			),
+			'gutenberg_help_description'              => __( 'Select a Form using the Form option in the Gutenberg sidebar.', 'convertkit' ),
 
 			// Gutenberg: JS function to call when rendering the block preview in the Gutenberg editor.
 			// If not defined, render_callback above will be used.
-			'gutenberg_preview_render_callback' => 'convertKitGutenbergFormTriggerBlockRenderPreview',
+			'gutenberg_preview_render_callback'       => 'convertKitGutenbergFormTriggerBlockRenderPreview',
+
+			// Whether an API Key exists in the Plugin, and are the required resources (forms) available.
+			// If no API Key is specified in the Plugin's settings, render the "No API Key" output.
+			'has_api_key'                             => $settings->has_api_key_and_secret(),
+			'has_resources'                           => $convertkit_forms->exist(),
 		);
 
 	}

--- a/resources/backend/js/gutenberg-block-form-trigger.js
+++ b/resources/backend/js/gutenberg-block-form-trigger.js
@@ -36,9 +36,6 @@ function convertKitGutenbergFormTriggerBlockRenderPreview( block, props ) {
 		);
 	}
 
-	// Get selected form.
-	var form = block.fields.form.data.forms[ props.attributes.form ];
-
 	// If no Form has been selected for display, return a prompt to tell the editor
 	// what to do.
 	if ( props.attributes.form === '' ) {

--- a/resources/backend/js/gutenberg-block-form-trigger.js
+++ b/resources/backend/js/gutenberg-block-form-trigger.js
@@ -14,18 +14,35 @@
  */
 function convertKitGutenbergFormTriggerBlockRenderPreview( block, props ) {
 
+	// If no API Key has been defined in the Plugin, return a prompt to tell the editor
+	// what to do.
+	if ( ! block.has_api_key ) {
+		return convertKitGutenbergDisplayBlockNoticeWithLink(
+			block.name,
+			block.gutenberg_help_description_no_api_key.notice,
+			block.gutenberg_help_description_no_api_key.link,
+			block.gutenberg_help_description_no_api_key.link_text
+		);
+	}
+
+	// If no Forms exist in ConvertKit, return a prompt to tell the editor
+	// what to do.
+	if ( ! block.has_resources ) {
+		return convertKitGutenbergDisplayBlockNoticeWithLink(
+			block.name,
+			block.gutenberg_help_description_no_resources.notice,
+			block.gutenberg_help_description_no_resources.link,
+			block.gutenberg_help_description_no_resources.link_text
+		);
+	}
+
+	// Get selected form.
+	var form = block.fields.form.data.forms[ props.attributes.form ];
+
 	// If no Form has been selected for display, return a prompt to tell the editor
 	// what to do.
 	if ( props.attributes.form === '' ) {
-		return wp.element.createElement(
-			'div',
-			{
-				// convertkit-no-content class allows resources/backend/css/gutenberg.css
-				// to apply styling/branding to the block.
-				className: 'convertkit-' + block.name + ' convertkit-no-content'
-			},
-			block.gutenberg_help_description
-		);
+		return convertKitGutenbergDisplayBlockNotice( block.name, block.gutenberg_help_description );
 	}
 
 	// A Form is specified.

--- a/tests/acceptance/forms/PageBlockFormTriggerCest.php
+++ b/tests/acceptance/forms/PageBlockFormTriggerCest.php
@@ -16,10 +16,6 @@ class PageBlockFormTriggerCest
 	public function _before(AcceptanceTester $I)
 	{
 		$I->activateConvertKitPlugin($I);
-
-		// Setup ConvertKit Plugin with no default form specified.
-		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
-		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**
@@ -31,6 +27,10 @@ class PageBlockFormTriggerCest
 	 */
 	public function testFormTriggerBlockWithValidFormParameter(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form Trigger: Valid Form Param');
 
@@ -69,6 +69,10 @@ class PageBlockFormTriggerCest
 	 */
 	public function testFormTriggerBlocksWithValidFormParameter(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form Trigger: Valid Form Param, Multiple Blocks');
 
@@ -121,6 +125,10 @@ class PageBlockFormTriggerCest
 	 */
 	public function testFormTriggerBlockWithNoFormParameter(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form Trigger: No Form Param');
 
@@ -160,6 +168,10 @@ class PageBlockFormTriggerCest
 	 */
 	public function testFormTriggerBlockWithTextParameter(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form Trigger: Text Param');
 
@@ -190,6 +202,10 @@ class PageBlockFormTriggerCest
 	 */
 	public function testFormTriggerBlockWithBlankTextParameter(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form Trigger: Blank Text Param');
 
@@ -220,6 +236,10 @@ class PageBlockFormTriggerCest
 	 */
 	public function testFormTriggerBlockWithThemeColorParameters(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Define colors.
 		$backgroundColor = 'white';
 		$textColor       = 'purple';
@@ -260,6 +280,10 @@ class PageBlockFormTriggerCest
 	 */
 	public function testFormTriggerBlockWithHexColorParameters(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Define colors.
 		$backgroundColor = '#ee1616';
 		$textColor       = '#1212c0';
@@ -298,6 +322,10 @@ class PageBlockFormTriggerCest
 	 */
 	public function testFormTriggerBlockParameterEscaping(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Define a 'bad' block.  This is difficult to do in Gutenberg, but let's assume it's possible.
 		$I->havePageInDatabase(
 			[
@@ -321,6 +349,101 @@ class PageBlockFormTriggerCest
 
 		// Confirm that the ConvertKit Form Trigger is displayed.
 		$I->seeFormTriggerOutput($I, $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_URL'], 'Subscribe');
+	}
+
+	/**
+	 * Test the Form Trigger block displays a message with a link to the Plugin's
+	 * settings screen, when the Plugin has no API key specified.
+	 *
+	 * @since   2.2.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFormTriggerBlockWhenNoAPIKey(AcceptanceTester $I)
+	{
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form Trigger: Block: No API Key');
+
+		// Add block to Page.
+		$I->addGutenbergBlock($I, 'ConvertKit Form Trigger', 'convertkit-formtrigger');
+
+		// Confirm that the Form block displays instructions to the user on how to enter their API Key.
+		$I->see(
+			'No API Key specified.',
+			[
+				'css' => '.convertkit-no-content',
+			]
+		);
+
+		// Click the link to confirm it loads the Plugin's settings screen.
+		$I->click(
+			'Click here to add your API Key.',
+			[
+				'css' => '.convertkit-no-content',
+			]
+		);
+
+		// Switch to next browser tab, as the link opens in a new tab.
+		$I->switchToNextTab();
+
+		// Confirm the Plugin's settings screen is displayed.
+		$I->seeElementInDOM('input[name="_wp_convertkit_settings[api_key]"]');
+		$I->seeElementInDOM('input[name="_wp_convertkit_settings[api_secret]"]');
+
+		// Close tab.
+		$I->closeTab();
+
+		// Save page to avoid alert box when _passed() runs to deactivate the Plugin.
+		$I->publishGutenbergPage($I);
+	}
+
+	/**
+	 * Test the Form Trigger block displays a message with a link to the Plugin's
+	 * settings screen, when the ConvertKit account has no forms.
+	 *
+	 * @since   2.2.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFormTriggerBlockWhenNoForms(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA'], '', '', '');
+		$I->setupConvertKitPluginResourcesNoData($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form Trigger: Block: No Forms');
+
+		// Add block to Page.
+		$I->addGutenbergBlock($I, 'ConvertKit Form Trigger', 'convertkit-formtrigger');
+
+		// Confirm that the Form block displays instructions to the user on how to add a Form in ConvertKit.
+		$I->see(
+			'No forms exist in ConvertKit.',
+			[
+				'css' => '.convertkit-no-content',
+			]
+		);
+
+		// Click the link to confirm it loads ConvertKit.
+		$I->click(
+			'Click here to create your first form.',
+			[
+				'css' => '.convertkit-no-content',
+			]
+		);
+
+		// Switch to next browser tab, as the link opens in a new tab.
+		$I->switchToNextTab();
+
+		// Confirm the ConvertKit login screen loaded.
+		$I->seeElementInDOM('input[name="user[email]"]');
+
+		// Close tab.
+		$I->closeTab();
+
+		// Save page to avoid alert box when _passed() runs to deactivate the Plugin.
+		$I->publishGutenbergPage($I);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

When adding the ConvertKit Form Trigger Block, displays a notice if no API key is specified, or the ConvertKit account has no forms specified, including a link to the settings screen / ConvertKit to resolve.

![Screenshot 2023-06-05 at 15 02 21](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/0991dddb-5a82-4a5e-b502-755b01ac4645)

![Screenshot 2023-06-05 at 15 02 33](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/ed20b331-fd42-4ea3-ba35-c99a4f6c8665)

## Testing

- `PageBlockFormTriggerCest:testFormTriggerBlockWhenNoAPIKey`: Confirms that the expected message displays when no forms exist in ConvertKit
- `PageBlockFormTriggerCest:testFormTriggerBlockWhenNoForms`: Confirms that the expected message displays when no forms exist in ConvertKit

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)