### PR TITLE
Broadcasts to Posts: Display next import date and time

### DIFF
--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -140,7 +140,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 			if ( $broadcasts->get_cron_event_next_scheduled() ) {
 				$enabled_description .= sprintf(
 					'<br />%s %s',
-					esc_html__( 'Broadcasts will next import on ', 'convertkit' ),
+					esc_html__( 'Broadcasts will next import at approximately ', 'convertkit' ),
 					// The cron event's next scheduled timestamp is always in UTC.
 					// Display it converted to the WordPress site's timezone.
 					get_date_from_gmt(

--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -129,6 +129,28 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 		// Initialize classes that will be used.
 		$restrict_content_settings = new ConvertKit_Settings_Restrict_Content();
 
+		// Define description for the 'Enabled' setting.
+		$enabled_description = __( 'Enables automatic publication of ConvertKit broadcasts to WordPress Posts.', 'convertkit' );
+
+		// If enabled, include the next scheduled date and time the Plugin will import broadcasts.
+		if ( $this->settings->enabled() ) {
+			$broadcasts = new ConvertKit_Resource_Broadcasts( 'cron' );
+
+			// If a next scheduled timestamp exists, include it in the description.
+			if ( $broadcasts->get_cron_event_next_scheduled() ) {
+				$enabled_description .= sprintf(
+					'<br />%s %s',
+					esc_html__( 'Broadcasts will next import on ', 'convertkit' ),
+					// The cron event's next scheduled timestamp is always in UTC.
+					// Display it converted to the WordPress site's timezone.
+					get_date_from_gmt(
+						gmdate( 'Y-m-d H:i:s', $broadcasts->get_cron_event_next_scheduled() ),
+						get_option( 'date_format' ) . ' ' . get_option( 'time_format' )
+					)
+				);
+			}
+		}
+
 		add_settings_field(
 			'enabled',
 			__( 'Enable', 'convertkit' ),
@@ -137,7 +159,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 			$this->name,
 			array(
 				'name'        => 'enabled',
-				'description' => __( 'Enables automatic publication of ConvertKit broadcasts to WordPress Posts.', 'convertkit' ),
+				'description' => $enabled_description,
 			)
 		);
 

--- a/tests/acceptance/broadcasts/BroadcastsToPostsSettingsCest.php
+++ b/tests/acceptance/broadcasts/BroadcastsToPostsSettingsCest.php
@@ -58,6 +58,9 @@ class BroadcastsToPostsSettingsCest
 		// Check the WordPress Cron task was scheduled.
 		$I->seeCronEvent($I, 'convertkit_resource_refresh_broadcasts');
 
+		// Check the next import date and time is displayed.
+		$I->see('Broadcasts will next import at approximately');
+
 		// Disable Broadcasts to Posts.
 		$I->uncheckOption('#enabled');
 
@@ -76,6 +79,9 @@ class BroadcastsToPostsSettingsCest
 
 		// Check the WordPress Cron task was unscheduled.
 		$I->dontSeeCronEvent($I, 'convertkit_resource_refresh_broadcasts');
+
+		// Check the next import date and time is not displayed.
+		$I->dontSee('Broadcasts will next import at approximately');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Displays the next import date and time when Broadcasts to Posts functionality is enabled

<img width="806" alt="Screenshot 2023-08-10 at 16 59 43" src="https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/0c0b175b-f47b-4e69-a161-c7dab5f1352f">

## Testing

- `BroadcastsToPostsSettingsCest:testEnableDisable`: Confirm description below `Enabled` field shows the next import date and time, when enabled.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)