### PR TITLE
Fix `block.json` for block discovery

### DIFF
--- a/includes/blocks/broadcasts/block.json
+++ b/includes/blocks/broadcasts/block.json
@@ -62,5 +62,6 @@
             "background": true,
             "text": true
         }
-    }
+    },
+    "editorScript": "convertkit-gutenberg"
 }

--- a/includes/blocks/form/block.json
+++ b/includes/blocks/form/block.json
@@ -5,7 +5,13 @@
     "title": "ConvertKit Form",
     "category": "convertkit",
     "description": "Displays a ConvertKit Form.",
-    "keywords": [ "convertkit", "form" ],
+    "keywords": [
+        "form",
+        "embed",
+        "subscriber",
+        "email",
+        "convertkit"
+    ],
     "textdomain": "convertkit",
     "attributes": {
         "form": {
@@ -18,5 +24,6 @@
     },
     "supports": {
         "className": true
-    }
+    },
+    "editorScript": "convertkit-gutenberg"
 }

--- a/includes/blocks/formtrigger/block.json
+++ b/includes/blocks/formtrigger/block.json
@@ -37,5 +37,6 @@
             "background": true,
             "text": true
         }
-    }
+    },
+    "editorScript": "convertkit-gutenberg"
 }

--- a/includes/blocks/product/block.json
+++ b/includes/blocks/product/block.json
@@ -37,5 +37,6 @@
             "background": true,
             "text": true
         }
-    }
+    },
+    "editorScript": "convertkit-gutenberg"
 }

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -8,7 +8,7 @@
  * @wordpress-plugin
  * Plugin Name: ConvertKit
  * Plugin URI: https://convertkit.com/
- * Description: Quickly and easily integrate ConvertKit forms into your site.
+ * Description: Display ConvertKit email subscription forms, landing pages, products, broadcasts and more.
  * Version: 2.3.0
  * Author: ConvertKit
  * Author URI: https://convertkit.com/


### PR DESCRIPTION
## Summary

- Fixes the `block.json` definitions to meet WordPress' requirements for possible inclusion in the 'Available to install' section of the block editor.
- Adds more keywords for the Form block, to aid discovery
- Updates the description displayed in the 'Available to install' section, to better reflect what functionality ConvertKit provides.

Before:
![before](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/058ac864-5655-4214-88fb-7f6ac7957812)

After:
![after](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/e2c59f6d-519f-440d-99b2-f7598b625320)

We're already listed in the [block directory](https://en-gb.wordpress.org/plugins/browse/blocks/page/4/) as WordPress approved our previous manual submission as a [plugin containing blocks](https://developer.wordpress.org/plugins/wordpress-org/add-your-plugin-to-the-block-directory/#plugins-containing-blocks).

## Testing

Not sure how to perform testing, or perhaps didn't include a test in this PR? Walk through the following in order for a beginner-friendly guide:
- [Setup](SETUP.md) - setting up your local environment for development and testing
- [Development](DEVELOPMENT.md) - best practices for development
- [Testing](TESTING.md) - how to write and run tests

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)