### PR TITLE
Remove ‘beta’ label from Member Content

### DIFF
--- a/admin/class-convertkit-admin-settings-restrict-content.php
+++ b/admin/class-convertkit-admin-settings-restrict-content.php
@@ -32,9 +32,6 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 		$this->title    = __( 'Member Content', 'convertkit' );
 		$this->tab_text = __( 'Member Content', 'convertkit' );
 
-		// Identify that this is beta functionality.
-		$this->is_beta = true;
-
 		// Enqueue scripts.
 		add_action( 'convertkit_admin_settings_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 
@@ -174,7 +171,6 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 	public function print_section_info() {
 
 		?>
-		<span class="convertkit-beta-label"><?php esc_html_e( 'Beta', 'convertkit' ); ?></span>
 		<p class="description"><?php esc_html_e( 'Defines the text and button labels to display when a Page, Post or Custom Post has its Member Content setting set to a Product, and the visitor has not authenticated/subscribed.', 'convertkit' ); ?></p>
 		<div class="notice notice-warning">
 			<p>


### PR DESCRIPTION
## Summary

Removes the  ‘beta’ label from Settings > ConvertKit > Member Content, as this has been available since Feb 15th 2023.

Before:
![Screenshot 2023-07-17 at 13 16 40](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/e8ceb144-7d97-4ca5-a684-29eb0d7b6256)

After:
![Screenshot 2023-07-17 at 13 16 31](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/117003f2-944b-49ca-8225-e38d5588285a)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)