### PR TITLE
Fix undefined method `get_by`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,15 @@ jobs:
 
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
-          'acceptance/general'
+          'acceptance/broadcasts',
+          'acceptance/forms',
+          'acceptance/general',
+          'acceptance/integrations',
+          'acceptance/landing-pages',
+          'acceptance/products',
+          'acceptance/restrict-content',
+          'acceptance/tags',
+          'acceptance/wlm'
         ]
 
     # Steps to install, configure and run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
       DB_PASS: root
       DB_HOST: localhost
       INSTALL_PLUGINS: "contact-form-7 convertkit-for-woocommerce classic-editor disable-welcome-messages-and-tips elementor woocommerce wordpress-seo wpforms-lite litespeed-cache wp-super-cache w3-total-cache wp-fastest-cache wp-optimize" # Don't include this repository's Plugin here.
-      INSTALL_PLUGINS_URLS: "https://downloads.wordpress.org/plugin/integrate-convertkit-wpforms.1.5.5.zip" # URLs to specific third party Plugins
+      INSTALL_PLUGINS_URLS: "https://downloads.wordpress.org/plugin/convertkit-for-woocommerce.1.6.4.zip" # URLs to specific third party Plugins
       CONVERTKIT_API_KEY: ${{ secrets.CONVERTKIT_API_KEY }} # ConvertKit API Key, stored in the repository's Settings > Secrets
       CONVERTKIT_API_SECRET: ${{ secrets.CONVERTKIT_API_SECRET }} # ConvertKit API Secret, stored in the repository's Settings > Secrets
       CONVERTKIT_API_KEY_NO_DATA: ${{ secrets.CONVERTKIT_API_KEY_NO_DATA }} # ConvertKit API Key for ConvertKit account with no data, stored in the repository's Settings > Secrets

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,8 @@ jobs:
       DB_USER: root
       DB_PASS: root
       DB_HOST: localhost
-      INSTALL_PLUGINS: "contact-form-7 convertkit-for-woocommerce classic-editor disable-welcome-messages-and-tips elementor integrate-convertkit-wpforms woocommerce wordpress-seo wpforms-lite litespeed-cache wp-super-cache w3-total-cache wp-fastest-cache wp-optimize" # Don't include this repository's Plugin here.
+      INSTALL_PLUGINS: "contact-form-7 convertkit-for-woocommerce classic-editor disable-welcome-messages-and-tips elementor woocommerce wordpress-seo wpforms-lite litespeed-cache wp-super-cache w3-total-cache wp-fastest-cache wp-optimize" # Don't include this repository's Plugin here.
+      INSTALL_PLUGINS_URLS: "https://downloads.wordpress.org/plugin/integrate-convertkit-wpforms.1.5.5.zip" # URLs to specific third party Plugins
       CONVERTKIT_API_KEY: ${{ secrets.CONVERTKIT_API_KEY }} # ConvertKit API Key, stored in the repository's Settings > Secrets
       CONVERTKIT_API_SECRET: ${{ secrets.CONVERTKIT_API_SECRET }} # ConvertKit API Secret, stored in the repository's Settings > Secrets
       CONVERTKIT_API_KEY_NO_DATA: ${{ secrets.CONVERTKIT_API_KEY_NO_DATA }} # ConvertKit API Key for ConvertKit account with no data, stored in the repository's Settings > Secrets
@@ -50,15 +51,7 @@ jobs:
 
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
-          'acceptance/broadcasts',
-          'acceptance/forms',
-          'acceptance/general',
-          'acceptance/integrations',
-          'acceptance/landing-pages',
-          'acceptance/products',
-          'acceptance/restrict-content',
-          'acceptance/tags',
-          'acceptance/wlm'
+          'acceptance/general'
         ]
 
     # Steps to install, configure and run tests
@@ -116,6 +109,11 @@ jobs:
       - name: Install Free Third Party WordPress Plugins
         working-directory: ${{ env.ROOT_DIR }}
         run: wp-cli plugin install ${{ env.INSTALL_PLUGINS }}
+
+      # env.INSTALL_PLUGINS_URLS is a list of Plugin URLs, space separated, to install specific versions ot third party Plugins.
+      - name: Install Free Third Party WordPress Specific Version Plugins
+        working-directory: ${{ env.ROOT_DIR }}
+        run: wp-cli plugin install ${{ env.INSTALL_PLUGINS_URLS }}
 
       # These should be stored as a separated list of URLs in the repository Settings > Secrets > Repository Secret > CONVERTKIT_PAID_PLUGIN_URLS.
       # We cannot include the URLs in this file, as they're not Plugins we are permitted to distribute.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       DB_USER: root
       DB_PASS: root
       DB_HOST: localhost
-      INSTALL_PLUGINS: "contact-form-7 convertkit-for-woocommerce classic-editor disable-welcome-messages-and-tips elementor woocommerce wordpress-seo wpforms-lite litespeed-cache wp-super-cache w3-total-cache wp-fastest-cache wp-optimize" # Don't include this repository's Plugin here.
+      INSTALL_PLUGINS: "contact-form-7 classic-editor disable-welcome-messages-and-tips elementor woocommerce wordpress-seo wpforms-lite litespeed-cache wp-super-cache w3-total-cache wp-fastest-cache wp-optimize" # Don't include this repository's Plugin here.
       INSTALL_PLUGINS_URLS: "https://downloads.wordpress.org/plugin/convertkit-for-woocommerce.1.6.4.zip" # URLs to specific third party Plugins
       CONVERTKIT_API_KEY: ${{ secrets.CONVERTKIT_API_KEY }} # ConvertKit API Key, stored in the repository's Settings > Secrets
       CONVERTKIT_API_SECRET: ${{ secrets.CONVERTKIT_API_SECRET }} # ConvertKit API Secret, stored in the repository's Settings > Secrets

--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -58,9 +58,17 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource {
 	 *
 	 * @since   2.2.4
 	 *
-	 * @return  array
+	 * @return  bool|array
 	 */
 	public function get_non_inline() {
+
+		// If the ConvertKit WordPress Libraries are < 1.3.6 (e.g. loaded by an outdated
+		// addon), or a WordPress site updates this Plugin before other ConvertKit Plugins,
+		// get_by() won't be available and will cause an E_ERROR, crashing the site.
+		// @see https://wordpress.org/support/topic/error-1795/.
+		if ( ! method_exists( $this, 'get_by' ) ) {
+			return false;
+		}
 
 		return $this->get_by( 'format', array( 'modal', 'slide in', 'sticky bar' ) );
 

--- a/tests/acceptance/general/ActivateDeactivatePluginCest.php
+++ b/tests/acceptance/general/ActivateDeactivatePluginCest.php
@@ -31,11 +31,13 @@ class ActivateDeactivatePluginCest
 	public function testPluginActivationAndDeactivationWithOtherPlugins(AcceptanceTester $I)
 	{
 		// Activate other ConvertKit Plugins from wordpress.org.
-		$I->activateThirdPartyPlugin($I, 'wpforms-lite');
-		$I->activateThirdPartyPlugin($I, 'integrate-convertkit-wpforms');
+		$I->activateThirdPartyPlugin($I, 'convertkit-for-woocommerce');
 
 		// Activate this Plugin.
 		$I->activateConvertKitPlugin($I);
+
+		// If this Plugin calls a function that doesn't exist in the outdated ConvertKit WordPress Library,
+		// this will throw an error and the test will fail at this point.
 
 		// Setup API Keys at Settings > ConvertKit, which will use WordPress Libraries and show errors
 		// if there's a conflict e.g. an older WordPress Library was loaded from another ConvertKit Plugin.

--- a/tests/acceptance/general/ActivateDeactivatePluginCest.php
+++ b/tests/acceptance/general/ActivateDeactivatePluginCest.php
@@ -34,10 +34,9 @@ class ActivateDeactivatePluginCest
 		$I->activateThirdPartyPlugin($I, 'convertkit-for-woocommerce');
 
 		// Activate this Plugin.
-		$I->activateConvertKitPlugin($I);
-
 		// If this Plugin calls a function that doesn't exist in the outdated ConvertKit WordPress Library,
-		// this will throw an error and the test will fail at this point.
+		// activating this Plugin will fail, therefore failing the test.
+		$I->activateConvertKitPlugin($I);
 
 		// Setup API Keys at Settings > ConvertKit, which will use WordPress Libraries and show errors
 		// if there's a conflict e.g. an older WordPress Library was loaded from another ConvertKit Plugin.


### PR DESCRIPTION
## Summary

Fixes the error reported [here](https://wordpress.org/support/topic/error-1795/) and [here](https://wordpress.org/support/topic/uncaught-error-call-to-undefined-method-convertkit_resource_formsget_by/), by checking that the ConvertKit WordPress Libraries loaded contain the necessary `get_by` function before using it.

<img width="670" alt="Screenshot 2023-06-20 at 23 29 42" src="https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/699161eb-e648-4358-9e91-749447fdb72a">

This covers the scenario where:
- a WordPress site has the ConvertKit Plugin 2.2.3 or older and (in this case) the ConvertKit for WooCommerce 1.6.4 Plugin installed and active, and
- the main ConvertKit Plugin is updated to the latest version, 2.2.4, which includes a newer version of the ConvertKit WordPress Libraries (in this case, 1.3.6), and
- other ConvertKit Plugins are not (yet) updated - either because the user did not select them for updating, or the user did select them for updating, but WordPress chose to update the main ConvertKit Plugin first.

As we do not control the order of Plugin updates, or which Plugin 'wins' in loading their ConvertKit WordPress Libraries first, the above scenario results in an undefined method `get_by()` error, because an older library (1.3.5) is loaded by the outdated ConvertKit for WooCommerce Plugin.

## Testing

- The GitHub action deliberately loads ConvertKit for WPForms 1.5.5, which contains a version of the ConvertKit WordPress Libraries that does not contain the `get_by()` method.  The `testPluginActivationAndDeactivationWithOtherPlugins` test will then fail if we don't conditionally check that the `get_by()` method is available in the main ConvertKit Plugin.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)