### PR TITLE
Check if `useAnchor` is available

### DIFF
--- a/resources/backend/js/gutenberg-block-formatters.js
+++ b/resources/backend/js/gutenberg-block-formatters.js
@@ -41,6 +41,7 @@ function convertKitGutenbergRegisterBlockFormatter( formatter ) {
 			registerFormatType,
 			toggleFormat,
 			applyFormat,
+			useAnchorRef,
 			useAnchor
 		} = richText;
 		const {
@@ -271,10 +272,19 @@ function convertKitGutenbergRegisterBlockFormatter( formatter ) {
 		 */
 		const editFormatType = function( props ) {
 
-			// Get props and anchor reference to the text.
+			// Get props.
 			const { contentRef, isActive, value } = props;
 			const { activeFormats }               = value;
-			const anchorRef                       = useAnchor( { editableContentElement: contentRef.current, value } );
+			let anchorRef;
+
+			// Get anchor reference to the text.
+			if ( typeof useAnchor === 'undefined' ) {
+				// Use WordPress 6.0 and lower useAnchorRef(), as useAnchor() isn't available.
+				anchorRef = useAnchorRef( { ref: contentRef, value } );
+			} else {
+				// Use WordPress 6.1+ useAnchor(), as useAnchorRef() is deprecated in 6.2+.
+				anchorRef = useAnchor( { editableContentElement: contentRef.current, value } );
+			}
 
 			// State to show popover.
 			const [ showPopover, setShowPopover ] = useState( false );


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://convertkit.atlassian.net/jira/software/c/projects/T3/boards/27?modal=detail&selectedIssue=T3-486), where `useAnchor` isn't available in WordPress versions below 6.1, resulting in an error.

<img width="602" alt="Screenshot 2023-08-05 at 15 08 54" src="https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/da152def-2e75-4df8-a5ef-dcb8a62009ac">

Issue first introduced by [this PR](https://github.com/ConvertKit/convertkit-wordpress/pull/500), where `useAnchorRef` was replaced by `useAnchor`.

## Testing

Existing tests pass. Also manually tested on WordPress 5.9.7 to confirm this will work on the specific site in question.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)