### PR TITLE
Implement `useAnchor` instead of deprecated `useAnchorRef`

### DIFF
--- a/resources/backend/js/gutenberg-block-formatters.js
+++ b/resources/backend/js/gutenberg-block-formatters.js
@@ -41,7 +41,7 @@ function convertKitGutenbergRegisterBlockFormatter( formatter ) {
 			registerFormatType,
 			toggleFormat,
 			applyFormat,
-			useAnchorRef
+			useAnchor
 		} = richText;
 		const {
 			BlockControls,
@@ -274,7 +274,7 @@ function convertKitGutenbergRegisterBlockFormatter( formatter ) {
 			// Get props and anchor reference to the text.
 			const { contentRef, isActive, value } = props;
 			const { activeFormats }               = value;
-			const anchorRef                       = useAnchorRef( { ref: contentRef, value } );
+			const anchorRef                       = useAnchor( { editableContentElement: contentRef.current, value } );
 
 			// State to show popover.
 			const [ showPopover, setShowPopover ] = useState( false );


### PR DESCRIPTION
## Summary

When applying or editing a block formatter (for adding/editing a form trigger or product trigger), implement the `useAnchor` hook instead of the deprecated `useAnchorRef`.

Before:
![Screenshot_2023-06-21_at_17_30_24](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/90888f15-63cb-4974-b3f9-6cfbf179cba5)

After:
![Screenshot 2023-06-21 at 17 30 38](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/85b709e4-c938-4ac5-ab15-3124a9dae0d4)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)