### PR TITLE
Broadcasts to Posts: Add test when disabled

### DIFF
--- a/tests/acceptance/broadcasts/import/BroadcastsToPostsCest.php
+++ b/tests/acceptance/broadcasts/import/BroadcastsToPostsCest.php
@@ -57,6 +57,41 @@ class BroadcastsToPostsCest
 	}
 
 	/**
+	 * Tests that Broadcasts do not import when disabled in the Plugin's settings.
+	 *
+	 * @since   2.2.9
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsImportWhenDisabled(AcceptanceTester $I)
+	{
+		// Enable Broadcasts to Posts.
+		$I->setupConvertKitPluginBroadcastsToPosts(
+			$I,
+			[
+				'enabled' => false,
+			]
+		);
+
+		// Run the WordPress Cron event to refresh Broadcasts.
+		$I->runCronEvent($I, $this->cronEventName);
+
+		// Wait a few seconds for the Cron event to complete importing Broadcasts.
+		$I->wait(7);
+
+		// Load the Posts screen.
+		$I->amOnAdminPage('edit.php');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm no Broadcasts exist as Posts.
+		$I->dontSee($_ENV['CONVERTKIT_API_BROADCAST_FIRST_TITLE']);
+		$I->dontSee($_ENV['CONVERTKIT_API_BROADCAST_SECOND_TITLE']);
+		$I->dontSee($_ENV['CONVERTKIT_API_BROADCAST_THIRD_TITLE']);
+	}
+
+	/**
 	 * Tests that Broadcasts import when enabled in the Plugin's settings.
 	 *
 	 * @since   2.2.8


### PR DESCRIPTION
## Summary

Adds a test to confirm Broadcasts are not imported as WordPress Posts when functionality disabled in settings

## Testing

- `BroadcastsToPostsCest:testBroadcastsImportWhenDisabled`: Test that Broadcasts are not imported as WordPress Posts when functionality disabled in settings

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)