### PR TITLE
Broadcasts to Posts: Conditionally display `Disable Styles` setting

### DIFF
--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -352,7 +352,11 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 			$args['name'],
 			'on',
 			$this->settings->no_styles(), // phpcs:ignore WordPress.Security.EscapeOutput
-			$args['description'] // phpcs:ignore WordPress.Security.EscapeOutput
+			$args['description'], // phpcs:ignore WordPress.Security.EscapeOutput
+			'',
+			array(
+				'enabled',
+			)
 		);
 
 	}

--- a/admin/section/class-convertkit-settings-base.php
+++ b/admin/section/class-convertkit-settings-base.php
@@ -345,9 +345,10 @@ abstract class ConvertKit_Settings_Base {
 	 * @param   bool              $checked        Should checkbox be checked/ticked.
 	 * @param   bool|string       $label          Label.
 	 * @param   bool|string|array $description    Description.
+	 * @param   bool|array        $css_classes    CSS class(es).
 	 * @return  string                            HTML Checkbox
 	 */
-	public function get_checkbox_field( $name, $value, $checked = false, $label = '', $description = '' ) {
+	public function get_checkbox_field( $name, $value, $checked = false, $label = '', $description = '', $css_classes = false ) {
 
 		$html = '';
 
@@ -359,10 +360,11 @@ abstract class ConvertKit_Settings_Base {
 		}
 
 		$html .= sprintf(
-			'<input type="checkbox" id="%s" name="%s[%s]" value="%s" %s />',
+			'<input type="checkbox" id="%s" name="%s[%s]" class="%s" value="%s" %s />',
 			$name,
 			$this->settings_key,
 			$name,
+			( is_array( $css_classes ) ? implode( ' ', $css_classes ) : '' ),
 			$value,
 			( $checked ? ' checked' : '' )
 		);

--- a/tests/acceptance/broadcasts/BroadcastsToPostsSettingsCest.php
+++ b/tests/acceptance/broadcasts/BroadcastsToPostsSettingsCest.php
@@ -53,7 +53,9 @@ class BroadcastsToPostsSettingsCest
 
 		// Confirm that settings saved and additional fields remain displayed.
 		$I->seeCheckboxIsChecked('#enabled');
-		$I->seeElement('input.enabled');
+		$I->seeElement('div.convertkit-select2-container');
+		$I->seeElement('input#send_at_min_date');
+		$I->seeElement('input#no_styles');
 
 		// Check the WordPress Cron task was scheduled.
 		$I->seeCronEvent($I, 'convertkit_resource_refresh_broadcasts');
@@ -72,7 +74,9 @@ class BroadcastsToPostsSettingsCest
 
 		// Confirm that settings saved and additional fields are hidden, because the 'Enable' option is not checked.
 		$I->dontSeeCheckboxIsChecked('#enabled');
-		$I->dontSeeElement('input.enabled');
+		$I->dontSeeElement('div.convertkit-select2-container');
+		$I->dontSeeElement('input#send_at_min_date');
+		$I->dontSeeElement('input#no_styles');
 
 		// Check the WordPress Cron task was unscheduled.
 		$I->dontSeeCronEvent($I, 'convertkit_resource_refresh_broadcasts');


### PR DESCRIPTION
## Summary

Fixes a bug where the `Disable Styles` setting would remain displayed when the `Enable` setting was not checked.

![Screenshot 2023-08-11 at 11 40 00](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/185d5dd6-2c58-4cd4-9a47-93e0b6084827)
![Screenshot 2023-08-11 at 11 40 04](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/751b6afe-dea0-41d5-9c0d-38d679c4a18d)

## Testing

- `BroadcastsToPostsSettingsCest:testEnableDisable`: Improved test by checking for named fields, rather than assuming an `enabled` class was added to every named field.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)