### PR TITLE
Add block.json definitions

### DIFF
--- a/includes/blocks/broadcasts/block.json
+++ b/includes/blocks/broadcasts/block.json
@@ -1,0 +1,66 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 1,
+    "name": "convertkit/broadcasts",
+    "title": "ConvertKit Broadcasts",
+    "category": "convertkit",
+    "description": "Displays a list of your ConvertKit broadcasts.",
+    "keywords": [ "convertkit", "broadcasts", "posts" ],
+    "textdomain": "convertkit",
+    "attributes": {
+        "display_grid": {
+            "type": "boolean"
+        },
+        "date_format": {
+            "type": "string"
+        },
+        "display_image": {
+            "type": "boolean"
+        },
+        "display_description": {
+            "type": "boolean"
+        },
+        "display_read_more": {
+            "type": "boolean"
+        },
+        "read_more_label": {
+            "type": "string"
+        },
+        "limit": {
+            "type": "number"
+        },
+        "page": {
+            "type": "number"
+        },
+        "paginate": {
+            "type": "boolean"
+        },
+        "paginate_label_prev": {
+            "type": "string"
+        },
+        "paginate_label_next": {
+            "type": "string"
+        },
+        "style": {
+            "type": "object"
+        },
+        "backgroundColor": {
+            "type": "string"
+        },
+        "textColor": {
+            "type": "string"
+        },
+        "is_gutenberg_example": {
+            "type": "boolean",
+            "default": false
+        }
+    },
+    "supports": {
+        "className": true,
+        "color": {
+            "link": true,
+            "background": true,
+            "text": true
+        }
+    }
+}

--- a/includes/blocks/form/block.json
+++ b/includes/blocks/form/block.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 1,
+    "name": "convertkit/form",
+    "title": "ConvertKit Form",
+    "category": "convertkit",
+    "description": "Displays a ConvertKit Form.",
+    "keywords": [ "convertkit", "form" ],
+    "textdomain": "convertkit",
+    "attributes": {
+        "form": {
+            "type": "string"
+        },
+        "is_gutenberg_example": {
+            "type": "boolean",
+            "default": false
+        }
+    },
+    "supports": {
+        "className": true
+    }
+}

--- a/includes/blocks/formtrigger/block.json
+++ b/includes/blocks/formtrigger/block.json
@@ -1,0 +1,41 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 1,
+    "name": "convertkit/formtrigger",
+    "title": "ConvertKit Form Trigger",
+    "category": "convertkit",
+    "description": "Displays a modal, sticky bar or slide in form to display when the button is pressed.",
+    "keywords": [ "convertkit", "form" ],
+    "textdomain": "convertkit",
+    "attributes": {
+        "form": {
+            "type": "string"
+        },
+        "text": {
+            "type": "string"
+        },
+        "fontSize": {
+            "type": "string"
+        },
+        "style": {
+            "type": "object"
+        },
+        "backgroundColor": {
+            "type": "string"
+        },
+        "textColor": {
+            "type": "string"
+        },
+        "is_gutenberg_example": {
+            "type": "boolean",
+            "default": false
+        }
+    },
+    "supports": {
+        "className": true,
+        "color": {
+            "background": true,
+            "text": true
+        }
+    }
+}

--- a/includes/blocks/product/block.json
+++ b/includes/blocks/product/block.json
@@ -1,0 +1,41 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 1,
+    "name": "convertkit/product",
+    "title": "ConvertKit Product",
+    "category": "convertkit",
+    "description": "Displays a button to purchase a ConvertKit product.",
+    "keywords": [ "convertkit", "product" ],
+    "textdomain": "convertkit",
+    "attributes": {
+        "product": {
+            "type": "string"
+        },
+        "text": {
+            "type": "string"
+        },
+        "fontSize": {
+            "type": "string"
+        },
+        "style": {
+            "type": "object"
+        },
+        "backgroundColor": {
+            "type": "string"
+        },
+        "textColor": {
+            "type": "string"
+        },
+        "is_gutenberg_example": {
+            "type": "boolean",
+            "default": false
+        }
+    },
+    "supports": {
+        "className": true,
+        "color": {
+            "background": true,
+            "text": true
+        }
+    }
+}

--- a/includes/class-convertkit-gutenberg.php
+++ b/includes/class-convertkit-gutenberg.php
@@ -104,7 +104,7 @@ class ConvertKit_Gutenberg {
 
 			// Register block.
 			register_block_type(
-				'convertkit/' . $block,
+				CONVERTKIT_PLUGIN_PATH . '/includes/blocks/' . $block,
 				array(
 					'attributes'      => $properties['attributes'],
 					'editor_script'   => 'convertkit-gutenberg',
@@ -114,6 +114,7 @@ class ConvertKit_Gutenberg {
 					),
 				)
 			);
+
 		}
 
 		// Enqueue block scripts and styles in the editor view.


### PR DESCRIPTION
## Summary

The plugin is listed in the [block directory](https://en-gb.wordpress.org/plugins/browse/blocks/page/4/) - but to be eligible for inclusion in the `Available to install` section of the block editor (for sites where this Plugin is not installed), `block.json` definitions for each block (broadcasts, form, form trigger, products) need to be included:

https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#benefits-using-the-metadata-file

![Screenshot 2023-09-11 at 11 34 40](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/83b4d6c5-3e04-49b7-91ec-981f1904d48e)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)