### PR TITLE
Form Trigger Shortcode: Display notice when no API Key or Resources

### DIFF
--- a/includes/blocks/class-convertkit-block-form-trigger.php
+++ b/includes/blocks/class-convertkit-block-form-trigger.php
@@ -84,54 +84,54 @@ class ConvertKit_Block_Form_Trigger extends ConvertKit_Block {
 		$settings         = new ConvertKit_Settings();
 
 		return array(
-			'title'                                   => __( 'ConvertKit Form Trigger', 'convertkit' ),
-			'description'                             => __( 'Displays a modal, sticky bar or slide in form to display when the button is pressed.', 'convertkit' ),
-			'icon'                                    => 'resources/backend/images/block-icon-formtrigger.png',
-			'category'                                => 'convertkit',
-			'keywords'                                => array(
+			'title'                             => __( 'ConvertKit Form Trigger', 'convertkit' ),
+			'description'                       => __( 'Displays a modal, sticky bar or slide in form to display when the button is pressed.', 'convertkit' ),
+			'icon'                              => 'resources/backend/images/block-icon-formtrigger.png',
+			'category'                          => 'convertkit',
+			'keywords'                          => array(
 				__( 'ConvertKit', 'convertkit' ),
 				__( 'Form', 'convertkit' ),
 			),
 
 			// Function to call when rendering as a block or a shortcode on the frontend web site.
-			'render_callback'                         => array( $this, 'render' ),
+			'render_callback'                   => array( $this, 'render' ),
 
 			// Shortcode: TinyMCE / QuickTags Modal Width and Height.
-			'modal'                                   => array(
+			'modal'                             => array(
 				'width'  => 500,
 				'height' => 352,
 			),
 
 			// Shortcode: Include a closing [/shortcode] tag when using TinyMCE or QuickTag Modals.
-			'shortcode_include_closing_tag'           => false,
+			'shortcode_include_closing_tag'     => false,
 
 			// Gutenberg: Block Icon in Editor.
-			'gutenberg_icon'                          => convertkit_get_file_contents( CONVERTKIT_PLUGIN_PATH . '/resources/backend/images/block-icon-formtrigger.svg' ),
+			'gutenberg_icon'                    => convertkit_get_file_contents( CONVERTKIT_PLUGIN_PATH . '/resources/backend/images/block-icon-formtrigger.svg' ),
 
 			// Gutenberg: Example image showing how this block looks when choosing it in Gutenberg.
-			'gutenberg_example_image'                 => CONVERTKIT_PLUGIN_URL . 'resources/backend/images/block-example-formtrigger.png',
+			'gutenberg_example_image'           => CONVERTKIT_PLUGIN_URL . 'resources/backend/images/block-example-formtrigger.png',
 
-			// Gutenberg: Help descriptions, displayed when no settings defined for a newly added Block, or API keys / forms don't exist.
-			'gutenberg_help_description_no_api_key'   => array(
+			// Help descriptions, displayed when no API key / resources exist and this block/shortcode is added.
+			'no_api_key'                        => array(
 				'notice'    => __( 'No API Key specified.', 'convertkit' ),
-				'link'      => convertkit_get_settings_link(),
+				'link'      => convertkit_get_setup_wizard_plugin_link(),
 				'link_text' => __( 'Click here to add your API Key.', 'convertkit' ),
 			),
-			'gutenberg_help_description_no_resources' => array(
+			'no_resources'                      => array(
 				'notice'    => __( 'No forms exist in ConvertKit.', 'convertkit' ),
 				'link'      => convertkit_get_new_form_url(),
 				'link_text' => __( 'Click here to create your first form.', 'convertkit' ),
 			),
-			'gutenberg_help_description'              => __( 'Select a Form using the Form option in the Gutenberg sidebar.', 'convertkit' ),
+			'gutenberg_help_description'        => __( 'Select a Form using the Form option in the Gutenberg sidebar.', 'convertkit' ),
 
 			// Gutenberg: JS function to call when rendering the block preview in the Gutenberg editor.
 			// If not defined, render_callback above will be used.
-			'gutenberg_preview_render_callback'       => 'convertKitGutenbergFormTriggerBlockRenderPreview',
+			'gutenberg_preview_render_callback' => 'convertKitGutenbergFormTriggerBlockRenderPreview',
 
 			// Whether an API Key exists in the Plugin, and are the required resources (forms) available.
 			// If no API Key is specified in the Plugin's settings, render the "No API Key" output.
-			'has_api_key'                             => $settings->has_api_key_and_secret(),
-			'has_resources'                           => $convertkit_forms->exist(),
+			'has_api_key'                       => $settings->has_api_key_and_secret(),
+			'has_resources'                     => $convertkit_forms->exist(),
 		);
 
 	}

--- a/resources/backend/js/gutenberg-block-form-trigger.js
+++ b/resources/backend/js/gutenberg-block-form-trigger.js
@@ -19,9 +19,9 @@ function convertKitGutenbergFormTriggerBlockRenderPreview( block, props ) {
 	if ( ! block.has_api_key ) {
 		return convertKitGutenbergDisplayBlockNoticeWithLink(
 			block.name,
-			block.gutenberg_help_description_no_api_key.notice,
-			block.gutenberg_help_description_no_api_key.link,
-			block.gutenberg_help_description_no_api_key.link_text
+			block.no_api_key.notice,
+			block.no_api_key.link,
+			block.no_api_key.link_text
 		);
 	}
 
@@ -30,9 +30,9 @@ function convertKitGutenbergFormTriggerBlockRenderPreview( block, props ) {
 	if ( ! block.has_resources ) {
 		return convertKitGutenbergDisplayBlockNoticeWithLink(
 			block.name,
-			block.gutenberg_help_description_no_resources.notice,
-			block.gutenberg_help_description_no_resources.link,
-			block.gutenberg_help_description_no_resources.link_text
+			block.no_resources.notice,
+			block.no_resources.link,
+			block.no_resources.link_text
 		);
 	}
 

--- a/tests/acceptance/forms/PageBlockFormTriggerCest.php
+++ b/tests/acceptance/forms/PageBlockFormTriggerCest.php
@@ -386,9 +386,8 @@ class PageBlockFormTriggerCest
 		// Switch to next browser tab, as the link opens in a new tab.
 		$I->switchToNextTab();
 
-		// Confirm the Plugin's settings screen is displayed.
-		$I->seeElementInDOM('input[name="_wp_convertkit_settings[api_key]"]');
-		$I->seeElementInDOM('input[name="_wp_convertkit_settings[api_secret]"]');
+		// Confirm the Plugin's setup wizard is displayed.
+		$I->seeInCurrentUrl('index.php?page=convertkit-setup');
 
 		// Close tab.
 		$I->closeTab();

--- a/tests/acceptance/forms/PageShortcodeFormTriggerCest.php
+++ b/tests/acceptance/forms/PageShortcodeFormTriggerCest.php
@@ -16,10 +16,6 @@ class PageShortcodeFormTriggerCest
 	public function _before(AcceptanceTester $I)
 	{
 		$I->activateConvertKitPlugin($I);
-
-		// Setup ConvertKit Plugin with no default form specified.
-		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
-		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**
@@ -32,6 +28,10 @@ class PageShortcodeFormTriggerCest
 	 */
 	public function testFormTriggerShortcodeInVisualEditorWithValidFormParameter(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Classic Editor.
 		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Form Trigger: Shortcode: Visual Editor');
 
@@ -62,6 +62,10 @@ class PageShortcodeFormTriggerCest
 	 */
 	public function testFormTriggerShortcodeInTextEditorWithValidFormTriggerParameter(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Classic Editor.
 		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Form Trigger: Shortcode: Text Editor');
 
@@ -91,6 +95,10 @@ class PageShortcodeFormTriggerCest
 	 */
 	public function testFormTriggerShortcodeWithInvalidFormParameter(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Create Page with Shortcode.
 		$I->havePageInDatabase(
 			[
@@ -118,6 +126,10 @@ class PageShortcodeFormTriggerCest
 	 */
 	public function testFormTriggerShortcodeInVisualEditorWithTextParameter(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Classic Editor.
 		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Form Trigger: Shortcode: Text Param');
 
@@ -148,6 +160,10 @@ class PageShortcodeFormTriggerCest
 	 */
 	public function testFormTriggerShortcodeInVisualEditorWithBlankTextParameter(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Classic Editor.
 		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Form Trigger: Shortcode: Blank Text Param');
 
@@ -178,6 +194,10 @@ class PageShortcodeFormTriggerCest
 	 */
 	public function testFormTriggerShortcodeWithHexColorParameters(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Define colors.
 		$backgroundColor = '#ee1616';
 		$textColor       = '#1212c0';
@@ -216,6 +236,10 @@ class PageShortcodeFormTriggerCest
 	 */
 	public function testFormTriggerShortcodeParameterEscaping(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
 		// Define a 'bad' shortcode.
 		$I->havePageInDatabase(
 			[
@@ -239,6 +263,118 @@ class PageShortcodeFormTriggerCest
 
 		// Confirm that the ConvertKit Form Trigger is displayed.
 		$I->seeFormTriggerOutput($I, $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_URL'], 'Subscribe');
+	}
+
+	/**
+	 * Test the Form Trigger shortcode displays a message with a link to the Plugin's
+	 * setup wizard, when the Plugin has no API key specified.
+	 *
+	 * @since   2.2.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFormTriggerShortcodeWhenNoAPIKey(AcceptanceTester $I)
+	{
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Form Trigger: Shortcode: No API Key');
+
+		// Open Visual Editor modal for the shortcode.
+		$I->openVisualEditorShortcodeModal(
+			$I,
+			'ConvertKit Form Trigger'
+		);
+
+		// Confirm an error notice displays.
+		$I->waitForElementVisible('#convertkit-modal-body-body div.notice');
+
+		// Confirm that the modal displays instructions to the user on how to enter their API Key.
+		$I->see(
+			'No API Key specified.',
+			[
+				'css' => '#convertkit-modal-body-body',
+			]
+		);
+
+		// Click the link to confirm it loads the Plugin's settings screen.
+		$I->click(
+			'Click here to add your API Key.',
+			[
+				'css' => '#convertkit-modal-body-body',
+			]
+		);
+
+		// Switch to next browser tab, as the link opens in a new tab.
+		$I->switchToNextTab();
+
+		// Confirm the Plugin's setup wizard is displayed.
+		$I->seeInCurrentUrl('index.php?page=convertkit-setup');
+
+		// Close tab.
+		$I->closeTab();
+
+		// Close modal.
+		$I->click('#convertkit-modal-body-head button.mce-close');
+
+		// Save page to avoid alert box when _passed() runs to deactivate the Plugin.
+		$I->publishAndViewClassicEditorPage($I);
+	}
+
+	/**
+	 * Test the Form shortcode displays a message with a link to ConvertKit,
+	 * when the ConvertKit account has no forms.
+	 *
+	 * @since   2.2.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFormTriggerShortcodeWhenNoForms(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA'], '', '', '');
+		$I->setupConvertKitPluginResourcesNoData($I);
+
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Form Trigger: Shortcode: No Forms');
+
+		// Open Visual Editor modal for the shortcode.
+		$I->openVisualEditorShortcodeModal(
+			$I,
+			'ConvertKit Form Trigger'
+		);
+
+		// Confirm an error notice displays.
+		$I->waitForElementVisible('#convertkit-modal-body-body div.notice');
+
+		// Confirm that the Form block displays instructions to the user on how to add a Form in ConvertKit.
+		$I->see(
+			'No forms exist in ConvertKit.',
+			[
+				'css' => '#convertkit-modal-body-body',
+			]
+		);
+
+		// Click the link to confirm it loads ConvertKit.
+		$I->click(
+			'Click here to create your first form.',
+			[
+				'css' => '#convertkit-modal-body-body',
+			]
+		);
+
+		// Switch to next browser tab, as the link opens in a new tab.
+		$I->switchToNextTab();
+
+		// Confirm the ConvertKit login screen loaded.
+		$I->seeElementInDOM('input[name="user[email]"]');
+
+		// Close tab.
+		$I->closeTab();
+
+		// Close modal.
+		$I->click('#convertkit-modal-body-head button.mce-close');
+
+		// Save page to avoid alert box when _passed() runs to deactivate the Plugin.
+		$I->publishAndViewClassicEditorPage($I);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Similar to the [PR on Form and Product Shortcodes,](https://github.com/ConvertKit/convertkit-wordpress/pull/488) displays a message in the modal window when using the Form Trigger shortcode in the Classic Editor, and either no API Key is specified, or no Forms exist in ConvertKit.

## Testing

- `PageShortcodeFormTriggerCest:testFormTriggerShortcodeWhenNoAPIKey`: Confirms that the expected message displays when no API key is specified in the Plugin's settings.
- `PageShortcodeFormTriggerCest:testFormTriggerShortcodeWhenNoForms`: Confirms that the expected message displays when no forms exist in ConvertKit

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)