### PR TITLE
Annotate PR with Coding Standard Errors

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -106,6 +106,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           coverage: xdebug
+          tools: cs2pr
 
       # Installs wp-browser, Codeception, PHP CodeSniffer and anything else needed to run tests.
       - name: Run Composer
@@ -118,15 +119,28 @@ jobs:
 
       # Run Coding Standards on Tests.
       - name: Run Coding Standards on Tests
+        id: phpcs-tests
         working-directory: ${{ env.PLUGIN_DIR }}
-        run: php vendor/bin/phpcs ./tests --standard=phpcs.tests.xml -v -s
+        run: php vendor/bin/phpcs ./tests --standard=phpcs.tests.xml --report-full --report-checkstyle=./phpcs-tests-report.xml -v -s
 
       # Run WordPress Coding Standards on Plugin.
       - name: Run WordPress Coding Standards
+        id: phpcs
         working-directory: ${{ env.PLUGIN_DIR }}
-        run: php vendor/bin/phpcs ./ --standard=phpcs.xml -v -s
+        run: php vendor/bin/phpcs ./ --standard=phpcs.xml --report-full --report-checkstyle=./phpcs-report.xml -v -s
 
       # Run PHPStan for static analysis.
       - name: Run PHPStan Static Analysis
+        id: phpstan
         working-directory: ${{ env.PLUGIN_DIR }}
         run: php vendor/bin/phpstan --memory-limit=1024M
+
+      # Show Coding Standards on Tests Errors in PR
+      - name: Show Coding Standards on Tests Errors in PR
+        if: ${{ always() && steps.phpcs-tests.outcome == 'failure' }}
+        run: cs2pr ./phpcs-tests-report.xml
+
+      # Show Coding Standards Errors in PR
+      - name: Show Coding Standards Errors in PR
+        if: ${{ always() && steps.phpcs.outcome == 'failure' }}
+        run: cs2pr ./phpcs-report.xml

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -121,26 +121,16 @@ jobs:
       - name: Run Coding Standards on Tests
         id: phpcs-tests
         working-directory: ${{ env.PLUGIN_DIR }}
-        run: php vendor/bin/phpcs ./tests --standard=phpcs.tests.xml --report-full --report-checkstyle=./phpcs-tests-report.xml -v -s
+        run: php vendor/bin/phpcs -q --standard=phpcs.tests.xml --report=checkstyle ./tests | cs2pr
 
       # Run WordPress Coding Standards on Plugin.
       - name: Run WordPress Coding Standards
         id: phpcs
         working-directory: ${{ env.PLUGIN_DIR }}
-        run: php vendor/bin/phpcs ./ --standard=phpcs.xml --report-full --report-checkstyle=./phpcs-report.xml -v -s
+        run: php vendor/bin/phpcs -q --standard=phpcs.xml --report=checkstyle ./ | cs2pr
 
       # Run PHPStan for static analysis.
       - name: Run PHPStan Static Analysis
         id: phpstan
         working-directory: ${{ env.PLUGIN_DIR }}
         run: php vendor/bin/phpstan --memory-limit=1024M
-
-      # Show Coding Standards on Tests Errors in PR
-      - name: Show Coding Standards on Tests Errors in PR
-        if: ${{ always() && steps.phpcs-tests.outcome == 'failure' }}
-        run: cs2pr ./phpcs-tests-report.xml
-
-      # Show Coding Standards Errors in PR
-      - name: Show Coding Standards Errors in PR
-        if: ${{ always() && steps.phpcs.outcome == 'failure' }}
-        run: cs2pr ./phpcs-report.xml

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -119,18 +119,15 @@ jobs:
 
       # Run Coding Standards on Tests.
       - name: Run Coding Standards on Tests
-        id: phpcs-tests
         working-directory: ${{ env.PLUGIN_DIR }}
         run: php vendor/bin/phpcs -q --standard=phpcs.tests.xml --report=checkstyle ./tests | cs2pr
 
       # Run WordPress Coding Standards on Plugin.
       - name: Run WordPress Coding Standards
-        id: phpcs
         working-directory: ${{ env.PLUGIN_DIR }}
         run: php vendor/bin/phpcs -q --standard=phpcs.xml --report=checkstyle ./ | cs2pr
 
       # Run PHPStan for static analysis.
       - name: Run PHPStan Static Analysis
-        id: phpstan
         working-directory: ${{ env.PLUGIN_DIR }}
-        run: php vendor/bin/phpstan --memory-limit=1024M
+        run: php vendor/bin/phpstan analyse --memory-limit=1024M


### PR DESCRIPTION
## Summary

Annotates code in a PR when coding standards errors are detected by the GitHub action:

![Screenshot 2023-08-22 at 15 36 41](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/b434ec7d-6822-43d6-ab19-31cbba1c969e)

## Testing

[]

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)