### PR TITLE
Add refresh button to blocks

### DIFF
--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -113,7 +113,8 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 	public function get_overview() {
 
 		// Fetch Posts.
-		$posts = new ConvertKit_Resource_Posts( 'output_broadcasts' );
+		$posts 		= new ConvertKit_Resource_Posts( 'output_broadcasts' );
+		$settings   = new ConvertKit_Settings();
 
 		return array(
 			'title'                             => __( 'ConvertKit Broadcasts', 'convertkit' ),
@@ -144,15 +145,26 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 			// Gutenberg: Example image showing how this block looks when choosing it in Gutenberg.
 			'gutenberg_example_image'           => CONVERTKIT_PLUGIN_URL . 'resources/backend/images/block-example-broadcasts.png',
 
-			// Gutenberg: Help description, displayed when no Posts exist.
-			'gutenberg_help_description'        => __( 'No Broadcasts exist in ConvertKit. Send your first Broadcast in ConvertKit to see the link to it here.', 'convertkit' ),
+			// Help descriptions, displayed when no API key / resources exist and this block/shortcode is added.
+			'no_api_key'                        => array(
+				'notice'    => __( 'No API Key specified.', 'convertkit' ),
+				'link'      => convertkit_get_setup_wizard_plugin_link(),
+				'link_text' => __( 'Click here to add your API Key.', 'convertkit' ),
+			),
+			'no_resources'                      => array(
+				'notice'    => __( 'No broadcasts exist in ConvertKit.', 'convertkit' ),
+				'link'      => convertkit_get_new_broadcast_url(),
+				'link_text' => __( 'Click here to send your first broadcast.', 'convertkit' ),
+			),
 
 			// Gutenberg: JS function to call when rendering the block preview in the Gutenberg editor.
 			// If not defined, render_callback above will be used.
 			'gutenberg_preview_render_callback' => 'convertKitGutenbergBroadcastsBlockRenderPreview',
 
-			// Flag to determine if Broadcasts exist.
-			'has_posts'                         => $posts->exist(),
+			// Whether an API Key exists in the Plugin, and are the required resources (broadcasts) available.
+			// If no API Key is specified in the Plugin's settings, render the "No API Key" output.
+			'has_api_key'                       => $settings->has_api_key_and_secret(),
+			'has_resources'                     => $posts->exist(),
 		);
 
 	}

--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -113,8 +113,8 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 	public function get_overview() {
 
 		// Fetch Posts.
-		$posts 		= new ConvertKit_Resource_Posts( 'output_broadcasts' );
-		$settings   = new ConvertKit_Settings();
+		$posts    = new ConvertKit_Resource_Posts( 'output_broadcasts' );
+		$settings = new ConvertKit_Settings();
 
 		return array(
 			'title'                             => __( 'ConvertKit Broadcasts', 'convertkit' ),

--- a/includes/class-convertkit-ajax.php
+++ b/includes/class-convertkit-ajax.php
@@ -47,6 +47,17 @@ class ConvertKit_AJAX {
 		// Check nonce.
 		check_ajax_referer( 'convertkit_get_blocks', 'nonce' );
 
+		// Refresh resources from the API, to reflect any changes.
+		// @TODO Optimize this based on the block we want to refresh, so we only make one API call?
+		$forms = new ConvertKit_Resource_Forms( 'block_edit' );
+		$forms->refresh();
+
+		$posts = new ConvertKit_Resource_Posts( 'block_edit' );
+		$posts->refresh();
+
+		$products = new ConvertKit_Resource_Products( 'block_edit' );
+		$products->refresh();
+
 		// Return blocks.
 		wp_send_json_success( convertkit_get_blocks() );
 

--- a/includes/class-convertkit-ajax.php
+++ b/includes/class-convertkit-ajax.php
@@ -20,6 +20,8 @@ class ConvertKit_AJAX {
 	 */
 	public function __construct() {
 
+		add_action( 'wp_ajax_convertkit_get_blocks', array( $this, 'get_blocks' ) );
+
 		add_action( 'wp_ajax_nopriv_convertkit_store_subscriber_id_in_cookie', array( $this, 'store_subscriber_id_in_cookie' ) );
 		add_action( 'wp_ajax_convertkit_store_subscriber_id_in_cookie', array( $this, 'store_subscriber_id_in_cookie' ) );
 
@@ -30,6 +32,25 @@ class ConvertKit_AJAX {
 		add_action( 'wp_ajax_convertkit_tag_subscriber', array( $this, 'tag_subscriber' ) );
 
 	}
+
+	/**
+	 * Returns all ConvertKit registered blocks.
+	 * 
+	 * Typically used when a refresh button in a block has been pressed when
+	 * convertKitGutenbergDisplayBlockNoticeWithLink() is called, because either
+	 * no API keys were specified, or no resources exist in ConvertKit.
+	 * 
+	 * @since 	2.2.6
+	 */
+	 public function get_blocks() {
+
+	 	// @TODO Check nonce.
+	 	// check_ajax_referer( 'convertkit', 'convertkit_nonce' );
+
+	 	// Return blocks.
+	 	wp_send_json_success( convertkit_get_blocks() );
+
+	 }
 
 	/**
 	 * Stores the ConvertKit Subscriber's ID in a cookie.

--- a/includes/class-convertkit-ajax.php
+++ b/includes/class-convertkit-ajax.php
@@ -35,22 +35,22 @@ class ConvertKit_AJAX {
 
 	/**
 	 * Returns all ConvertKit registered blocks.
-	 * 
+	 *
 	 * Typically used when a refresh button in a block has been pressed when
 	 * convertKitGutenbergDisplayBlockNoticeWithLink() is called, because either
 	 * no API keys were specified, or no resources exist in ConvertKit.
-	 * 
-	 * @since 	2.2.6
+	 *
+	 * @since   2.2.6
 	 */
-	 public function get_blocks() {
+	public function get_blocks() {
 
-	 	// Check nonce.
-	 	check_ajax_referer( 'convertkit_get_blocks', 'nonce' );
+		// Check nonce.
+		check_ajax_referer( 'convertkit_get_blocks', 'nonce' );
 
-	 	// Return blocks.
-	 	wp_send_json_success( convertkit_get_blocks() );
+		// Return blocks.
+		wp_send_json_success( convertkit_get_blocks() );
 
-	 }
+	}
 
 	/**
 	 * Stores the ConvertKit Subscriber's ID in a cookie.

--- a/includes/class-convertkit-ajax.php
+++ b/includes/class-convertkit-ajax.php
@@ -44,8 +44,8 @@ class ConvertKit_AJAX {
 	 */
 	 public function get_blocks() {
 
-	 	// @TODO Check nonce.
-	 	// check_ajax_referer( 'convertkit', 'convertkit_nonce' );
+	 	// Check nonce.
+	 	check_ajax_referer( 'convertkit_get_blocks', 'nonce' );
 
 	 	// Return blocks.
 	 	wp_send_json_success( convertkit_get_blocks() );

--- a/includes/class-convertkit-ajax.php
+++ b/includes/class-convertkit-ajax.php
@@ -48,7 +48,6 @@ class ConvertKit_AJAX {
 		check_ajax_referer( 'convertkit_get_blocks', 'nonce' );
 
 		// Refresh resources from the API, to reflect any changes.
-		// @TODO Optimize this based on the block we want to refresh, so we only make one API call?
 		$forms = new ConvertKit_Resource_Forms( 'block_edit' );
 		$forms->refresh();
 

--- a/includes/class-convertkit-gutenberg.php
+++ b/includes/class-convertkit-gutenberg.php
@@ -148,9 +148,13 @@ class ConvertKit_Gutenberg {
 		// Enqueue Gutenberg Javascript, and set the blocks data.
 		wp_enqueue_script( 'convertkit-gutenberg', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/gutenberg.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
 		wp_localize_script( 'convertkit-gutenberg', 'convertkit_blocks', $blocks );
-		wp_localize_script( 'convertkit-gutenberg', 'convertkit_gutenberg', array(
-			'get_blocks_nonce' => wp_create_nonce( 'convertkit_get_blocks' ),
-		) );
+		wp_localize_script(
+			'convertkit-gutenberg',
+			'convertkit_gutenberg',
+			array(
+				'get_blocks_nonce' => wp_create_nonce( 'convertkit_get_blocks' ),
+			)
+		);
 
 		// Enqueue Gutenberg Block Toolbar Javascript, and set the block toolbar buttons data.
 		wp_enqueue_script( 'convertkit-gutenberg-block-formatters', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/gutenberg-block-formatters.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );

--- a/includes/class-convertkit-gutenberg.php
+++ b/includes/class-convertkit-gutenberg.php
@@ -148,6 +148,9 @@ class ConvertKit_Gutenberg {
 		// Enqueue Gutenberg Javascript, and set the blocks data.
 		wp_enqueue_script( 'convertkit-gutenberg', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/gutenberg.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
 		wp_localize_script( 'convertkit-gutenberg', 'convertkit_blocks', $blocks );
+		wp_localize_script( 'convertkit-gutenberg', 'convertkit_gutenberg', array(
+			'get_blocks_nonce' => wp_create_nonce( 'convertkit_get_blocks' ),
+		) );
 
 		// Enqueue Gutenberg Block Toolbar Javascript, and set the block toolbar buttons data.
 		wp_enqueue_script( 'convertkit-gutenberg-block-formatters', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/gutenberg-block-formatters.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -366,6 +366,26 @@ function convertkit_get_form_editor_url() {
 }
 
 /**
+ * Helper method to return the URL the user needs to visit on the ConvertKit app to create a new Broadcast.
+ *
+ * @since   2.2.6
+ *
+ * @return  string  ConvertKit App URL.
+ */
+function convertkit_get_new_broadcast_url() {
+
+	return add_query_arg(
+		array(
+			'utm_source'  => 'wordpress',
+			'utm_term'    => get_locale(),
+			'utm_content' => 'convertkit',
+		),
+		'https://app.convertkit.com/campaigns/'
+	);
+
+}
+
+/**
  * Helper method to return the URL the user needs to visit on the ConvertKit app to create a new Product.
  *
  * @since   2.2.3

--- a/resources/backend/css/gutenberg.css
+++ b/resources/backend/css/gutenberg.css
@@ -11,8 +11,19 @@
 .wp-block .convertkit-no-content iframe {
 	max-width: 400px;
 }
-
-
+.wp-block .convertkit-no-content a {
+	display: block;
+	padding: calc(0.667em + 2px) calc(1.333em + 2px);
+}
+.wp-block .convertkit-no-content button.convertkit-block-refresh {
+	position: absolute;
+	top: 20px;
+	right: 20px;
+}
+.wp-block .convertkit-no-content button.convertkit-block-refresh span.dashicon {
+	display: inline-block;
+	padding: 0;
+}
 .convertkit-popover .components-popover__content {
 	width: 300px;
 	padding: 15px;

--- a/resources/backend/css/gutenberg.css
+++ b/resources/backend/css/gutenberg.css
@@ -19,6 +19,7 @@
 	position: absolute;
 	top: 20px;
 	right: 20px;
+	line-height: 22px;
 }
 .wp-block .convertkit-no-content button.convertkit-block-refresh span.dashicon {
 	display: inline-block;

--- a/resources/backend/js/gutenberg-block-broadcasts.js
+++ b/resources/backend/js/gutenberg-block-broadcasts.js
@@ -14,20 +14,6 @@
  */
 function convertKitGutenbergBroadcastsBlockRenderPreview( block, props ) {
 
-	// If no Broadcasts exist, return a prompt to tell the editor what to do.
-	if ( ! block.has_posts ) {
-		return wp.element.createElement(
-			'div',
-			{
-				// convertkit-no-content class allows resources/backend/css/gutenberg.css
-				// to apply styling/branding to the block.
-				className: 'convertkit-' + block.name + ' convertkit-no-content'
-			},
-			block.gutenberg_help_description
-		);
-	}
-
-	// A Product is specified.
 	// Use the block's PHP's render() function by calling the ServerSideRender component.
 	return wp.element.createElement(
 		wp.serverSideRender,

--- a/resources/backend/js/gutenberg-block-form-trigger.js
+++ b/resources/backend/js/gutenberg-block-form-trigger.js
@@ -14,28 +14,6 @@
  */
 function convertKitGutenbergFormTriggerBlockRenderPreview( block, props ) {
 
-	// If no API Key has been defined in the Plugin, return a prompt to tell the editor
-	// what to do.
-	if ( ! block.has_api_key ) {
-		return convertKitGutenbergDisplayBlockNoticeWithLink(
-			block.name,
-			block.no_api_key.notice,
-			block.no_api_key.link,
-			block.no_api_key.link_text
-		);
-	}
-
-	// If no Forms exist in ConvertKit, return a prompt to tell the editor
-	// what to do.
-	if ( ! block.has_resources ) {
-		return convertKitGutenbergDisplayBlockNoticeWithLink(
-			block.name,
-			block.no_resources.notice,
-			block.no_resources.link,
-			block.no_resources.link_text
-		);
-	}
-
 	// If no Form has been selected for display, return a prompt to tell the editor
 	// what to do.
 	if ( props.attributes.form === '' ) {

--- a/resources/backend/js/gutenberg-block-form.js
+++ b/resources/backend/js/gutenberg-block-form.js
@@ -17,26 +17,10 @@
  */
 function convertKitGutenbergFormBlockRenderPreview( block, props ) {
 
-	// If no API Key has been defined in the Plugin, return a prompt to tell the editor
-	// what to do.
-	if ( ! block.has_api_key ) {
-		return convertKitGutenbergDisplayBlockNoticeWithLink(
-			block.name,
-			block.no_api_key.notice,
-			block.no_api_key.link,
-			block.no_api_key.link_text
-		);
-	}
-
-	// If no Forms exist in ConvertKit, return a prompt to tell the editor
-	// what to do.
-	if ( ! block.has_resources ) {
-		return convertKitGutenbergDisplayBlockNoticeWithLink(
-			block.name,
-			block.no_resources.notice,
-			block.no_resources.link,
-			block.no_resources.link_text
-		);
+	// If no API Key has been defined in the Plugin, or no Forms exist in ConvertKit,
+	// return a prompt to tell the editor what to do.
+	if ( ! block.has_api_key || ! block.has_resources ) {
+		return convertKitGutenbergDisplayBlockNoticeWithLink( block, props );
 	}
 
 	// Get selected form.

--- a/resources/backend/js/gutenberg-block-form.js
+++ b/resources/backend/js/gutenberg-block-form.js
@@ -17,12 +17,6 @@
  */
 function convertKitGutenbergFormBlockRenderPreview( block, props ) {
 
-	// If no API Key has been defined in the Plugin, or no Forms exist in ConvertKit,
-	// return a prompt to tell the editor what to do.
-	if ( ! block.has_api_key || ! block.has_resources ) {
-		return convertKitGutenbergDisplayBlockNoticeWithLink( block, props );
-	}
-
 	// Get selected form.
 	var form = block.fields.form.data.forms[ props.attributes.form ];
 

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -358,16 +358,16 @@ function convertKitGutenbergRegisterBlock( block ) {
 		const displayNoticeWithLink = function( props ) {
 
 			// Build notice, depending on the type of notice that needs displaying.
-			let notice = '',
-				link = '',
+			let notice    = '',
+				link      = '',
 				link_text = '';
 			if ( ! block.has_api_key ) {
-				notice = block.no_api_key.notice;
-				link = block.no_api_key.link;
+				notice    = block.no_api_key.notice;
+				link      = block.no_api_key.link;
 				link_text = block.no_api_key.link_text;
 			} else {
-				notice = block.no_resources.notice;
-				link = block.no_resources.link;
+				notice    = block.no_resources.notice;
+				link      = block.no_resources.link;
 				link_text = block.no_resources.link_text;
 			}
 
@@ -417,7 +417,6 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 */
 		const refreshBlocksDefinitions = function( props ) {
 
-			// @TODO Can we use fetch() instead of jQuery?
 			jQuery.ajax(
 				{
 					type: 'POST',
@@ -438,9 +437,11 @@ function convertKitGutenbergRegisterBlock( block ) {
 
 						// Call setAttributes on props to trigger the editBlock() function, which will re-render
 						// the block, reflecting any changes to its properties.
-						props.setAttributes( {
-							refresh: Date.now()
-						} );
+						props.setAttributes(
+							{
+								refresh: Date.now()
+							}
+						);
 
 					}
 				}

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -397,10 +397,11 @@ function convertKitGutenbergRegisterBlock( block ) {
 		}
 
 		/**
-		 * Returns a refresh button.
-		 * 
+		 * Returns a refresh button, used to refresh a block when it has no API Keys
+		 * or resources.
+		 *
 		 * @since 	2.2.6
-		 * 
+		 *
 		 * @param 	object 	props 	Block properties.
 		 * @return 	object 			Button.
 		 */
@@ -417,15 +418,15 @@ function convertKitGutenbergRegisterBlock( block ) {
 							icon: 'update'
 						}
 					),
-					onClick: function( e ) {
+				onClick: function( e ) {
 
-						// Disable button to prevent multiple clicks.
-						e.target.disabled = true;
+					// Disable button to prevent multiple clicks.
+					e.target.disabled = true;
 
-						// Refresh block definitions.
-						refreshBlocksDefinitions( props, e.target );
+					// Refresh block definitions.
+					refreshBlocksDefinitions( props, e.target );
 
-					}
+				}
 				}
 			)
 

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -38,6 +38,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 		const { Fragment }          = element;
 		const {
 			Button,
+			Dashicon,
 			TextControl,
 			SelectControl,
 			ToggleControl,
@@ -389,18 +390,44 @@ function convertKitGutenbergRegisterBlock( block ) {
 						},
 						link_text
 					),
-					el(
-						Button,
-						{
-							className: 'button button-secondary',
-							text: 'Refresh',
-							onClick: function() {
-								refreshBlocksDefinitions( props );
-							}
-						}
-					)
+					getRefreshButton( props )
 				]
 			);
+
+		}
+
+		/**
+		 * Returns a refresh button.
+		 * 
+		 * @since 	2.2.6
+		 * 
+		 * @param 	object 	props 	Block properties.
+		 * @return 	object 			Button.
+		 */
+		const getRefreshButton = function( props ) {
+
+			return el(
+				Button,
+				{
+					className: 'button button-secondary convertkit-block-refresh',
+					text: 'Refresh',
+					icon: el(
+						Dashicon,
+						{
+							icon: 'update'
+						}
+					),
+					onClick: function( e ) {
+
+						// Disable button to prevent multiple clicks.
+						e.target.disabled = true;
+
+						// Refresh block definitions.
+						refreshBlocksDefinitions( props, e.target );
+
+					}
+				}
+			)
 
 		}
 
@@ -413,9 +440,10 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 * @since 	2.2.5
 		 *
 		 * @param   object  props   Block properties.
+		 * @param 	object  button 	Refresh button.
 		 * @return  object          Notice.
 		 */
-		const refreshBlocksDefinitions = function( props ) {
+		const refreshBlocksDefinitions = function( props, button ) {
 
 			jQuery.ajax(
 				{
@@ -443,6 +471,9 @@ function convertKitGutenbergRegisterBlock( block ) {
 							}
 						);
 
+						// Enable refresh button.
+						button.disabled = false;
+
 					}
 				}
 			).fail(
@@ -455,6 +486,9 @@ function convertKitGutenbergRegisterBlock( block ) {
 							id: 'convertkit-error'
 						}
 					);
+
+					// Enable refresh button.
+					button.disabled = false;
 
 				}
 			);

--- a/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
@@ -70,6 +70,42 @@ class PageBlockBroadcastsCest
 	}
 
 	/**
+	 * Test the Broadcasts block's refresh button works.
+	 *
+	 * @since   2.2.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsBlockRefreshButton(AcceptanceTester $I)
+	{
+		// Setup Plugin with API keys for ConvertKit Account that has no Broadcasts.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
+		$I->setupConvertKitPluginResourcesNoData($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Refresh Button');
+
+		// Add block to Page.
+		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
+
+		// Setup Plugin with resources.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Click the refresh button.
+		$I->click('button.convertkit-block-refresh');
+
+		// Wait for the refresh button to disappear, confirming that an API Key and resources now exist.
+		$I->waitForElementNotVisible('button.convertkit-block-refresh');
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that the block displays correctly with the expected number of Broadcasts.
+		$I->seeBroadcastsOutput($I, 3);
+	}
+
+	/**
 	 * Test the Broadcasts block works when using the default parameters.
 	 *
 	 * @since   1.9.7.4

--- a/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
@@ -88,7 +88,8 @@ class PageBlockBroadcastsCest
 		// Add block to Page.
 		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
 
-		// Setup Plugin with resources.
+		// Setup Plugin with a valid API Key and resources, as if the user performed the necessary steps to authenticate
+		// and created a broadcast.
 		$I->setupConvertKitPlugin($I);
 		$I->setupConvertKitPluginResources($I);
 

--- a/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
@@ -37,13 +37,30 @@ class PageBlockBroadcastsCest
 		// Add block to Page.
 		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
 
-		// Confirm that the Broadcasts block tells the user that no Broadcasts exist in ConvertKit.
+		// Confirm that the Broadcasts block displays instructions to the user on how to add a Broadcast in ConvertKit.
 		$I->see(
-			'No Broadcasts exist in ConvertKit. Send your first Broadcast in ConvertKit to see the link to it here.',
+			'No broadcasts exist in ConvertKit.',
 			[
 				'css' => '.convertkit-no-content',
 			]
 		);
+
+		// Click the link to confirm it loads ConvertKit.
+		$I->click(
+			'Click here to send your first broadcast.',
+			[
+				'css' => '.convertkit-no-content',
+			]
+		);
+
+		// Switch to next browser tab, as the link opens in a new tab.
+		$I->switchToNextTab();
+
+		// Confirm the ConvertKit login screen loaded.
+		$I->seeElementInDOM('input[name="user[email]"]');
+
+		// Close tab.
+		$I->closeTab();
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);

--- a/tests/acceptance/forms/PageBlockFormCest.php
+++ b/tests/acceptance/forms/PageBlockFormCest.php
@@ -595,6 +595,47 @@ class PageBlockFormCest
 	}
 
 	/**
+	 * Test the Form block's refresh button works.
+	 *
+	 * @since   2.2.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFormBlockRefreshButton(AcceptanceTester $I)
+	{
+		// Setup Plugin with API keys for ConvertKit Account that has no Broadcasts.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
+		$I->setupConvertKitPluginResourcesNoData($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Forms: Refresh Button');
+
+		// Add block to Page.
+		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form');
+
+		// Setup Plugin with resources.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Click the refresh button.
+		$I->click('button.convertkit-block-refresh');
+
+		// Wait for the refresh button to disappear, confirming that an API Key and resources now exist.
+		$I->waitForElementNotVisible('button.convertkit-block-refresh');
+
+		// Confirm that the Form block displays instructions to the user on how to select a Form.
+		$I->see(
+			'Select a Form using the Form option in the Gutenberg sidebar.',
+			[
+				'css' => '.convertkit-no-content',
+			]
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/acceptance/forms/PageBlockFormCest.php
+++ b/tests/acceptance/forms/PageBlockFormCest.php
@@ -613,7 +613,8 @@ class PageBlockFormCest
 		// Add block to Page.
 		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form');
 
-		// Setup Plugin with resources.
+		// Setup Plugin with a valid API Key and resources, as if the user performed the necessary steps to authenticate
+		// and create a form.
 		$I->setupConvertKitPlugin($I);
 		$I->setupConvertKitPluginResources($I);
 

--- a/tests/acceptance/forms/PageBlockFormTriggerCest.php
+++ b/tests/acceptance/forms/PageBlockFormTriggerCest.php
@@ -464,7 +464,8 @@ class PageBlockFormTriggerCest
 		// Add block to Page.
 		$I->addGutenbergBlock($I, 'ConvertKit Form Trigger', 'convertkit-formtrigger');
 
-		// Setup Plugin with resources.
+		// Setup Plugin with a valid API Key and resources, as if the user performed the necessary steps to authenticate
+		// and create a form.
 		$I->setupConvertKitPlugin($I);
 		$I->setupConvertKitPluginResources($I);
 

--- a/tests/acceptance/forms/PageBlockFormTriggerCest.php
+++ b/tests/acceptance/forms/PageBlockFormTriggerCest.php
@@ -446,6 +446,47 @@ class PageBlockFormTriggerCest
 	}
 
 	/**
+	 * Test the Form Trigger block's refresh button works.
+	 *
+	 * @since   2.2.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFormTriggerBlockRefreshButton(AcceptanceTester $I)
+	{
+		// Setup Plugin with API keys for ConvertKit Account that has no Broadcasts.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
+		$I->setupConvertKitPluginResourcesNoData($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form Trigger: Refresh Button');
+
+		// Add block to Page.
+		$I->addGutenbergBlock($I, 'ConvertKit Form Trigger', 'convertkit-formtrigger');
+
+		// Setup Plugin with resources.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Click the refresh button.
+		$I->click('button.convertkit-block-refresh');
+
+		// Wait for the refresh button to disappear, confirming that an API Key and resources now exist.
+		$I->waitForElementNotVisible('button.convertkit-block-refresh');
+
+		// Confirm that the Form Trigger block displays instructions to the user on how to select a Form.
+		$I->see(
+			'Select a Form using the Form option in the Gutenberg sidebar.',
+			[
+				'css' => '.convertkit-no-content',
+			]
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/acceptance/products/PageBlockProductCest.php
+++ b/tests/acceptance/products/PageBlockProductCest.php
@@ -351,6 +351,48 @@ class PageBlockProductCest
 	}
 
 	/**
+	 * Test the Product block's refresh button works.
+	 *
+	 * @since   2.2.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testProductBlockRefreshButton(AcceptanceTester $I)
+	{
+		// Setup Plugin with API keys for ConvertKit Account that has no Broadcasts.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
+		$I->setupConvertKitPluginResourcesNoData($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Refresh Button');
+
+		// Add block to Page.
+		$I->addGutenbergBlock($I, 'ConvertKit Product', 'convertkit-product');
+
+		// Setup Plugin with a valid API Key and resources, as if the user performed the necessary steps to authenticate
+		// and create a product.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Click the refresh button.
+		$I->click('button.convertkit-block-refresh');
+
+		// Wait for the refresh button to disappear, confirming that an API Key and resources now exist.
+		$I->waitForElementNotVisible('button.convertkit-block-refresh');
+
+		// Confirm that the Product block displays instructions to the user on how to select a Product.
+		$I->see(
+			'Select a Product using the Product option in the Gutenberg sidebar.',
+			[
+				'css' => '.convertkit-no-content',
+			]
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+	}
+
+	/**
 	 * Test the Product block's parameters are correctly escaped on output,
 	 * to prevent XSS.
 	 *


### PR DESCRIPTION
## Summary

Adds a refresh button to the Broadcast, Form, Form Trigger and Product blocks when either no API Keys are specified, or no resources (forms, broadcasts etc) exist.

<img width="1058" alt="Screenshot 2023-06-26 at 14 24 11" src="https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/b0cf0a31-6239-4176-b2fe-814b317edb76">

Demo:
https://www.loom.com/share/9e751c61a6c44a4d84cf88b6c9231912?sid=600e5c5b-c186-4575-94c0-f7704f34c9cc

This is part of a larger goal to have new users discover the ConvertKit Plugin through the "available to install" blocks section by e.g. searching for a form block, adding it, authorizing / registering through oAuth and then selecting a form - all without needing to leave the editor screen to enter API keys etc.

<img width="343" alt="Screenshot 2023-06-26 at 14 22 44" src="https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/752e4157-6dbf-4268-8a75-306d20a5877d">

## Testing

- `testBroadcastsBlockRefreshButton`: Test that the refresh button works when adding a Broadcasts block with no API Keys or ConvertKit posts, adding said items and then clicking refresh
- `testFormBlockRefreshButton`: Test that the refresh button works when adding a Form block with no API Keys or ConvertKit posts, adding said items and then clicking refresh
- `testFormTriggerBlockRefreshButton`: Test that the refresh button works when adding a Form Trigger block with no API Keys or ConvertKit posts, adding said items and then clicking refresh
- `testProductBlockRefreshButton`: Test that the refresh button works when adding a Product block with no API Keys or ConvertKit posts, adding said items and then clicking refresh

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)