### PR TITLE
Broadcasts to Posts: Settings UI: Member Content

### DIFF
--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -126,6 +126,9 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 	 */
 	public function register_fields() {
 
+		// Initialize classes that will be used.
+		$restrict_content_settings = new ConvertKit_Settings_Restrict_Content();
+
 		add_settings_field(
 			'enabled',
 			__( 'Enable', 'convertkit' ),
@@ -134,7 +137,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 			$this->name,
 			array(
 				'name'        => 'enabled',
-				'description' => __( 'Enables automatic publication of ConvertKit Broadcasts to WordPress Posts.', 'convertkit' ),
+				'description' => __( 'Enables automatic publication of ConvertKit broadcasts to WordPress Posts.', 'convertkit' ),
 			)
 		);
 
@@ -146,7 +149,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 			$this->name,
 			array(
 				'name'        => 'category',
-				'description' => __( 'The category to assign imported Broadcasts to.', 'convertkit' ),
+				'description' => __( 'The category to assign imported broadcasts to.', 'convertkit' ),
 			)
 		);
 
@@ -158,21 +161,24 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 			$this->name,
 			array(
 				'name'        => 'send_at_min_date',
-				'description' => __( 'The earliest date to import Broadcasts from, based on the Broadcast\'s sent date and time.', 'convertkit' ),
+				'description' => __( 'The earliest date to import broadcasts from, based on the broadcast\'s sent date and time.', 'convertkit' ),
 			)
 		);
 
-		add_settings_field(
-			'restrict_content',
-			__( 'Member Content', 'convertkit' ),
-			array( $this, 'restrict_content_callback' ),
-			$this->settings_key,
-			$this->name,
-			array(
-				'name'        => 'restrict_content',
-				'description' => __( 'For Broadcasts marked as "paid subscribers only" in ConvertKit, select the ConvertKit product that the visitor must be subscribed to, permitting them access to view this members only content.', 'convertkit' ),
-			)
-		);
+		// Only register the Member Content field if Restrict Content is enabled.
+		if ( $restrict_content_settings->enabled() ) {
+			add_settings_field(
+				'restrict_content',
+				__( 'Member Content', 'convertkit' ),
+				array( $this, 'restrict_content_callback' ),
+				$this->settings_key,
+				$this->name,
+				array(
+					'name'        => 'restrict_content',
+					'description' => __( 'Select the ConvertKit product that the visitor must be subscribed to, permitting them access to view the imported broadcast.', 'convertkit' ),
+				)
+			);
+		}
 
 	}
 

--- a/tests/acceptance/broadcasts/BroadcastsSettingsCest.php
+++ b/tests/acceptance/broadcasts/BroadcastsSettingsCest.php
@@ -33,7 +33,7 @@ class BroadcastsSettingsCest
 	 */
 	public function testEnableDisable(AcceptanceTester $I)
 	{
-		// Go to the Plugin's Member Content Screen.
+		// Go to the Plugin's Broadcasts Screen.
 		$I->loadConvertKitSettingsBroadcastsScreen($I);
 
 		// Confirm that additional fields are hidden, because the 'Enable' option is not checked.
@@ -87,14 +87,13 @@ class BroadcastsSettingsCest
 	 */
 	public function testSaveSettings(AcceptanceTester $I)
 	{
-		// Go to the Plugin's Member Content Screen.
+		// Go to the Plugin's Broadcasts Screen.
 		$I->loadConvertKitSettingsBroadcastsScreen($I);
 
 		// Enable Broadcasts to Posts, and modify settings.
 		$I->checkOption('#enabled');
 		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_broadcasts_category-container', 'ConvertKit Broadcasts to Posts');
 		$I->fillField('_wp_convertkit_settings_broadcasts[send_at_min_date]', '01/01/2023');
-		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_broadcasts_restrict_content-container', $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
 
 		// Click the Save Changes button.
 		$I->click('Save Changes');
@@ -106,6 +105,62 @@ class BroadcastsSettingsCest
 		$I->seeCheckboxIsChecked('#enabled');
 		$I->seeInField('_wp_convertkit_settings_broadcasts[category]', 'ConvertKit Broadcasts to Posts');
 		$I->seeInField('_wp_convertkit_settings_broadcasts[send_at_min_date]', '2023-01-01');
+	}
+
+	/**
+	 * Tests that the Member Content setting is not displayed when Member Content is disabled at
+	 * Settings > ConvertKit > Member Content.
+	 *
+	 * @since   2.2.8
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentSettingHiddenWhenRestrictContentDisabled(AcceptanceTester $I)
+	{
+		// Go to the Plugin's Broadcasts Screen.
+		$I->loadConvertKitSettingsBroadcastsScreen($I);
+
+		// Enable Broadcasts to Posts.
+		$I->checkOption('#enabled');
+
+		// Confirm no Restrict Content option is displayed.
+		$I->dontSeeElementInDOM('select#_wp_convertkit_settings_broadcasts_restrict_content');
+	}
+
+	/**
+	 * Tests that the Member Content setting is displayed when Member Content is disabled at
+	 * Settings > ConvertKit > Member Content.
+	 *
+	 * @since   2.2.8
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentSettingDisplayedWhenRestrictContentEnabled(AcceptanceTester $I)
+	{
+		// Enable Restrict Content.
+		$I->setupConvertKitPluginRestrictContent(
+			$I,
+			[
+				'enabled' => true,
+			]
+		);
+
+		// Go to the Plugin's Broadcasts Screen.
+		$I->loadConvertKitSettingsBroadcastsScreen($I);
+
+		// Enable Broadcasts to Posts.
+		$I->checkOption('#enabled');
+
+		// Confirm no Restrict Content option is displayed.
+		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_broadcasts_restrict_content-container', $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
+
+		// Click the Save Changes button.
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm the setting saved.
 		$I->seeInField('_wp_convertkit_settings_broadcasts[restrict_content]', $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
 	}
 


### PR DESCRIPTION
## Summary

Shows or hides the Member Content setting at `Settings > ConvertKit > Broadcasts`, depending on whether Member Content functionality is enabled at `Settings > ConvertKit > Member Content`.

![Screenshot 2023-08-02 at 13 57 54](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/db62c212-77d5-46db-b9ab-ad2992436e6a)

![Screenshot 2023-08-02 at 13 58 04](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/c9880e2d-c228-4997-b7f1-d96cb2020fed)

## Testing

- `BroadcastsSettingsCest:testRestrictContentSettingHiddenWhenRestrictContentDisabled`: Test that the Member Content setting is not displayed when Member Content is disabled at `Settings > ConvertKit > Member Content`
- `BroadcastsSettingsCest:testRestrictContentSettingDisplayedWhenRestrictContentEnabled`: Test that the Member Content setting is displayed when Member Content is disabled at `Settings > ConvertKit > Member Content`

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)