### PR TITLE
Display WordPress Site Icon as favicon for Legacy Landing Pages

### DIFF
--- a/includes/class-convertkit-resource-landing-pages.php
+++ b/includes/class-convertkit-resource-landing-pages.php
@@ -126,9 +126,25 @@ class ConvertKit_Resource_Landing_Pages extends ConvertKit_Resource {
 			return $html;
 		}
 
+		// Define the ConvertKit favicon tag that exists in Landing Pages.
+		$convertkit_favicon_tag = '<link rel="shortcut icon" type="image/x-icon" href="https://pages.convertkit.com/templates/favicon.ico">';
+
+		// If the ConvertKit favicon tag does not exist in the HTML, this is a legacy landing page, which doesn't specify a link rel="shortcut icon".
+		if ( strpos( $html, $convertkit_favicon_tag ) === false ) {
+			// Prepend the WordPress site icon tags imemdiately before the closing </head> tag.
+			$html = str_replace(
+				'</head>',
+				$site_icon . "\n" . '</head>',
+				$html
+			);
+
+			return $html;
+		}
+
+		// This is a standard landing page that contains link rel="shortcut icon".
 		// Replace the link rel="shortcut icon" with the above.
 		$html = str_replace(
-			'<link rel="shortcut icon" type="image/x-icon" href="https://pages.convertkit.com/templates/favicon.ico">',
+			$convertkit_favicon_tag,
 			$site_icon,
 			$html
 		);

--- a/tests/acceptance/forms/general/PageLandingPageCest.php
+++ b/tests/acceptance/forms/general/PageLandingPageCest.php
@@ -218,6 +218,53 @@ class PageLandingPageCest
 	}
 
 	/**
+	 * Test that the WordPress site icon is output as the favicon on a Legacy Landing Page,
+	 * when defined.
+	 *
+	 * @since   2.3.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testLegacyLandingPageSiteIcon(AcceptanceTester $I)
+	{
+		// Define a WordPress Site Icon.
+		$imageID = $I->haveAttachmentInDatabase(codecept_data_dir('icon.png'));
+		$I->haveOptionInDatabase('site_icon', $imageID);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Legacy Landing Page: Site Icon: ' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME']);
+
+		// Configure metabox's Landing Page setting to value specified in the .env file.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME'] ],
+			]
+		);
+
+		// Get Landing Page ID.
+		$landingPageID = $I->grabValueFrom('#wp-convertkit-landing_page');
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that the basic HTML structure is correct.
+		$this->_seeBasicHTMLStructure($I);
+
+		// Confirm the WordPress Site Icon displays.
+		$I->seeInSource('<link rel="icon" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/uploads/' . date( 'Y' ) . '/' . date( 'm' ) . '/icon-150x150.png" sizes="32x32">');
+		$I->seeInSource('<link rel="icon" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/uploads/' . date( 'Y' ) . '/' . date( 'm' ) . '/icon-300x300.png" sizes="192x192">');
+		$I->seeInSource('<link rel="apple-touch-icon" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/uploads/' . date( 'Y' ) . '/' . date( 'm' ) . '/icon-300x300.png">');
+		$I->seeInSource('<meta name="msapplication-TileImage" content="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/uploads/' . date( 'Y' ) . '/' . date( 'm' ) . '/icon-300x300.png">');
+		$I->dontSeeInSource('<link rel="shortcut icon" type="image/x-icon" href="https://pages.convertkit.com/templates/favicon.ico">');
+
+		// Confirm that the ConvertKit Landing Page displays.
+		$I->dontSeeElementInDOM('body.page'); // WordPress didn't load its template, which is correct.
+		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://app.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_ID'] . '/subscribe" data-remote="true">'); // ConvertKit injected its Landing Page Form, which is correct.
+	}
+
+	/**
 	 * Test that the Legacy Landing Page specified in the Page Settings works when
 	 * the Landing Page was defined by the ConvertKit Plugin < 1.9.6, which used a URL
 	 * instead of an ID.


### PR DESCRIPTION
## Summary

Extends #542, adding support for displaying WordPress' Site Icon for legacy landing pages, as legacy landing pages don't have a `link rel` specified by default.

## Testing

`testLegacyLandingPageSiteIcon`: Tests that the WordPress Site Icon is output in the legacy landing page HTML

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)