### PR TITLE
Fix flaky tests

### DIFF
--- a/tests/_support/Helper/Acceptance/WPBulkEdit.php
+++ b/tests/_support/Helper/Acceptance/WPBulkEdit.php
@@ -43,9 +43,6 @@ class WPBulkEdit extends \Codeception\Module
 			}
 		}
 
-		// Scroll to Update button.
-		$I->scrollTo('#bulk_edit');
-
 		// Click Update.
 		$I->click('#bulk_edit');
 

--- a/tests/_support/Helper/Acceptance/WPBulkEdit.php
+++ b/tests/_support/Helper/Acceptance/WPBulkEdit.php
@@ -47,7 +47,7 @@ class WPBulkEdit extends \Codeception\Module
 		$I->scrollTo('#bulk_edit');
 
 		// Click Update.
-		$I->click('Update');
+		$I->click('#bulk_edit');
 
 		// Wait for the WP_List_Table of Pages to load.
 		$I->waitForElementVisible('tbody#the-list');

--- a/tests/acceptance/restrict-content/RestrictContentSetupCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentSetupCest.php
@@ -217,6 +217,9 @@ class RestrictContentSetupCest
 		// Click View link.
 		$I->click('tr.iedit:first-child span.view a');
 
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible('body.page-template-default');
+
 		// Confirm the Start Course button exists.
 		$I->see('Start Course');
 


### PR DESCRIPTION
## Summary

Fixes flaky tests when interacting with specific elements, ensuring they pass first time:

![Screenshot 2023-06-22 at 17 20 18](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/314fa260-35a0-4a19-8e39-ae99950dec76)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)