### PR TITLE
Upgrade to WordPress Coding Standards v3

### DIFF
--- a/admin/class-convertkit-admin-post.php
+++ b/admin/class-convertkit-admin-post.php
@@ -205,7 +205,7 @@ class ConvertKit_Admin_Post {
 
 			// Skip if the setting value is -2, as this means it's a Bulk Edit request and this setting
 			// is set as 'No Change'.
-			if ( $new_value == '-2' ) { // phpcs:ignore WordPress.PHP.StrictComparisons
+			if ( $new_value == '-2' ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
 				continue;
 			}
 

--- a/admin/class-convertkit-admin-settings-restrict-content.php
+++ b/admin/class-convertkit-admin-settings-restrict-content.php
@@ -175,7 +175,7 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 		<div class="notice notice-warning">
 			<p>
 				<?php
-				echo sprintf(
+				printf(
 					'%s %s %s',
 					esc_html__( 'If your web host has caching configured (or you are using a caching plugin), you must configure it to disable caching when the', 'convertkit' ),
 					'<code>ck_subscriber_id</code>',
@@ -248,7 +248,7 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 // Bootstrap.
 add_action(
 	'convertkit_admin_settings_register_sections',
-	function( $sections ) {
+	function ( $sections ) {
 
 		$sections['restrict-content'] = new ConvertKit_Admin_Settings_Restrict_Content();
 		return $sections;

--- a/admin/class-convertkit-admin-settings.php
+++ b/admin/class-convertkit-admin-settings.php
@@ -153,7 +153,7 @@ class ConvertKit_Admin_Settings {
 				// Output Documentation link, if it exists.
 				$documentation_url = $this->get_active_section_documentation_url( $active_section );
 				if ( $documentation_url !== false ) {
-					echo sprintf(
+					printf(
 						'%s <a href="%s" target="_blank">%s</a>',
 						esc_html__( 'If you need help setting up the plugin please refer to the', 'convertkit' ),
 						esc_attr( $documentation_url ),

--- a/admin/class-multi-value-field-table.php
+++ b/admin/class-multi-value-field-table.php
@@ -198,7 +198,7 @@ class Multi_Value_Field_Table extends WP_List_Table {
 
 		usort(
 			$data,
-			function( $a, $b ) {
+			function ( $a, $b ) {
 
 				if ( empty( $_REQUEST['orderby'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 					$orderby = 'title';

--- a/admin/section/class-convertkit-settings-base.php
+++ b/admin/section/class-convertkit-settings-base.php
@@ -382,13 +382,13 @@ abstract class ConvertKit_Settings_Base {
 	 *
 	 * @since   1.9.8.5
 	 *
-	 * @param   array $array  Attributes.
-	 * @return  string          HTML attributes string
+	 * @param   array $attributes_array  Attributes.
+	 * @return  string                  HTML attributes string
 	 */
-	private function array_to_attributes( $array ) {
+	private function array_to_attributes( $attributes_array ) {
 
 		$attributes = '';
-		foreach ( $array as $key => $value ) {
+		foreach ( $attributes_array as $key => $value ) {
 			$attributes .= esc_attr( $key ) . '="' . esc_attr( $value ) . '" ';
 		}
 

--- a/admin/section/class-convertkit-settings-tools.php
+++ b/admin/section/class-convertkit-settings-tools.php
@@ -202,15 +202,15 @@ class ConvertKit_Settings_Tools extends ConvertKit_Settings_Base {
 		}
 
 		// Bail if no configuration file was supplied.
-		if ( ! is_array( $_FILES ) ) {
+		if ( ! is_array( $_FILES ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$this->redirect_to_tools_screen();
 		}
-		if ( $_FILES['import']['error'] !== 0 ) {
+		if ( $_FILES['import']['error'] !== 0 ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$this->redirect_to_tools_screen( 'import_configuration_upload_error' );
 		}
 
 		// Read file.
-		$json = $wp_filesystem->get_contents( $_FILES['import']['tmp_name'] );
+		$json = $wp_filesystem->get_contents( $_FILES['import']['tmp_name'] ); // phpcs:ignore WordPress.Security.NonceVerification
 
 		// Decode.
 		$import = json_decode( $json, true );

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,7 @@
         "codeception/module-filesystem": "^1.0",                                   
         "codeception/module-cli": "^1.0",                                          
         "codeception/util-universalframework": "^1.0",
-        "squizlabs/php_codesniffer": "3.*",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-        "wp-coding-standards/wpcs": "*",
+        "wp-coding-standards/wpcs": "^3.0.0",
         "phpstan/phpstan": "^1.7",
         "szepeviktor/phpstan-wordpress": "^1.0",
         "wp-cli/wp-cli": "2.7.1"

--- a/includes/block-formatters/class-convertkit-block-formatter-form-link.php
+++ b/includes/block-formatters/class-convertkit-block-formatter-form-link.php
@@ -191,32 +191,32 @@ class ConvertKit_Block_Formatter_Form_Link extends ConvertKit_Block_Formatter {
 	 *
 	 * @since   2.2.0
 	 *
-	 * @param   array $match  preg_replace_callback() match.
-	 * @return  string          Link with script appended
+	 * @param   array $preg_match  preg_replace_callback() match.
+	 * @return  string              Link with script appended
 	 */
-	public function enqueue_scripts( $match ) {
+	public function enqueue_scripts( $preg_match ) {
 
 		// Get Form by its ID.
-		$form = $this->forms->get_by_id( absint( $match[1] ) );
+		$form = $this->forms->get_by_id( absint( $preg_match[1] ) );
 
 		// Just return the original element, unedited, if the Form could not be found.
 		if ( ! $form ) {
-			return $match[0];
+			return $preg_match[0];
 		}
 
 		// Return the original link, unedited, if the Form doesn't have a UID or JS embed.
 		// This prevents issues with legacy modal forms.
 		if ( ! array_key_exists( 'uid', $form ) ) {
-			return $match[0];
+			return $preg_match[0];
 		}
 		if ( ! array_key_exists( 'embed_js', $form ) ) {
-			return $match[0];
+			return $preg_match[0];
 		}
 
 		// Register the script, so it's only loaded once for this non-inline form across the entire page.
 		add_filter(
 			'convertkit_output_scripts_footer',
-			function( $scripts ) use ( $form ) {
+			function ( $scripts ) use ( $form ) {
 
 				$scripts[] = array(
 					'async'    => true,
@@ -230,7 +230,7 @@ class ConvertKit_Block_Formatter_Form_Link extends ConvertKit_Block_Formatter {
 		);
 
 		// Return original link.
-		return $match[0];
+		return $preg_match[0];
 
 	}
 

--- a/includes/blocks/class-convertkit-block-form-trigger.php
+++ b/includes/blocks/class-convertkit-block-form-trigger.php
@@ -467,7 +467,7 @@ class ConvertKit_Block_Form_Trigger extends ConvertKit_Block {
 		// Register the script, so it's only loaded once for this non-inline form across the entire page.
 		add_filter(
 			'convertkit_output_scripts_footer',
-			function( $scripts ) use ( $form ) {
+			function ( $scripts ) use ( $form ) {
 
 				$scripts[] = array(
 					'async'    => true,

--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -153,7 +153,7 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource {
 		if ( $this->resources[ $id ]['format'] !== 'inline' ) {
 			add_filter(
 				'convertkit_output_scripts_footer',
-				function( $scripts ) use ( $id ) {
+				function ( $scripts ) use ( $id ) {
 
 					$scripts[] = array(
 						'async'    => true,

--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
@@ -57,7 +57,7 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 		</p>
 		<p>
 			<?php
-			echo sprintf(
+			printf(
 				'%s <code>text*</code> %s <code>your-name</code> %s <code>email*</code> %s <code>your-email</code>%s',
 				esc_html__( 'The Contact Form 7 form must have a', 'convertkit' ),
 				esc_html__( 'field named', 'convertkit' ),
@@ -233,7 +233,7 @@ add_filter(
 	 * @param   array   $sections   Settings Sections.
 	 * @return  array
 	 */
-	function( $sections ) {
+	function ( $sections ) {
 
 		// Bail if Contact Form 7 isn't enabled.
 		if ( ! defined( 'WPCF7_VERSION' ) ) {

--- a/includes/integrations/contactform7/class-convertkit-contactform7.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7.php
@@ -132,7 +132,7 @@ class ConvertKit_ContactForm7 {
 // Bootstrap.
 add_action(
 	'convertkit_initialize_global',
-	function() {
+	function () {
 
 		new ConvertKit_ContactForm7();
 

--- a/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php
@@ -206,7 +206,7 @@ add_filter(
 	 * @param   array   $sections   Settings Sections.
 	 * @return  array
 	 */
-	function( $sections ) {
+	function ( $sections ) {
 
 		// Bail if WishList Member isn't enabled.
 		if ( ! function_exists( 'wlmapi_get_levels' ) ) {

--- a/includes/integrations/wishlist/class-convertkit-wishlist.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist.php
@@ -224,7 +224,7 @@ class ConvertKit_Wishlist {
 // Bootstrap.
 add_action(
 	'convertkit_initialize_global',
-	function() {
+	function () {
 
 		new ConvertKit_Wishlist();
 

--- a/includes/integrations/woocommerce/class-convertkit-woocommerce-product-form.php
+++ b/includes/integrations/woocommerce/class-convertkit-woocommerce-product-form.php
@@ -102,7 +102,7 @@ class ConvertKit_WooCommerce_Product_Form {
 // Bootstrap.
 add_action(
 	'convertkit_initialize_global',
-	function() {
+	function () {
 
 		new ConvertKit_WooCommerce_Product_Form();
 

--- a/phpcs.tests.xml
+++ b/phpcs.tests.xml
@@ -22,26 +22,28 @@
         <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterOpenParenthesis" />
         <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.ExtraSpaceAfterCloseParenthesis" />
         <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterOpen" />
+        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingBeforeClose" />
         <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceBeforeCloseParenthesis" />
         <exclude name="Generic.Classes.OpeningBraceSameLine.BraceOnNewLine" />
         <exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie.BraceOnNewLine" />
         <exclude name="PEAR.Functions.FunctionCallSignature.SpaceBeforeOpenBracket" />
         <exclude name="PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket" />
         <exclude name="PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket" />
+        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction" />
 
         <!-- _before() and _passed() must use underscores in Codeception -->
         <exclude name="PSR2.Methods.MethodDeclaration.Underscore" />
 
         <!-- Permit [] instead of array() -->
-        <exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
-        
+        <exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />
+
         <!-- We might use some datetime functions for tests -->
         <exclude name="WordPress.DateTime.RestrictedFunctions" />
 
         <!-- Handles false positives where Coding Standards thinks we did something wrong when we're just checking for e.g. a stylesheet -->
         <exclude name="WordPress.WP.EnqueuedResources" />
         <exclude name="WordPress.PHP.DiscouragedPHPFunctions" />
-        <exclude name="WordPress.WP.CapitalPDangit.Misspelled" />
+        <exclude name="WordPress.WP.CapitalPDangit.MisspelledInText" />
     </rule>
 
     <!-- Check that code is documented to WordPress Standards. -->

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -29,6 +29,8 @@
 		<exclude name="WordPress.Security.EscapeOutput"/>
 		-->
 		<exclude name="WordPress.PHP.YodaConditions" />
+		<exclude name="PSR2.Methods.FunctionClosingBrace.SpacingBeforeClose" />
+		<exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody" />
 	</rule>
 
 	<!-- Check that code is documented to WordPress Standards. -->

--- a/resources/backend/js/bulk-edit.js
+++ b/resources/backend/js/bulk-edit.js
@@ -14,7 +14,7 @@
  * @since 	1.9.8.0
  */
 jQuery( document ).ready(
-	function( $ ) {
+	function ( $ ) {
 
 		// Move Bulk Edit fields from footer into the hidden bulk-edit table row,
 		// if a bulk-edit table row exists (it won't exist if searching returns no pages).

--- a/resources/backend/js/gutenberg-block-formatters.js
+++ b/resources/backend/js/gutenberg-block-formatters.js
@@ -29,7 +29,7 @@ if ( typeof wp !== 'undefined' &&
  */
 function convertKitGutenbergRegisterBlockFormatter( formatter ) {
 
-	( function( editor, richText, element, components ) {
+	( function ( editor, richText, element, components ) {
 
 		// Define the Gutenberg/React components to use.
 		const {
@@ -62,7 +62,7 @@ function convertKitGutenbergRegisterBlockFormatter( formatter ) {
 		 *
 		 * @return  element|string
 		 */
-		const getIcon = function() {
+		const getIcon = function () {
 
 			// Return a fallback default icon if none is specified for this block formatter.
 			if ( typeof formatter.gutenberg_icon === 'undefined' ) {
@@ -95,7 +95,7 @@ function convertKitGutenbergRegisterBlockFormatter( formatter ) {
 		 * @param   object  activeFormats   All active formatters applied to the selected text.
 		 * @return  object
 		 */
-		const getAttributes = function( activeFormats ) {
+		const getAttributes = function ( activeFormats ) {
 
 			// Define the attribute object.
 			let attributes = {};
@@ -138,7 +138,7 @@ function convertKitGutenbergRegisterBlockFormatter( formatter ) {
 		 * @param   array   field         Field definition.
 		 * @param   string  newValue      New value
 		 */
-		const setAttributes = function( props, field, newValue ) {
+		const setAttributes = function ( props, field, newValue ) {
 
 			// Define properties and functions to use.
 			const { onChange, value } = props;
@@ -190,7 +190,7 @@ function convertKitGutenbergRegisterBlockFormatter( formatter ) {
 		 * @param   object  attributes      Field attributes.
 		 * @return  array                   Field elements
 		 */
-		const getFields = function( props, setShowPopover, attributes ) {
+		const getFields = function ( props, setShowPopover, attributes ) {
 
 			// Define array of field elements.
 			let elements = [];
@@ -242,7 +242,7 @@ function convertKitGutenbergRegisterBlockFormatter( formatter ) {
 							value:      attributes[ fieldName ],
 							help:       field.description,
 							options:    fieldOptions,
-							onChange:   function( newValue ) {
+							onChange:   function ( newValue ) {
 
 								// Hide popover.
 								setShowPopover( false );
@@ -270,7 +270,7 @@ function convertKitGutenbergRegisterBlockFormatter( formatter ) {
 		 * @param   object  props   Block formatter properties.
 		 * @return  object          Block formatter button and modal elements
 		 */
-		const editFormatType = function( props ) {
+		const editFormatType = function ( props ) {
 
 			// Get props.
 			const { contentRef, isActive, value } = props;
@@ -310,7 +310,7 @@ function convertKitGutenbergRegisterBlockFormatter( formatter ) {
 							icon:     getIcon( formatter ),
 							title:    formatter.title,
 							isActive: isActive,
-							onClick:  function() {
+							onClick:  function () {
 								setShowPopover( true );
 							}
 						},
@@ -322,7 +322,7 @@ function convertKitGutenbergRegisterBlockFormatter( formatter ) {
 							key:        'convertkit_' + formatter.name + '_popover',
 							className:  'convertkit-popover',
 							anchor:     anchorRef,
-							onClose:    function() {
+							onClose:    function () {
 								setShowPopover( false );
 							}
 						},

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -29,7 +29,7 @@ if ( typeof wp !== 'undefined' &&
  */
 function convertKitGutenbergRegisterBlock( block ) {
 
-	( function( blocks, editor, element, components ) {
+	( function ( blocks, editor, element, components ) {
 
 		// Define some constants for the various items we'll use.
 		const el                    = element.createElement;
@@ -58,7 +58,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 *
 		 * @return  element|string
 		 */
-		const getIcon = function() {
+		const getIcon = function () {
 
 			// Return a fallback default icon if none is specified for this block.
 			if ( typeof block.gutenberg_icon === 'undefined' ) {
@@ -90,7 +90,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 * @param 	string 	attribute 		Attribute name to store the field's data in.
 		 * @return  array                   Field element
 		 */
-		const getField = function( props, field, attribute ) {
+		const getField = function ( props, field, attribute ) {
 
 			// Define some field properties shared across all field types.
 			let fieldProperties = {
@@ -98,7 +98,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 				label: 		field.label,
 				help: 		field.description,
 				value: 		props.attributes[ attribute ],
-				onChange: 	function( value ) {
+				onChange: 	function ( value ) {
 					if ( field.type === 'number' ) {
 						// If value is a blank string i.e. no attribute value was provided,
 						// cast it to the field's minimum number setting.
@@ -210,7 +210,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 * @param   string  panel 	Panel name.
 		 * @return  array           Panel rows
 		 */
-		const getPanelRows = function( props, panel ) {
+		const getPanelRows = function ( props, panel ) {
 
 			// Build Inspector Control Panel Rows, one for each Field.
 			let rows = [];
@@ -249,7 +249,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 * @param   object  props 	Block formatter properties.
 		 * @return 	array 			Block sidebar panels.
 		 */
-		const getPanels = function( props ) {
+		const getPanels = function ( props ) {
 
 			let panels      = [],
 				initialOpen = true;
@@ -294,7 +294,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 * @param   object  props   Block properties.
 		 * @return  object          Block settings sidebar elements
 		 */
-		const editBlock = function( props ) {
+		const editBlock = function ( props ) {
 
 			// If requesting an example of how this block looks (which is requested
 			// when the user adds a new block and hovers over this block's icon),
@@ -359,7 +359,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 * @param   object  props   Block properties.
 		 * @return  object          Notice.
 		 */
-		const displayNoticeWithLink = function( props ) {
+		const displayNoticeWithLink = function ( props ) {
 
 			// useState to toggle the refresh button's disabled state.
 			const [ buttonDisabled, setButtonDisabled ] = useState( false );
@@ -404,7 +404,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 * @param   object  props   			Block properties.
 		 * @return  object          			Spinner.
 		 */
-		const spinner = function( props ) {
+		const spinner = function ( props ) {
 
 			return el(
 				'span',
@@ -424,7 +424,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 * @param   string 	iconName 	Dashicon Name.
 		 * @return  object 				Dashicon.
 		 */
-		const dashIcon = function( iconName ) {
+		const dashIcon = function ( iconName ) {
 
 			return el(
 				Dashicon,
@@ -444,7 +444,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 * @param 	object 	setButtonDisabled 	Function to enable or disable the refresh button.
 		 * @return  object          			Notice Link.
 		 */
-		const noticeLink = function( props, setButtonDisabled ) {
+		const noticeLink = function ( props, setButtonDisabled ) {
 
 			return el(
 				'a',
@@ -453,7 +453,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 					href: ( ! block.has_api_key ? block.no_api_key.link : block.no_resources.link ),
 					className: ( ! block.has_api_key ? 'convertkit-block-modal' : '' ),
 					target: '_blank',
-					onClick: function( e ) {
+					onClick: function ( e ) {
 
 						// Show popup window with setup wizard if we need to define an API Key.
 						if ( ! block.has_api_key ) {
@@ -480,7 +480,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 * @param 	object 	setButtonDisabled 	Function to enable or disable the refresh button.
 		 * @return 	object 						Button.
 		 */
-		const refreshButton = function( props, buttonDisabled, setButtonDisabled ) {
+		const refreshButton = function ( props, buttonDisabled, setButtonDisabled ) {
 
 			return el(
 				Button,
@@ -490,7 +490,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 					disabled: buttonDisabled,
 					text: 'Refresh',
 					icon: dashIcon( 'update' ),
-					onClick: function() {
+					onClick: function () {
 
 						// Refresh block definitions.
 						refreshBlocksDefinitions( props, setButtonDisabled );
@@ -515,7 +515,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 * @param 	object 	link 				Link that was clicked.
 		 * @param 	object 	setButtonDisabled 	Function to enable or disable the refresh button.
 		 */
-		const showConvertKitPopupWindow = function( props, link, setButtonDisabled ) {
+		const showConvertKitPopupWindow = function ( props, link, setButtonDisabled ) {
 
 			// Define popup width, height and positioning.
 			const 	width  = 640,
@@ -542,7 +542,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 			// the window is closed.
 			// See https://stackoverflow.com/questions/9388380/capture-the-close-event-of-popup-window-in-javascript/48240128#48240128.
 			var convertKitPopupTimer = setInterval(
-				function() {
+				function () {
 					if ( convertKitPopup.closed ) {
 						clearInterval( convertKitPopupTimer );
 
@@ -567,7 +567,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 		 * @param 	object 	setButtonDisabled 	Function to enable or disable the refresh button.
 		 * @return  object          			Notice.
 		 */
-		const refreshBlocksDefinitions = function( props, setButtonDisabled ) {
+		const refreshBlocksDefinitions = function ( props, setButtonDisabled ) {
 
 			// Define data for WordPress AJAX request.
 			let data = new FormData();
@@ -587,7 +587,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 				}
 			)
 			.then(
-				function( response ) {
+				function ( response ) {
 
 					// Convert response JSON string to object.
 					return response.json();
@@ -595,7 +595,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 				}
 			)
 			.then(
-				function( response ) {
+				function ( response ) {
 
 					// Update global ConvertKit Blocks object, so that any updated resources
 					// are reflected when adding new ConvertKit Blocks.
@@ -619,7 +619,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 				}
 			)
 			.catch(
-				function( error ) {
+				function ( error ) {
 
 					// Show an error in the Gutenberg editor.
 					wp.data.dispatch( 'core/notices' ).createErrorNotice(
@@ -658,7 +658,7 @@ function convertKitGutenbergRegisterBlock( block ) {
 				edit: editBlock,
 
 				// Output.
-				save: function( props ) {
+				save: function ( props ) {
 
 					// Deliberate; preview in the editor is determined by the return statement in `edit` above.
 					// On the frontend site, the block's render() PHP class is always called, so we dynamically

--- a/resources/backend/js/modal.js
+++ b/resources/backend/js/modal.js
@@ -8,13 +8,13 @@
  */
 
 jQuery( document ).ready(
-	function( $ ) {
+	function ( $ ) {
 
 		// Cancel.
 		$( 'body' ).on(
 			'click',
 			'#convertkit-modal-body div.mce-cancel button, #convertkit-quicktags-modal .media-toolbar .media-toolbar-secondary button.cancel',
-			function( e ) {
+			function ( e ) {
 
 				// TinyMCE.
 				if ( typeof tinyMCE !== 'undefined' && tinyMCE.activeEditor && ! tinyMCE.activeEditor.isHidden() ) {
@@ -33,7 +33,7 @@ jQuery( document ).ready(
 		$( 'body' ).on(
 			'click',
 			'#convertkit-modal-body div.mce-insert button, #convertkit-quicktags-modal .media-toolbar .media-toolbar-primary button.button-primary',
-			function( e ) {
+			function ( e ) {
 
 				// Prevent default action.
 				e.preventDefault();
@@ -46,7 +46,7 @@ jQuery( document ).ready(
 				shortcodeClose = ( $( 'input[name="close_shortcode"]', $( form ) ).val() === '1' ? true : false );
 
 				$( 'input, select', $( form ) ).each(
-					function( i ) {
+					function ( i ) {
 						// Skip if no data-shortcode attribute.
 						if ( typeof $( this ).data( 'shortcode' ) === 'undefined' ) {
 							return true;
@@ -122,7 +122,7 @@ if ( typeof wp !== 'undefined' && typeof wp.media !== 'undefined' ) {
 	// Declared globally, as used in this file and quicktags.js.
 	var convertKitQuickTagsModal          = new wp.media.view.Modal(
 		{
-			controller: { trigger: function() {} },
+			controller: { trigger: function () {} },
 			className: 'convertkit-quicktags-modal'
 		}
 	);
@@ -142,7 +142,7 @@ if ( typeof wp !== 'undefined' && typeof wp.media !== 'undefined' ) {
 	 */
 	convertKitQuickTagsModal.on(
 		'close',
-		function( e ) {
+		function ( e ) {
 			this.content( new convertKitQuickTagsModalContent() );
 		}
 	);

--- a/resources/backend/js/preview-output.js
+++ b/resources/backend/js/preview-output.js
@@ -11,12 +11,12 @@
  * @since 	1.9.8.5
  */
 jQuery( document ).ready(
-	function( $ ) {
+	function ( $ ) {
 
 		// Appends a <select> field value to a link. Used for previews.
 		$( 'select.convertkit-preview-output-link' ).on(
 			'change',
-			function() {
+			function () {
 
 				var target = $( this ).data( 'target' ),
 				link       = $( this ).data( 'link' ) + $( this ).val();

--- a/resources/backend/js/quick-edit.js
+++ b/resources/backend/js/quick-edit.js
@@ -18,7 +18,7 @@
  * @since 	1.9.8.0
  */
 jQuery( document ).ready(
-	function( $ ) {
+	function ( $ ) {
 
 		// Move Quick Edit fields from footer into the hidden inline-edit table row.
 		$( 'tr#inline-edit .inline-edit-wrapper fieldset.inline-edit-col-left' ).first().append( $( '#convertkit-quick-edit' ) );
@@ -29,7 +29,7 @@ jQuery( document ).ready(
 		var convertKitInlineEditPost = inlineEditPost.edit;
 
 		// Extend WordPress' inline edit function to load the Plugin's Quick Edit fields.
-		inlineEditPost.edit = function( id ) {
+		inlineEditPost.edit = function ( id ) {
 
 			// Merge arguments from original function.
 			convertKitInlineEditPost.apply( this, arguments );
@@ -41,7 +41,7 @@ jQuery( document ).ready(
 
 			// Iterate through any ConvertKit inline data, assigning values to Quick Edit fields.
 			$( '.convertkit', $( '#inline_' + id ) ).each(
-				function() {
+				function () {
 
 					// Assign the setting's value to the setting's Quick Edit field.
 					$( '#convertkit-quick-edit select[name="wp-convertkit[' + $( this ).data( 'setting' ) + ']"]' ).val( $( this ).data( 'value' ) );

--- a/resources/backend/js/quicktags.js
+++ b/resources/backend/js/quicktags.js
@@ -23,12 +23,12 @@ for ( const block in convertkit_quicktags ) {
  */
 function convertKitQuickTagRegister( block ) {
 
-	( function( $ ) {
+	( function ( $ ) {
 
 		QTags.addButton(
 			'convertkit-' + block.name,
 			block.title,
-			function() {
+			function () {
 
 				// Perform an AJAX call to load the modal's view.
 				$.post(
@@ -40,7 +40,7 @@ function convertKitQuickTagRegister( block ) {
 						'shortcode': 	block.name
 
 					},
-					function( response ) {
+					function ( response ) {
 
 						// Show Modal.
 						convertKitQuickTagsModal.open();

--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -11,11 +11,11 @@
  * @since 	1.9.8.0
  */
 jQuery( document ).ready(
-	function( $ ) {
+	function ( $ ) {
 
 		$( 'button.wp-convertkit-refresh-resources' ).on(
 			'click',
-			function( e ) {
+			function ( e ) {
 
 				// Prevent default button behaviour.
 				e.preventDefault();
@@ -63,7 +63,7 @@ jQuery( document ).ready(
 
 							// Remove existing select options.
 							$( 'option', $( field ) ).each(
-								function() {
+								function () {
 									// Skip if data-preserve-on-refresh is specified, as this means we want to keep this specific option.
 									// This will be present on the 'None' and 'Default' options.
 									if ( typeof $( this ).data( 'preserve-on-refresh' ) !== 'undefined' ) {
@@ -77,7 +77,7 @@ jQuery( document ).ready(
 
 							// Populate select options from response data.
 							response.data.forEach(
-								function( item ) {
+								function ( item ) {
 									$( field ).append( new Option( item.name, item.id, false, ( selectedOption == item.id ? true : false ) ) );
 								}
 							);
@@ -127,7 +127,7 @@ function convertKitRefreshResourcesRemoveNotices() {
 	}
 
 	// Classic Editor, WP_List_Table (Bulk/Quick edit) or Edit Term.
-	( function( $ ) {
+	( function ( $ ) {
 
 		$( 'div.convertkit-error' ).remove();
 
@@ -162,7 +162,7 @@ function convertKitRefreshResourcesOutputErrorNotice( message ) {
 	}
 
 	// Classic Editor, WP_List_Table (Bulk/Quick edit) or Edit Term.
-	( function( $ ) {
+	( function ( $ ) {
 
 		var notice = '<div id="message" class="error convertkit-error notice is-dismissible"><p>' + message + '</p></div>';
 

--- a/resources/backend/js/restrict-content.js
+++ b/resources/backend/js/restrict-content.js
@@ -12,15 +12,15 @@
  * @since 	2.1.0
  */
 jQuery( document ).ready(
-	function( $ ) {
+	function ( $ ) {
 
 		$( 'input[name=type]' ).on(
 			'change',
-			function( e ) {
+			function ( e ) {
 
 				// For all type radio buttons, hide elements with a class matching the value.
 				$( 'input[name=type]' ).each(
-					function() {
+					function () {
 						$( 'div.' + $( this ).val() ).hide();
 					}
 				);

--- a/resources/backend/js/select2.js
+++ b/resources/backend/js/select2.js
@@ -14,7 +14,7 @@
  */
 function convertKitSelect2Init() {
 
-	( function( $ ) {
+	( function ( $ ) {
 
 		$( '.convertkit-select2' ).select2();
 
@@ -23,7 +23,7 @@ function convertKitSelect2Init() {
 }
 
 jQuery( document ).ready(
-	function( $ ) {
+	function ( $ ) {
 
 		convertKitSelect2Init();
 

--- a/resources/backend/js/settings-conditional-display.js
+++ b/resources/backend/js/settings-conditional-display.js
@@ -13,12 +13,12 @@
  * @since 	2.2.4
  */
 jQuery( document ).ready(
-	function( $ ) {
+	function ( $ ) {
 
 		// Update settings and refresh UI when a setting is changed.
 		$( 'input[type=checkbox]' ).on(
 			'change',
-			function() {
+			function () {
 
 				convertKitConditionallyDisplaySettings( $( this ).attr( 'id' ), $( this ).prop( 'checked' ) );
 
@@ -39,7 +39,7 @@ jQuery( document ).ready(
  */
 function convertKitConditionallyDisplaySettings( name, display ) {
 
-	( function( $ ) {
+	( function ( $ ) {
 
 		// Show all rows.
 		$( 'table.form-table tr' ).show();
@@ -51,7 +51,7 @@ function convertKitConditionallyDisplaySettings( name, display ) {
 
 		// Iterate through the table rows, hiding any settings.
 		$( 'table.form-table tr' ).each(
-			function() {
+			function () {
 
 				// Skip if this table row is for the setting we've just checked/unchecked.
 				if ( $( '[id="' + name + '"]', $( this ) ).length > 0 ) {

--- a/resources/backend/js/setup-wizard.js
+++ b/resources/backend/js/setup-wizard.js
@@ -12,20 +12,20 @@
  * @since 	1.9.8.4
  */
 jQuery( document ).ready(
-	function( $ ) {
+	function ( $ ) {
 
 		// Redirect parent screen to a given URL after clicking a link that opens
 		// the href URL in a new tab.
 		$( 'a.convertkit-redirect' ).on(
 			'click',
-			function( e ) {
+			function ( e ) {
 
 				var link = this;
 
 				// Delay the redirect, otherwise browsers will block opening the href attribute
 				// thinking it's a popup.
 				setTimeout(
-					function() {
+					function () {
 						// Redirect the parent screen to the link's data-convertkit-redirect-url property.
 						window.location.href = $( link ).data( 'convertkit-redirect-url' );
 					},
@@ -38,7 +38,7 @@ jQuery( document ).ready(
 		// Show a confirmation dialog for specific links.
 		$( 'a.convertkit-confirm' ).on(
 			'click',
-			function( e ) {
+			function ( e ) {
 
 				if ( ! confirm( $( this ).data( 'message' ) ) ) {
 					e.preventDefault();

--- a/resources/backend/js/tabs.js
+++ b/resources/backend/js/tabs.js
@@ -14,14 +14,14 @@
  */
 function convertKitTabsInit() {
 
-	( function( $ ) {
+	( function ( $ ) {
 
 		// Safely call this function by destroying any previously initialized instances.
 		convertKitTabsDestroy();
 
 		// Iterate through all JS tab instances, initializing each one.
 		$( '.convertkit-js-tabs' ).each(
-			function() {
+			function () {
 
 				const nav_tab_container  = $( this ),
 				nav_tab_panels_container = $( nav_tab_container ).data( 'panels-container' ),
@@ -41,7 +41,7 @@ function convertKitTabsInit() {
 				$( nav_tab_container ).on(
 					'click.convertkit_tabs',
 					'a',
-					function( e ) {
+					function ( e ) {
 
 						e.preventDefault();
 
@@ -73,7 +73,7 @@ function convertKitTabsInit() {
  */
 function convertKitTabsUpdate( nav_tab_container, nav_tab_panels_container, nav_tab_panel, nav_tab_active, active_tab ) {
 
-	( function( $ ) {
+	( function ( $ ) {
 
 		// If we don't have an active tab at this point, we don't have any tabs, so bail.
 		if ( typeof active_tab === 'undefined' ) {
@@ -107,11 +107,11 @@ function convertKitTabsUpdate( nav_tab_container, nav_tab_panels_container, nav_
  */
 function convertKitTabsDestroy() {
 
-	( function( $ ) {
+	( function ( $ ) {
 
 		// Iterate through all JS tab instances, destroying each one.
 		$( '.convertkit-js-tabs' ).each(
-			function() {
+			function () {
 
 				$( this ).off( 'click.convertkit_tabs', 'a' );
 

--- a/resources/backend/js/tinymce.js
+++ b/resources/backend/js/tinymce.js
@@ -17,11 +17,11 @@
  */
 function convertKitTinyMCERegisterPlugin( block ) {
 
-	( function( $ ) {
+	( function ( $ ) {
 
 		tinymce.PluginManager.add(
 			'convertkit_' + block.name,
-			function( editor, url ) {
+			function ( editor, url ) {
 
 				// Add Button to Visual Editor Toolbar.
 				editor.addButton(
@@ -36,7 +36,7 @@ function convertKitTinyMCERegisterPlugin( block ) {
 				// Load View when button clicked.
 				editor.addCommand(
 					'convertkit_' + block.name,
-					function() {
+					function () {
 
 						// Close any existing QuickTags modal.
 						convertKitQuickTagsModal.close();
@@ -75,7 +75,7 @@ function convertKitTinyMCERegisterPlugin( block ) {
 								'editor_type':  'tinymce',
 								'shortcode': 	block.name
 							},
-							function( response ) {
+							function ( response ) {
 
 								// Inject HTML into modal.
 								$( '#convertkit-modal-body-body' ).html( response );

--- a/resources/backend/js/wp-list-table-buttons.js
+++ b/resources/backend/js/wp-list-table-buttons.js
@@ -7,11 +7,11 @@
  */
 
 jQuery( document ).ready(
-	function( $ ) {
+	function ( $ ) {
 
 		// Move any buttons from the filter list to display next to the Add New button.
 		$( 'ul.subsubsub a' ).each(
-			function() {
+			function () {
 
 				// Ignore if not a ConvertKit Group Action.
 				if ( ! $( this ).hasClass( 'convertkit-action' ) ) {

--- a/resources/frontend/js/broadcasts.js
+++ b/resources/frontend/js/broadcasts.js
@@ -11,12 +11,12 @@
  * Register events
  */
 jQuery( document ).ready(
-	function( $ ) {
+	function ( $ ) {
 
 		$( document ).on(
 			'click',
 			'ul.convertkit-broadcasts-pagination a',
-			function( e ) {
+			function ( e ) {
 
 				e.preventDefault();
 
@@ -57,7 +57,7 @@ jQuery( document ).ready(
  */
 function convertKitBroadcastsRender( blockContainer, atts ) {
 
-	( function( $ ) {
+	( function ( $ ) {
 
 		// Append action.
 		atts.action = convertkit_broadcasts.action;
@@ -76,7 +76,7 @@ function convertKitBroadcastsRender( blockContainer, atts ) {
 				type:       'POST',
 				async:      true,
 				data:      	atts,
-				success: function( result ) {
+				success: function ( result ) {
 					if ( convertkit_broadcasts.debug ) {
 						console.log( result );
 					}

--- a/resources/frontend/js/convertkit.js
+++ b/resources/frontend/js/convertkit.js
@@ -26,7 +26,7 @@ function convertKitTagSubscriber( subscriber_id, tag, post_id ) {
 		console.log( post_id );
 	}
 
-	( function( $ ) {
+	( function ( $ ) {
 
 		$.ajax(
 			{
@@ -79,7 +79,7 @@ function convertStoreSubscriberIDInCookie( subscriber_id ) {
 		console.log( subscriber_id );
 	}
 
-	( function( $ ) {
+	( function ( $ ) {
 
 		$.ajax(
 			{
@@ -132,7 +132,7 @@ function convertStoreSubscriberEmailAsIDInCookie( emailAddress ) {
 		console.log( emailAddress );
 	}
 
-	( function( $ ) {
+	( function ( $ ) {
 
 		$.ajax(
 			{
@@ -203,7 +203,7 @@ function convertKitSleep( milliseconds ) {
  * Register events
  */
 jQuery( document ).ready(
-	function( $ ) {
+	function ( $ ) {
 
 		if ( convertkit.subscriber_id > 0 && convertkit.tag && convertkit.post_id ) {
 			// If the user can be detected as a ConvertKit Subscriber (i.e. their Subscriber ID is in a cookie or the URL),
@@ -219,7 +219,7 @@ jQuery( document ).ready(
 		$( document ).on(
 			'click',
 			'.formkit-submit',
-			function() {
+			function () {
 				var emailAddress = $( 'input[name="email_address"]' ).val();
 
 				// If the email address is empty, don't attempt to get the subscriber ID by email.

--- a/tests/acceptance/broadcasts/blocks/PageBlockBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/blocks/PageBlockBroadcastsCest.php
@@ -208,7 +208,6 @@ class PageBlockBroadcastsCest
 			false, // Don't check next pagination label.
 			true // Confirm grid mode is set.
 		);
-
 	}
 
 	/**
@@ -292,7 +291,6 @@ class PageBlockBroadcastsCest
 			true, // Confirm grid mode is set.
 			true // Confirm images are displayed.
 		);
-
 	}
 
 	/**
@@ -334,7 +332,6 @@ class PageBlockBroadcastsCest
 			false, // Confirm images are not displayed.
 			true // Confirm description is displayed.
 		);
-
 	}
 
 	/**
@@ -378,7 +375,6 @@ class PageBlockBroadcastsCest
 			false, // Confirm description is not displayed.
 			'Continue reading' // Confirm read more link is displayed with correct text.
 		);
-
 	}
 
 	/**

--- a/tests/acceptance/broadcasts/shortcodes/PageShortcodeBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/shortcodes/PageShortcodeBroadcastsCest.php
@@ -776,7 +776,6 @@ class PageShortcodeBroadcastsCest
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewClassicEditorPage($I);
-
 	}
 
 	/**

--- a/tests/acceptance/restrict-content/RestrictContentFilterCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentFilterCest.php
@@ -17,7 +17,6 @@ class RestrictContentFilterCest
 	{
 		// Activate ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
-
 	}
 
 	/**
@@ -37,7 +36,6 @@ class RestrictContentFilterCest
 
 		// Check no filter is displayed, as the Plugin isn't configured.
 		$I->dontSeeElementInDOM('#wp-convertkit-restrict-content-filter');
-
 	}
 
 	/**

--- a/views/backend/post/meta-box.php
+++ b/views/backend/post/meta-box.php
@@ -49,7 +49,7 @@
 						<?php esc_html_e( 'Any other option will display that form after the main content.', 'convertkit' ); ?>
 						<br />
 						<?php
-						echo sprintf(
+						printf(
 							/* translators: Link to sign in to ConvertKit */
 							esc_html__( 'To make changes to your forms, %s', 'convertkit' ),
 							'<a href="' . esc_url( convertkit_get_sign_in_url() ) . '" target="_blank">' . esc_html__( 'sign in to ConvertKit', 'convertkit' ) . '</a>'
@@ -101,7 +101,7 @@
 							<?php esc_html_e( 'Select a landing page to make it appear in place of this page.', 'convertkit' ); ?>
 							<br />
 							<?php
-							echo sprintf(
+							printf(
 								/* translators: Link to sign in to ConvertKit */
 								esc_html__( 'To make changes to your landing pages, %s', 'convertkit' ),
 								'<a href="' . esc_url( convertkit_get_sign_in_url() ) . '" target="_blank">' . esc_html__( 'sign in to ConvertKit', 'convertkit' ) . '</a>'

--- a/views/backend/post/no-api-key.php
+++ b/views/backend/post/no-api-key.php
@@ -10,7 +10,7 @@
 
 <p>
 	<?php
-	echo sprintf(
+	printf(
 		/* translators: %1$s: Post Type Singular Name, %2$s: Link to Plugin Settings */
 		esc_html__( 'To configure the ConvertKit Form / Landing Page to display on this %1$s, enter your ConvertKit API credentials in the %2$s', 'convertkit' ),
 		esc_attr( $post_type->labels->singular_name ),

--- a/views/backend/setup-wizard/convertkit-restrict-content-setup/content-1.php
+++ b/views/backend/setup-wizard/convertkit-restrict-content-setup/content-1.php
@@ -11,7 +11,7 @@
 <h1><?php esc_html_e( 'Member Content', 'convertkit' ); ?></h1>
 <p>
 	<?php
-	echo sprintf(
+	printf(
 		/* translators: Link to ConvertKit Products */
 		esc_html__( 'This will generate content that visitors can access once they purchase a %s.', 'convertkit' ),
 		sprintf(

--- a/views/backend/setup-wizard/convertkit-restrict-content-setup/content-2.php
+++ b/views/backend/setup-wizard/convertkit-restrict-content-setup/content-2.php
@@ -10,7 +10,7 @@
 
 <h1>
 	<?php
-	echo sprintf(
+	printf(
 		/* translators: Type of content (download, course) */
 		esc_html__( 'Configure %s', 'convertkit' ),
 		esc_html( $this->type_label )

--- a/views/backend/setup-wizard/convertkit-setup/content-2.php
+++ b/views/backend/setup-wizard/convertkit-setup/content-2.php
@@ -31,7 +31,7 @@ if ( ! $this->is_modal() ) {
 	<input type="text" name="api_key" id="api_key" value="<?php echo esc_attr( $this->settings->get_api_key() ); ?>" class="widefat" placeholder="<?php esc_attr_e( 'Click the link below, copy the API Key, and paste it here.', 'convertkit' ); ?>" required />
 	<p class="description">
 		<?php
-		echo sprintf(
+		printf(
 			/* translators: %1$s: Link to ConvertKit Account */
 			esc_html__( '%1$s, and enter it in the above field.', 'convertkit' ),
 			'<a href="' . esc_url( convertkit_get_api_key_url() ) . '" target="_blank">' . esc_html__( 'Click here to get your ConvertKit API Key', 'convertkit' ) . '</a>'
@@ -47,7 +47,7 @@ if ( ! $this->is_modal() ) {
 	<input type="text" name="api_secret" id="api_secret" value="<?php echo esc_attr( $this->settings->get_api_secret() ); ?>" class="widefat" placeholder="<?php esc_attr_e( 'Click the link below, copy the API Secret, and paste it here.', 'convertkit' ); ?>" required />
 	<p class="description">
 		<?php
-		echo sprintf(
+		printf(
 			/* translators: %1$s: Link to ConvertKit Account */
 			esc_html__( '%1$s, and enter it in the above field.', 'convertkit' ),
 			'<a href="' . esc_url( convertkit_get_api_key_url() ) . '" target="_blank">' . esc_html__( 'Click here to get your ConvertKit API Secret', 'convertkit' ) . '</a>'

--- a/views/backend/setup-wizard/convertkit-setup/content-3.php
+++ b/views/backend/setup-wizard/convertkit-setup/content-3.php
@@ -25,7 +25,7 @@ if ( ! $this->forms->exist() ) {
 
 	<p>
 		<?php
-		echo sprintf(
+		printf(
 			'%1$s <a href="https://help.convertkit.com/en/articles/3860348-how-to-create-your-first-form-in-convertkit" target="_blank">%2$s</a>',
 			esc_html__( 'Not sure how to do this in ConvertKit?', 'convertkit' ),
 			esc_html__( 'Follow our step by step documentation', 'convertkit' )
@@ -67,7 +67,7 @@ if ( ! $this->forms->exist() ) {
 		<p class="description">
 			<?php
 			if ( $this->preview_post_url ) {
-				echo sprintf(
+				printf(
 					'%s %s %s',
 					esc_html__( 'Select a form above.', 'convertkit' ),
 					'<a href="' . esc_url( $this->preview_post_url ) . '" id="convertkit-preview-form-post" target="_blank">' . esc_html__( 'Click here', 'convertkit' ) . '</a>',
@@ -102,7 +102,7 @@ if ( ! $this->forms->exist() ) {
 		<p class="description">
 			<?php
 			if ( $this->preview_page_url ) {
-				echo sprintf(
+				printf(
 					'%s %s %s',
 					esc_html__( 'Select a form above.', 'convertkit' ),
 					'<a href="' . esc_url( $this->preview_page_url ) . '" id="convertkit-preview-form-page" target="_blank">' . esc_html__( 'Click here', 'convertkit' ) . '</a>',

--- a/views/backend/setup-wizard/header.php
+++ b/views/backend/setup-wizard/header.php
@@ -69,7 +69,7 @@
 					<div id="convertkit-setup-wizard-content">
 						<div id="convertkit-setup-wizard-step">
 							<?php
-							echo sprintf(
+							printf(
 								/* translators: %1$s: Current Step, %2$s: Total Steps */
 								esc_html__( 'Step %1$s of %2$s', 'convertkit' ),
 								esc_html( $this->step ),

--- a/views/backend/term/fields-add.php
+++ b/views/backend/term/fields-add.php
@@ -35,7 +35,7 @@
 			<?php esc_html_e( ': Display a form based on the Post\'s settings.', 'convertkit' ); ?>
 			<br />
 			<?php
-			echo sprintf(
+			printf(
 				/* translators: Taxonomy Name */
 				esc_html__( 'Any other option will display that form after the main content for Posts assigned to this %s.', 'convertkit' ),
 				'category'

--- a/views/backend/term/fields-edit.php
+++ b/views/backend/term/fields-edit.php
@@ -37,7 +37,7 @@
 				<?php esc_html_e( ': Display a form based on the Post\'s settings.', 'convertkit' ); ?>
 				<br />
 				<?php
-				echo sprintf(
+				printf(
 					/* translators: Taxonomy Name */
 					esc_html__( 'Any other option will display that form after the main content for Posts assigned to this %s.', 'convertkit' ),
 					'category'


### PR DESCRIPTION
## Summary

Applies changes per the upgrade guide [here](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Upgrade-Guide-to-WordPressCS-3.0.0-for-Developers-of-external-standards), to support `3.0.0` of the WordPress Coding Standards rulesets, released August 21st.

This covers:
- Not using reserved keywords `$match` and `$array` in varaibles
- Using `printf` instead of `echo sprintf`
- Spacing for anonymous functions
- Renaming some exclusion rules as they have been renamed in WordPress Coding Standards `3.0.0`

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)