### PR TITLE
Forminator: Add Creator Network Recommendations

### DIFF
--- a/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
+++ b/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
@@ -97,7 +97,8 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 		do_settings_sections( $this->settings_key );
 
 		// Get Forms.
-		$forms = new ConvertKit_Resource_Forms( 'forminator' );
+		$forms                           = new ConvertKit_Resource_Forms( 'forminator' );
+		$creator_network_recommendations = new ConvertKit_Resource_Creator_Network_Recommendations( 'forminator' );
 
 		// Bail with an error if no ConvertKit Forms exist.
 		if ( ! $forms->exist() ) {
@@ -114,6 +115,9 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 			$options[ esc_attr( $form['id'] ) ] = esc_html( $form['name'] );
 		}
 
+		// Get Creator Network Recommendations script.
+		$creator_network_recommendations_enabled = $creator_network_recommendations->enabled();
+
 		// Get Forminator Forms.
 		$forminator_forms = $this->get_forminator_forms();
 
@@ -128,6 +132,7 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 		$table = new Multi_Value_Field_Table();
 		$table->add_column( 'title', __( 'Forminator Form', 'convertkit' ), true );
 		$table->add_column( 'form', __( 'ConvertKit Form', 'convertkit' ), false );
+		$table->add_column( 'creator_network_recommendations', __( 'Enable Creator Network Recommendations', 'convertkit' ), false );
 
 		// Iterate through Forminator Forms, adding a table row for each Forminator Form.
 		foreach ( $forminator_forms as $forminator_form ) {
@@ -140,6 +145,24 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 					$options
 				),
 			);
+
+			// Add Creator Network Recommendations table column.
+			if ( $creator_network_recommendations_enabled ) {
+				// Show checkbox to enable Creator Network Recommendations for this Contact Form 7 Form.
+				$table_row['creator_network_recommendations'] = $this->get_checkbox_field(
+					'creator_network_recommendations_' . $forminator_form['id'],
+					'1',
+					$this->settings->get_creator_network_recommendations_enabled_by_forminator_form_id( $forminator_form['id'] )
+				);
+			} else {
+				// Show a link to the ConvertKit billing page, as a paid plan is required for Creator Network Recommendations.
+				$table_row['creator_network_recommendations'] = sprintf(
+					'%s <a href="%s" target="_blank">%s</a>',
+					esc_html__( 'Creator Network Recommendations requires a', 'convertkit' ),
+					convertkit_get_billing_url(),
+					esc_html__( 'paid ConvertKit Plan', 'convertkit' )
+				);
+			}
 
 			// Add row to table of settings.
 			$table->add_item( $table_row );

--- a/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
+++ b/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
@@ -148,7 +148,7 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 
 			// Add Creator Network Recommendations table column.
 			if ( $creator_network_recommendations_enabled ) {
-				// Show checkbox to enable Creator Network Recommendations for this Contact Form 7 Form.
+				// Show checkbox to enable Creator Network Recommendations for this Forminator Form.
 				$table_row['creator_network_recommendations'] = $this->get_checkbox_field(
 					'creator_network_recommendations_' . $forminator_form['id'],
 					'1',

--- a/includes/integrations/forminator/class-convertkit-forminator-settings.php
+++ b/includes/integrations/forminator/class-convertkit-forminator-settings.php
@@ -106,6 +106,30 @@ class ConvertKit_Forminator_Settings {
 	}
 
 	/**
+	 * Returns whether Creator Network Recommendations are enabled for the given Forminator Form ID.
+	 *
+	 * @since   2.3.0
+	 *
+	 * @param   int $forminator_form_id    Forminator Form ID.
+	 * @return  bool
+	 */
+	public function get_creator_network_recommendations_enabled_by_forminator_form_id( $forminator_form_id ) {
+
+		// Bail if no settings exist for any Forminator Forms.
+		if ( ! $this->has_settings() ) {
+			return false;
+		}
+
+		// Bail if no setting exists for the given Forminator Form.
+		if ( ! array_key_exists( 'creator_network_recommendations_' . $forminator_form_id, $this->get() ) ) {
+			return false;
+		}
+
+		return (bool) $this->get()[ 'creator_network_recommendations_' . $forminator_form_id ];
+
+	}
+
+	/**
 	 * The default settings, used when this integration's Settings haven't been saved
 	 * e.g. on a new installation or when the integration's Plugin has just been activated
 	 * for the first time.

--- a/tests/acceptance/integrations/other/ForminatorCest.php
+++ b/tests/acceptance/integrations/other/ForminatorCest.php
@@ -148,7 +148,7 @@ class ForminatorCest
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testSettingsForminatorCreatorNetworkRecommendationsOptionWhenDisabledOnConvertKitAccount(AcceptanceTester $I)
+	public function testSettingsForminatorCreatorNetworkRecommendationsWhenDisabledOnConvertKitAccount(AcceptanceTester $I)
 	{
 		// Setup ConvertKit Plugin.
 		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA'], '', '', '');
@@ -268,19 +268,24 @@ class ForminatorCest
 				'post_status' => 'publish',
 				'meta_input'  => [
 					'forminator_form_meta' => [
-						'fields' => [
+						'fields'   => [
 							[
 								'id'          => 'name-1',
 								'element_id'  => 'name-1',
 								'type'        => 'name',
-								'field_label' => 'Name',
+								'required'    => 'true',
+								'field_label' => 'First Name',
 							],
 							[
 								'id'          => 'email-1',
 								'element_id'  => 'email-1',
 								'type'        => 'email',
-								'field_label' => 'email',
+								'required'    => 'true',
+								'field_label' => 'Email Address',
 							],
+						],
+						'settings' => [
+							'enable-ajax' => 'true',
 						],
 					],
 				],

--- a/tests/acceptance/integrations/other/ForminatorCest.php
+++ b/tests/acceptance/integrations/other/ForminatorCest.php
@@ -141,6 +141,116 @@ class ForminatorCest
 	}
 
 	/**
+	 * Tests that the 'Enable Creator Network Recommendations' is not displayed when API Keys are specified
+	 * for a ConvertKit account that does not have Creator Network Recommendations enabled.
+	 *
+	 * @since   2.3.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSettingsForminatorCreatorNetworkRecommendationsOptionWhenDisabledOnConvertKitAccount(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA'], '', '', '');
+		$I->setupConvertKitPluginResources($I);
+
+		// Create Forminator Form.
+		$forminatorFormID = $this->_createForminatorForm($I);
+
+		// Load Forminator Plugin Settings.
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=forminator');
+
+		// Confirm a message is displayed telling the user a paid plan is required.
+		$I->seeInSource('Creator Network Recommendations requires a <a href="https://app.convertkit.com/account_settings/billing/?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit" target="_blank">paid ConvertKit Plan</a>');
+
+		// Create Page with Forminator Shortcode.
+		$pageID = $I->havePageInDatabase(
+			[
+				'post_title'   => 'ConvertKit: Forminator: Creator Network Recommendations Disabled on ConvertKit',
+				'post_name'    => 'convertkit-forminator-creator-network-recommendations-disabled-convertkit',
+				'post_content' => 'Form:
+[forminator_form id="' . $forminatorFormID . '"]',
+			]
+		);
+
+		// Confirm the recommendations script was not loaded, as the API Key and Secret are invalid.
+		$I->dontSeeCreatorNetworkRecommendationsScript($I, $pageID);
+	}
+
+	/**
+	 * Tests that the 'Enable Creator Network Recommendations' option is displayed and saves correctly when
+	 * a valid API Key and Secret are specified, and the ConvertKit account has the Creator Network enabled.
+	 * Viewing and submitting the Form then correctly displays the Creator Network Recommendations modal.
+	 *
+	 * @since   2.3.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSettingsForminatorCreatorNetworkRecommendationsWhenEnabledOnConvertKitAccount(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Create Forminator Form.
+		$forminatorFormID = $this->_createForminatorForm($I);
+
+		// Load Forminator Plugin Settings.
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=forminator');
+
+		// Enable Creator Network Recommendations on the Forminator Form.
+		$I->checkOption('#creator_network_recommendations_' . $forminatorFormID);
+
+		// Save.
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm checkbox is checked after saving.
+		$I->seeCheckboxIsChecked('#creator_network_recommendations_' . $forminatorFormID);
+
+		// Create Page with Forminator Shortcode.
+		$pageID = $I->havePageInDatabase(
+			[
+				'post_title'   => 'ConvertKit: Forminator: Creator Network Recommendations',
+				'post_name'    => 'convertkit-forminator-creator-network-recommendations',
+				'post_content' => 'Form:
+[forminator_form id="' . $forminatorFormID . '"]',
+			]
+		);
+
+		// Confirm the recommendations script was loaded.
+		$I->seeCreatorNetworkRecommendationsScript($I, $pageID);
+
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Complete Name and Email.
+		$I->fillField('input[name=name-1]', 'ConvertKit Name');
+		$I->fillField('input[name=email-1]', $emailAddress);
+
+		// Submit Form.
+		$I->click('button.forminator-button-submit');
+
+		// Wait for response message.
+		$I->waitForElementVisible('.forminator-response-message');
+
+		// Confirm the form submitted without errors.
+		$I->performOn(
+			'.forminator-response-message',
+			function($I) {
+				$I->see('Form entry saved');
+			}
+		);
+
+		// Wait for Creator Network Recommendations modal to display.
+		$I->waitForElementVisible('.formkit-modal');
+		$I->switchToIFrame('.formkit-modal iframe');
+		$I->waitForElementVisible('div[data-component="Page"]');
+	}
+
+	/**
 	 * Creates a Forminator Form
 	 *
 	 * @since   2.3.0
@@ -183,7 +293,7 @@ class ForminatorCest
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
 	 *
-	 * @since   2.3.0.7
+	 * @since   2.3.0
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */


### PR DESCRIPTION
## Summary

Adds an option to enable the Creator Network Recommendations to a Forminator Form within the ConvertKit Plugin at `Settings > ConvertKit > Forminator`:

![Screenshot 2023-09-08 at 15 41 49](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/e7fed215-7a82-4b29-bd04-8e58392f57f3)

When enabled, the modal is displayed when the form is submitted:

![Screenshot 2023-09-08 at 15 42 25](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/1b3dab47-fa59-4fc3-a8d3-a1f543bddeab)

Requirements must be met for this to work:

### Creator Network Recommendations enabled

If the [API endpoint](https://github.com/ConvertKit/convertkit/pull/24419) `enabled` property returns `false`, the user is prompted to upgrade their ConvertKit Plan.

### Method

The Forminator Form's method setting must be set to Ajax

![Screenshot 2023-09-08 at 15 43 27](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/1e08beff-d909-431a-8b7b-b02631cefbf9)


## Testing

- `testSettingsForminatorCreatorNetworkRecommendationsWhenDisabledOnConvertKitAccount`: Tests that the 'Enable Creator Network Recommendations' option on a Form's settings is not displayed when Creator Network Recommendations are not enabled on the ConvertKit account.
- `testSettingsForminatorCreatorNetworkRecommendationsWhenEnabledOnConvertKitAccount`: Test that the Creator Network Recommendations modal displays when enabled on a Forminator Form

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)