### PR TITLE
Add `non_inline_exist` method to Forms resource class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "dev-add-get-by-method"
+        "convertkit/convertkit-wordpress-libraries": "1.3.6"
     },
     "require-dev": {
         "lucatume/wp-browser": "^3.0",

--- a/includes/block-formatters/class-convertkit-block-formatter-form-link.php
+++ b/includes/block-formatters/class-convertkit-block-formatter-form-link.php
@@ -40,9 +40,9 @@ class ConvertKit_Block_Formatter_Form_Link extends ConvertKit_Block_Formatter {
 	public function __construct() {
 
 		// Register this as a Gutenberg block formatter in the ConvertKit Plugin,
-		// if forms exist on ConvertKit.
+		// if non-inline forms exist on ConvertKit.
 		$this->forms = new ConvertKit_Resource_Forms( 'block_formatter_register' );
-		if ( $this->forms->exist() ) {
+		if ( $this->forms->non_inline_exist() ) {
 			add_filter( 'convertkit_get_block_formatters', array( $this, 'register' ) );
 		}
 

--- a/includes/blocks/class-convertkit-block-form-trigger.php
+++ b/includes/blocks/class-convertkit-block-form-trigger.php
@@ -118,9 +118,9 @@ class ConvertKit_Block_Form_Trigger extends ConvertKit_Block {
 				'link_text' => __( 'Click here to add your API Key.', 'convertkit' ),
 			),
 			'no_resources'                      => array(
-				'notice'    => __( 'No forms exist in ConvertKit.', 'convertkit' ),
+				'notice'    => __( 'No modal, sticky bar or slide in forms exist in ConvertKit.', 'convertkit' ),
 				'link'      => convertkit_get_new_form_url(),
-				'link_text' => __( 'Click here to create your first form.', 'convertkit' ),
+				'link_text' => __( 'Click here to create a form.', 'convertkit' ),
 			),
 			'gutenberg_help_description'        => __( 'Select a Form using the Form option in the Gutenberg sidebar.', 'convertkit' ),
 
@@ -128,10 +128,10 @@ class ConvertKit_Block_Form_Trigger extends ConvertKit_Block {
 			// If not defined, render_callback above will be used.
 			'gutenberg_preview_render_callback' => 'convertKitGutenbergFormTriggerBlockRenderPreview',
 
-			// Whether an API Key exists in the Plugin, and are the required resources (forms) available.
+			// Whether an API Key exists in the Plugin, and are the required resources (non-inline forms) available.
 			// If no API Key is specified in the Plugin's settings, render the "No API Key" output.
 			'has_api_key'                       => $settings->has_api_key_and_secret(),
-			'has_resources'                     => $convertkit_forms->exist(),
+			'has_resources'                     => $convertkit_forms->non_inline_exist(),
 		);
 
 	}
@@ -246,7 +246,7 @@ class ConvertKit_Block_Form_Trigger extends ConvertKit_Block {
 		// Get non-inline ConvertKit Forms.
 		$forms            = array();
 		$convertkit_forms = new ConvertKit_Resource_Forms( 'block_edit' );
-		if ( $convertkit_forms->exist() ) {
+		if ( $convertkit_forms->non_inline_exist() ) {
 			foreach ( $convertkit_forms->get_non_inline() as $form ) {
 				$forms[ absint( $form['id'] ) ] = sanitize_text_field( $form['name'] );
 			}

--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -82,11 +82,6 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource {
 
 		return true;
 
-		// If no forms exist, return false.
-		if ( ! $this->exist() ) {
-			return false;
-		}
-
 	}
 
 	/**

--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -54,6 +54,44 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource {
 	}
 
 	/**
+	 * Returns whether any non-inline forms exist in the options table.
+	 *
+	 * @since   2.2.4
+	 *
+	 * @return  bool
+	 */
+	public function non_inline_exist() {
+
+		// If no forms exist, return false.
+		if ( ! $this->exist() ) {
+			return false;
+		}
+
+		// Iterate through forms until a non-inline form is found.
+		foreach ( $this->resources as $form_id => $form ) {
+			// Ignore inline forms.
+			if ( ! array_key_exists( 'format', $form ) ) {
+				continue;
+			}
+			if ( $form['format'] === 'inline' ) {
+				continue;
+			}
+
+			// Ignore forms that are missing a uid.
+			if ( ! array_key_exists( 'uid', $form ) ) {
+				continue;
+			}
+
+			// This is a non-inline form.
+			return true;
+		}
+
+		// If here, no non-inline forms exist.
+		return false;
+
+	}
+
+	/**
 	 * Returns the HTML/JS markup for the given Form ID.
 	 *
 	 * Legacy Forms will return HTML.

--- a/tests/acceptance/forms/PageBlockFormTriggerCest.php
+++ b/tests/acceptance/forms/PageBlockFormTriggerCest.php
@@ -418,7 +418,7 @@ class PageBlockFormTriggerCest
 
 		// Confirm that the Form block displays instructions to the user on how to add a Form in ConvertKit.
 		$I->see(
-			'No forms exist in ConvertKit.',
+			'No modal, sticky bar or slide in forms exist in ConvertKit.',
 			[
 				'css' => '.convertkit-no-content',
 			]
@@ -426,7 +426,7 @@ class PageBlockFormTriggerCest
 
 		// Click the link to confirm it loads ConvertKit.
 		$I->click(
-			'Click here to create your first form.',
+			'Click here to create a form.',
 			[
 				'css' => '.convertkit-no-content',
 			]

--- a/tests/acceptance/forms/PageShortcodeFormTriggerCest.php
+++ b/tests/acceptance/forms/PageShortcodeFormTriggerCest.php
@@ -347,7 +347,7 @@ class PageShortcodeFormTriggerCest
 
 		// Confirm that the Form block displays instructions to the user on how to add a Form in ConvertKit.
 		$I->see(
-			'No forms exist in ConvertKit.',
+			'No modal, sticky bar or slide in forms exist in ConvertKit.',
 			[
 				'css' => '#convertkit-modal-body-body',
 			]
@@ -355,7 +355,7 @@ class PageShortcodeFormTriggerCest
 
 		// Click the link to confirm it loads ConvertKit.
 		$I->click(
-			'Click here to create your first form.',
+			'Click here to create a form.',
 			[
 				'css' => '#convertkit-modal-body-body',
 			]

--- a/tests/wpunit/ResourceFormsNoDataTest.php
+++ b/tests/wpunit/ResourceFormsNoDataTest.php
@@ -148,4 +148,16 @@ class ResourceFormsNoDataTest extends \Codeception\TestCase\WPTestCase
 		$result = $this->resource->exist();
 		$this->assertSame($result, false);
 	}
+
+	/**
+	 * Test that the non_inline_exist() function performs as expected.
+	 *
+	 * @since   2.2.4
+	 */
+	public function testNonInlineExist()
+	{
+		// Confirm that the function returns true, because resources exist.
+		$result = $this->resource->non_inline_exist();
+		$this->assertSame($result, false);
+	}
 }

--- a/tests/wpunit/ResourceFormsTest.php
+++ b/tests/wpunit/ResourceFormsTest.php
@@ -224,6 +224,18 @@ class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
+	 * Test that the non_inline_exist() function performs as expected.
+	 *
+	 * @since   2.2.4
+	 */
+	public function testNonInlineExist()
+	{
+		// Confirm that the function returns true, because resources exist.
+		$result = $this->resource->non_inline_exist();
+		$this->assertSame($result, true);
+	}
+
+	/**
 	 * Test that the get_html() function returns the expected data.
 	 *
 	 * @since   2.0.4


### PR DESCRIPTION
## Summary

Adds a `non_inline_exist` method to the Form resource class, to determine if non-inline ConvertKit Forms exist.

Updates the message displayed on the Form Trigger block and shortcode when no non-inline ConvertKit Forms exist:

![Screenshot 2023-06-09 at 15 42 03](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/a1a7a0cb-afee-4a25-ac8f-917eb28bf3aa)

## Testing

- `ResourceFormsTest:testNonInlineExist`: Test that using the `non_inline_exist` returns true when non inline forms exist.
- `ResourceFormsNoDataTest:testNonInlineExist`: Test that using the `non_inline_exist` returns false when no non inline forms exist.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)