### PR TITLE
Remove duplicate `codeception/util-universalframework` entry

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
         "codeception/module-filesystem": "^1.0",                                   
         "codeception/module-cli": "^1.0",                                          
         "codeception/util-universalframework": "^1.0",
-        "codeception/util-universalframework": "^1.0",
         "php-webdriver/webdriver": "<=1.14.0",
         "wp-coding-standards/wpcs": "^3.0.0",
         "phpstan/phpstan": "^1.7",


### PR DESCRIPTION
## Summary

Remove duplicate `codeception/util-universalframework` entry in `composer.json`

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)