### PR TITLE
Setup Wizard: Modal View

### DIFF
--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php
@@ -245,6 +245,10 @@ class ConvertKit_Admin_Setup_Wizard_Plugin extends ConvertKit_Admin_Setup_Wizard
 	 */
 	public function load_screen_data( $step ) {
 
+		// If this wizard is being served in a modal window, adjust the steps.
+		if ( $this->is_modal() ) {
+			unset( $this->steps[3], $this->steps[4] );
+		}
 		switch ( $step ) {
 			case 2:
 				// Load settings class.
@@ -252,6 +256,9 @@ class ConvertKit_Admin_Setup_Wizard_Plugin extends ConvertKit_Admin_Setup_Wizard
 				break;
 
 			case 3:
+				// If this wizard is being served in a modal window, we can exit after obtaining valid API credentials.
+				$this->maybe_close_modal();
+
 				// Re-load settings class now that the API Key and Secret has been defined.
 				$this->settings = new ConvertKit_Settings();
 

--- a/resources/backend/css/gutenberg.css
+++ b/resources/backend/css/gutenberg.css
@@ -25,6 +25,9 @@
 	display: inline-block;
 	padding: 0;
 }
+.wp-block .convertkit-no-content .spinner {
+	float: none;
+}
 .convertkit-popover .components-popover__content {
 	width: 300px;
 	padding: 15px;

--- a/resources/backend/css/setup-wizard.css
+++ b/resources/backend/css/setup-wizard.css
@@ -215,3 +215,34 @@
 #convertkit-setup-wizard-exit-link a {
 	color: #8c8f9a;
 }
+
+/**
+ * Modal View
+ */
+body.convertkit-modal #convertkit-setup-wizard {
+	width: 100%;
+	max-width: 760px;
+	margin: 0;
+	padding: 0;
+}
+body.convertkit-modal #convertkit-setup-wizard .wrap {
+	margin: 0;
+}
+body.convertkit-modal #convertkit-setup-wizard-header {
+	display: none;
+}
+body.convertkit-modal #convertkit-setup-wizard-progress {
+	display: none;
+}
+body.convertkit-modal #convertkit-setup-wizard-body {
+	box-shadow: none;
+}
+body.convertkit-modal #convertkit-setup-wizard-content {
+	padding: 20px 20px 0 20px;
+}
+body.convertkit-modal #convertkit-setup-wizard-footer {
+	padding: 0 20px 20px 20px;
+}
+body.convertkit-modal #convertkit-setup-wizard-exit-link {
+	display: none;
+}

--- a/resources/backend/css/setup-wizard.css
+++ b/resources/backend/css/setup-wizard.css
@@ -219,6 +219,7 @@
 /**
  * Modal View
  */
+body.convertkit-modal { overflow: hidden; }
 body.convertkit-modal #convertkit-setup-wizard {
 	width: 100%;
 	max-width: 100%;

--- a/resources/backend/css/setup-wizard.css
+++ b/resources/backend/css/setup-wizard.css
@@ -221,18 +221,12 @@
  */
 body.convertkit-modal #convertkit-setup-wizard {
 	width: 100%;
-	max-width: 760px;
+	max-width: 100%;
 	margin: 0;
 	padding: 0;
 }
 body.convertkit-modal #convertkit-setup-wizard .wrap {
 	margin: 0;
-}
-body.convertkit-modal #convertkit-setup-wizard-header {
-	display: none;
-}
-body.convertkit-modal #convertkit-setup-wizard-progress {
-	display: none;
 }
 body.convertkit-modal #convertkit-setup-wizard-body {
 	box-shadow: none;
@@ -242,7 +236,4 @@ body.convertkit-modal #convertkit-setup-wizard-content {
 }
 body.convertkit-modal #convertkit-setup-wizard-footer {
 	padding: 0 20px 20px 20px;
-}
-body.convertkit-modal #convertkit-setup-wizard-exit-link {
-	display: none;
 }

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -35,7 +35,10 @@ function convertKitGutenbergRegisterBlock( block ) {
 		const el                    = element.createElement;
 		const { registerBlockType } = blocks;
 		const { InspectorControls } = editor;
-		const { Fragment }          = element;
+		const {
+			Fragment,
+			useState
+		}                           = element;
 		const {
 			Button,
 			Dashicon,
@@ -358,21 +361,29 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 */
 		const displayNoticeWithLink = function( props ) {
 
-			// Build notice, depending on the type of notice that needs displaying.
-			let notice    = '',
-				link      = '',
-				link_text = '';
-			if ( ! block.has_api_key ) {
-				notice    = block.no_api_key.notice;
-				link      = block.no_api_key.link;
-				link_text = block.no_api_key.link_text;
+			// useState to toggle the refresh button's disabled state.
+			const [ buttonDisabled, setButtonDisabled ] = useState( false );
+
+			// Holds the array of elements to display in the notice component.
+			let elements;
+
+			// Define elements to display, based on whether the refresh button is disabled.
+			if ( buttonDisabled ) {
+				// Refresh button disabled; display a spinner and the button.
+				elements = [
+					spinner( props ),
+					refreshButton( props, buttonDisabled, setButtonDisabled )
+				];
 			} else {
-				notice    = block.no_resources.notice;
-				link      = block.no_resources.link;
-				link_text = block.no_resources.link_text;
+				// Refresh button enabled; display the notice, link and button.
+				elements = [
+					( ! block.has_api_key ? block.no_api_key.notice : block.no_resources.notice ),
+					noticeLink( props, setButtonDisabled ),
+					refreshButton( props, buttonDisabled, setButtonDisabled )
+				];
 			}
 
-			// Return the element with the notice and refresh button.
+			// Return the element.
 			return el(
 				'div',
 				{
@@ -380,18 +391,80 @@ function convertKitGutenbergRegisterBlock( block ) {
 					// to apply styling/branding to the block.
 					className: 'convertkit-' + block.name + ' convertkit-no-content'
 				},
-				[
-					notice + ' ',
-					el(
-						'a',
-						{
-							href: link,
-							target: '_blank'
-						},
-						link_text
-					),
-					getRefreshButton( props )
-				]
+				elements
+			);
+
+		}
+
+		/**
+		 * Returns a spinner element, to show that a block is loading / refreshing.
+		 *
+		 * @since 	2.2.6
+		 *
+		 * @param   object  props   			Block properties.
+		 * @return  object          			Spinner.
+		 */
+		const spinner = function( props ) {
+
+			return el(
+				'span',
+				{
+					key: props.clientId + '-spinner',
+					className: 'spinner is-active'
+				}
+			);
+
+		}
+
+		/**
+		 * Returns a WordPress Dashicon element.
+		 *
+		 * @since 	2.2.6
+		 *
+		 * @param   string 	iconName 	Dashicon Name.
+		 * @return  object 				Dashicon.
+		 */
+		const dashIcon = function( iconName ) {
+
+			return el(
+				Dashicon,
+				{
+					icon: iconName
+				}
+			);
+
+		}
+
+		/**
+		 * Returns the notice link for the displayNoticeWithLink element.
+		 *
+		 * @since 	2.2.6
+		 *
+		 * @param   object  props   			Block properties.
+		 * @param 	object 	setButtonDisabled 	Function to enable or disable the refresh button.
+		 * @return  object          			Notice Link.
+		 */
+		const noticeLink = function( props, setButtonDisabled ) {
+
+			return el(
+				'a',
+				{
+					key: props.clientId + '-notice-link',
+					href: ( ! block.has_api_key ? block.no_api_key.link : block.no_resources.link ),
+					className: ( ! block.has_api_key ? 'convertkit-block-modal' : '' ),
+					target: '_blank',
+					onClick: function( e ) {
+
+						// Show popup window with setup wizard if we need to define an API Key.
+						if ( ! block.has_api_key ) {
+							e.preventDefault();
+							showConvertKitPopupWindow( props, e.target, setButtonDisabled );
+						}
+
+						// Allow the link to load, as it's likely a link to the ConvertKit site.
+					}
+				},
+				( ! block.has_api_key ? block.no_api_key.link_text : block.no_resources.link_text )
 			);
 
 		}
@@ -402,33 +475,83 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 *
 		 * @since 	2.2.6
 		 *
-		 * @param 	object 	props 	Block properties.
-		 * @return 	object 			Button.
+		 * @param 	object 	props 				Block properties.
+		 * @param 	bool 	buttonDisabled 		Whether the refresh button is disabled (true) or enabled (false)/
+		 * @param 	object 	setButtonDisabled 	Function to enable or disable the refresh button.
+		 * @return 	object 						Button.
 		 */
-		const getRefreshButton = function( props ) {
+		const refreshButton = function( props, buttonDisabled, setButtonDisabled ) {
 
 			return el(
 				Button,
 				{
+					key: props.clientId + '-refresh-button',
 					className: 'button button-secondary convertkit-block-refresh',
+					disabled: buttonDisabled,
 					text: 'Refresh',
-					icon: el(
-						Dashicon,
-						{
-							icon: 'update'
-						}
-					),
-				onClick: function( e ) {
+					icon: dashIcon( 'update' ),
+					onClick: function() {
 
-					// Disable button to prevent multiple clicks.
-					e.target.disabled = true;
+						// Refresh block definitions.
+						refreshBlocksDefinitions( props, setButtonDisabled );
 
-					// Refresh block definitions.
-					refreshBlocksDefinitions( props, e.target );
-
-				}
+					}
 				}
 			)
+
+		}
+
+		/**
+		 * Displays a new window with a given width and height to display the given URL.
+		 *
+		 * Typically used for displaying a modal version of the Setup Wizard, where the
+		 * user clicks the 'click here to add your API Key' link in a block, and then
+		 * enters their API Key and Secret.  Will be used to show the ConvertKit
+		 * oAuth window in the future.
+		 *
+		 * @since 	2.2.6
+		 *
+		 * @param 	object 	props 				Block properties.
+		 * @param 	object 	link 				Link that was clicked.
+		 * @param 	object 	setButtonDisabled 	Function to enable or disable the refresh button.
+		 */
+		const showConvertKitPopupWindow = function( props, link, setButtonDisabled ) {
+
+			// Define popup width, height and positioning.
+			const 	width  = 640,
+					height = 520,
+					top    = ( window.screen.height - height ) / 2,
+					left   = ( window.screen.width - width ) / 2;
+
+			// Open popup.
+			const convertKitPopup = window.open(
+				link.href + '&convertkit-modal=1',
+				'convertkit_popup_window',
+				'toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=' + width + ',height=' + height + ',top=' + top + ',left=' + left
+			);
+
+			// Center popup and focus.
+			convertKitPopup.moveTo( left, top );
+			convertKitPopup.focus();
+
+			// Refresh the block when the popup is closed using self.close().
+			// Won't fire if the user closes the popup manually, which is fine because that means
+			// they didn't complete the steps, so refreshing wouldn't show anything new.
+			// The onbeforeunload would seem suitable here, but it fires whenever the popup window's
+			// document changes (e.g. as the user steps through a wizard), and doesn't fire when
+			// the window is closed.
+			// See https://stackoverflow.com/questions/9388380/capture-the-close-event-of-popup-window-in-javascript/48240128#48240128.
+			var convertKitPopupTimer = setInterval(
+				function() {
+					if ( convertKitPopup.closed ) {
+						clearInterval( convertKitPopupTimer );
+
+						// Refresh block.
+						refreshBlocksDefinitions( props, setButtonDisabled );
+					}
+				},
+				1000
+			);
 
 		}
 
@@ -438,58 +561,76 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 * - storing the registered blocks in the `convertkit_blocks` global object,
 		 * - updating this block's properties by updating the `block` object.
 		 *
-		 * @since 	2.2.5
+		 * @since 	2.2.6
 		 *
-		 * @param   object  props   Block properties.
-		 * @param 	object  button 	Refresh button.
-		 * @return  object          Notice.
+		 * @param   object  props   			Block properties.
+		 * @param 	object 	setButtonDisabled 	Function to enable or disable the refresh button.
+		 * @return  object          			Notice.
 		 */
-		const refreshBlocksDefinitions = function( props, button ) {
+		const refreshBlocksDefinitions = function( props, setButtonDisabled ) {
 
-			jQuery.ajax(
+			// Define data for WordPress AJAX request.
+			let data = new FormData();
+			data.append( 'action', 'convertkit_get_blocks' );
+			data.append( 'nonce', convertkit_gutenberg.get_blocks_nonce );
+
+			// Disable the button.
+			setButtonDisabled( true );
+
+			// Send AJAX request.
+			fetch(
+				ajaxurl,
 				{
-					type: 'POST',
-					data: {
-						action: 'convertkit_get_blocks',
-						nonce: convertkit_gutenberg.get_blocks_nonce,
-					},
-					url: ajaxurl,
-					success: function ( response ) {
-
-						// Update global ConvertKit Blocks object, so that any updated resources
-						// are reflected when adding new ConvertKit Blocks.
-						convertkit_blocks = response.data;
-
-						// Update this block's properties, so that has_api_key, has_resources
-						// and the resources properties are updated.
-						block = convertkit_blocks[ block.name ];
-
-						// Call setAttributes on props to trigger the editBlock() function, which will re-render
-						// the block, reflecting any changes to its properties.
-						props.setAttributes(
-							{
-								refresh: Date.now()
-							}
-						);
-
-						// Enable refresh button.
-						button.disabled = false;
-
-					}
+					method: 'POST',
+					credentials: 'same-origin',
+					body: data
 				}
-			).fail(
-				function ( response ) {
+			)
+			.then(
+				function( response ) {
+
+					// Convert response JSON string to object.
+					return response.json();
+
+				}
+			)
+			.then(
+				function( response ) {
+
+					// Update global ConvertKit Blocks object, so that any updated resources
+					// are reflected when adding new ConvertKit Blocks.
+					convertkit_blocks = response.data;
+
+					// Update this block's properties, so that has_api_key, has_resources
+					// and the resources properties are updated.
+					block = convertkit_blocks[ block.name ];
+
+					// Call setAttributes on props to trigger the editBlock() function, which will re-render
+					// the block, reflecting any changes to its properties.
+					props.setAttributes(
+						{
+							refresh: Date.now()
+						}
+					);
+
+					// Enable refresh button.
+					setButtonDisabled( false );
+
+				}
+			)
+			.catch(
+				function( error ) {
 
 					// Show an error in the Gutenberg editor.
 					wp.data.dispatch( 'core/notices' ).createErrorNotice(
-						'ConvertKit: ' + response.status + ' ' + response.statusText,
+						'ConvertKit: ' + error,
 						{
 							id: 'convertkit-error'
 						}
 					);
 
 					// Enable refresh button.
-					button.disabled = false;
+					setButtonDisabled( false );
 
 				}
 			);

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -1231,6 +1231,102 @@ class Plugin extends \Codeception\Module
 	}
 
 	/**
+	 * Test that the 'Click here to add your API Key' link displays a popup window,
+	 * when using a block with no API Keys specified.
+	 *
+	 * @since   2.2.6
+	 *
+	 * @param   AcceptanceTester $I                 Tester.
+	 * @param   string           $blockName         Block Name.
+	 * @param   bool|string      $expectedMessage   Expected message displayed in block after entering valid API Keys.
+	 */
+	public function testBlockNoAPIKeyPopupWindow($I, $blockName, $expectedMessage = false)
+	{
+		// Confirm that the Form block displays instructions to the user on how to enter their API Key.
+		$I->see(
+			'No API Key specified.',
+			[
+				'css' => '.convertkit-no-content',
+			]
+		);
+
+		// Click the link to confirm it loads the Plugin's setup wizard.
+		$I->click(
+			'Click here to add your API Key.',
+			[
+				'css' => '.convertkit-no-content',
+			]
+		);
+
+		// Switch to the window that just opened.
+		$I->switchToWindow('convertkit_popup_window');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm no logo or progress bar is displayed, as this is the modal version of the wizard.
+		$I->dontSeeElementInDOM('#convertkit-setup-wizard-header');
+
+		// Confirm no exit wizard link is displayed.
+		$I->dontSeeElementInDOM('#convertkit-setup-wizard-exit-link');
+
+		// Confirm expected title is displayed.
+		$I->see('Welcome to the ConvertKit Setup Wizard');
+
+		// Confirm Step text is correct.
+		$I->see('Step 1 of 2');
+
+		// Test Connect button.
+		$I->click('Connect');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm no logo or progress bar is displayed, as this is the modal version of the wizard.
+		$I->dontSeeElementInDOM('#convertkit-setup-wizard-header');
+
+		// Confirm no exit wizard link is displayed.
+		$I->dontSeeElementInDOM('#convertkit-setup-wizard-exit-link');
+
+		// Confirm expected title is displayed.
+		$I->see('Connect your ConvertKit account');
+
+		// Confirm Step text is correct.
+		$I->see('Step 2 of 2');
+
+		// Confirm Back and Connect buttons display.
+		$I->seeElementInDOM('#convertkit-setup-wizard-footer div.left a.button');
+		$I->seeElementInDOM('#convertkit-setup-wizard-footer div.right button');
+
+		// Fill fields with valid API Keys.
+		$I->fillField('api_key', $_ENV['CONVERTKIT_API_KEY']);
+		$I->fillField('api_secret', $_ENV['CONVERTKIT_API_SECRET']);
+
+		// Click Connect button.
+		$I->click('Connect');
+
+		// Switch back to the main browser window.
+		$I->switchToWindow();
+
+		// Wait until the block changes to refreshing.
+		$I->waitForElementVisible('.' . $blockName . ' span.spinner', 5);
+
+		// Wait for the refresh button to disappear, confirming that the block refresh completed
+		// and that resources now exist.
+		$I->waitForElementNotVisible('button.convertkit-block-refresh');
+
+		// Confirm that the block displays the expected message.
+		if ($expectedMessage) {
+			$I->see(
+				$expectedMessage,
+				[
+					'css' => '.convertkit-no-content',
+				]
+			);
+		}
+	}
+
+	/**
 	 * Selects all text for the given input field.
 	 *
 	 * @since   2.2.0

--- a/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/PageBlockBroadcastsCest.php
@@ -19,6 +19,36 @@ class PageBlockBroadcastsCest
 	}
 
 	/**
+	 * Test the Broadcasts block displays a message with a link that opens
+	 * a popup window with the Plugin's Setup Wizard, when the Plugin has
+	 * no API key specified.
+	 *
+	 * @since   2.2.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsBlockWhenNoAPIKey(AcceptanceTester $I)
+	{
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcasts: Block: No API Key');
+
+		// Add block to Page.
+		$I->addGutenbergBlock($I, 'ConvertKit Broadcasts', 'convertkit-broadcasts');
+
+		// Test that the popup window works.
+		$I->testBlockNoAPIKeyPopupWindow(
+			$I,
+			'convertkit-broadcasts'
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that the block displays correctly with the expected number of Broadcasts.
+		$I->seeBroadcastsOutput($I, 3);
+	}
+
+	/**
 	 * Test the Broadcasts block outputs a message when no Broadcasts exist.
 	 *
 	 * @since   2.0.1

--- a/tests/acceptance/forms/PageBlockFormCest.php
+++ b/tests/acceptance/forms/PageBlockFormCest.php
@@ -501,8 +501,9 @@ class PageBlockFormCest
 	}
 
 	/**
-	 * Test the Form block displays a message with a link to the Plugin's
-	 * settings screen, when the Plugin has no API key specified.
+	 * Test the Forms block displays a message with a link that opens
+	 * a popup window with the Plugin's Setup Wizard, when the Plugin has
+	 * no API key specified.
 	 *
 	 * @since   2.2.3
 	 *
@@ -516,30 +517,12 @@ class PageBlockFormCest
 		// Add block to Page.
 		$I->addGutenbergBlock($I, 'ConvertKit Form', 'convertkit-form');
 
-		// Confirm that the Form block displays instructions to the user on how to enter their API Key.
-		$I->see(
-			'No API Key specified.',
-			[
-				'css' => '.convertkit-no-content',
-			]
+		// Test that the popup window works.
+		$I->testBlockNoAPIKeyPopupWindow(
+			$I,
+			'convertkit-form',
+			'Select a Form using the Form option in the Gutenberg sidebar.'
 		);
-
-		// Click the link to confirm it loads the Plugin's settings screen.
-		$I->click(
-			'Click here to add your API Key.',
-			[
-				'css' => '.convertkit-no-content',
-			]
-		);
-
-		// Switch to next browser tab, as the link opens in a new tab.
-		$I->switchToNextTab();
-
-		// Confirm the Plugin's setup wizard is displayed.
-		$I->seeInCurrentUrl('index.php?page=convertkit-setup');
-
-		// Close tab.
-		$I->closeTab();
 
 		// Save page to avoid alert box when _passed() runs to deactivate the Plugin.
 		$I->publishGutenbergPage($I);

--- a/tests/acceptance/forms/PageBlockFormTriggerCest.php
+++ b/tests/acceptance/forms/PageBlockFormTriggerCest.php
@@ -367,30 +367,12 @@ class PageBlockFormTriggerCest
 		// Add block to Page.
 		$I->addGutenbergBlock($I, 'ConvertKit Form Trigger', 'convertkit-formtrigger');
 
-		// Confirm that the Form block displays instructions to the user on how to enter their API Key.
-		$I->see(
-			'No API Key specified.',
-			[
-				'css' => '.convertkit-no-content',
-			]
+		// Test that the popup window works.
+		$I->testBlockNoAPIKeyPopupWindow(
+			$I,
+			'convertkit-formtrigger',
+			'Select a Form using the Form option in the Gutenberg sidebar.'
 		);
-
-		// Click the link to confirm it loads the Plugin's settings screen.
-		$I->click(
-			'Click here to add your API Key.',
-			[
-				'css' => '.convertkit-no-content',
-			]
-		);
-
-		// Switch to next browser tab, as the link opens in a new tab.
-		$I->switchToNextTab();
-
-		// Confirm the Plugin's setup wizard is displayed.
-		$I->seeInCurrentUrl('index.php?page=convertkit-setup');
-
-		// Close tab.
-		$I->closeTab();
 
 		// Save page to avoid alert box when _passed() runs to deactivate the Plugin.
 		$I->publishGutenbergPage($I);

--- a/tests/acceptance/general/PluginSetupWizardCest.php
+++ b/tests/acceptance/general/PluginSetupWizardCest.php
@@ -404,6 +404,71 @@ class PluginSetupWizardCest
 	}
 
 	/**
+	 * Tests that a slimline modal version of the Plugin Setup Wizard is displayed
+	 * when the `convertkit-modal` request parameter is included.
+	 *
+	 * @since   2.2.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSetupWizardModal(AcceptanceTester $I)
+	{
+		// Activate ConvertKit Plugin.
+		$I->activateConvertKitPlugin($I);
+
+		// Manually navigate to the Plugin Setup Wizard; this will be performed via a block
+		// in a future PR, so this test can be moved to e.g. PageBlockFormCest.
+		$I->amOnAdminPage('index.php?page=convertkit-setup&convertkit-modal=1');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm no logo or progress bar is displayed.
+		$I->dontSeeElementInDOM('#convertkit-setup-wizard-header');
+
+		// Confirm no exit wizard link is displayed.
+		$I->dontSeeElementInDOM('#convertkit-setup-wizard-exit-link');
+
+		// Confirm expected title is displayed.
+		$I->see('Welcome to the ConvertKit Setup Wizard');
+
+		// Confirm Step text is correct.
+		$I->see('Step 1 of 2');
+
+		// Test Connect button.
+		$I->click('Connect');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm no logo or progress bar is displayed.
+		$I->dontSeeElementInDOM('#convertkit-setup-wizard-header');
+
+		// Confirm no exit wizard link is displayed.
+		$I->dontSeeElementInDOM('#convertkit-setup-wizard-exit-link');
+
+		// Confirm expected title is displayed.
+		$I->see('Connect your ConvertKit account');
+
+		// Confirm Step text is correct.
+		$I->see('Step 2 of 2');
+
+		// Confirm Back and Connect buttons display.
+		$I->seeElementInDOM('#convertkit-setup-wizard-footer div.left a.button');
+		$I->seeElementInDOM('#convertkit-setup-wizard-footer div.right button');
+
+		// Fill fields with valid API Keys.
+		$I->fillField('api_key', $_ENV['CONVERTKIT_API_KEY']);
+		$I->fillField('api_secret', $_ENV['CONVERTKIT_API_SECRET']);
+
+		// Click Connect button.
+		$I->click('Connect');
+
+		// Confirm the close modal view was loaded, which includes some JS.
+		$I->seeInSource('self.close();');
+	}
+
+	/**
 	 * Activate the Plugin, without checking it is activated, so that its Setup Wizard
 	 * screen loads.
 	 *

--- a/tests/acceptance/products/PageBlockProductCest.php
+++ b/tests/acceptance/products/PageBlockProductCest.php
@@ -272,30 +272,12 @@ class PageBlockProductCest
 		// Add block to Page.
 		$I->addGutenbergBlock($I, 'ConvertKit Product', 'convertkit-product');
 
-		// Confirm that the Product block displays instructions to the user on how to enter their API Key.
-		$I->see(
-			'No API Key specified.',
-			[
-				'css' => '.convertkit-no-content',
-			]
+		// Test that the popup window works.
+		$I->testBlockNoAPIKeyPopupWindow(
+			$I,
+			'convertkit-product',
+			'Select a Product using the Product option in the Gutenberg sidebar.'
 		);
-
-		// Click the link to confirm it loads the Plugin's settings screen.
-		$I->click(
-			'Click here to add your API Key.',
-			[
-				'css' => '.convertkit-no-content',
-			]
-		);
-
-		// Switch to next browser tab, as the link opens in a new tab.
-		$I->switchToNextTab();
-
-		// Confirm the Plugin's setup wizard is displayed.
-		$I->seeInCurrentUrl('index.php?page=convertkit-setup');
-
-		// Close tab.
-		$I->closeTab();
 
 		// Save page to avoid alert box when _passed() runs to deactivate the Plugin.
 		$I->publishGutenbergPage($I);
@@ -359,7 +341,7 @@ class PageBlockProductCest
 	 */
 	public function testProductBlockRefreshButton(AcceptanceTester $I)
 	{
-		// Setup Plugin with API keys for ConvertKit Account that has no Broadcasts.
+		// Setup Plugin with API keys for ConvertKit Account that has no Products.
 		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
 		$I->setupConvertKitPluginResourcesNoData($I);
 

--- a/views/backend/setup-wizard/close-modal.php
+++ b/views/backend/setup-wizard/close-modal.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Runs JS to close the Setup Wizard screen
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+?>
+<!DOCTYPE html>
+<html>
+	<head>
+	</head>
+	<body>
+	</body>
+	<script type="text/javascript">
+		self.close();
+	</script>
+</html>

--- a/views/backend/setup-wizard/convertkit-setup/content-2.php
+++ b/views/backend/setup-wizard/convertkit-setup/content-2.php
@@ -9,13 +9,20 @@
 ?>
 
 <h1><?php esc_html_e( 'Connect your ConvertKit account', 'convertkit' ); ?></h1>
-<p>
-	<?php
-	esc_html_e( 'To connect this Plugin to your ConvertKit account, we need your API Key and Secret.', 'convertkit' );
-	?>
-</p>
 
-<hr />
+<?php
+if ( ! $this->is_modal() ) {
+	?>
+	<p>
+		<?php
+		esc_html_e( 'To connect this Plugin to your ConvertKit account, we need your API Key and Secret.', 'convertkit' );
+		?>
+	</p>
+
+	<hr />
+	<?php
+}
+?>
 
 <div>
 	<label for="api_key">

--- a/views/backend/setup-wizard/footer.php
+++ b/views/backend/setup-wizard/footer.php
@@ -50,7 +50,7 @@
 
 			<?php
 			// Show exit link if we're not on the last step.
-			if ( $this->step < count( $this->steps ) ) {
+			if ( $this->step < count( $this->steps ) && ! $this->is_modal() ) {
 				?>
 				<div id="convertkit-setup-wizard-exit-link">
 					<a href="<?php echo esc_url( $this->exit_url ); ?>" class="convertkit-confirm" title="<?php esc_html_e( 'Exit wizard', 'convertkit' ); ?>" data-message="<?php esc_html_e( 'Are you sure you want to exit the wizard? Setup is incomplete.', 'convertkit' ); ?>">

--- a/views/backend/setup-wizard/header.php
+++ b/views/backend/setup-wizard/header.php
@@ -22,7 +22,7 @@
 		do_action( 'admin_head' );
 		?>
 	</head>
-	<body class="wp-admin wp-core-ui convertkit">
+	<body class="wp-admin wp-core-ui convertkit <?php echo esc_attr( $this->is_modal() ? ' convertkit-modal' : '' ); ?>">
 		<div id="convertkit-setup-wizard">
 			<header id="convertkit-setup-wizard-header">
 				<h1><?php echo esc_html( CONVERTKIT_PLUGIN_NAME ); ?></h1>

--- a/views/backend/setup-wizard/header.php
+++ b/views/backend/setup-wizard/header.php
@@ -24,24 +24,34 @@
 	</head>
 	<body class="wp-admin wp-core-ui convertkit <?php echo esc_attr( $this->is_modal() ? ' convertkit-modal' : '' ); ?>">
 		<div id="convertkit-setup-wizard">
-			<header id="convertkit-setup-wizard-header">
-				<h1><?php echo esc_html( CONVERTKIT_PLUGIN_NAME ); ?></h1>
-			</header>
+			<?php
+			if ( ! $this->is_modal() ) {
+				?>
+				<header id="convertkit-setup-wizard-header">
+					<h1><?php echo esc_html( CONVERTKIT_PLUGIN_NAME ); ?></h1>
+				</header>
+				<?php
+			}
+			?>
 
 			<div class="wrap">
-				<div id="convertkit-setup-wizard-progress">
-					<ol>
-						<?php
-						foreach ( $this->steps as $step_count => $step ) {
-							?>
-							<li class="step-<?php echo esc_attr( $step_count ); ?><?php echo ( $step_count <= $this->step ? ' done' : '' ); ?>"><?php echo esc_html( $step['name'] ); ?></li>
-							<?php
-						}
-						?>
-					</ol>
-				</div>
-
 				<?php
+				if ( ! $this->is_modal() ) {
+					?>
+					<div id="convertkit-setup-wizard-progress">
+						<ol>
+							<?php
+							foreach ( $this->steps as $step_count => $step ) {
+								?>
+								<li class="step-<?php echo esc_attr( $step_count ); ?><?php echo ( $step_count <= $this->step ? ' done' : '' ); ?>"><?php echo esc_html( $step['name'] ); ?></li>
+								<?php
+							}
+							?>
+						</ol>
+					</div>
+					<?php
+				}
+
 				// If an error occured, display an error notice.
 				if ( $this->error ) {
 					?>


### PR DESCRIPTION
## Summary

Provides the option to serve a Setup Wizard in a modal or popup, by removing the header, progress bar and footer, used in [this PR](https://github.com/ConvertKit/convertkit-wordpress/pull/505).

Modal version:

![Screenshot 2023-07-04 at 15 04 38](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/8f58fde0-56b5-4297-8759-19230db31dab)

Non-modal version:

![Screenshot 2023-07-04 at 16 03 46](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/45203757-d01a-45cc-809b-1bb66f308a28)

This is used when first installing the Plugin, adding a block and clicking the link to enter API credentials, all from within the Gutenberg editor.  [See PR](https://github.com/ConvertKit/convertkit-wordpress/pull/505).

## Testing

- `PluginSetupWizardCest:testSetupWizardModal`: Test that the modal version of the Plugin's Setup Wizard displays when the `convertkit-modal` parameter is included in the request.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)