### PR TITLE
Forminator Integration

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -30,7 +30,7 @@ jobs:
       DB_USER: root
       DB_PASS: root
       DB_HOST: localhost
-      INSTALL_PLUGINS: "classic-editor contact-form-7 elementor woocommerce wordpress-seo litespeed-cache w3-total-cache" # Don't include this repository's Plugin here.
+      INSTALL_PLUGINS: "classic-editor contact-form-7 elementor forminator woocommerce wordpress-seo litespeed-cache w3-total-cache" # Don't include this repository's Plugin here.
 
     # Defines the WordPress and PHP Versions matrix to run tests on.
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       DB_USER: root
       DB_PASS: root
       DB_HOST: localhost
-      INSTALL_PLUGINS: "contact-form-7 classic-editor disable-welcome-messages-and-tips elementor woocommerce wordpress-seo wpforms-lite litespeed-cache wp-crontrol wp-super-cache w3-total-cache wp-fastest-cache wp-optimize" # Don't include this repository's Plugin here.
+      INSTALL_PLUGINS: "contact-form-7 classic-editor disable-welcome-messages-and-tips elementor forminator woocommerce wordpress-seo wpforms-lite litespeed-cache wp-crontrol wp-super-cache w3-total-cache wp-fastest-cache wp-optimize" # Don't include this repository's Plugin here.
       INSTALL_PLUGINS_URLS: "https://downloads.wordpress.org/plugin/convertkit-for-woocommerce.1.6.4.zip" # URLs to specific third party Plugins
       CONVERTKIT_API_KEY: ${{ secrets.CONVERTKIT_API_KEY }} # ConvertKit API Key, stored in the repository's Settings > Secrets
       CONVERTKIT_API_SECRET: ${{ secrets.CONVERTKIT_API_SECRET }} # ConvertKit API Secret, stored in the repository's Settings > Secrets

--- a/admin/section/class-convertkit-settings-base.php
+++ b/admin/section/class-convertkit-settings-base.php
@@ -47,7 +47,7 @@ abstract class ConvertKit_Settings_Base {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @var     false|ConvertKit_Settings|ConvertKit_ContactForm7_Settings|ConvertKit_Wishlist_Settings|ConvertKit_Settings_Restrict_Content|ConvertKit_Settings_Broadcasts
+	 * @var     false|ConvertKit_Settings|ConvertKit_ContactForm7_Settings|ConvertKit_Wishlist_Settings|ConvertKit_Settings_Restrict_Content|ConvertKit_Settings_Broadcasts|ConvertKit_Forminator_Settings
 	 */
 	public $settings;
 

--- a/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
+++ b/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
@@ -16,8 +16,8 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 
 	/**
 	 * Constructor
-	 * 
-	 * @since 	2.3.0
+	 *
+	 * @since   2.3.0
 	 */
 	public function __construct() {
 
@@ -38,8 +38,8 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 
 	/**
 	 * Register fields for this section
-	 * 
-	 * @since 	2.3.0
+	 *
+	 * @since   2.3.0
 	 */
 	public function register_fields() {
 
@@ -50,8 +50,8 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 
 	/**
 	 * Prints help info for this section.
-	 * 
-	 * @since 	2.3.0
+	 *
+	 * @since   2.3.0
 	 */
 	public function print_section_info() {
 
@@ -97,8 +97,7 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 		do_settings_sections( $this->settings_key );
 
 		// Get Forms.
-		$forms                           = new ConvertKit_Resource_Forms( 'forminator' );
-		$creator_network_recommendations = new ConvertKit_Resource_Creator_Network_Recommendations( 'forminator' );
+		$forms = new ConvertKit_Resource_Forms( 'forminator' );
 
 		// Bail with an error if no ConvertKit Forms exist.
 		if ( ! $forms->exist() ) {
@@ -115,9 +114,6 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 			$options[ esc_attr( $form['id'] ) ] = esc_html( $form['name'] );
 		}
 
-		// Get Creator Network Recommendations script.
-		$creator_network_recommendations_enabled = $creator_network_recommendations->enabled();
-
 		// Get Forminator Forms.
 		$forminator_forms = $this->get_forminator_forms();
 
@@ -132,7 +128,6 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 		$table = new Multi_Value_Field_Table();
 		$table->add_column( 'title', __( 'Forminator Form', 'convertkit' ), true );
 		$table->add_column( 'form', __( 'ConvertKit Form', 'convertkit' ), false );
-		$table->add_column( 'creator_network_recommendations', __( 'Enable Creator Network Recommendations', 'convertkit' ), false );
 
 		// Iterate through Forminator Forms, adding a table row for each Forminator Form.
 		foreach ( $forminator_forms as $forminator_form ) {
@@ -144,27 +139,7 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 					(string) $this->settings->get_convertkit_form_id_by_forminator_form_id( $forminator_form['id'] ),
 					$options
 				),
-				'email' => 'your-email',
-				'name'  => 'your-name',
 			);
-
-			// Add Creator Network Recommendations table column.
-			if ( $creator_network_recommendations_enabled ) {
-				// Show checkbox to enable Creator Network Recommendations for this Forminator Form.
-				$table_row['creator_network_recommendations'] = $this->get_checkbox_field(
-					'creator_network_recommendations_' . $forminator_form['id'],
-					'1',
-					$this->settings->get_creator_network_recommendations_enabled_by_forminator_form_id( $forminator_form['id'] )
-				);
-			} else {
-				// Show a link to the ConvertKit billing page, as a paid plan is required for Creator Network Recommendations.
-				$table_row['creator_network_recommendations'] = sprintf(
-					'%s <a href="%s" target="_blank">%s</a>',
-					esc_html__( 'Creator Network Recommendations requires a', 'convertkit' ),
-					convertkit_get_billing_url(),
-					esc_html__( 'paid ConvertKit Plan', 'convertkit' )
-				);
-			}
 
 			// Add row to table of settings.
 			$table->add_item( $table_row );
@@ -187,10 +162,10 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 
 	/**
 	 * Gets available forms from Forminator
-	 * 
-	 * @since 	2.3.0
-	 * 
-	 * @return 	bool|array
+	 *
+	 * @since   2.3.0
+	 *
+	 * @return  bool|array
 	 */
 	private function get_forminator_forms() {
 

--- a/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
+++ b/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * ConvertKit Forminator Admin Settings class.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Registers Forminator Settings that can be edited at Settings > ConvertKit > Forminator.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
+
+	/**
+	 * Constructor
+	 * 
+	 * @since 	2.3.0
+	 */
+	public function __construct() {
+
+		// Define the class that reads/writes settings.
+		$this->settings = new ConvertKit_Forminator_Settings();
+
+		// Define the settings key.
+		$this->settings_key = $this->settings::SETTINGS_NAME;
+
+		// Define the programmatic name, Title and Tab Text.
+		$this->name     = 'forminator';
+		$this->title    = __( 'Forminator Integration Settings', 'convertkit' );
+		$this->tab_text = __( 'Forminator', 'convertkit' );
+
+		parent::__construct();
+
+	}
+
+	/**
+	 * Register fields for this section
+	 * 
+	 * @since 	2.3.0
+	 */
+	public function register_fields() {
+
+		// No fields are registered, because they are output in a WP_List_Table
+		// in this class' render() function.
+		// This function is deliberately blank.
+	}
+
+	/**
+	 * Prints help info for this section.
+	 * 
+	 * @since 	2.3.0
+	 */
+	public function print_section_info() {
+
+		?>
+		<p>
+			<?php
+			esc_html_e( 'ConvertKit seamlessly integrates with Forminator to let you add subscribers using Forminator forms.', 'convertkit' );
+			?>
+		</p>
+		<p>
+			<?php
+			esc_html_e( 'The Forminator form must have Name and Email fields. These fields will be sent to ConvertKit for the subscription', 'convertkit' );
+			?>
+		</p>
+		<?php
+
+	}
+
+	/**
+	 * Returns the URL for the ConvertKit documentation for this setting section.
+	 *
+	 * @since   2.3.0
+	 *
+	 * @return  string  Documentation URL.
+	 */
+	public function documentation_url() {
+
+		return 'https://help.convertkit.com/en/articles/2502591-the-convertkit-wordpress-plugin';
+
+	}
+
+	/**
+	 * Outputs the section as a WP_List_Table of Forminator Forms, with options to choose
+	 * a ConvertKit Form mapping for each.
+	 *
+	 * @since   2.3.0
+	 */
+	public function render() {
+
+		// Render opening container.
+		$this->render_container_start();
+
+		do_settings_sections( $this->settings_key );
+
+		// Get Forms.
+		$forms                           = new ConvertKit_Resource_Forms( 'forminator' );
+		$creator_network_recommendations = new ConvertKit_Resource_Creator_Network_Recommendations( 'forminator' );
+
+		// Bail with an error if no ConvertKit Forms exist.
+		if ( ! $forms->exist() ) {
+			$this->output_error( __( 'No Forms exist on ConvertKit.', 'convertkit' ) );
+			$this->render_container_end();
+			return;
+		}
+
+		// Build array of select options.
+		$options = array(
+			'default' => __( 'None', 'convertkit' ),
+		);
+		foreach ( $forms->get() as $form ) {
+			$options[ esc_attr( $form['id'] ) ] = esc_html( $form['name'] );
+		}
+
+		// Get Creator Network Recommendations script.
+		$creator_network_recommendations_enabled = $creator_network_recommendations->enabled();
+
+		// Get Forminator Forms.
+		$forminator_forms = $this->get_forminator_forms();
+
+		// Bail with an error if no Forminator Forms exist.
+		if ( ! $forminator_forms ) {
+			$this->output_error( __( 'No Forminator Forms exist in the Forminator Plugin.', 'convertkit' ) );
+			$this->render_container_end();
+			return;
+		}
+
+		// Setup WP_List_Table.
+		$table = new Multi_Value_Field_Table();
+		$table->add_column( 'title', __( 'Forminator Form', 'convertkit' ), true );
+		$table->add_column( 'form', __( 'ConvertKit Form', 'convertkit' ), false );
+		$table->add_column( 'creator_network_recommendations', __( 'Enable Creator Network Recommendations', 'convertkit' ), false );
+
+		// Iterate through Forminator Forms, adding a table row for each Forminator Form.
+		foreach ( $forminator_forms as $forminator_form ) {
+			// Build row.
+			$table_row = array(
+				'title' => $forminator_form['name'],
+				'form'  => $this->get_select_field(
+					$forminator_form['id'],
+					(string) $this->settings->get_convertkit_form_id_by_forminator_form_id( $forminator_form['id'] ),
+					$options
+				),
+				'email' => 'your-email',
+				'name'  => 'your-name',
+			);
+
+			// Add Creator Network Recommendations table column.
+			if ( $creator_network_recommendations_enabled ) {
+				// Show checkbox to enable Creator Network Recommendations for this Forminator Form.
+				$table_row['creator_network_recommendations'] = $this->get_checkbox_field(
+					'creator_network_recommendations_' . $forminator_form['id'],
+					'1',
+					$this->settings->get_creator_network_recommendations_enabled_by_forminator_form_id( $forminator_form['id'] )
+				);
+			} else {
+				// Show a link to the ConvertKit billing page, as a paid plan is required for Creator Network Recommendations.
+				$table_row['creator_network_recommendations'] = sprintf(
+					'%s <a href="%s" target="_blank">%s</a>',
+					esc_html__( 'Creator Network Recommendations requires a', 'convertkit' ),
+					convertkit_get_billing_url(),
+					esc_html__( 'paid ConvertKit Plan', 'convertkit' )
+				);
+			}
+
+			// Add row to table of settings.
+			$table->add_item( $table_row );
+		}
+
+		// Prepare and display WP_List_Table.
+		$table->prepare_items();
+		$table->display();
+
+		// Register settings field.
+		settings_fields( $this->settings_key );
+
+		// Render submit button.
+		submit_button();
+
+		// Render closing container.
+		$this->render_container_end();
+
+	}
+
+	/**
+	 * Gets available forms from Forminator
+	 * 
+	 * @since 	2.3.0
+	 * 
+	 * @return 	bool|array
+	 */
+	private function get_forminator_forms() {
+
+		$forms = array();
+
+		// Get forms using Forminator API class.
+		$results = Forminator_API::get_forms( null, 1, 100 );
+
+		// Bail if no results.
+		if ( ! count( $results ) ) {
+			return false;
+		}
+
+		foreach ( $results as $forminator_form ) {
+			$forms[] = array(
+				'id'   => $forminator_form->id,
+				'name' => $forminator_form->name,
+			);
+		}
+
+		return $forms;
+
+	}
+
+}
+
+// Register Admin Settings section.
+add_filter(
+	'convertkit_admin_settings_register_sections',
+	/**
+	 * Register Forminator as a settings section at Settings > ConvertKit.
+	 *
+	 * @param   array   $sections   Settings Sections.
+	 * @return  array
+	 */
+	function ( $sections ) {
+
+		// Bail if Forminator isn't enabled.
+		if ( ! defined( 'FORMINATOR_VERSION' ) ) {
+			return $sections;
+		}
+
+		// Register this class as a section at Settings > ConvertKit.
+		$sections['forminator'] = new ConvertKit_Forminator_Admin_Settings();
+		return $sections;
+
+	}
+);

--- a/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
+++ b/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
@@ -171,8 +171,8 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 
 		$forms = array();
 
-		// Get forms using Forminator API class.
-		$results = Forminator_API::get_forms( null, 1, 100 );
+		// Get all forms using Forminator API class.
+		$results = Forminator_API::get_forms( null, 1, -1 );
 
 		// Bail if no results.
 		if ( ! count( $results ) ) {

--- a/includes/integrations/forminator/class-convertkit-forminator-settings.php
+++ b/includes/integrations/forminator/class-convertkit-forminator-settings.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * ConvertKit Forminator Settings class.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Class to read ConvertKit Forminator Integration Settings.
+ *
+ * @since   2.3.0
+ */
+class ConvertKit_Forminator_Settings {
+
+	/**
+	 * Holds the Settings Key that stores this integration's settings.
+	 *
+	 * @var     string
+	 * 
+	 * @since 	2.3.0
+	 */
+	const SETTINGS_NAME = '_wp_convertkit_integration_forminator_settings';
+
+	/**
+	 * Holds the Settings
+	 *
+	 * @var     array
+	 * 
+	 * @since 	2.3.0
+	 */
+	private $settings = array();
+
+	/**
+	 * Constructor. Reads settings from options table, falling back to defaults
+	 * if no settings exist.
+	 *
+	 * @since   2.3.0
+	 */
+	public function __construct() {
+
+		// Get Settings.
+		$settings = get_option( self::SETTINGS_NAME );
+
+		// If no Settings exist, falback to default settings.
+		if ( ! $settings ) {
+			$this->settings = $this->get_defaults();
+		} else {
+			$this->settings = $settings;
+		}
+
+	}
+
+	/**
+	 * Returns Integration settings.
+	 *
+	 * @since   2.3.0
+	 *
+	 * @return  array
+	 */
+	public function get() {
+
+		return $this->settings;
+
+	}
+
+	/**
+	 * Checks if any settings are defined.
+	 *
+	 * @since   2.3.0
+	 *
+	 * @return  bool
+	 */
+	public function has_settings() {
+
+		if ( empty( $this->get() ) ) {
+			return false;
+		}
+
+		return true;
+
+	}
+
+	/**
+	 * Returns the ConvertKit Form ID that is mapped against the given Forminator Form ID.
+	 *
+	 * @since   2.3.0
+	 *
+	 * @param   int $forminator_form_id    Forminator Form ID.
+	 * @return  bool|int
+	 */
+	public function get_convertkit_form_id_by_forminator_form_id( $forminator_form_id ) {
+
+		// Bail if no settings exist.
+		if ( ! $this->has_settings() ) {
+			return false;
+		}
+
+		// Bail if no mapping exists.
+		if ( ! array_key_exists( $forminator_form_id, $this->get() ) ) {
+			return false;
+		}
+
+		return $this->get()[ $forminator_form_id ];
+
+	}
+
+	/**
+	 * Returns whether Creator Network Recommendations are enabled for the given Forminator Form ID.
+	 *
+	 * @since   2.3.0
+	 *
+	 * @param   int $forminator_form_id    Forminator Form ID.
+	 * @return  bool
+	 */
+	public function get_creator_network_recommendations_enabled_by_forminator_form_id( $forminator_form_id ) {
+
+		// Bail if no settings exist for any Forminator Forms.
+		if ( ! $this->has_settings() ) {
+			return false;
+		}
+
+		// Bail if no setting exists for the given Forminator Form.
+		if ( ! array_key_exists( 'creator_network_recommendations_' . $forminator_form_id, $this->get() ) ) {
+			return false;
+		}
+
+		return (bool) $this->get()[ 'creator_network_recommendations_' . $forminator_form_id ];
+
+	}
+
+	/**
+	 * The default settings, used when this integration's Settings haven't been saved
+	 * e.g. on a new installation or when the integration's Plugin has just been activated
+	 * for the first time.
+	 *
+	 * @since   2.3.0
+	 *
+	 * @return  array
+	 */
+	public function get_defaults() {
+
+		$defaults = array();
+
+		/**
+		 * The default settings, used when Forminator's Settings haven't been saved
+		 * e.g. on a new installation or when the Forminator Plugin has just been activated
+		 * for the first time.
+		 *
+		 * @since   2.3.0
+		 *
+		 * @param   array   $defaults   Default Settings.
+		 */
+		$defaults = apply_filters( 'convertkit_forminator_settings_get_defaults', $defaults );
+
+		return $defaults;
+
+	}
+
+}

--- a/includes/integrations/forminator/class-convertkit-forminator-settings.php
+++ b/includes/integrations/forminator/class-convertkit-forminator-settings.php
@@ -17,8 +17,8 @@ class ConvertKit_Forminator_Settings {
 	 * Holds the Settings Key that stores this integration's settings.
 	 *
 	 * @var     string
-	 * 
-	 * @since 	2.3.0
+	 *
+	 * @since   2.3.0
 	 */
 	const SETTINGS_NAME = '_wp_convertkit_integration_forminator_settings';
 
@@ -26,8 +26,8 @@ class ConvertKit_Forminator_Settings {
 	 * Holds the Settings
 	 *
 	 * @var     array
-	 * 
-	 * @since 	2.3.0
+	 *
+	 * @since   2.3.0
 	 */
 	private $settings = array();
 
@@ -102,30 +102,6 @@ class ConvertKit_Forminator_Settings {
 		}
 
 		return $this->get()[ $forminator_form_id ];
-
-	}
-
-	/**
-	 * Returns whether Creator Network Recommendations are enabled for the given Forminator Form ID.
-	 *
-	 * @since   2.3.0
-	 *
-	 * @param   int $forminator_form_id    Forminator Form ID.
-	 * @return  bool
-	 */
-	public function get_creator_network_recommendations_enabled_by_forminator_form_id( $forminator_form_id ) {
-
-		// Bail if no settings exist for any Forminator Forms.
-		if ( ! $this->has_settings() ) {
-			return false;
-		}
-
-		// Bail if no setting exists for the given Forminator Form.
-		if ( ! array_key_exists( 'creator_network_recommendations_' . $forminator_form_id, $this->get() ) ) {
-			return false;
-		}
-
-		return (bool) $this->get()[ 'creator_network_recommendations_' . $forminator_form_id ];
 
 	}
 

--- a/includes/integrations/forminator/class-convertkit-forminator.php
+++ b/includes/integrations/forminator/class-convertkit-forminator.php
@@ -21,47 +21,7 @@ class ConvertKit_Forminator {
 	 */
 	public function __construct() {
 
-		//add_action( 'wpcf7_contact_form', array( $this, 'maybe_enqueue_creator_network_recommendations_script' ) );
 		add_action( 'forminator_custom_form_submit_before_set_fields', array( $this, 'maybe_subscribe' ), 10, 3 );
-
-
-	}
-
-	/**
-	 * Enqueues the Creator Network Recommendations script, if the Forminator Form
-	 * has the 'Enable Creator Network Recommendations' setting enabled at Settings >
-	 * ConvertKit > Forminator.
-	 *
-	 * @since   2.3.0
-	 *
-	 * @param   WPCF7_ContactForm $contact_form   Forminator Form.
-	 */
-	public function maybe_enqueue_creator_network_recommendations_script( $contact_form ) {
-
-		// Don't enqueue if this is a WordPress Admin screen request.
-		if ( is_admin() ) {
-			return;
-		}
-
-		// Initialize classes.
-		$creator_network_recommendations = new ConvertKit_Resource_Creator_Network_Recommendations( 'contact_form_7' );
-		$forminator_settings         = new ConvertKit_Forminator_Settings();
-
-		// Bail if Creator Network Recommendations are not enabled for this form.
-		if ( ! $forminator_settings->get_creator_network_recommendations_enabled_by_forminator_form_id( $contact_form->id() ) ) {
-			return;
-		}
-
-		// Get script.
-		$script_url = $creator_network_recommendations->get();
-
-		// Bail if no script exists (i.e. the Creator Network Recommendations is not enabled on the ConvertKit account).
-		if ( ! $script_url ) {
-			return;
-		}
-
-		// Enqueue script.
-		wp_enqueue_script( 'convertkit-creator-network-recommendations', $script_url, array(), CONVERTKIT_PLUGIN_VERSION, true );
 
 	}
 
@@ -72,13 +32,15 @@ class ConvertKit_Forminator {
 	 *
 	 * @since   2.3.0
 	 *
-	 * @param   int 	$form_id 	Forminator Form ID.
+	 * @param   array $entry              Entry.
+	 * @param   int   $form_id            Forminator Form ID.
+	 * @param   array $form_data_array    Forminator submitted data.
 	 */
 	public function maybe_subscribe( $entry, $form_id, $form_data_array ) {
 
 		// Get ConvertKit Form ID mapped to this Forminator Form.
 		$forminator_settings = new ConvertKit_Forminator_Settings();
-		$convertkit_form_id      = $forminator_settings->get_convertkit_form_id_by_forminator_form_id( $form_id );
+		$convertkit_form_id  = $forminator_settings->get_convertkit_form_id_by_forminator_form_id( $form_id );
 
 		// If no ConvertKit Form is mapped to this Forminator Form, bail.
 		if ( ! $convertkit_form_id ) {
@@ -93,7 +55,7 @@ class ConvertKit_Forminator {
 
 		// Extract the name and email field values.
 		$first_name = false;
-		$email = false;
+		$email      = false;
 		foreach ( $form_data_array as $form_field ) {
 			// Skip field if it doesn't have a type - it's likely an IP address value.
 			if ( ! array_key_exists( 'field_type', $form_field ) ) {
@@ -120,7 +82,7 @@ class ConvertKit_Forminator {
 
 		// If here, subscribe the user to the ConvertKit Form.
 		// Initialize the API.
-		$api = new ConvertKit_API( $settings->get_api_key(), $settings->get_api_secret(), $settings->debug_enabled(), 'contact_form_7' );
+		$api = new ConvertKit_API( $settings->get_api_key(), $settings->get_api_secret(), $settings->debug_enabled(), 'forminator' );
 
 		// Send request.
 		$api->form_subscribe( $convertkit_form_id, $email, $first_name );

--- a/includes/integrations/forminator/class-convertkit-forminator.php
+++ b/includes/integrations/forminator/class-convertkit-forminator.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * ConvertKit Forminator class.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Forminator Integration
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+class ConvertKit_Forminator {
+
+	/**
+	 * Constructor. Registers required hooks with Forminator.
+	 *
+	 * @since   2.3.0
+	 */
+	public function __construct() {
+
+		//add_action( 'wpcf7_contact_form', array( $this, 'maybe_enqueue_creator_network_recommendations_script' ) );
+		add_action( 'forminator_custom_form_submit_before_set_fields', array( $this, 'maybe_subscribe' ), 10, 3 );
+
+
+	}
+
+	/**
+	 * Enqueues the Creator Network Recommendations script, if the Forminator Form
+	 * has the 'Enable Creator Network Recommendations' setting enabled at Settings >
+	 * ConvertKit > Forminator.
+	 *
+	 * @since   2.3.0
+	 *
+	 * @param   WPCF7_ContactForm $contact_form   Forminator Form.
+	 */
+	public function maybe_enqueue_creator_network_recommendations_script( $contact_form ) {
+
+		// Don't enqueue if this is a WordPress Admin screen request.
+		if ( is_admin() ) {
+			return;
+		}
+
+		// Initialize classes.
+		$creator_network_recommendations = new ConvertKit_Resource_Creator_Network_Recommendations( 'contact_form_7' );
+		$forminator_settings         = new ConvertKit_Forminator_Settings();
+
+		// Bail if Creator Network Recommendations are not enabled for this form.
+		if ( ! $forminator_settings->get_creator_network_recommendations_enabled_by_forminator_form_id( $contact_form->id() ) ) {
+			return;
+		}
+
+		// Get script.
+		$script_url = $creator_network_recommendations->get();
+
+		// Bail if no script exists (i.e. the Creator Network Recommendations is not enabled on the ConvertKit account).
+		if ( ! $script_url ) {
+			return;
+		}
+
+		// Enqueue script.
+		wp_enqueue_script( 'convertkit-creator-network-recommendations', $script_url, array(), CONVERTKIT_PLUGIN_VERSION, true );
+
+	}
+
+	/**
+	 * Sends a Forminator's Form Name and Email values through the ConvertKit API
+	 * if a ConvertKit Form is mapped to this Forminator Form in the ConvertKit
+	 * Settings.
+	 *
+	 * @since   2.3.0
+	 *
+	 * @param   int 	$form_id 	Forminator Form ID.
+	 */
+	public function maybe_subscribe( $entry, $form_id, $form_data_array ) {
+
+		// Get ConvertKit Form ID mapped to this Forminator Form.
+		$forminator_settings = new ConvertKit_Forminator_Settings();
+		$convertkit_form_id      = $forminator_settings->get_convertkit_form_id_by_forminator_form_id( $form_id );
+
+		// If no ConvertKit Form is mapped to this Forminator Form, bail.
+		if ( ! $convertkit_form_id ) {
+			return;
+		}
+
+		// Bail if the API hasn't been configured.
+		$settings = new ConvertKit_Settings();
+		if ( ! $settings->has_api_key_and_secret() ) {
+			return;
+		}
+
+		// Extract the name and email field values.
+		$first_name = false;
+		$email = false;
+		foreach ( $form_data_array as $form_field ) {
+			// Skip field if it doesn't have a type - it's likely an IP address value.
+			if ( ! array_key_exists( 'field_type', $form_field ) ) {
+				continue;
+			}
+
+			// Extract the name / email address, depending on the field type.
+			switch ( $form_field['field_type'] ) {
+				case 'name':
+					$name       = explode( ' ', $form_field['value'] );
+					$first_name = $name[0];
+					break;
+
+				case 'email':
+					$email = $form_field['value'];
+					break;
+			}
+		}
+
+		// Bail if no email address could be found.
+		if ( ! $email ) {
+			return;
+		}
+
+		// If here, subscribe the user to the ConvertKit Form.
+		// Initialize the API.
+		$api = new ConvertKit_API( $settings->get_api_key(), $settings->get_api_secret(), $settings->debug_enabled(), 'contact_form_7' );
+
+		// Send request.
+		$api->form_subscribe( $convertkit_form_id, $email, $first_name );
+
+	}
+
+}
+
+// Bootstrap.
+add_action(
+	'convertkit_initialize_global',
+	function () {
+
+		new ConvertKit_Forminator();
+
+	}
+);

--- a/tests/acceptance/integrations/other/ForminatorCest.php
+++ b/tests/acceptance/integrations/other/ForminatorCest.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Tests for ConvertKit Forms integration with Forminator.
+ *
+ * @since   2.3.0
+ */
+class ForminatorCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   2.3.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'forminator');
+	}
+
+	/**
+	 * Tests that no Forminator settings display and a 'No Forms exist on ConvertKit'
+	 * notification displays when no API Key and Secret are defined in the Plugin's settings.
+	 *
+	 * @since   2.3.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSettingsForminatorWhenNoAPIKeyAndSecret(AcceptanceTester $I)
+	{
+		// Load Forminator Plugin Settings.
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=forminator');
+
+		// Confirm notice is displayed.
+		$I->see('No Forms exist on ConvertKit.');
+
+		// Confirm no settings table is displayed.
+		$I->dontSeeElementInDOM('table.wp-list-table');
+	}
+
+	/**
+	 * Tests that no Forminator settings display and a 'No Forms exist on ConvertKit'
+	 * notification displays when no Forms exist.
+	 *
+	 * @since   2.3.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSettingsForminatorWhenNoForms(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA'], '', '', '');
+		$I->setupConvertKitPluginResourcesNoData($I);
+
+		// Load Forminator Plugin Settings.
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=forminator');
+
+		// Confirm notice is displayed.
+		$I->see('No Forms exist on ConvertKit.');
+
+		// Confirm no settings table is displayed.
+		$I->dontSeeElementInDOM('table.wp-list-table');
+	}
+
+	/**
+	 * Test that saving a Forminator to ConvertKit Form Mapping works.
+	 *
+	 * @since   2.3.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSettingsForminatorToConvertKitFormMapping(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Create Forminator Form.
+		$forminatorFormID = $this->_createForminatorForm($I);
+
+		// Load Forminator Plugin Settings.
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=forminator');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check that a Form Mapping option is displayed.
+		$I->seeElementInDOM('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID);
+
+		// Change Form to value specified in the .env file.
+		$I->selectOption('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID, $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME']);
+
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check the value of the Form field matches the input provided.
+		$I->seeOptionIsSelected('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID, $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME']);
+
+		// Create Page with Forminator Shortcode.
+		$I->havePageInDatabase(
+			[
+				'post_title'   => 'ConvertKit: Forminator Shortcode',
+				'post_name'    => 'convertkit-forminator-form-shortcode',
+				'post_content' => 'Form:
+[forminator_form id="' . $forminatorFormID . '"]',
+			]
+		);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/convertkit-forminator-form-shortcode');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Complete Name and Email.
+		$I->fillField('input[name=name-1]', 'ConvertKit Name');
+		$I->fillField('input[name=email-1]', $emailAddress);
+
+		// Submit Form.
+		$I->click('button.forminator-button-submit');
+
+		// Wait for response message.
+		$I->waitForElementVisible('.forminator-response-message');
+
+		// Confirm the form submitted without errors.
+		$I->performOn(
+			'.forminator-response-message',
+			function($I) {
+				$I->see('Form entry saved');
+			}
+		);
+
+		// Confirm that the email address was added to ConvertKit.
+		$I->apiCheckSubscriberExists($I, $emailAddress);
+	}
+
+	/**
+	 * Creates a Forminator Form
+	 *
+	 * @since   2.3.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 * @return  int                     Form ID
+	 */
+	private function _createForminatorForm(AcceptanceTester $I)
+	{
+		return $I->havePostInDatabase(
+			[
+				'post_name'   => 'forminator-form',
+				'post_title'  => 'Forminator Form',
+				'post_type'   => 'forminator_forms',
+				'post_status' => 'publish',
+				'meta_input'  => [
+					'forminator_form_meta' => [
+						'fields' => [
+							[
+								'id'          => 'name-1',
+								'element_id'  => 'name-1',
+								'type'        => 'name',
+								'field_label' => 'Name',
+							],
+							[
+								'id'          => 'email-1',
+								'element_id'  => 'email-1',
+								'type'        => 'email',
+								'field_label' => 'email',
+							],
+						],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   2.3.0.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->deactivateThirdPartyPlugin($I, 'forminator');
+		$I->resetConvertKitPlugin($I);
+	}
+}

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -87,6 +87,10 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/contactform7/class
 // Elementor Integration.
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/elementor/class-convertkit-elementor.php';
 
+// Forminator Integration.
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/forminator/class-convertkit-forminator.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/forminator/class-convertkit-forminator-settings.php';
+
 // WishList Member Integration.
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/wishlist/class-convertkit-wishlist.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/wishlist/class-convertkit-wishlist-settings.php';
@@ -115,6 +119,9 @@ if ( is_admin() ) {
 
 	// Contact Form 7 Integration.
 	require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php';
+
+	// Forminator Integration.
+	require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php';
 
 	// WishList Member Integration.
 	require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php';


### PR DESCRIPTION
## Summary

Similar to the Contact Form 7 integration, adds options to subscribe entries to a specified ConvertKit Form when a Forminator Form is submitted.

![Screenshot 2023-09-08 at 12 59 00](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/e989c5d7-b0f9-4314-a7c5-3b4fa94bc548)

## Testing

- `ForminatorCest:testSettingsForminatorWhenNoAPIKeyAndSecret`: Test that no Forminator settings are displayed when no API Key and Secret are defined.
- `ForminatorCest:testSettingsForminatorWhenNoForms`: Test that no Forminator settings are displayed when an API Key and Secret are defined, but the ConvertKit account has no forms
- `ForminatorCest:testSettingsForminatorToConvertKitFormMapping`: Test that the email address and name are subscribed to the selected ConvertKit Form when a Forminator Form mapping is defined and the form submitted

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)