### PR TITLE
Restrict Content: Conditionally display settings

### DIFF
--- a/admin/class-convertkit-admin-settings-restrict-content.php
+++ b/admin/class-convertkit-admin-settings-restrict-content.php
@@ -44,18 +44,18 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 
 	/**
 	 * Enqueues scripts for the Settings > Member's Content screen.
-	 * 
-	 * @since 	2.2.4
-	 * 
-	 * @param 	string 	$section 	Settings section / tab (general|tools|restrict-content).
-	 */ 
+	 *
+	 * @since   2.2.4
+	 *
+	 * @param   string $section    Settings section / tab (general|tools|restrict-content).
+	 */
 	public function enqueue_scripts( $section ) {
 
 		// Bail if we're not on the Member's Content section.
 		if ( $section !== $this->name ) {
 			return;
 		}
-		
+
 		// Enqueue JS.
 		wp_enqueue_script( 'convertkit-admin-settings-conditional-display', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/settings-conditional-display.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
 

--- a/admin/class-convertkit-admin-settings-restrict-content.php
+++ b/admin/class-convertkit-admin-settings-restrict-content.php
@@ -35,7 +35,29 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 		// Identify that this is beta functionality.
 		$this->is_beta = true;
 
+		// Enqueue scripts.
+		add_action( 'convertkit_admin_settings_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+
 		parent::__construct();
+
+	}
+
+	/**
+	 * Enqueues scripts for the Settings > Member's Content screen.
+	 * 
+	 * @since 	2.2.4
+	 * 
+	 * @param 	string 	$section 	Settings section / tab (general|tools|restrict-content).
+	 */ 
+	public function enqueue_scripts( $section ) {
+
+		// Bail if we're not on the Member's Content section.
+		if ( $section !== $this->name ) {
+			return;
+		}
+		
+		// Enqueue JS.
+		wp_enqueue_script( 'convertkit-admin-settings-conditional-display', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/settings-conditional-display.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
 
 	}
 
@@ -219,6 +241,7 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			$args['description'], // phpcs:ignore WordPress.Security.EscapeOutput
 			array(
 				'widefat',
+				'enabled',
 			)
 		);
 

--- a/admin/class-convertkit-admin-settings.php
+++ b/admin/class-convertkit-admin-settings.php
@@ -56,18 +56,17 @@ class ConvertKit_Admin_Settings {
 			return;
 		}
 
-		// Enqueue Select2 JS.
-		convertkit_select2_enqueue_scripts();
-
-		// Enqueue Preview Output JS.
-		wp_enqueue_script( 'convertkit-admin-preview-output', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/preview-output.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
+		// Get active settings section / tab that has been requested.
+		$section = $this->get_active_section();
 
 		/**
 		 * Enqueue JavaScript for the Settings Screen at Settings > ConvertKit
 		 *
 		 * @since   1.9.6
+		 * 
+		 * @param 	string 	$section 	Settings section / tab (general|tools|restrict-content).
 		 */
-		do_action( 'convertkit_admin_settings_enqueue_scripts' );
+		do_action( 'convertkit_admin_settings_enqueue_scripts', $section );
 
 	}
 
@@ -85,18 +84,20 @@ class ConvertKit_Admin_Settings {
 			return;
 		}
 
-		// Enqueue Select2 CSS.
-		convertkit_select2_enqueue_styles();
+		// Get active settings section / tab that has been requested.
+		$section = $this->get_active_section();
 
-		// Enqueue Settings CSS.
+		// Always enqueue Settings CSS, as this is used for the UI across all settings sections.
 		wp_enqueue_style( 'convertkit-admin-settings', CONVERTKIT_PLUGIN_URL . 'resources/backend/css/settings.css', array(), CONVERTKIT_PLUGIN_VERSION );
 
 		/**
 		 * Enqueue CSS for the Settings Screen at Settings > ConvertKit
 		 *
 		 * @since   1.9.6
+		 *
+		 * @param 	string 	$section 	Settings section / tab (general|tools|restrict-content).
 		 */
-		do_action( 'convertkit_admin_settings_enqueue_styles' );
+		do_action( 'convertkit_admin_settings_enqueue_styles', $section );
 
 	}
 

--- a/admin/class-convertkit-admin-settings.php
+++ b/admin/class-convertkit-admin-settings.php
@@ -63,8 +63,8 @@ class ConvertKit_Admin_Settings {
 		 * Enqueue JavaScript for the Settings Screen at Settings > ConvertKit
 		 *
 		 * @since   1.9.6
-		 * 
-		 * @param 	string 	$section 	Settings section / tab (general|tools|restrict-content).
+		 *
+		 * @param   string  $section    Settings section / tab (general|tools|restrict-content).
 		 */
 		do_action( 'convertkit_admin_settings_enqueue_scripts', $section );
 
@@ -95,7 +95,7 @@ class ConvertKit_Admin_Settings {
 		 *
 		 * @since   1.9.6
 		 *
-		 * @param 	string 	$section 	Settings section / tab (general|tools|restrict-content).
+		 * @param   string  $section    Settings section / tab (general|tools|restrict-content).
 		 */
 		do_action( 'convertkit_admin_settings_enqueue_styles', $section );
 

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -57,10 +57,55 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 		$this->title    = __( 'General Settings', 'convertkit' );
 		$this->tab_text = __( 'General', 'convertkit' );
 
+		// Enqueue scripts and CSS.
+		add_action( 'convertkit_admin_settings_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'convertkit_admin_settings_enqueue_styles', array( $this, 'enqueue_styles' ) );
+
 		// Render container element.
 		add_action( 'convertkit_settings_base_render_before', array( $this, 'render_before' ) );
 
 		parent::__construct();
+
+	}
+
+	/**
+	 * Enqueues scripts for the Settings > General screen.
+	 * 
+	 * @since 	2.2.4
+	 * 
+	 * @param 	string 	$section 	Settings section / tab (general|tools|restrict-content).
+	 */ 
+	public function enqueue_scripts( $section ) {
+
+		// Bail if we're not on the general section.
+		if ( $section !== $this->name ) {
+			return;
+		}
+		
+		// Enqueue Select2 JS.
+		convertkit_select2_enqueue_scripts();
+
+		// Enqueue Preview Output JS.
+		wp_enqueue_script( 'convertkit-admin-preview-output', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/preview-output.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
+
+	}
+
+	/**
+	 * Enqueues styles for the Settings > General screen.
+	 * 
+	 * @since 	2.2.4
+	 * 
+	 * @param 	string 	$section 	Settings section / tab (general|tools|restrict-content).
+	 */ 
+	public function enqueue_styles( $section ) {
+
+		// Bail if we're not on the general section.
+		if ( $section !== $this->name ) {
+			return;
+		}
+		
+		// Enqueue Select2 CSS.
+		convertkit_select2_enqueue_styles();
 
 	}
 

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -70,18 +70,18 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 
 	/**
 	 * Enqueues scripts for the Settings > General screen.
-	 * 
-	 * @since 	2.2.4
-	 * 
-	 * @param 	string 	$section 	Settings section / tab (general|tools|restrict-content).
-	 */ 
+	 *
+	 * @since   2.2.4
+	 *
+	 * @param   string $section    Settings section / tab (general|tools|restrict-content).
+	 */
 	public function enqueue_scripts( $section ) {
 
 		// Bail if we're not on the general section.
 		if ( $section !== $this->name ) {
 			return;
 		}
-		
+
 		// Enqueue Select2 JS.
 		convertkit_select2_enqueue_scripts();
 
@@ -92,18 +92,18 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 
 	/**
 	 * Enqueues styles for the Settings > General screen.
-	 * 
-	 * @since 	2.2.4
-	 * 
-	 * @param 	string 	$section 	Settings section / tab (general|tools|restrict-content).
-	 */ 
+	 *
+	 * @since   2.2.4
+	 *
+	 * @param   string $section    Settings section / tab (general|tools|restrict-content).
+	 */
 	public function enqueue_styles( $section ) {
 
 		// Bail if we're not on the general section.
 		if ( $section !== $this->name ) {
 			return;
 		}
-		
+
 		// Enqueue Select2 CSS.
 		convertkit_select2_enqueue_styles();
 

--- a/resources/backend/js/settings-conditional-display.js
+++ b/resources/backend/js/settings-conditional-display.js
@@ -1,0 +1,71 @@
+/**
+ * Displays or hides settings in the UI, depending on which settings are enabled
+ * or disabled.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Displays or hides settings in the UI, depending on which settings are enabled
+ * or disabled.
+ *
+ * @since 	2.2.4
+ */
+jQuery( document ).ready(
+	function( $ ) {
+
+		// Update settings and refresh UI when a setting is changed.
+		$( 'input[type=checkbox]' ).on(
+			'change',
+			function() {
+
+				convertKitConditionallyDisplaySettings( $( this ).attr( 'id' ), $( this ).prop( 'checked' ) );
+
+			}
+		);
+
+		// Restrict Content.
+		convertKitConditionallyDisplaySettings( 'enabled', $( 'input#enabled' ).prop( 'checked' ) );
+
+	}
+);
+
+/**
+ * Shows all table rows on a ConvertKit settings screen, and then hides
+ * table rows related to a setting, if that setting is disabled.
+ *
+ * @since 	2.2.4
+ */
+function convertKitConditionallyDisplaySettings( name, display ) {
+
+	( function( $ ) {
+
+		// Show all rows.
+		$( 'table.form-table tr' ).show();
+
+		// Don't do anything else if display is true.
+		if ( display ) {
+			return;
+		}
+
+		// Iterate through the table rows, hiding any settings.
+		$( 'table.form-table tr' ).each(
+			function() {
+
+				// Skip if this table row is for the setting we've just checked/unchecked.
+				if ( $( '[id="' + name + '"]', $( this ) ).length > 0 ) {
+					return;
+				}
+
+				// Hide this row if the input, select, link or span element within the row has the CSS class of the setting name.
+				if ( $( 'input, select, a, span', $( this ) ).hasClass( name ) ) {
+					$( this ).hide();
+				}
+
+			}
+		);
+
+	} )( jQuery );
+
+}

--- a/tests/acceptance/general/PluginSettingsToolsCest.php
+++ b/tests/acceptance/general/PluginSettingsToolsCest.php
@@ -143,10 +143,10 @@ class PluginSettingsToolsCest
 		$I->setupConvertKitPluginRestrictContent(
 			$I,
 			array_merge(
-				$I->getRestrictedContentDefaultSettings(),
 				[
 					'enabled' => 'on',
-				]
+				],
+				$I->getRestrictedContentDefaultSettings(),
 			)
 		);
 		$I->loadConvertKitSettingsToolsScreen($I);

--- a/tests/acceptance/general/PluginSettingsToolsCest.php
+++ b/tests/acceptance/general/PluginSettingsToolsCest.php
@@ -146,7 +146,7 @@ class PluginSettingsToolsCest
 				[
 					'enabled' => 'on',
 				],
-				$I->getRestrictedContentDefaultSettings(),
+				$I->getRestrictedContentDefaultSettings()
 			)
 		);
 		$I->loadConvertKitSettingsToolsScreen($I);

--- a/tests/acceptance/restrict-content/RestrictContentSettingsCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentSettingsCest.php
@@ -22,7 +22,8 @@ class RestrictContentSettingsCest
 
 
 	/**
-	 * Tests that enabling and disabling Restrict Content works with no errors.
+	 * Tests that enabling and disabling Restrict Content works with no errors,
+	 * and that other form fields show / hide depending on the setting.
 	 *
 	 * @since   2.1.0
 	 *
@@ -30,27 +31,43 @@ class RestrictContentSettingsCest
 	 */
 	public function testEnableDisable(AcceptanceTester $I)
 	{
-		// Save settings.
-		$I->setupConvertKitPluginRestrictContent(
-			$I,
-			[
-				'enabled' => true,
-			]
-		);
+		// Go to the Plugin's Member Content Screen.
+		$I->loadConvertKitSettingsRestrictContentScreen($I);
 
-		// Confirm settings were saved.
+		// Confirm that additional fields are hidden, because the 'Enable' option is not checked.
+		$I->dontSeeElement('input.enabled');
+
+		// Enable Member Content.
+		$I->checkOption('#enabled');
+
+		// Confirm that additional fields are now displayed.
+		$I->waitForElementVisible('input.enabled');
+
+		// Click the Save Changes button.
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that settings saved and additional fields remain displayed.
 		$I->seeCheckboxIsChecked('#enabled');
+		$I->seeElement('input.enabled');
 
-		// Save settings.
-		$I->setupConvertKitPluginRestrictContent(
-			$I,
-			[
-				'enabled' => false,
-			]
-		);
+		// Disable Member Content.
+		$I->uncheckOption('#enabled');
 
-		// Confirm settings were saved.
+		// Confirm that additional fields are hidden, because the 'Enable' option is not checked.
+		$I->waitForElementNotVisible('input.enabled');
+
+		// Click the Save Changes button.
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that settings saved and additional fields are hidden, because the 'Enable' option is not checked.
 		$I->dontSeeCheckboxIsChecked('#enabled');
+		$I->dontSeeElement('input.enabled');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Conditionally displays settings on `Settings > ConvertKit > Member Content`, depending on whether the `Enable` checkbox is checked or not.

Loads specific JS and CSS depending on the settings screen that is requested, by using our `convertkit_admin_settings_enqueue_scripts` action.  Specifically:
- `General`: Load Select2 JS and CSS. We don't need this on the Tools or Member Content settings screens
- `Member Content`: Load `settings-conditional-display.js` to conditionally show/hide settings fields

![Screenshot 2023-06-14 at 17 00 14](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/7b712886-c776-4e5e-b8a7-6382f4b9f481)

![Screenshot 2023-06-14 at 17 00 08](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/05a609e8-fb61-4ce9-bb37-60c699652a56)


## Testing

- `RestrictContentSettingsCest:testEnableDisable`: Updated test to check that settings fields display / hide depending on whether the `Enable` checkbox is checked or not.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)