### PR TITLE
Forms: Add `get_non_inline` method

### DIFF
--- a/ACTIONS-FILTERS.md
+++ b/ACTIONS-FILTERS.md
@@ -67,6 +67,10 @@
 						<td><a href="#convertkit_block_broadcasts_render_ajax"><code>convertkit_block_broadcasts_render_ajax</code></a></td>
 						<td>Filter the block's inner content immediately before it is output by AJAX, which occurs when pagination was clicked.</td>
 					</tr><tr>
+						<td>&nbsp;</td>
+						<td><a href="#convertkit_block_broadcasts_build_html_list_item"><code>convertkit_block_broadcasts_build_html_list_item</code></a></td>
+						<td>Defines the HTML for an individual broadcast item in the Broadcasts block.</td>
+					</tr><tr>
 						<td colspan="3">../includes/blocks/class-convertkit-block-form.php</td>
 					</tr><tr>
 						<td>&nbsp;</td>
@@ -423,7 +427,7 @@ add_filter( 'convertkit_block_content_render', function( $content, $atts, $subsc
 </pre>
 <h3 id="convertkit_block_product_render">
 						convertkit_block_product_render
-						<code>includes/blocks/class-convertkit-block-product.php::389</code>
+						<code>includes/blocks/class-convertkit-block-product.php::407</code>
 					</h3><h4>Overview</h4>
 						<p>Filter the block's content immediately before it is output.</p><h4>Parameters</h4>
 					<table>
@@ -454,7 +458,7 @@ add_filter( 'convertkit_block_product_render', function( $html, $atts ) {
 </pre>
 <h3 id="convertkit_block_broadcasts_render">
 						convertkit_block_broadcasts_render
-						<code>includes/blocks/class-convertkit-block-broadcasts.php::408</code>
+						<code>includes/blocks/class-convertkit-block-broadcasts.php::596</code>
 					</h3><h4>Overview</h4>
 						<p>Filter the block's content immediately before it is output.</p><h4>Parameters</h4>
 					<table>
@@ -485,7 +489,7 @@ add_filter( 'convertkit_block_broadcasts_render', function( $html, $atts ) {
 </pre>
 <h3 id="convertkit_block_broadcasts_render_ajax">
 						convertkit_block_broadcasts_render_ajax
-						<code>includes/blocks/class-convertkit-block-broadcasts.php::455</code>
+						<code>includes/blocks/class-convertkit-block-broadcasts.php::511</code>
 					</h3><h4>Overview</h4>
 						<p>Filter the block's inner content immediately before it is output by AJAX, which occurs when pagination was clicked.</p><h4>Parameters</h4>
 					<table>
@@ -514,9 +518,44 @@ add_filter( 'convertkit_block_broadcasts_render_ajax', function( $html, $atts ) 
 	return $html;
 }, 10, 2 );
 </pre>
+<h3 id="convertkit_block_broadcasts_build_html_list_item">
+						convertkit_block_broadcasts_build_html_list_item
+						<code>includes/blocks/class-convertkit-block-broadcasts.php::677</code>
+					</h3><h4>Overview</h4>
+						<p>Defines the HTML for an individual broadcast item in the Broadcasts block.</p><h4>Parameters</h4>
+					<table>
+						<thead>
+							<tr>
+								<th>Parameter</th>
+								<th>Type</th>
+								<th>Description</th>
+							</tr>
+						</thead>
+						<tbody><tr>
+							<td>$html</td>
+							<td>string</td>
+							<td>HTML.</td>
+						</tr><tr>
+							<td>$broadcast</td>
+							<td>array</td>
+							<td>Broadcast.</td>
+						</tr><tr>
+							<td>$atts</td>
+							<td>array</td>
+							<td>Block attributes.</td>
+						</tr>
+						</tbody>
+					</table><h4>Usage</h4>
+<pre>
+add_filter( 'convertkit_block_broadcasts_build_html_list_item', function( $html, $broadcast, $atts ) {
+	// ... your code here
+	// Return value
+	return $html;
+}, 10, 3 );
+</pre>
 <h3 id="convertkit_block_form_render">
 						convertkit_block_form_render
-						<code>includes/blocks/class-convertkit-block-form.php::324</code>
+						<code>includes/blocks/class-convertkit-block-form.php::342</code>
 					</h3><h4>Overview</h4>
 						<p>Filter the block's content immediately before it is output.</p><h4>Parameters</h4>
 					<table>

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "1.3.5"
+        "convertkit/convertkit-wordpress-libraries": "dev-add-get-by-method"
     },
     "require-dev": {
         "lucatume/wp-browser": "^3.0",

--- a/includes/block-formatters/class-convertkit-block-formatter-form-link.php
+++ b/includes/block-formatters/class-convertkit-block-formatter-form-link.php
@@ -120,7 +120,7 @@ class ConvertKit_Block_Formatter_Form_Link extends ConvertKit_Block_Formatter {
 		// Get non-inline ConvertKit Forms.
 		$forms      = array();
 		$forms_data = array();
-		if ( count( $this->forms->get_non_inline() ) > 0 ) {
+		if ( $this->forms->exist() ) {
 			foreach ( $this->forms->get_non_inline() as $form ) {
 				// Add this form's necessary to the attribute arrays.
 				$forms[ absint( $form['id'] ) ]      = sanitize_text_field( $form['name'] );

--- a/includes/block-formatters/class-convertkit-block-formatter-form-link.php
+++ b/includes/block-formatters/class-convertkit-block-formatter-form-link.php
@@ -117,19 +117,11 @@ class ConvertKit_Block_Formatter_Form_Link extends ConvertKit_Block_Formatter {
 			return false;
 		}
 
-		// Get ConvertKit Forms.
+		// Get non-inline ConvertKit Forms.
 		$forms      = array();
 		$forms_data = array();
-		if ( $this->forms->exist() ) {
-			foreach ( $this->forms->get() as $form ) {
-				// Ignore inline forms; this formatter is only for modal, slide in and sticky bar forms.
-				if ( ! array_key_exists( 'format', $form ) ) {
-					continue;
-				}
-				if ( $form['format'] === 'inline' ) {
-					continue;
-				}
-
+		if ( count( $this->forms->get_non_inline() ) > 0 ) {
+			foreach ( $this->forms->get_non_inline() as $form ) {
 				// Add this form's necessary to the attribute arrays.
 				$forms[ absint( $form['id'] ) ]      = sanitize_text_field( $form['name'] );
 				$forms_data[ absint( $form['id'] ) ] = array(

--- a/includes/blocks/class-convertkit-block-form-trigger.php
+++ b/includes/blocks/class-convertkit-block-form-trigger.php
@@ -243,24 +243,11 @@ class ConvertKit_Block_Form_Trigger extends ConvertKit_Block {
 			return false;
 		}
 
-		// Get ConvertKit Forms.
+		// Get non-inline ConvertKit Forms.
 		$forms            = array();
 		$convertkit_forms = new ConvertKit_Resource_Forms( 'block_edit' );
-		if ( $convertkit_forms->exist() ) {
-			foreach ( $convertkit_forms->get() as $form ) {
-				// Ignore inline forms; this button link is only for modal, slide in and sticky bar forms.
-				if ( ! array_key_exists( 'format', $form ) ) {
-					continue;
-				}
-				if ( $form['format'] === 'inline' ) {
-					continue;
-				}
-
-				// Ignore forms that are missing a uid.
-				if ( ! array_key_exists( 'uid', $form ) ) {
-					continue;
-				}
-
+		if ( count( $convertkit_forms->get_non_inline() ) > 0 ) {
+			foreach ( $convertkit_forms->get_non_inline() as $form ) {
 				$forms[ absint( $form['id'] ) ] = sanitize_text_field( $form['name'] );
 			}
 		}

--- a/includes/blocks/class-convertkit-block-form-trigger.php
+++ b/includes/blocks/class-convertkit-block-form-trigger.php
@@ -246,7 +246,7 @@ class ConvertKit_Block_Form_Trigger extends ConvertKit_Block {
 		// Get non-inline ConvertKit Forms.
 		$forms            = array();
 		$convertkit_forms = new ConvertKit_Resource_Forms( 'block_edit' );
-		if ( count( $convertkit_forms->get_non_inline() ) > 0 ) {
+		if ( $convertkit_forms->exist() ) {
 			foreach ( $convertkit_forms->get_non_inline() as $form ) {
 				$forms[ absint( $form['id'] ) ] = sanitize_text_field( $form['name'] );
 			}

--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -62,54 +62,7 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource {
 	 */
 	public function get_non_inline() {
 
-		// Don't mutate the underlying resources, so multiple calls to get()
-		// with different order_by and order properties are supported.
-		$resources = $this->resources;
-
-		// Don't attempt sorting if no resources exist.
-		if ( ! $this->exist() ) {
-			return $resources;
-		}
-
-		// Remove forms that are inline or cannot have their format determined.
-		foreach ( $resources as $form_id => $form ) {
-			// Ignore inline forms.
-			if ( ! array_key_exists( 'format', $form ) ) {
-				unset( $resources[ $form_id ] );
-				continue;
-			}
-			if ( $form['format'] === 'inline' ) {
-				unset( $resources[ $form_id ] );
-				continue;
-			}
-
-			// Ignore forms that are missing a uid.
-			if ( ! array_key_exists( 'uid', $form ) ) {
-				unset( $resources[ $form_id ] );
-				continue;
-			}
-		}
-
-		// Don't attempt sorting if the order_by property doesn't exist as a key
-		// in the API response.
-		if ( ! array_key_exists( $this->order_by, reset( $resources ) ) ) {
-			return $resources;
-		}
-
-		// Sort resources ascending by the order_by property.
-		uasort(
-			$resources,
-			function( $a, $b ) {
-				return strcmp( $a[ $this->order_by ], $b[ $this->order_by ] );
-			}
-		);
-
-		// Reverse the array if the results should be returned in descending order.
-		if ( $this->order === 'desc' ) {
-			$resources = array_reverse( $resources, true );
-		}
-
-		return $resources;
+		return $this->get_by( 'format', array( 'modal', 'slide in', 'sticky bar' ) );
 
 	}
 

--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -54,6 +54,66 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource {
 	}
 
 	/**
+	 * Returns all non-inline forms based on the sort order.
+	 *
+	 * @since   2.2.4
+	 *
+	 * @return  array
+	 */
+	public function get_non_inline() {
+
+		// Don't mutate the underlying resources, so multiple calls to get()
+		// with different order_by and order properties are supported.
+		$resources = $this->resources;
+
+		// Don't attempt sorting if no resources exist.
+		if ( ! $this->exist() ) {
+			return $resources;
+		}
+
+		// Remove forms that are inline or cannot have their format determined.
+		foreach ( $resources as $form_id => $form ) {
+			// Ignore inline forms.
+			if ( ! array_key_exists( 'format', $form ) ) {
+				unset( $resources[ $form_id ] );
+				continue;
+			}
+			if ( $form['format'] === 'inline' ) {
+				unset( $resources[ $form_id ] );
+				continue;
+			}
+
+			// Ignore forms that are missing a uid.
+			if ( ! array_key_exists( 'uid', $form ) ) {
+				unset( $resources[ $form_id ] );
+				continue;
+			}
+		}
+
+		// Don't attempt sorting if the order_by property doesn't exist as a key
+		// in the API response.
+		if ( ! array_key_exists( $this->order_by, reset( $resources ) ) ) {
+			return $resources;
+		}
+
+		// Sort resources ascending by the order_by property.
+		uasort(
+			$resources,
+			function( $a, $b ) {
+				return strcmp( $a[ $this->order_by ], $b[ $this->order_by ] );
+			}
+		);
+
+		// Reverse the array if the results should be returned in descending order.
+		if ( $this->order === 'desc' ) {
+			$resources = array_reverse( $resources, true );
+		}
+
+		return $resources;
+
+	}
+
+	/**
 	 * Returns the HTML/JS markup for the given Form ID.
 	 *
 	 * Legacy Forms will return HTML.

--- a/languages/convertkit.pot
+++ b/languages/convertkit.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the same license as the ConvertKit plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: ConvertKit 2.2.2\n"
+"Project-Id-Version: ConvertKit 2.2.3\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/convertkit\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2023-05-23T17:35:49+00:00\n"
+"POT-Creation-Date: 2023-06-06T11:43:14+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.7.1\n"
 "X-Domain: convertkit\n"
@@ -23,8 +23,8 @@ msgstr ""
 #: includes/blocks/class-convertkit-block-broadcasts.php:124
 #: includes/blocks/class-convertkit-block-content.php:62
 #: includes/blocks/class-convertkit-block-form-trigger.php:89
-#: includes/blocks/class-convertkit-block-form.php:94
-#: includes/blocks/class-convertkit-block-product.php:111
+#: includes/blocks/class-convertkit-block-form.php:97
+#: includes/blocks/class-convertkit-block-product.php:114
 #: includes/integrations/elementor/class-convertkit-elementor.php:70
 msgid "ConvertKit"
 msgstr ""
@@ -188,11 +188,11 @@ msgid "General Settings"
 msgstr ""
 
 #: admin/section/class-convertkit-settings-general.php:58
-#: includes/blocks/class-convertkit-block-broadcasts.php:316
+#: includes/blocks/class-convertkit-block-broadcasts.php:358
 #: includes/blocks/class-convertkit-block-content.php:146
 #: includes/blocks/class-convertkit-block-form-trigger.php:297
-#: includes/blocks/class-convertkit-block-form.php:216
-#: includes/blocks/class-convertkit-block-product.php:305
+#: includes/blocks/class-convertkit-block-form.php:234
+#: includes/blocks/class-convertkit-block-product.php:323
 msgid "General"
 msgstr ""
 
@@ -341,7 +341,27 @@ msgid "Prevent plugin from loading JavaScript files. This will disable the custo
 msgstr ""
 
 #: admin/section/class-convertkit-settings-general.php:482
-msgid "Prevent plugin from loading CSS files. This will disable styling on broadcasts, product buttons and member's content. Use with caution!"
+msgid "Prevents loading plugin CSS files. This will disable styling on broadcasts, form trigger buttons, product buttons and member's content. Use with caution!"
+msgstr ""
+
+#: admin/section/class-convertkit-settings-general.php:486
+msgid "To customize forms and their styling, use the"
+msgstr ""
+
+#: admin/section/class-convertkit-settings-general.php:488
+msgid "ConvertKit form editor"
+msgstr ""
+
+#: admin/section/class-convertkit-settings-general.php:492
+msgid "For developers who require custom form designs through use of CSS, consider using the"
+msgstr ""
+
+#: admin/section/class-convertkit-settings-general.php:493
+msgid "or"
+msgstr ""
+
+#: admin/section/class-convertkit-settings-general.php:494
+msgid "integrations."
 msgstr ""
 
 #: admin/section/class-convertkit-settings-tools.php:28
@@ -471,8 +491,8 @@ msgstr ""
 #: includes/block-formatters/class-convertkit-block-formatter-form-link.php:146
 #: includes/blocks/class-convertkit-block-form-trigger.php:90
 #: includes/blocks/class-convertkit-block-form-trigger.php:254
-#: includes/blocks/class-convertkit-block-form.php:95
-#: includes/blocks/class-convertkit-block-form.php:186
+#: includes/blocks/class-convertkit-block-form.php:98
+#: includes/blocks/class-convertkit-block-form.php:204
 #: includes/widgets/class-ck-widget-form.php:79
 #: views/backend/post/bulk-edit.php:14
 #: views/backend/post/meta-box.php:15
@@ -493,8 +513,8 @@ msgid "Displays the Product modal when the link is pressed."
 msgstr ""
 
 #: includes/block-formatters/class-convertkit-block-formatter-product-link.php:134
-#: includes/blocks/class-convertkit-block-product.php:112
-#: includes/blocks/class-convertkit-block-product.php:263
+#: includes/blocks/class-convertkit-block-product.php:115
+#: includes/blocks/class-convertkit-block-product.php:281
 msgid "Product"
 msgstr ""
 
@@ -522,63 +542,95 @@ msgstr ""
 msgid "No Broadcasts exist in ConvertKit. Send your first Broadcast in ConvertKit to see the link to it here."
 msgstr ""
 
-#: includes/blocks/class-convertkit-block-broadcasts.php:250
-msgid "Date format"
-msgstr ""
-
-#: includes/blocks/class-convertkit-block-broadcasts.php:260
-msgid "Number of posts"
-msgstr ""
-
-#: includes/blocks/class-convertkit-block-broadcasts.php:267
-msgid "Display pagination"
-msgstr ""
-
-#: includes/blocks/class-convertkit-block-broadcasts.php:269
-msgid "If the number of broadcasts exceeds the \"Number of posts\" settings above, previous/next pagination links will be displayed."
+#: includes/blocks/class-convertkit-block-broadcasts.php:270
+msgid "Display as grid"
 msgstr ""
 
 #: includes/blocks/class-convertkit-block-broadcasts.php:272
-msgid "Newer posts label"
+msgid "If enabled, displays broadcasts in a grid, instead of a list."
 msgstr ""
 
-#: includes/blocks/class-convertkit-block-broadcasts.php:274
-msgid "The label to display for the link to newer broadcasts."
-msgstr ""
-
-#: includes/blocks/class-convertkit-block-broadcasts.php:277
-msgid "Older posts label"
-msgstr ""
-
-#: includes/blocks/class-convertkit-block-broadcasts.php:279
-msgid "The label to display for the link to older broadcasts."
+#: includes/blocks/class-convertkit-block-broadcasts.php:275
+msgid "Date format"
 msgstr ""
 
 #: includes/blocks/class-convertkit-block-broadcasts.php:285
-msgid "Link color"
+msgid "Display images"
 msgstr ""
 
 #: includes/blocks/class-convertkit-block-broadcasts.php:289
-#: includes/blocks/class-convertkit-block-form-trigger.php:268
-#: includes/blocks/class-convertkit-block-product.php:276
-msgid "Background color"
+msgid "Display descriptions"
 msgstr ""
 
 #: includes/blocks/class-convertkit-block-broadcasts.php:293
+msgid "Display read more links"
+msgstr ""
+
+#: includes/blocks/class-convertkit-block-broadcasts.php:297
+msgid "Read more label"
+msgstr ""
+
+#: includes/blocks/class-convertkit-block-broadcasts.php:299
+msgid "The label to display for the \"read more\" link below each broadcast."
+msgstr ""
+
+#: includes/blocks/class-convertkit-block-broadcasts.php:302
+msgid "Number of posts"
+msgstr ""
+
+#: includes/blocks/class-convertkit-block-broadcasts.php:309
+msgid "Display pagination"
+msgstr ""
+
+#: includes/blocks/class-convertkit-block-broadcasts.php:311
+msgid "If the number of broadcasts exceeds the \"Number of posts\" settings above, previous/next pagination links will be displayed."
+msgstr ""
+
+#: includes/blocks/class-convertkit-block-broadcasts.php:314
+msgid "Newer posts label"
+msgstr ""
+
+#: includes/blocks/class-convertkit-block-broadcasts.php:316
+msgid "The label to display for the link to newer broadcasts."
+msgstr ""
+
+#: includes/blocks/class-convertkit-block-broadcasts.php:319
+msgid "Older posts label"
+msgstr ""
+
+#: includes/blocks/class-convertkit-block-broadcasts.php:321
+msgid "The label to display for the link to older broadcasts."
+msgstr ""
+
+#: includes/blocks/class-convertkit-block-broadcasts.php:327
+msgid "Link color"
+msgstr ""
+
+#: includes/blocks/class-convertkit-block-broadcasts.php:331
+#: includes/blocks/class-convertkit-block-form-trigger.php:268
+#: includes/blocks/class-convertkit-block-product.php:294
+msgid "Background color"
+msgstr ""
+
+#: includes/blocks/class-convertkit-block-broadcasts.php:335
 #: includes/blocks/class-convertkit-block-form-trigger.php:272
-#: includes/blocks/class-convertkit-block-product.php:280
+#: includes/blocks/class-convertkit-block-product.php:298
 msgid "Text color"
 msgstr ""
 
-#: includes/blocks/class-convertkit-block-broadcasts.php:345
+#: includes/blocks/class-convertkit-block-broadcasts.php:394
+msgid "Read more"
+msgstr ""
+
+#: includes/blocks/class-convertkit-block-broadcasts.php:397
 msgid "Previous"
 msgstr ""
 
-#: includes/blocks/class-convertkit-block-broadcasts.php:346
+#: includes/blocks/class-convertkit-block-broadcasts.php:398
 msgid "Next"
 msgstr ""
 
-#: includes/blocks/class-convertkit-block-broadcasts.php:392
+#: includes/blocks/class-convertkit-block-broadcasts.php:444
 msgid "No Broadcasts exist in ConvertKit."
 msgstr ""
 
@@ -605,7 +657,7 @@ msgid "Displays a modal, sticky bar or slide in form to display when the button 
 msgstr ""
 
 #: includes/blocks/class-convertkit-block-form-trigger.php:112
-#: includes/blocks/class-convertkit-block-form.php:117
+#: includes/blocks/class-convertkit-block-form.php:130
 msgid "Select a Form using the Form option in the Gutenberg sidebar."
 msgstr ""
 
@@ -614,12 +666,12 @@ msgid "The modal, sticky bar or slide in form to display when the button is pres
 msgstr ""
 
 #: includes/blocks/class-convertkit-block-form-trigger.php:260
-#: includes/blocks/class-convertkit-block-product.php:268
+#: includes/blocks/class-convertkit-block-product.php:286
 msgid "Button Text"
 msgstr ""
 
 #: includes/blocks/class-convertkit-block-form-trigger.php:262
-#: includes/blocks/class-convertkit-block-product.php:270
+#: includes/blocks/class-convertkit-block-product.php:288
 msgid "The text to display for the button."
 msgstr ""
 
@@ -644,7 +696,7 @@ msgstr ""
 msgid "ConvertKit Form ID %s has no embed_js property."
 msgstr ""
 
-#: includes/blocks/class-convertkit-block-form.php:89
+#: includes/blocks/class-convertkit-block-form.php:92
 #: includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php:131
 #: includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php:142
 #: views/backend/term/fields-add.php:11
@@ -652,38 +704,64 @@ msgstr ""
 msgid "ConvertKit Form"
 msgstr ""
 
-#: includes/blocks/class-convertkit-block-form.php:90
+#: includes/blocks/class-convertkit-block-form.php:93
 msgid "Displays a ConvertKit Form."
 msgstr ""
 
-#. translators: Form name in ConvertKit
+#: includes/blocks/class-convertkit-block-form.php:121
+#: includes/blocks/class-convertkit-block-product.php:138
+msgid "No API Key specified."
+msgstr ""
+
+#: includes/blocks/class-convertkit-block-form.php:123
+#: includes/blocks/class-convertkit-block-product.php:140
+msgid "Click here to add your API Key."
+msgstr ""
+
 #: includes/blocks/class-convertkit-block-form.php:126
+msgid "No forms exist in ConvertKit."
+msgstr ""
+
+#: includes/blocks/class-convertkit-block-form.php:128
+msgid "Click here to create your first form."
+msgstr ""
+
+#. translators: Form name in ConvertKit
+#: includes/blocks/class-convertkit-block-form.php:139
 msgid "Modal form \"%s\" selected. View on the frontend site to see the modal form."
 msgstr ""
 
 #. translators: Form name in ConvertKit
-#: includes/blocks/class-convertkit-block-form.php:129
+#: includes/blocks/class-convertkit-block-form.php:142
 msgid "Slide in form \"%s\" selected. View on the frontend site to see the slide in form."
 msgstr ""
 
 #. translators: Form name in ConvertKit
-#: includes/blocks/class-convertkit-block-form.php:132
+#: includes/blocks/class-convertkit-block-form.php:145
 msgid "Sticky bar form \"%s\" selected. View on the frontend site to see the sticky bar form."
 msgstr ""
 
-#: includes/blocks/class-convertkit-block-product.php:106
+#: includes/blocks/class-convertkit-block-product.php:109
 msgid "ConvertKit Product"
 msgstr ""
 
-#: includes/blocks/class-convertkit-block-product.php:107
+#: includes/blocks/class-convertkit-block-product.php:110
 msgid "Displays a button to purchase a ConvertKit product."
 msgstr ""
 
-#: includes/blocks/class-convertkit-block-product.php:134
+#: includes/blocks/class-convertkit-block-product.php:143
+msgid "No products exist in ConvertKit."
+msgstr ""
+
+#: includes/blocks/class-convertkit-block-product.php:145
+msgid "Click here to create your first product."
+msgstr ""
+
+#: includes/blocks/class-convertkit-block-product.php:147
 msgid "Select a Product using the Product option in the Gutenberg sidebar."
 msgstr ""
 
-#: includes/blocks/class-convertkit-block-product.php:328
+#: includes/blocks/class-convertkit-block-product.php:346
 msgid "Buy my product"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: email marketing, email newsletter, newsletter, subscribers, convertkit
 Requires at least: 5.0
 Tested up to: 6.2.2
 Requires PHP: 5.6.20
-Stable tag: 2.2.2
+Stable tag: 2.2.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -133,6 +133,14 @@ Full Plugin documentation can be found [here](https://help.convertkit.com/en/art
 7. Track subscriber growth
 
 == Changelog ==
+
+### 2.2.3 2023-06-06
+* Added: Broadcasts: Options to display grid, images, descriptions and/or read more link
+* Added: Broadcasts: Output as single column on smaller screen resolutions
+* Added: Forms: Block: Display message with link when no API Key specified, or no Forms exist in ConvertKit
+* Added: Products: Block: Display message with link when no API Key specified, or no Products exist in ConvertKit
+* Fix: Settings: Disable CSS: Improve description of Disable CSS functionality, making it clearer what this setting does
+* Fix: Use `esc_url` instead of `esc_attr` for link `href` properties
 
 ### 2.2.2 2023-05-24
 * Added: Elementor: ConvertKit Form Trigger Block

--- a/tests/wpunit/ResourceFormsTest.php
+++ b/tests/wpunit/ResourceFormsTest.php
@@ -201,6 +201,94 @@ class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
+	 * Tests that the get_non_inline() function returns resources in alphabetical ascending order
+	 * by default.
+	 *
+	 * @since   1.9.7.4
+	 */
+	public function testGetNonInline()
+	{
+		// Call resource class' get_non_inline() function.
+		$result = $this->resource->get_non_inline();
+
+		// Assert result is an array.
+		$this->assertIsArray($result);
+
+		// Assert top level array keys are preserved.
+		$this->assertArrayHasKey($_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'], $result);
+		$this->assertArrayHasKey($_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_ID'], $result);
+
+		// Assert resource within results has expected array keys.
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
+
+		// Assert order of data is in ascending alphabetical order.
+		$this->assertEquals($_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'], reset($result)[ $this->resource->order_by ]);
+		$this->assertEquals($_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'], end($result)[ $this->resource->order_by ]);
+	}
+
+	/**
+	 * Tests that the get_non_inline() function returns resources in alphabetical descending order
+	 * when a valid order_by and order properties are defined.
+	 *
+	 * @since   2.0.8
+	 */
+	public function testGetNonInlineWithValidOrderByAndOrder()
+	{
+		// Define order_by and order.
+		$this->resource->order_by = 'name';
+		$this->resource->order    = 'desc';
+
+		// Call resource class' get_non_inline() function.
+		$result = $this->resource->get_non_inline();
+
+		// Assert result is an array.
+		$this->assertIsArray($result);
+
+		// Assert top level array keys are preserved.
+		$this->assertArrayHasKey($_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'], $result);
+		$this->assertArrayHasKey($_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_ID'], $result);
+
+		// Assert resource within results has expected array keys.
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
+
+		// Assert order of data is in ascending alphabetical order.
+		$this->assertEquals($_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'], reset($result)[ $this->resource->order_by ]);
+		$this->assertEquals($_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'], end($result)[ $this->resource->order_by ]);
+	}
+
+	/**
+	 * Tests that the get_non_inline() function returns resources in their original order
+	 * when populated with Forms and an invalid order_by value is specified.
+	 *
+	 * @since   2.2.4
+	 */
+	public function testGetNonInlineWithInvalidOrderBy()
+	{
+		// Define order_by with an invalid value (i.e. an array key that does not exist).
+		$this->resource->order_by = 'invalid_key';
+
+		// Call resource class' get_non_inline() function.
+		$result = $this->resource->get_non_inline();
+
+		// Assert result is an array.
+		$this->assertIsArray($result);
+
+		// Assert top level array keys are preserved.
+		$this->assertArrayHasKey($_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'], $result);
+		$this->assertArrayHasKey($_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_ID'], $result);
+
+		// Assert resource within results has expected array keys.
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
+
+		// Assert order of data has not changed.
+		$this->assertEquals($_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'], reset($result)['name']);
+		$this->assertEquals($_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME'], end($result)['name']);
+	}
+
+	/**
 	 * Test that the count() function returns the number of resources.
 	 *
 	 * @since   1.9.7.6

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -9,7 +9,7 @@
  * Plugin Name: ConvertKit
  * Plugin URI: https://convertkit.com/
  * Description: Quickly and easily integrate ConvertKit forms into your site.
- * Version: 2.2.2
+ * Version: 2.2.3
  * Author: ConvertKit
  * Author URI: https://convertkit.com/
  * Text Domain: convertkit
@@ -25,7 +25,7 @@ define( 'CONVERTKIT_PLUGIN_NAME', 'ConvertKit' ); // Used for user-agent in API 
 define( 'CONVERTKIT_PLUGIN_FILE', plugin_basename( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_PATH', __DIR__ );
-define( 'CONVERTKIT_PLUGIN_VERSION', '2.2.2' );
+define( 'CONVERTKIT_PLUGIN_VERSION', '2.2.3' );
 
 // Load shared classes, if they have not been included by another ConvertKit Plugin.
 if ( ! class_exists( 'ConvertKit_API' ) ) {


### PR DESCRIPTION
## Summary

Adds a `get_non_inline` method to the Form resource class, to fetch ConvertKit Forms that are not inline.

This replaces two instances which would previously iterate through all Forms, to determine if each Form is inline or not.

## Testing

- `ResourceFormsTest:testGetNonInline`: Test that using the `get_non_inline` method returns the expected non inline forms in the correct order.
- `ResourceFormsTest:testGetNonInlineWithValidOrderByAndOrder`: Test that using the `get_non_inline` method returns the expected non inline forms in the correct order, when `order_by` and `order are specified.
- `ResourceFormsTest:testGetNonInlineWithInvalidOrderBy`: Test that using the `get_non_inline` method returns the expected non inline forms in the correct order, when an invalid `order_by` parameter is specified.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)