### PR TITLE
Broadcasts to Posts: Improve Parsing

### DIFF
--- a/includes/class-convertkit-broadcasts-importer.php
+++ b/includes/class-convertkit-broadcasts-importer.php
@@ -34,12 +34,6 @@ class ConvertKit_Broadcasts_Importer {
 		// Create WordPress Posts when the ConvertKit Posts Resource is refreshed.
 		add_action( 'convertkit_resource_refreshed_posts', array( $this, 'refresh' ) );
 
-		add_action( 'xxx', function() {
-			$resource = new ConvertKit_Resource_Posts();
-			$resource->refresh();
-			die('Done');
-		} );
-
 	}
 
 	/**

--- a/tests/acceptance/broadcasts/import/BroadcastsToPostsCest.php
+++ b/tests/acceptance/broadcasts/import/BroadcastsToPostsCest.php
@@ -108,6 +108,12 @@ class BroadcastsToPostsCest
 		$I->seeElementInDOM('div.ck-inner-section');
 		$I->assertNotNull($I->grabAttributeFrom('div.wp-block-post-content h1', 'style'));
 
+		// Confirm tracking image has been removed.
+		$I->dontSee('<img src="https://preview.convertkit-mail2.com/open" alt="">');
+
+		// Confirm unsubscribe link section has been removed.
+		$I->dontSee('<div class="ck-section ck-hide-in-public-posts"');
+
 		// Confirm published date matches the Broadcast.
 		$date = date('Y-m-d', strtotime($_ENV['CONVERTKIT_API_BROADCAST_FIRST_DATE'])) . 'T' . date('H:i:s', strtotime($_ENV['CONVERTKIT_API_BROADCAST_FIRST_DATE']));
 		$I->seeInSource('<time datetime="' . $date);


### PR DESCRIPTION
## Summary

- Removes the open tracking image from imported Broadcasts
- Remove leading and trailing spaces / newlines
- Improves the regex for removing the unsubscribe / preferences section, to prevent stray closing HTML elements remaining, resulting in incorrect layout when elements follow after the Broadcast (such as a ConvertKit Form embed)

Before:
![Screenshot 2023-09-04 at 13 46 08](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/f4c7fbb8-241b-4b7c-8d15-a4257937c63a)

After:
![Screenshot 2023-09-04 at 13 45 34](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/a1b6e204-ffa4-42cd-845c-bb0c3be85c48)

## Testing

- `testBroadcastsImportWhenEnabled`: Add checks to confirm open tracking and unsubscribe / preferences are removed on imported Broadcasts.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)