### PR TITLE
Tests: Compatibility with W3 Total Cache 2.4.0

### DIFF
--- a/tests/_support/Helper/Acceptance/WPCachePlugins.php
+++ b/tests/_support/Helper/Acceptance/WPCachePlugins.php
@@ -70,9 +70,10 @@ class WPCachePlugins extends \Codeception\Module
 
 		// Navigate to its settings screen.
 		$I->waitForElementVisible('input.button-buy-plugin');
-		$I->amOnAdminPage('admin.php?page=w3tc_general');
+		$I->click('General Settings');
 
 		// Enable.
+		$I->waitForElementVisible('#pgcache__enabled');
 		$I->checkOption('#pgcache__enabled');
 
 		// Save.

--- a/tests/_support/Helper/Acceptance/WPCachePlugins.php
+++ b/tests/_support/Helper/Acceptance/WPCachePlugins.php
@@ -69,7 +69,7 @@ class WPCachePlugins extends \Codeception\Module
 		$I->click('#w3tc-wizard-skip');
 
 		// Navigate to its settings screen.
-		$I->waitForElementVisible('input.w3tc-gopro-button');
+		$I->waitForElementVisible('input.button-buy-plugin');
 		$I->amOnAdminPage('admin.php?page=w3tc_general');
 
 		// Enable.

--- a/tests/_support/Helper/Acceptance/WPCachePlugins.php
+++ b/tests/_support/Helper/Acceptance/WPCachePlugins.php
@@ -62,15 +62,11 @@ class WPCachePlugins extends \Codeception\Module
 	 */
 	public function enableCachingW3TotalCachePlugin($I)
 	{
-		// Navigate to its settings screen.
+		// Bypass the setup guide.
+		$I->haveOptionInDatabase('w3tc_setupguide_completed', strtotime('now'));
+
+		// Navigate to the General Settings screen.
 		$I->amOnAdminPage('admin.php?page=w3tc_general');
-
-		// Skip Setup Guide.
-		$I->click('#w3tc-wizard-skip');
-
-		// Navigate to its settings screen.
-		$I->waitForElementVisible('input.button-buy-plugin');
-		$I->click('General Settings');
 
 		// Enable.
 		$I->waitForElementVisible('#pgcache__enabled');

--- a/tests/_support/Helper/Acceptance/WPCachePlugins.php
+++ b/tests/_support/Helper/Acceptance/WPCachePlugins.php
@@ -76,7 +76,7 @@ class WPCachePlugins extends \Codeception\Module
 		$I->checkOption('#pgcache__enabled');
 
 		// Save.
-		$I->click('Save all settings');
+		$I->click('Save Settings');
 	}
 
 	/**
@@ -98,8 +98,7 @@ class WPCachePlugins extends \Codeception\Module
 		$I->fillField('#pgcache_reject_cookie', $cookieName);
 
 		// Save.
-		$I->scrollTo('#notes');
-		$I->click('#w3tc_save_options_pagecache_advanced');
+		$I->click('Save Settings');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Makes existing tests compatible with W3 Total Cache 2.4.0's UI changes for clicking buttons.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)