### PR TITLE
Remove whitespace on <option> elements

### DIFF
--- a/includes/widgets/class-ck-widget-form.php
+++ b/includes/widgets/class-ck-widget-form.php
@@ -81,9 +81,7 @@ class CK_Widget_Form extends WP_Widget {
 				<?php
 				foreach ( $forms->get() as $form ) {
 					?>
-					<option value="<?php echo esc_attr( $form['id'] ); ?>"<?php selected( $form['id'], $instance['form'] ); ?>>
-						<?php echo esc_attr( $form['name'] ); ?>
-					</option>
+					<option value="<?php echo esc_attr( $form['id'] ); ?>"<?php selected( $form['id'], $instance['form'] ); ?>><?php echo esc_attr( $form['name'] ); ?></option>
 					<?php
 				}
 				?>

--- a/views/backend/post/bulk-edit.php
+++ b/views/backend/post/bulk-edit.php
@@ -52,9 +52,7 @@
 				// Therefore, we use -2 to denote 'No Change', even though this setting is for the Tag, so we're at least consistent.
 				?>
 				<option value="-2" data-preserve-on-refresh="1"><?php esc_html_e( '— No Change —', 'convertkit' ); ?></option>
-				<option value="0" data-preserve-on-refresh="1">
-					<?php esc_html_e( 'None', 'convertkit' ); ?>
-				</option>
+				<option value="0" data-preserve-on-refresh="1"><?php esc_html_e( 'None', 'convertkit' ); ?></option>
 				<?php
 				if ( $convertkit_tags->exist() ) {
 					foreach ( $convertkit_tags->get() as $convertkit_tag ) {
@@ -87,9 +85,7 @@
 					// Therefore, we use -2 to denote 'No Change', even though this setting is for the Tag, so we're at least consistent.
 					?>
 					<option value="-2" data-preserve-on-refresh="1"><?php esc_html_e( '— No Change —', 'convertkit' ); ?></option>
-					<option value="0" data-preserve-on-refresh="1">
-						<?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?>
-					</option>
+					<option value="0" data-preserve-on-refresh="1"><?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?></option>
 
 					<?php
 					// Products.
@@ -99,9 +95,7 @@
 							<?php
 							foreach ( $convertkit_products->get() as $product ) {
 								?>
-								<option value="product_<?php echo esc_attr( $product['id'] ); ?>">
-									<?php echo esc_attr( $product['name'] ); ?>
-								</option>
+								<option value="product_<?php echo esc_attr( $product['id'] ); ?>"><?php echo esc_attr( $product['name'] ); ?></option>
 								<?php
 							}
 							?>

--- a/views/backend/post/meta-box.php
+++ b/views/backend/post/meta-box.php
@@ -17,19 +17,13 @@
 			<td>
 				<div class="convertkit-select2-container convertkit-select2-container-grid">
 					<select name="wp-convertkit[form]" id="wp-convertkit-form" class="convertkit-select2 widefat">
-						<option value="-1"<?php selected( - 1, $convertkit_post->get_form() ); ?> data-preserve-on-refresh="1">
-							<?php esc_html_e( 'Default', 'convertkit' ); ?>
-						</option>
-						<option value="0"<?php selected( 0, $convertkit_post->get_form() ); ?> data-preserve-on-refresh="1">
-							<?php esc_html_e( 'None', 'convertkit' ); ?>
-						</option>
+						<option value="-1"<?php selected( - 1, $convertkit_post->get_form() ); ?> data-preserve-on-refresh="1"><?php esc_html_e( 'Default', 'convertkit' ); ?></option>
+						<option value="0"<?php selected( 0, $convertkit_post->get_form() ); ?> data-preserve-on-refresh="1"><?php esc_html_e( 'None', 'convertkit' ); ?></option>
 						<?php
 						if ( $convertkit_forms->exist() ) {
 							foreach ( $convertkit_forms->get() as $form ) {
 								?>
-								<option value="<?php echo esc_attr( $form['id'] ); ?>"<?php selected( $form['id'], $convertkit_post->get_form() ); ?>>
-									<?php echo esc_attr( $form['name'] ); ?>
-								</option>
+								<option value="<?php echo esc_attr( $form['id'] ); ?>"<?php selected( $form['id'], $convertkit_post->get_form() ); ?>><?php echo esc_attr( $form['name'] ); ?></option>
 								<?php
 							}
 						}
@@ -71,23 +65,17 @@
 				<td>
 					<div class="convertkit-select2-container convertkit-select2-container-grid">
 						<select name="wp-convertkit[landing_page]" id="wp-convertkit-landing_page" class="convertkit-select2">
-							<option <?php selected( '', $convertkit_post->get_landing_page() ); ?> value="0" data-preserve-on-refresh="1">
-								<?php esc_html_e( 'None', 'convertkit' ); ?>
-							</option>
+							<option <?php selected( '', $convertkit_post->get_landing_page() ); ?> value="0" data-preserve-on-refresh="1"><?php esc_html_e( 'None', 'convertkit' ); ?></option>
 							<?php
 							if ( $convertkit_landing_pages->exist() ) {
 								foreach ( $convertkit_landing_pages->get() as $landing_page ) {
 									if ( isset( $convertkit_landing_page['url'] ) ) {
 										?>
-										<option value="<?php echo esc_attr( $landing_page['url'] ); ?>"<?php selected( $landing_page['url'], $convertkit_post->get_landing_page() ); ?>>
-											<?php echo esc_attr( $landing_page['name'] ); ?>
-										</option>
+										<option value="<?php echo esc_attr( $landing_page['url'] ); ?>"<?php selected( $landing_page['url'], $convertkit_post->get_landing_page() ); ?>><?php echo esc_attr( $landing_page['name'] ); ?></option>
 										<?php
 									} else {
 										?>
-										<option value="<?php echo esc_attr( $landing_page['id'] ); ?>"<?php selected( $landing_page['id'], $convertkit_post->get_landing_page() ); ?>>
-											<?php echo esc_attr( $landing_page['name'] ); ?>
-										</option>
+										<option value="<?php echo esc_attr( $landing_page['id'] ); ?>"<?php selected( $landing_page['id'], $convertkit_post->get_landing_page() ); ?>><?php echo esc_attr( $landing_page['name'] ); ?></option>
 										<?php
 									}
 								}
@@ -123,16 +111,12 @@
 			<td>
 				<div class="convertkit-select2-container convertkit-select2-container-grid">
 					<select name="wp-convertkit[tag]" id="wp-convertkit-tag" class="convertkit-select2">
-						<option value="0"<?php selected( '', $convertkit_post->get_tag() ); ?> data-preserve-on-refresh="1">
-							<?php esc_html_e( 'None', 'convertkit' ); ?>
-						</option>
+						<option value="0"<?php selected( '', $convertkit_post->get_tag() ); ?> data-preserve-on-refresh="1"><?php esc_html_e( 'None', 'convertkit' ); ?></option>
 						<?php
 						if ( $convertkit_tags->exist() ) {
 							foreach ( $convertkit_tags->get() as $convertkit_tag ) {
 								?>
-								<option value="<?php echo esc_attr( $convertkit_tag['id'] ); ?>"<?php selected( $convertkit_tag['id'], $convertkit_post->get_tag() ); ?>>
-									<?php echo esc_attr( $convertkit_tag['name'] ); ?>
-								</option>
+								<option value="<?php echo esc_attr( $convertkit_tag['id'] ); ?>"<?php selected( $convertkit_tag['id'], $convertkit_post->get_tag() ); ?>><?php echo esc_attr( $convertkit_tag['name'] ); ?></option>
 								<?php
 							}
 						}
@@ -160,9 +144,7 @@
 				<td>
 					<div class="convertkit-select2-container convertkit-select2-container-grid">
 						<select name="wp-convertkit[restrict_content]" id="wp-convertkit-restrict_content" class="convertkit-select2">
-							<option value="0"<?php selected( '', $convertkit_post->get_restrict_content() ); ?> data-preserve-on-refresh="1">
-								<?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?>
-							</option>
+							<option value="0"<?php selected( '', $convertkit_post->get_restrict_content() ); ?> data-preserve-on-refresh="1"><?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?></option>
 
 							<?php
 							if ( $convertkit_products->exist() ) {
@@ -171,9 +153,7 @@
 									<?php
 									foreach ( $convertkit_products->get() as $product ) {
 										?>
-										<option value="product_<?php echo esc_attr( $product['id'] ); ?>"<?php selected( 'product_' . $product['id'], $convertkit_post->get_restrict_content() ); ?>>
-											<?php echo esc_attr( $product['name'] ); ?>
-										</option>
+										<option value="product_<?php echo esc_attr( $product['id'] ); ?>"<?php selected( 'product_' . $product['id'], $convertkit_post->get_restrict_content() ); ?>><?php echo esc_attr( $product['name'] ); ?></option>
 										<?php
 									}
 									?>

--- a/views/backend/post/quick-edit.php
+++ b/views/backend/post/quick-edit.php
@@ -36,9 +36,7 @@
 		<label for="wp-convertkit-quick-edit-tag">
 			<span class="title convertkit-icon-tag"><?php esc_html_e( 'Tag', 'convertkit' ); ?></span>
 			<select name="wp-convertkit[tag]" id="wp-convertkit-quick-edit-tag" size="1">
-				<option value="0" data-preserve-on-refresh="1">
-					<?php esc_html_e( 'None', 'convertkit' ); ?>
-				</option>
+				<option value="0" data-preserve-on-refresh="1"><?php esc_html_e( 'None', 'convertkit' ); ?></option>
 				<?php
 				if ( $convertkit_tags->exist() ) {
 					foreach ( $convertkit_tags->get() as $convertkit_tag ) {
@@ -63,9 +61,7 @@
 			<label for="wp-convertkit-quick-edit-restrict_content">
 				<span class="title convertkit-icon-restrict-content"><?php esc_html_e( 'Member', 'convertkit' ); ?></span>
 				<select name="wp-convertkit[restrict_content]" id="wp-convertkit-quick-edit-restrict_content" size="1">
-					<option value="0" data-preserve-on-refresh="1">
-						<?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?>
-					</option>
+					<option value="0" data-preserve-on-refresh="1"><?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?></option>
 
 					<?php
 					// Products.
@@ -75,9 +71,7 @@
 							<?php
 							foreach ( $convertkit_products->get() as $product ) {
 								?>
-								<option value="product_<?php echo esc_attr( $product['id'] ); ?>">
-									<?php echo esc_attr( $product['name'] ); ?>
-								</option>
+								<option value="product_<?php echo esc_attr( $product['id'] ); ?>"><?php echo esc_attr( $product['name'] ); ?></option>
 								<?php
 							}
 							?>

--- a/views/backend/post/wp-list-table-filter.php
+++ b/views/backend/post/wp-list-table-filter.php
@@ -8,9 +8,7 @@
 
 ?>
 <select name="convertkit_restrict_content" id="wp-convertkit-restrict-content-filter">
-	<option value="0">
-		<?php esc_html_e( 'All content', 'convertkit' ); ?>
-	</option>
+	<option value="0"><?php esc_html_e( 'All content', 'convertkit' ); ?></option>
 
 	<?php
 	// Products.
@@ -20,9 +18,7 @@
 			<?php
 			foreach ( $this->products->get() as $product ) {
 				?>
-				<option value="product_<?php echo esc_attr( $product['id'] ); ?>"<?php selected( 'product_' . $product['id'], $this->restrict_content_filter ); ?>>
-					<?php echo esc_attr( $product['name'] ); ?>
-				</option>
+				<option value="product_<?php echo esc_attr( $product['id'] ); ?>"<?php selected( 'product_' . $product['id'], $this->restrict_content_filter ); ?>><?php echo esc_attr( $product['name'] ); ?></option>
 				<?php
 			}
 			?>

--- a/views/backend/setup-wizard/convertkit-restrict-content-setup/content-2.php
+++ b/views/backend/setup-wizard/convertkit-restrict-content-setup/content-2.php
@@ -66,9 +66,7 @@ if ( $this->type === 'course' ) {
 					<?php
 					foreach ( $this->products->get() as $product ) {
 						?>
-						<option value="product_<?php echo esc_attr( $product['id'] ); ?>">
-							<?php echo esc_attr( $product['name'] ); ?>
-						</option>
+						<option value="product_<?php echo esc_attr( $product['id'] ); ?>"><?php echo esc_attr( $product['name'] ); ?></option>
 						<?php
 					}
 					?>

--- a/views/backend/setup-wizard/convertkit-setup/content-3.php
+++ b/views/backend/setup-wizard/convertkit-setup/content-3.php
@@ -50,15 +50,11 @@ if ( ! $this->forms->exist() ) {
 			<?php esc_html_e( 'Which form would you like to display below all blog posts?', 'convertkit' ); ?>
 		</label>
 		<select name="post_form" id="wp-convertkit-form-posts" class="convertkit-select2 convertkit-preview-output-link widefat" data-target="#convertkit-preview-form-post" data-link="<?php echo esc_attr( $this->preview_post_url ); ?>&convertkit_form_id=">
-			<option value="0">
-				<?php esc_html_e( 'Don\'t display an email subscription form on posts.', 'convertkit' ); ?>
-			</option>	
+			<option value="0"><?php esc_html_e( 'Don\'t display an email subscription form on posts.', 'convertkit' ); ?></option>	
 			<?php
 			foreach ( $this->forms->get() as $form ) {
 				?>
-				<option value="<?php echo esc_attr( $form['id'] ); ?>"<?php selected( $this->settings->get_default_form( 'post' ), $form['id'] ); ?>>
-					<?php echo esc_attr( $form['name'] ); ?>
-				</option>
+				<option value="<?php echo esc_attr( $form['id'] ); ?>"<?php selected( $this->settings->get_default_form( 'post' ), $form['id'] ); ?>><?php echo esc_attr( $form['name'] ); ?></option>
 				<?php
 			}
 			?>
@@ -85,15 +81,11 @@ if ( ! $this->forms->exist() ) {
 			<?php esc_html_e( 'Which form would you like to display below all Pages?', 'convertkit' ); ?>
 		</label>
 		<select name="page_form" id="wp-convertkit-form-pages" class="convertkit-select2 convertkit-preview-output-link widefat" data-target="#convertkit-preview-form-page" data-link="<?php echo esc_attr( $this->preview_page_url ); ?>&convertkit_form_id=">	
-			<option value="0">
-				<?php esc_html_e( 'Don\'t display an email subscription form on pages.', 'convertkit' ); ?>
-			</option>
+			<option value="0"><?php esc_html_e( 'Don\'t display an email subscription form on pages.', 'convertkit' ); ?></option>
 			<?php
 			foreach ( $this->forms->get() as $form ) {
 				?>
-				<option value="<?php echo esc_attr( $form['id'] ); ?>"<?php selected( $this->settings->get_default_form( 'page' ), $form['id'] ); ?>>
-					<?php echo esc_attr( $form['name'] ); ?>
-				</option>
+				<option value="<?php echo esc_attr( $form['id'] ); ?>"<?php selected( $this->settings->get_default_form( 'page' ), $form['id'] ); ?>><?php echo esc_attr( $form['name'] ); ?></option>
 				<?php
 			}
 			?>

--- a/views/backend/term/fields-add.php
+++ b/views/backend/term/fields-add.php
@@ -12,16 +12,12 @@
 
 	<div class="convertkit-select2-container convertkit-select2-container-grid">
 		<select name="wp-convertkit[form]" id="wp-convertkit-form" class="convertkit-select2">
-			<option value="0" data-preserve-on-refresh="1" selected>
-				<?php esc_html_e( 'Default', 'convertkit' ); ?>
-			</option>
+			<option value="0" data-preserve-on-refresh="1" selected><?php esc_html_e( 'Default', 'convertkit' ); ?></option>
 			<?php
 			if ( $convertkit_forms->exist() ) {
 				foreach ( $convertkit_forms->get() as $convertkit_form ) {
 					?>
-					<option value="<?php echo esc_attr( $convertkit_form['id'] ); ?>">
-						<?php echo esc_html( $convertkit_form['name'] ); ?>
-					</option>
+					<option value="<?php echo esc_attr( $convertkit_form['id'] ); ?>"><?php echo esc_html( $convertkit_form['name'] ); ?></option>
 					<?php
 				}
 			}

--- a/views/backend/term/fields-edit.php
+++ b/views/backend/term/fields-edit.php
@@ -14,16 +14,12 @@
 	<td>
 		<div class="convertkit-select2-container convertkit-select2-container-grid">
 			<select name="wp-convertkit[form]" id="wp-convertkit-form" class="convertkit-select2">
-				<option value="0"<?php selected( 0, $convertkit_term->get_form() ); ?> data-preserve-on-refresh="1">
-					<?php esc_html_e( 'Default', 'convertkit' ); ?>
-				</option>
+				<option value="0"<?php selected( 0, $convertkit_term->get_form() ); ?> data-preserve-on-refresh="1"><?php esc_html_e( 'Default', 'convertkit' ); ?></option>
 				<?php
 				if ( $convertkit_forms->exist() ) {
 					foreach ( $convertkit_forms->get() as $convertkit_form ) {
 						?>
-						<option value="<?php echo esc_attr( $convertkit_form['id'] ); ?>"<?php selected( $convertkit_form['id'], $convertkit_term->get_form() ); ?>>
-							<?php echo esc_html( $convertkit_form['name'] ); ?>
-						</option>
+						<option value="<?php echo esc_attr( $convertkit_form['id'] ); ?>"<?php selected( $convertkit_form['id'], $convertkit_term->get_form() ); ?>><?php echo esc_html( $convertkit_form['name'] ); ?></option>
 						<?php
 					}
 				}


### PR DESCRIPTION
## Summary

Removes whitespace on `<option>` elements, ensuring that select2 title attributes render correctly when the cursor is hovered over a select2 field.

Before:
![Screenshot 2023-09-13 at 15 46 25](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/3cc1bd7b-85af-4da8-91f4-c023f9cf3ba1)

After:
![Screenshot 2023-09-13 at 15 51 10](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/8a8189e4-426b-47a6-803a-ae7a4aef35bc)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)