### PR TITLE
Tests: Fix permissions for WP-Optimize

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -200,12 +200,16 @@ jobs:
       - name: Set Permissions for Caching Plugins
         if: ${{ matrix.test-groups == 'acceptance/restrict-content' }}
         run: |
-          mkdir ${{ env.ROOT_DIR }}/wp-content/wpo-cache
-          mkdir ${{ env.ROOT_DIR }}/wp-content/wpo-cache/config
           sudo chmod g+w ${{ env.ROOT_DIR }}/wp-config.php
           sudo chown www-data:www-data ${{ env.ROOT_DIR }}/wp-config.php
           sudo chmod g+w ${{ env.ROOT_DIR }}/wp-content
           sudo chown www-data:www-data ${{ env.ROOT_DIR }}/wp-content
+          mkdir ${{ env.ROOT_DIR }}/wp-content/wpo-cache
+          mkdir ${{ env.ROOT_DIR }}/wp-content/wpo-cache/config
+          sudo chmod g+w ${{ env.ROOT_DIR }}/wp-content/wpo-cache
+          sudo chown www-data:www-data ${{ env.ROOT_DIR }}/wp-content/wpo-cache
+          sudo chmod g+w ${{ env.ROOT_DIR }}/wp-content/wpo-cache/config
+          sudo chown www-data:www-data ${{ env.ROOT_DIR }}/wp-content/wpo-cache/config
 
       # This ensures the wp-content/uploads folder can be written to by WordPress and third party Plugins.
       - name: Set Permissions for Uploads Directory

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -200,12 +200,12 @@ jobs:
       - name: Set Permissions for Caching Plugins
         if: ${{ matrix.test-groups == 'acceptance/restrict-content' }}
         run: |
+          mkdir ${{ env.ROOT_DIR }}/wp-content/wpo-cache
+          mkdir ${{ env.ROOT_DIR }}/wp-content/wpo-cache/config
           sudo chmod g+w ${{ env.ROOT_DIR }}/wp-config.php
           sudo chown www-data:www-data ${{ env.ROOT_DIR }}/wp-config.php
           sudo chmod g+w ${{ env.ROOT_DIR }}/wp-content
           sudo chown www-data:www-data ${{ env.ROOT_DIR }}/wp-content
-          mkdir ${{ env.ROOT_DIR }}/wp-content/wpo-cache
-          mkdir ${{ env.ROOT_DIR }}/wp-content/wpo-cache/config
           sudo chmod g+w ${{ env.ROOT_DIR }}/wp-content/wpo-cache
           sudo chown www-data:www-data ${{ env.ROOT_DIR }}/wp-content/wpo-cache
           sudo chmod g+w ${{ env.ROOT_DIR }}/wp-content/wpo-cache/config

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,15 +51,7 @@ jobs:
 
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
-          'acceptance/broadcasts',
-          'acceptance/forms',
-          'acceptance/general',
-          'acceptance/integrations',
-          'acceptance/landing-pages',
-          'acceptance/products',
-          'acceptance/restrict-content',
-          'acceptance/tags',
-          'acceptance/wlm'
+          'acceptance/restrict-content'
         ]
 
     # Steps to install, configure and run tests
@@ -208,6 +200,8 @@ jobs:
       - name: Set Permissions for Caching Plugins
         if: ${{ matrix.test-groups == 'acceptance/restrict-content' }}
         run: |
+          mkdir ${{ env.ROOT_DIR }}/wp-content/wpo-cache
+          mkdir ${{ env.ROOT_DIR }}/wp-content/wpo-cache/config
           sudo chmod g+w ${{ env.ROOT_DIR }}/wp-config.php
           sudo chown www-data:www-data ${{ env.ROOT_DIR }}/wp-config.php
           sudo chmod g+w ${{ env.ROOT_DIR }}/wp-content

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,15 @@ jobs:
 
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
-          'acceptance/restrict-content'
+          'acceptance/broadcasts',
+          'acceptance/forms',
+          'acceptance/general',
+          'acceptance/integrations',
+          'acceptance/landing-pages',
+          'acceptance/products',
+          'acceptance/restrict-content',
+          'acceptance/tags',
+          'acceptance/wlm'
         ]
 
     # Steps to install, configure and run tests


### PR DESCRIPTION
## Summary

Fix a permissions error when running tests on GitHub Actions for WP-Optimize, since the release of WP-Optimize 3.2.17.

![RestrictContentCacheCest testRestrictContentWPOptimize default fail](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/a75374a2-8057-4237-9666-0c1151ab6403)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)