### PR TITLE
Add deploy readme.txt GitHub Action

### DIFF
--- a/.github/workflows/deploy-readme.yml
+++ b/.github/workflows/deploy-readme.yml
@@ -1,0 +1,18 @@
+name: Deploy readme.txt to WordPress.org
+on:
+  push:
+    branches:
+    - main
+jobs:
+  trunk:
+    name: Push to trunk
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: WordPress.org plugin asset/readme update
+      uses: 10up/action-wordpress-plugin-asset-update@stable
+      env:
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        SLUG: convertkit
+        IGNORE_OTHER_FILES: true

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: nathanbarry, growdev, travisnorthcutt, ggwicz
 Donate link: https://convertkit.com
 Tags: email marketing, email newsletter, newsletter, subscribers, membership
 Requires at least: 5.0
-Tested up to: 6.2.2
+Tested up to: 6.3
 Requires PHP: 5.6.20
 Stable tag: 2.2.8
 License: GPLv2 or later


### PR DESCRIPTION
## Summary

Adds a [GitHub Action](https://github.com/10up/action-wordpress-plugin-asset-update) to only deploy the readme.txt file if changed in the `main` branch.

This allows changes to be made to the readme file (typically the `Tested up to` WordPress version number), without needing to deploy an entire version update to the Plugin.

Screenshots of this action tested on the ConvertKit for WPForms Plugin, where the `Tested up to` value was changed to WordPress 6.3:

![Screenshot 2023-08-16 at 13 43 16](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/8f7a3c21-fd5f-4a7f-a799-5e26b5c1620c)

![Screenshot 2023-08-16 at 13 43 25](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/a2565527-98f6-45b5-b5bb-27c2ae4c7d40)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)