### PR TITLE
Fix QuickTags to TinyMCE Switching

### DIFF
--- a/resources/backend/js/modal.js
+++ b/resources/backend/js/modal.js
@@ -23,7 +23,8 @@ jQuery( document ).ready(
 				}
 
 				// Text Editor.
-				convertKitQuickTagsModalClose();
+				// Close the QuickTags modal.
+				convertKitQuickTagsModal.close();
 
 			}
 		);
@@ -105,7 +106,7 @@ jQuery( document ).ready(
 						QTags.insertContent( shortcode );
 
 						// Close modal.
-						convertKitQuickTagsModalClose();
+						convertKitQuickTagsModal.close();
 						break;
 				}
 			}
@@ -114,19 +115,6 @@ jQuery( document ).ready(
 	}
 );
 
-/**
- * Resets the content of the convertKitQuickTagsModal when closing.
- * 
- * If this isn't performed, switching from Text to Visual Editor for the same shortcode results
- * code picking up data from the QuickTags modal, not the TinyMCE one, due to this 'stale'
- * modal remaining in the DOM, resulting in e.g. the tabbed UI not loading correctly.
- */
-function convertKitQuickTagsModalClose() {
-
-	convertKitQuickTagsModal.close();
-	convertKitQuickTagsModal.content( new convertKitQuickTagsModalContent() );
-
-}
 
 // QuickTags: Setup Backbone Modal and Template.
 if ( typeof wp !== 'undefined' && typeof wp.media !== 'undefined' ) {
@@ -138,11 +126,22 @@ if ( typeof wp !== 'undefined' && typeof wp.media !== 'undefined' ) {
 			className: 'convertkit-quicktags-modal'
 		}
 	);
-	var convertKitQuickTagsModalContent = wp.Backbone.View.extend(
+	const convertKitQuickTagsModalContent = wp.Backbone.View.extend(
 		{
 			template: wp.template( 'convertkit-quicktags-modal' )
 		}
 	);
 	convertKitQuickTagsModal.content( new convertKitQuickTagsModalContent() );
+
+	/**
+	 * Resets the content of the convertKitQuickTagsModal when closing.
+	 * 
+	 * If this isn't performed, switching from Text to Visual Editor for the same shortcode results
+	 * code picking up data from the QuickTags modal, not the TinyMCE one, due to this 'stale'
+	 * modal remaining in the DOM, resulting in e.g. the tabbed UI not loading correctly.
+	 */
+	convertKitQuickTagsModal.on( 'close', function( e ) {
+		this.content( new convertKitQuickTagsModalContent() );
+	} );
 
 }

--- a/resources/backend/js/modal.js
+++ b/resources/backend/js/modal.js
@@ -135,13 +135,16 @@ if ( typeof wp !== 'undefined' && typeof wp.media !== 'undefined' ) {
 
 	/**
 	 * Resets the content of the convertKitQuickTagsModal when closing.
-	 * 
+	 *
 	 * If this isn't performed, switching from Text to Visual Editor for the same shortcode results
 	 * code picking up data from the QuickTags modal, not the TinyMCE one, due to this 'stale'
 	 * modal remaining in the DOM, resulting in e.g. the tabbed UI not loading correctly.
 	 */
-	convertKitQuickTagsModal.on( 'close', function( e ) {
-		this.content( new convertKitQuickTagsModalContent() );
-	} );
+	convertKitQuickTagsModal.on(
+		'close',
+		function( e ) {
+			this.content( new convertKitQuickTagsModalContent() );
+		}
+	);
 
 }

--- a/resources/backend/js/modal.js
+++ b/resources/backend/js/modal.js
@@ -23,13 +23,7 @@ jQuery( document ).ready(
 				}
 
 				// Text Editor.
-				convertKitQuickTagsModal.close();
-
-				// Reset the content in the non-TinyMCE modal.
-				// If we don't do this, switching from Text to Visual Editor for the same shortcode results
-				// code picking up data from the QuickTags modal, not the TinyMCE one, resulting in e.g.
-				// tabbed UI not loading correctly, form field values fetched from the wrong modal etc.
-				convertKitQuickTagsModal.content( new convertKitQuickTagsModalContent() );
+				convertKitQuickTagsModalClose();
 
 			}
 		);
@@ -111,13 +105,7 @@ jQuery( document ).ready(
 						QTags.insertContent( shortcode );
 
 						// Close modal.
-						convertKitQuickTagsModal.close();
-
-						// Reset the content in the non-TinyMCE modal.
-						// If we don't do this, switching from Text to Visual Editor for the same shortcode results
-						// code picking up data from the QuickTags modal, not the TinyMCE one, resulting in e.g.
-						// tabbed UI not loading correctly, form field values fetched from the wrong modal etc.
-						convertKitQuickTagsModal.content( new convertKitQuickTagsModalContent() );
+						convertKitQuickTagsModalClose();
 						break;
 				}
 			}
@@ -126,8 +114,23 @@ jQuery( document ).ready(
 	}
 );
 
+/**
+ * Resets the content of the convertKitQuickTagsModal when closing.
+ * 
+ * If this isn't performed, switching from Text to Visual Editor for the same shortcode results
+ * code picking up data from the QuickTags modal, not the TinyMCE one, due to this 'stale'
+ * modal remaining in the DOM, resulting in e.g. the tabbed UI not loading correctly.
+ */
+function convertKitQuickTagsModalClose() {
+
+	convertKitQuickTagsModal.close();
+	convertKitQuickTagsModal.content( new convertKitQuickTagsModalContent() );
+
+}
+
 // QuickTags: Setup Backbone Modal and Template.
 if ( typeof wp !== 'undefined' && typeof wp.media !== 'undefined' ) {
+
 	// Declared globally, as used in this file and quicktags.js.
 	var convertKitQuickTagsModal          = new wp.media.view.Modal(
 		{
@@ -141,4 +144,5 @@ if ( typeof wp !== 'undefined' && typeof wp.media !== 'undefined' ) {
 		}
 	);
 	convertKitQuickTagsModal.content( new convertKitQuickTagsModalContent() );
+
 }

--- a/resources/backend/js/modal.js
+++ b/resources/backend/js/modal.js
@@ -25,6 +25,12 @@ jQuery( document ).ready(
 				// Text Editor.
 				convertKitQuickTagsModal.close();
 
+				// Reset the content in the non-TinyMCE modal.
+				// If we don't do this, switching from Text to Visual Editor for the same shortcode results
+				// code picking up data from the QuickTags modal, not the TinyMCE one, resulting in e.g.
+				// tabbed UI not loading correctly, form field values fetched from the wrong modal etc.
+				convertKitQuickTagsModal.content( new convertKitQuickTagsModalContent() );
+
 			}
 		);
 
@@ -106,6 +112,12 @@ jQuery( document ).ready(
 
 						// Close modal.
 						convertKitQuickTagsModal.close();
+
+						// Reset the content in the non-TinyMCE modal.
+						// If we don't do this, switching from Text to Visual Editor for the same shortcode results
+						// code picking up data from the QuickTags modal, not the TinyMCE one, resulting in e.g.
+						// tabbed UI not loading correctly, form field values fetched from the wrong modal etc.
+						convertKitQuickTagsModal.content( new convertKitQuickTagsModalContent() );
 						break;
 				}
 			}
@@ -123,7 +135,7 @@ if ( typeof wp !== 'undefined' && typeof wp.media !== 'undefined' ) {
 			className: 'convertkit-quicktags-modal'
 		}
 	);
-	const convertKitQuickTagsModalContent = wp.Backbone.View.extend(
+	var convertKitQuickTagsModalContent = wp.Backbone.View.extend(
 		{
 			template: wp.template( 'convertkit-quicktags-modal' )
 		}

--- a/resources/backend/js/tinymce.js
+++ b/resources/backend/js/tinymce.js
@@ -38,6 +38,12 @@ function convertKitTinyMCERegisterPlugin( block ) {
 					'convertkit_' + block.name,
 					function() {
 
+						// Reset the content in the non-TinyMCE modal.
+						// If we don't do this, switching from Text to Visual Editor for the same shortcode results
+						// code picking up data from the QuickTags modal, not the TinyMCE one, resulting in e.g.
+						// tabbed UI not loading correctly, form field values fetched from the wrong modal etc.
+						convertKitQuickTagsModal.content( new convertKitQuickTagsModalContent() );
+
 						// Open the TinyMCE Modal.
 						editor.windowManager.open(
 							{

--- a/resources/backend/js/tinymce.js
+++ b/resources/backend/js/tinymce.js
@@ -38,8 +38,8 @@ function convertKitTinyMCERegisterPlugin( block ) {
 					'convertkit_' + block.name,
 					function() {
 
-						// Truly close any existing QuickTags modal.
-						convertKitQuickTagsModalClose();
+						// Close any existing QuickTags modal.
+						convertKitQuickTagsModal.close();
 
 						// Open the TinyMCE Modal.
 						editor.windowManager.open(

--- a/resources/backend/js/tinymce.js
+++ b/resources/backend/js/tinymce.js
@@ -38,11 +38,8 @@ function convertKitTinyMCERegisterPlugin( block ) {
 					'convertkit_' + block.name,
 					function() {
 
-						// Reset the content in the non-TinyMCE modal.
-						// If we don't do this, switching from Text to Visual Editor for the same shortcode results
-						// code picking up data from the QuickTags modal, not the TinyMCE one, resulting in e.g.
-						// tabbed UI not loading correctly, form field values fetched from the wrong modal etc.
-						convertKitQuickTagsModal.content( new convertKitQuickTagsModalContent() );
+						// Truly close any existing QuickTags modal.
+						convertKitQuickTagsModalClose();
 
 						// Open the TinyMCE Modal.
 						editor.windowManager.open(

--- a/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
@@ -744,6 +744,43 @@ class PageShortcodeBroadcastsCest
 	}
 
 	/**
+	 * Test that using the Broadcasts shortcode in the Text editor, switching to the Visual Editor and
+	 * then using the Broadcasts shortcode again works by interacting with the tabbed UI.
+	 * 
+	 * @since 	2.2.5
+	 * 
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsShortcodeWhenSwitchingEditors(AcceptanceTester $I)
+	{
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Shortcode: Editor Switching');
+
+		// Open Text Editor modal.
+		$I->openTextEditorShortcodeModal($I, 'convertkit-broadcasts', 'content');
+
+		// Close modal.
+		$I->click('.convertkit-quicktags-modal button.media-modal-close');
+
+		// Open Visual Editor modal, clicking the pagination tab to confirm that the UI
+		// still works, inserting the shortcode into the Visual Editor.
+		$I->addVisualEditorShortcode(
+			$I,
+			'ConvertKit Broadcasts',
+			[
+				'limit'    => [ 'input', '1', 'Pagination' ], // Click the Pagination tab first before starting to complete fields.
+				'paginate' => [ 'toggle', 'Yes' ],
+			],
+			'[convertkit_broadcasts display_grid="0" date_format="F j, Y" display_image="0" display_description="0" display_read_more="0" read_more_label="Read more" limit="1" paginate="1" paginate_label_prev="Previous" paginate_label_next="Next"]'
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage($I);
+
+
+	}
+
+	/**
 	 * Test the [convertkit_broadcasts] shortcode parameters are correctly escaped on output,
 	 * to prevent XSS.
 	 *

--- a/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageShortcodeBroadcastsCest.php
@@ -746,9 +746,9 @@ class PageShortcodeBroadcastsCest
 	/**
 	 * Test that using the Broadcasts shortcode in the Text editor, switching to the Visual Editor and
 	 * then using the Broadcasts shortcode again works by interacting with the tabbed UI.
-	 * 
-	 * @since 	2.2.5
-	 * 
+	 *
+	 * @since   2.2.5
+	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testBroadcastsShortcodeWhenSwitchingEditors(AcceptanceTester $I)
@@ -776,7 +776,6 @@ class PageShortcodeBroadcastsCest
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewClassicEditorPage($I);
-
 
 	}
 


### PR DESCRIPTION
## Summary

Fixes an issue where the TinyMCE modal for a shortcode would fail to load correctly (Insert / Cancel buttons would fail to work, and the tabbed interface wouldn't load), when switching from the Text Editor.

## Testing

- `PageShortcodeBroadcastsCest:testBroadcastsShortcodeWhenSwitchingEditors`: Tests that the modal window works correctly when used in the text editor, switching to the visual editor and attempting to use it again for the broadcasts shortcode.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)