### PR TITLE
Contact Form 7: Add Creator Network Recommendations

### DIFF
--- a/includes/class-convertkit-resource-creator-network-recommendations.php
+++ b/includes/class-convertkit-resource-creator-network-recommendations.php
@@ -76,6 +76,7 @@ class ConvertKit_Resource_Creator_Network_Recommendations extends ConvertKit_Res
 
 		// Bail if an error occured.
 		if ( is_wp_error( $result ) ) {
+			delete_option( $this->settings_name );
 			return false;
 		}
 
@@ -93,7 +94,11 @@ class ConvertKit_Resource_Creator_Network_Recommendations extends ConvertKit_Res
 	}
 
 	/**
-	 * Override the get() function of the ConvertKit_Resource class, as we store a string
+	 *
+	 * Returns the embed script, or false if no script exists i.e. Creator Network Recommendations
+	 * are disabled.
+	 *
+	 * Overrides the get() function of the ConvertKit_Resource class as we store a string
 	 * containing the embed script, not an array of data.
 	 *
 	 * @since   2.2.7

--- a/includes/class-convertkit-resource-creator-network-recommendations.php
+++ b/includes/class-convertkit-resource-creator-network-recommendations.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * ConvertKit Forms Resource class.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Reads ConvertKit Forms from the options table, and refreshes
+ * ConvertKit Forms data stored locally from the API.
+ *
+ * @since   2.2.7
+ */
+class ConvertKit_Resource_Creator_Network_Recommendations extends ConvertKit_Resource {
+
+	/**
+	 * Holds the Settings Key that stores site wide ConvertKit settings
+	 *
+	 * @since 	2.2.7
+	 *
+	 * @var     string
+	 */
+	public $settings_name = 'convertkit_creator_network_recommendations';
+
+	/**
+	 * Constructor.
+	 *
+	 * @since   2.2.7
+	 *
+	 * @param   bool|string $context    Context.
+	 */
+	public function __construct( $context = false ) {
+
+		// Initialize the API if the API Key and Secret have been defined in the Plugin Settings.
+		$settings = new ConvertKit_Settings();
+		if ( $settings->has_api_key_and_secret() ) {
+			$this->api = new ConvertKit_API(
+				$settings->get_api_key(),
+				$settings->get_api_secret(),
+				$settings->debug_enabled(),
+				$context
+			);
+		}
+
+		// Call parent initialization function.
+		parent::init();
+
+	}
+
+	/**
+	 * Queries the API to determine whether the Creator Network Recommendation feature is enabled
+	 * on the ConvertKit account.
+	 * 
+	 * If so, caches the script to use on the frontend site.
+	 * 
+	 * @since 	2.2.7
+	 * 
+	 * @return 	bool
+	 */
+	public function enabled() {
+
+		if ( ! $this->api ) {
+			return false;
+		}
+
+		// Sanity check that we're using the ConvertKit WordPress Libraries 1.3.7 or higher.
+		// If another ConvertKit Plugin is active and out of date, its libraries might
+		// be loaded that don't have this method.
+		if ( ! method_exists( $this->api, 'recommendations_script' ) ) {
+			return false;
+		}
+
+		// Get script from API.
+		$result = $this->api->recommendations_script();
+
+		// Bail if an error occured.
+		if ( is_wp_error( $result ) ) {
+			return false;
+		}
+
+		// Bail if not enabled.
+		if ( ! $result['enabled'] ) {
+			delete_option( $this->settings_name );
+			return false;
+		}
+
+		// Store script URL, as Creator Network Recommendations are available on this account.
+		update_option( $this->settings_name, $result['embed_js'] );
+
+		return true;
+
+	}
+
+	/**
+	 * Override the get() function of the ConvertKit_Resource class, as we store a string
+	 * containing the embed script, not an array of data.
+	 * 
+	 * @since 	2.2.7
+	 * 
+	 * @return 	bool|string
+	 */
+	public function get() {
+
+		return get_option( $this->settings_name );
+
+	}
+
+}

--- a/includes/class-convertkit-resource-creator-network-recommendations.php
+++ b/includes/class-convertkit-resource-creator-network-recommendations.php
@@ -103,7 +103,7 @@ class ConvertKit_Resource_Creator_Network_Recommendations extends ConvertKit_Res
 	 *
 	 * @since   2.2.7
 	 *
-	 * @return  bool|string
+	 * @return  bool|string|array
 	 */
 	public function get() {
 

--- a/includes/class-convertkit-resource-creator-network-recommendations.php
+++ b/includes/class-convertkit-resource-creator-network-recommendations.php
@@ -52,7 +52,7 @@ class ConvertKit_Resource_Creator_Network_Recommendations extends ConvertKit_Res
 	 * Queries the API to determine whether the Creator Network Recommendation feature is enabled
 	 * on the ConvertKit account.
 	 *
-	 * If so, caches the script to use on the frontend site.
+	 * If enabled, caches the script to use on the frontend site.
 	 *
 	 * @since   2.2.7
 	 *

--- a/includes/class-convertkit-resource-creator-network-recommendations.php
+++ b/includes/class-convertkit-resource-creator-network-recommendations.php
@@ -17,7 +17,7 @@ class ConvertKit_Resource_Creator_Network_Recommendations extends ConvertKit_Res
 	/**
 	 * Holds the Settings Key that stores site wide ConvertKit settings
 	 *
-	 * @since 	2.2.7
+	 * @since   2.2.7
 	 *
 	 * @var     string
 	 */
@@ -51,12 +51,12 @@ class ConvertKit_Resource_Creator_Network_Recommendations extends ConvertKit_Res
 	/**
 	 * Queries the API to determine whether the Creator Network Recommendation feature is enabled
 	 * on the ConvertKit account.
-	 * 
+	 *
 	 * If so, caches the script to use on the frontend site.
-	 * 
-	 * @since 	2.2.7
-	 * 
-	 * @return 	bool
+	 *
+	 * @since   2.2.7
+	 *
+	 * @return  bool
 	 */
 	public function enabled() {
 
@@ -95,10 +95,10 @@ class ConvertKit_Resource_Creator_Network_Recommendations extends ConvertKit_Res
 	/**
 	 * Override the get() function of the ConvertKit_Resource class, as we store a string
 	 * containing the embed script, not an array of data.
-	 * 
-	 * @since 	2.2.7
-	 * 
-	 * @return 	bool|string
+	 *
+	 * @since   2.2.7
+	 *
+	 * @return  bool|string
 	 */
 	public function get() {
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -306,6 +306,26 @@ function convertkit_get_sign_in_url() {
 }
 
 /**
+ * Helper method to return the URL the user needs to visit to manage thier billing.
+ *
+ * @since   2.2.8
+ *
+ * @return  string  ConvertKit Billing URL.
+ */
+function convertkit_get_billing_url() {
+
+	return add_query_arg(
+		array(
+			'utm_source'  => 'wordpress',
+			'utm_term'    => get_locale(),
+			'utm_content' => 'convertkit',
+		),
+		'https://app.convertkit.com/account_settings/billing/'
+	);
+
+}
+
+/**
  * Helper method to return the URL the user needs to visit on the ConvertKit app to obtain their API Key and Secret.
  *
  * @since   1.9.6.1

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -308,7 +308,7 @@ function convertkit_get_sign_in_url() {
 /**
  * Helper method to return the URL the user needs to visit to manage thier billing.
  *
- * @since   2.2.8
+ * @since   2.2.7
  *
  * @return  string  ConvertKit Billing URL.
  */

--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
@@ -118,6 +118,7 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 
 		// Get Creator Network Recommendations script.
 		$creator_network_recommendations_enabled = $creator_network_recommendations->enabled();
+		$creator_network_recommendations_enabled = false;
 
 		// Get Contact Form 7 Forms.
 		$cf7_forms = $this->get_cf7_forms();
@@ -159,7 +160,12 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 					$this->settings->get_creator_network_recommendations_enabled_by_cf7_form_id( $cf7_form['id'] )
 				);
 			} else {
-				$table_row['creator_network_recommendations'] = 'N/A';
+				$table_row['creator_network_recommendations'] = sprintf(
+					'%s <a href="%s" target="_blank">%s</a>',
+					esc_html__( 'Creator Network Recommendations requires a', 'convertkit' ),
+					convertkit_get_billing_url(),
+					esc_html__( 'paid ConvertKit Plan', 'convertkit' )
+				);
 			}
 
 			// Add row to table of settings.

--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
@@ -98,7 +98,7 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 		do_settings_sections( $this->settings_key );
 
 		// Get Forms.
-		$forms = new ConvertKit_Resource_Forms( 'contact_form_7' );
+		$forms                           = new ConvertKit_Resource_Forms( 'contact_form_7' );
 		$creator_network_recommendations = new ConvertKit_Resource_Creator_Network_Recommendations( 'contact_form_7' );
 
 		// Bail with an error if no ConvertKit Forms exist.
@@ -136,7 +136,7 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 		$table->add_column( 'email', __( 'Contact Form 7 Email Field', 'convertkit' ), false );
 		$table->add_column( 'name', __( 'Contact Form 7 Name Field', 'convertkit' ), false );
 		$table->add_column( 'creator_network_recommendations', __( 'Enable Creator Network Recommendations', 'convertkit' ), false );
-		
+
 		// Iterate through Contact Form 7 Forms, adding a table row for each Contact Form 7 Form.
 		foreach ( $cf7_forms as $cf7_form ) {
 			// Build row.

--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
@@ -99,6 +99,7 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 
 		// Get Forms.
 		$forms = new ConvertKit_Resource_Forms( 'contact_form_7' );
+		$creator_network_recommendations = new ConvertKit_Resource_Creator_Network_Recommendations( 'contact_form_7' );
 
 		// Bail with an error if no ConvertKit Forms exist.
 		if ( ! $forms->exist() ) {
@@ -114,6 +115,9 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 		foreach ( $forms->get() as $form ) {
 			$options[ esc_attr( $form['id'] ) ] = esc_html( $form['name'] );
 		}
+
+		// Get Creator Network Recommendations script.
+		$creator_network_recommendations_enabled = $creator_network_recommendations->enabled();
 
 		// Get Contact Form 7 Forms.
 		$cf7_forms = $this->get_cf7_forms();
@@ -131,21 +135,35 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 		$table->add_column( 'form', __( 'ConvertKit Form', 'convertkit' ), false );
 		$table->add_column( 'email', __( 'Contact Form 7 Email Field', 'convertkit' ), false );
 		$table->add_column( 'name', __( 'Contact Form 7 Name Field', 'convertkit' ), false );
-
+		$table->add_column( 'creator_network_recommendations', __( 'Enable Creator Network Recommendations', 'convertkit' ), false );
+		
 		// Iterate through Contact Form 7 Forms, adding a table row for each Contact Form 7 Form.
 		foreach ( $cf7_forms as $cf7_form ) {
-			$table->add_item(
-				array(
-					'title' => $cf7_form['name'],
-					'form'  => $this->get_select_field(
-						$cf7_form['id'],
-						(string) $this->settings->get_convertkit_form_id_by_cf7_form_id( $cf7_form['id'] ),
-						$options
-					),
-					'email' => 'your-email',
-					'name'  => 'your-name',
-				)
+			// Build row.
+			$table_row = array(
+				'title' => $cf7_form['name'],
+				'form'  => $this->get_select_field(
+					$cf7_form['id'],
+					(string) $this->settings->get_convertkit_form_id_by_cf7_form_id( $cf7_form['id'] ),
+					$options
+				),
+				'email' => 'your-email',
+				'name'  => 'your-name',
 			);
+
+			// If Creator Network Recommendations are enabled, add a table column.
+			if ( $creator_network_recommendations_enabled ) {
+				$table_row['creator_network_recommendations'] = $this->get_checkbox_field(
+					'creator_network_recommendations_' . $cf7_form['id'],
+					'1',
+					$this->settings->get_creator_network_recommendations_enabled_by_cf7_form_id( $cf7_form['id'] )
+				);
+			} else {
+				$table_row['creator_network_recommendations'] = 'N/A';
+			}
+
+			// Add row to table of settings.
+			$table->add_item( $table_row );
 		}
 
 		// Prepare and display WP_List_Table.

--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
@@ -118,7 +118,6 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 
 		// Get Creator Network Recommendations script.
 		$creator_network_recommendations_enabled = $creator_network_recommendations->enabled();
-		$creator_network_recommendations_enabled = false;
 
 		// Get Contact Form 7 Forms.
 		$cf7_forms = $this->get_cf7_forms();

--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
@@ -151,14 +151,16 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 				'name'  => 'your-name',
 			);
 
-			// If Creator Network Recommendations are enabled, add a table column.
+			// Add Creator Network Recommendations table column.
 			if ( $creator_network_recommendations_enabled ) {
+				// Show checkbox to enable Creator Network Recommendations for this Contact Form 7 Form.
 				$table_row['creator_network_recommendations'] = $this->get_checkbox_field(
 					'creator_network_recommendations_' . $cf7_form['id'],
 					'1',
 					$this->settings->get_creator_network_recommendations_enabled_by_cf7_form_id( $cf7_form['id'] )
 				);
 			} else {
+				// Show a link to the ConvertKit billing page, as a paid plan is required for Creator Network Recommendations.
 				$table_row['creator_network_recommendations'] = sprintf(
 					'%s <a href="%s" target="_blank">%s</a>',
 					esc_html__( 'Creator Network Recommendations requires a', 'convertkit' ),

--- a/includes/integrations/contactform7/class-convertkit-contactform7-settings.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-settings.php
@@ -102,6 +102,30 @@ class ConvertKit_ContactForm7_Settings {
 	}
 
 	/**
+	 * Returns whether Creator Network Recommendations are enabled for the given Contact Form 7 Form ID.
+	 * 
+	 * @since 	2.2.7
+	 * 
+	 * @param   int $cf7_form_id    Contact Form 7 Form ID.
+	 * @return  bool
+	 */
+	public function get_creator_network_recommendations_enabled_by_cf7_form_id( $cf7_form_id ) {
+
+		// Bail if no settings exist for any Contact Form 7 Forms.
+		if ( ! $this->has_settings() ) {
+			return false;
+		}
+
+		// Bail if no setting exists for the given Contact Form 7 Form.
+		if ( ! array_key_exists( 'creator_network_recommendations_' . $cf7_form_id, $this->get() ) ) {
+			return false;
+		}
+
+		return (bool) $this->get()[ 'creator_network_recommendations_' . $cf7_form_id ];
+
+	}
+
+	/**
 	 * The default settings, used when this integration's Settings haven't been saved
 	 * e.g. on a new installation or when the integration's Plugin has just been activated
 	 * for the first time.

--- a/includes/integrations/contactform7/class-convertkit-contactform7-settings.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-settings.php
@@ -103,9 +103,9 @@ class ConvertKit_ContactForm7_Settings {
 
 	/**
 	 * Returns whether Creator Network Recommendations are enabled for the given Contact Form 7 Form ID.
-	 * 
-	 * @since 	2.2.7
-	 * 
+	 *
+	 * @since   2.2.7
+	 *
 	 * @param   int $cf7_form_id    Contact Form 7 Form ID.
 	 * @return  bool
 	 */

--- a/includes/integrations/contactform7/class-convertkit-contactform7.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7.php
@@ -21,7 +21,46 @@ class ConvertKit_ContactForm7 {
 	 */
 	public function __construct() {
 
+		add_action( 'wpcf7_contact_form', array( $this, 'maybe_enqueue_creator_network_recommendations_script' ) );
 		add_action( 'wpcf7_submit', array( $this, 'handle_wpcf7_submit' ), 10, 2 );
+
+	}
+
+	/**
+	 * Enqueues the Creator Network Recommendations script, if the Contact Form 7 Form
+	 * has the 'Enable Creator Network Recommendations' setting enabled at Settings >
+	 * ConvertKit > Contact Form 7.
+	 *
+	 * @since   2.2.7
+	 *
+	 * @param   WPCF7_ContactForm $contact_form   Contact Form 7 Form.
+	 */
+	public function maybe_enqueue_creator_network_recommendations_script( $contact_form ) {
+
+		// Don't enqueue if this is a WordPress Admin screen request.
+		if ( is_admin() ) {
+			return;
+		}
+
+		// Initialize classes.
+		$creator_network_recommendations = new ConvertKit_Resource_Creator_Network_Recommendations( 'contact_form_7' );
+		$contact_form_7_settings = new ConvertKit_ContactForm7_Settings();
+
+		// Bail if Creator Network Recommendations are not enabled for this form.
+		if ( ! $contact_form_7_settings->get_creator_network_recommendations_enabled_by_cf7_form_id( $contact_form->id() ) ) {
+			return;
+		}
+
+		// Get script.
+		$script_url = $creator_network_recommendations->get();
+
+		// Bail if no script exists (i.e. the Creator Network Recommendations is not enabled on the ConvertKit account).
+		if ( ! $script_url ) {
+			return;
+		}
+
+		// Enqueue script.
+		wp_enqueue_script( 'convertkit-creator-network-recommendations', $script_url, array(), CONVERTKIT_PLUGIN_VERSION, true );
 
 	}
 

--- a/includes/integrations/contactform7/class-convertkit-contactform7.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7.php
@@ -44,7 +44,7 @@ class ConvertKit_ContactForm7 {
 
 		// Initialize classes.
 		$creator_network_recommendations = new ConvertKit_Resource_Creator_Network_Recommendations( 'contact_form_7' );
-		$contact_form_7_settings = new ConvertKit_ContactForm7_Settings();
+		$contact_form_7_settings         = new ConvertKit_ContactForm7_Settings();
 
 		// Bail if Creator Network Recommendations are not enabled for this form.
 		if ( ! $contact_form_7_settings->get_creator_network_recommendations_enabled_by_cf7_form_id( $contact_form->id() ) ) {

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -1327,6 +1327,48 @@ class Plugin extends \Codeception\Module
 	}
 
 	/**
+	 * Check that the given Page does output the Creator Network Recommendations
+	 * script.
+	 *
+	 * @since   2.2.7
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester.
+	 * @param   int              $pageID        Page ID.
+	 */
+	public function seeCreatorNetworkRecommendationsScript($I, $pageID)
+	{
+		// Load the Page on the frontend site.
+		$I->amOnPage('/?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm the recommendations script was not loaded.
+		$I->seeInSource('recommendations.js');
+	}
+
+	/**
+	 * Check that the given Page does not output the Creator Network Recommendations
+	 * script.
+	 *
+	 * @since   2.2.7
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester.
+	 * @param   int              $pageID        Page ID.
+	 */
+	public function dontSeeCreatorNetworkRecommendationsScript($I, $pageID)
+	{
+		// Load the Page on the frontend site.
+		$I->amOnPage('/?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm the recommendations script was not loaded.
+		$I->dontSeeInSource('recommendations.js');
+	}
+
+	/**
 	 * Selects all text for the given input field.
 	 *
 	 * @since   2.2.0

--- a/tests/acceptance/integrations/ContactForm7FormCest.php
+++ b/tests/acceptance/integrations/ContactForm7FormCest.php
@@ -17,8 +17,50 @@ class ContactForm7FormCest
 	{
 		$I->activateConvertKitPlugin($I);
 		$I->activateThirdPartyPlugin($I, 'contact-form-7');
-		$I->setupConvertKitPlugin($I);
-		$I->setupConvertKitPluginResources($I);
+	}
+
+	/**
+	 * Tests that no Contact Form 7 settings display and a 'No Forms exist on ConvertKit'
+	 * notification displays when no API Key and Secret are defined in the Plugin's settings.
+	 *
+	 * @since   2.2.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSettingsContactForm7WhenNoAPIKeyAndSecret(AcceptanceTester $I)
+	{
+		// Load Contact Form 7 Plugin Settings.
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=contactform7');
+
+		// Confirm notice is displayed.
+		$I->see('No Forms exist on ConvertKit.');
+
+		// Confirm no settings table is displayed.
+		$I->dontSeeElementInDOM('table.wp-list-table');
+	}
+
+	/**
+	 * Tests that no Contact Form 7 settings display and a 'No Forms exist on ConvertKit'
+	 * notification displays when no Forms exist.
+	 *
+	 * @since   2.2.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSettingsContactForm7WhenNoForms(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA'], '', '', '');
+		$I->setupConvertKitPluginResourcesNoData($I);
+
+		// Load Contact Form 7 Plugin Settings.
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=contactform7');
+
+		// Confirm notice is displayed.
+		$I->see('No Forms exist on ConvertKit.');
+
+		// Confirm no settings table is displayed.
+		$I->dontSeeElementInDOM('table.wp-list-table');
 	}
 
 	/**
@@ -30,6 +72,10 @@ class ContactForm7FormCest
 	 */
 	public function testSettingsContactForm7ToConvertKitFormMapping(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Create Contact Form 7 Form.
 		$contactForm7ID = $this->_createContactForm7Form($I);
 
@@ -90,6 +136,120 @@ class ContactForm7FormCest
 
 		// Confirm that the email address was added to ConvertKit.
 		$I->apiCheckSubscriberExists($I, $emailAddress);
+	}
+
+	/**
+	 * Tests that the 'Enable Creator Network Recommendations' option on a Form's settings
+	 * is not displayed when invalid API Key and Secret are specified at WPForms > Settings > Integrations > ConvertKit.
+	 *
+	 * @since   2.2.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSettingsContactForm7CreatorNetworkRecommendationsOptionWhenDisabledOnConvertKitAccount(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
+		// Create Contact Form 7 Form.
+		$contactForm7ID = $this->_createContactForm7Form($I);
+
+		// Load Contact Form 7 Plugin Settings.
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=contactform7');
+
+		// Confirm a message is displayed telling the user a paid plan is required.
+		$I->seeInSource('Creator Network Recommendations requires a <a href="https://app.convertkit.com/account_settings/billing/?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit" target="_blank">paid ConvertKit Plan</a>');
+
+		// Create Page with Contact Form 7 Shortcode.
+		$pageID = $I->havePageInDatabase(
+			[
+				'post_title'   => 'ConvertKit: Contact Form 7: Creator Network Recommendations Disabled on ConvertKit',
+				'post_name'    => 'convertkit-contact-form-7-creator-network-recommendations-disabled-convertkit',
+				'post_content' => 'Form:
+[contact-form-7 id="' . $contactForm7ID . '"]',
+			]
+		);
+
+		// Confirm the recommendations script was not loaded, as the API Key and Secret are invalid.
+		$I->dontSeeCreatorNetworkRecommendationsScript($I, $pageID);
+	}
+
+	/**
+	 * Tests that the 'Enable Creator Network Recommendations' option on a Form's settings
+	 * is displayed and saves correctly when valid API Key and Secret are specified at WPForms > Settings > Integrations > ConvertKit,
+	 * and the ConvertKit account has the Creator Network enabled.  Viewing and submitting the Form then correctly
+	 * displays the Creator Network Recommendations modal.
+	 *
+	 * @since   2.2.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSettingsContactForm7CreatorNetworkRecommendations(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Create Contact Form 7 Form.
+		$contactForm7ID = $this->_createContactForm7Form($I);
+
+		// Load Contact Form 7 Plugin Settings.
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=contactform7');
+
+		// Enable Creator Network Recommendations on the Contact Form 7.
+		$I->checkOption('#creator_network_recommendations_' . $contactForm7ID);
+
+		// Save.
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm checkbox is checked after saving.
+		$I->seeCheckboxIsChecked('#creator_network_recommendations_' . $contactForm7ID);
+
+		// Create Page with Contact Form 7 Shortcode.
+		$pageID = $I->havePageInDatabase(
+			[
+				'post_title'   => 'ConvertKit: Contact Form 7: Creator Network Recommendations',
+				'post_name'    => 'convertkit-contact-form-7-creator-network-recommendations',
+				'post_content' => 'Form:
+[contact-form-7 id="' . $contactForm7ID . '"]',
+			]
+		);
+
+		// Confirm the recommendations script was loaded.
+		$I->seeCreatorNetworkRecommendationsScript($I, $pageID);
+
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Complete Name and Email.
+		$I->fillField('input[name=your-name]', 'ConvertKit Name');
+		$I->fillField('input[name=your-email]', $emailAddress);
+		$I->fillField('input[name=your-subject]', 'ConvertKit Subject');
+
+		// Submit Form.
+		$I->click('Submit');
+
+		// Wait for Creator Network Recommendations modal to display.
+		$I->waitForElementVisible('.formkit-modal');
+		$I->switchToIFrame('.formkit-modal iframe');
+		$I->waitForElementVisible('div[data-component="Page"]');
+		$I->switchToIFrame();
+
+		// Close the modal.
+		$I->click('.formkit-modal button.formkit-close');
+		$I->waitForElementNotVisible('.formkit-modal');
+
+		// Confirm the form submitted without errors.
+		$I->performOn(
+			'form.sent',
+			function($I) {
+				$I->see('Thank you for your message. It has been sent.');
+			}
+		);
 	}
 
 	/**

--- a/tests/acceptance/integrations/ContactForm7FormCest.php
+++ b/tests/acceptance/integrations/ContactForm7FormCest.php
@@ -185,7 +185,7 @@ class ContactForm7FormCest
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testSettingsContactForm7CreatorNetworkRecommendations(AcceptanceTester $I)
+	public function testSettingsContactForm7CreatorNetworkRecommendationsWhenEnabledOnConvertKitAccount(AcceptanceTester $I)
 	{
 		// Setup ConvertKit Plugin.
 		$I->setupConvertKitPlugin($I);
@@ -240,6 +240,7 @@ class ContactForm7FormCest
 		$I->switchToIFrame();
 
 		// Close the modal.
+		$I->waitForElementVisible('.formkit-modal button.formkit-close');
 		$I->click('.formkit-modal button.formkit-close');
 		$I->waitForElementNotVisible('.formkit-modal');
 

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -51,6 +51,7 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-output.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-output-restrict-content.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-post.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-preview-output.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-resource-creator-network-recommendations.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-resource-forms.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-resource-landing-pages.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-resource-posts.php';


### PR DESCRIPTION
## Summary

Adds an option to enable the Creator Network Recommendations to a Contact Form 7 Form within the ConvertKit Plugin at `Settings > ConvertKit > Contact Form 7`:

![Screenshot 2023-07-20 at 14 47 21](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/f64c12df-9a8f-4ad4-b022-66e286b9492b)

When enabled, the modal is displayed when the form is submitted:

![Screenshot 2023-07-20 at 14 48 03](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/dbcf8b45-88f1-46f7-98bb-7b096bff2975)

Demonstration:
https://www.loom.com/share/45db4e9f41e54deca1ae83a66fbb0090?sid=3b32c69a-8005-4c84-aac9-0d0f665c4323

Requirements must be met for this to work:

### Creator Network Recommendations enabled

If the [API endpoint](https://github.com/ConvertKit/convertkit/pull/24419) `enabled` property returns `false`, the user is prompted to upgrade their ConvertKit Plan.

![ContactForm7FormCest testSettingsContactForm7CreatorNetworkRecommendationsOptionWhenDisabledOnConvertKitAccount default fail](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/346cea2f-b724-4da6-8635-306c576f1a6f)

## Testing

- `testSettingsContactForm7WhenNoAPIKeyAndSecret`: Confirm that no settings are displayed when no API Key and Secret are specified in the Plugin's settings (this isn't related to the Creator Network, but was a missing test that should have been added before)
- `testSettingsContactForm7WhenNoForms`: Confirm that no settings are displayed when no Forms exist on ConvertKit (this isn't related to the Creator Network, but was a missing test that should have been added before)
- `testSettingsContactForm7CreatorNetworkRecommendationsOptionWhenDisabledOnConvertKitAccount`: Tests that the 'Enable Creator Network Recommendations' option on a Form's settings is not displayed when invalid API Key and Secret are specified at WPForms > Settings > Integrations > ConvertKit.
- `testSettingsContactForm7CreatorNetworkRecommendations`: Test that the Creator Network Recommendations modal displays when enabled on a Contact Form 7 Form.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)