### PR TITLE
Add `for` attribute on `label` elements

### DIFF
--- a/admin/class-convertkit-admin-settings-restrict-content.php
+++ b/admin/class-convertkit-admin-settings-restrict-content.php
@@ -73,7 +73,7 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			$this->name,
 			array(
 				'name'        => 'enabled',
-				'label_for'	  => 'enabled',
+				'label_for'   => 'enabled',
 				'description' => __( 'Enables the Member Content functionality, displaying configuration options on pages to require a subscription to a ConvertKit product', 'convertkit' ),
 			)
 		);
@@ -86,7 +86,7 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			$this->name,
 			array(
 				'name'        => 'subscribe_text',
-				'label_for'	  => 'subscribe_text',
+				'label_for'   => 'subscribe_text',
 				'description' => array(
 					__( 'The text to display above the subscribe button, explaining why the content is only available to subscribers.', 'convertkit' ),
 				),
@@ -101,7 +101,7 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			$this->name,
 			array(
 				'name'        => 'subscribe_button_label',
-				'label_for'	  => 'subscribe_button_label',
+				'label_for'   => 'subscribe_button_label',
 				'description' => array(
 					__( 'The text to display for the call to action button to subscribe to the ConvertKit product.', 'convertkit' ),
 				),
@@ -116,7 +116,7 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			$this->name,
 			array(
 				'name'        => 'email_text',
-				'label_for'	  => 'email_text',
+				'label_for'   => 'email_text',
 				'description' => array(
 					__( 'The text to display above the email form, instructing the subscriber to enter their email address to receive a login link to access the member\'s only content.', 'convertkit' ),
 				),
@@ -131,7 +131,7 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			$this->name,
 			array(
 				'name'        => 'email_button_label',
-				'label_for'	  => 'email_button_label',
+				'label_for'   => 'email_button_label',
 				'description' => array(
 					__( 'The text to display for the button to submit the subscriber\'s email address and receive a login link to access the member only content.', 'convertkit' ),
 				),
@@ -146,7 +146,7 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			$this->name,
 			array(
 				'name'        => 'email_check_text',
-				'label_for'	  => 'email_check_text',
+				'label_for'   => 'email_check_text',
 				'description' => array(
 					__( 'The text to display instructing the subscriber to check their email for the login link that was sent.', 'convertkit' ),
 				),
@@ -161,7 +161,7 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			$this->name,
 			array(
 				'name'        => 'no_access_text',
-				'label_for'	  => 'no_access_text',
+				'label_for'   => 'no_access_text',
 				'description' => array(
 					__( 'The text to display for a subscriber who authenticates via the login link, but does not have access to the product.', 'convertkit' ),
 				),

--- a/admin/class-convertkit-admin-settings-restrict-content.php
+++ b/admin/class-convertkit-admin-settings-restrict-content.php
@@ -73,6 +73,7 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			$this->name,
 			array(
 				'name'        => 'enabled',
+				'label_for'	  => 'enabled',
 				'description' => __( 'Enables the Member Content functionality, displaying configuration options on pages to require a subscription to a ConvertKit product', 'convertkit' ),
 			)
 		);
@@ -85,6 +86,7 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			$this->name,
 			array(
 				'name'        => 'subscribe_text',
+				'label_for'	  => 'subscribe_text',
 				'description' => array(
 					__( 'The text to display above the subscribe button, explaining why the content is only available to subscribers.', 'convertkit' ),
 				),
@@ -99,6 +101,7 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			$this->name,
 			array(
 				'name'        => 'subscribe_button_label',
+				'label_for'	  => 'subscribe_button_label',
 				'description' => array(
 					__( 'The text to display for the call to action button to subscribe to the ConvertKit product.', 'convertkit' ),
 				),
@@ -113,6 +116,7 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			$this->name,
 			array(
 				'name'        => 'email_text',
+				'label_for'	  => 'email_text',
 				'description' => array(
 					__( 'The text to display above the email form, instructing the subscriber to enter their email address to receive a login link to access the member\'s only content.', 'convertkit' ),
 				),
@@ -127,6 +131,7 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			$this->name,
 			array(
 				'name'        => 'email_button_label',
+				'label_for'	  => 'email_button_label',
 				'description' => array(
 					__( 'The text to display for the button to submit the subscriber\'s email address and receive a login link to access the member only content.', 'convertkit' ),
 				),
@@ -141,6 +146,7 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			$this->name,
 			array(
 				'name'        => 'email_check_text',
+				'label_for'	  => 'email_check_text',
 				'description' => array(
 					__( 'The text to display instructing the subscriber to check their email for the login link that was sent.', 'convertkit' ),
 				),
@@ -155,6 +161,7 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			$this->name,
 			array(
 				'name'        => 'no_access_text',
+				'label_for'	  => 'no_access_text',
 				'description' => array(
 					__( 'The text to display for a subscriber who authenticates via the login link, but does not have access to the product.', 'convertkit' ),
 				),

--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -179,7 +179,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 			$this->name,
 			array(
 				'name'        => 'enabled',
-				'label_for'	  => 'enabled',
+				'label_for'   => 'enabled',
 				'label'       => __( 'Enables automatic publication of ConvertKit Broadcasts to WordPress Posts.', 'convertkit' ),
 				'description' => $enabled_description,
 			)
@@ -204,7 +204,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 			$this->name,
 			array(
 				'name'        => 'category_id',
-				'label_for'	  => 'category_id',
+				'label_for'   => 'category_id',
 				'description' => __( 'The category to assign imported broadcasts to.', 'convertkit' ),
 			)
 		);
@@ -217,7 +217,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 			$this->name,
 			array(
 				'name'        => 'published_at_min_date',
-				'label_for'	  => 'published_at_min_date',
+				'label_for'   => 'published_at_min_date',
 				'description' => __( 'The earliest date to import broadcasts from, based on the broadcast\'s published date and time.', 'convertkit' ),
 			)
 		);
@@ -230,7 +230,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 			$this->name,
 			array(
 				'name'        => 'no_styles',
-				'label_for'	  => 'no_styles',
+				'label_for'   => 'no_styles',
 				'description' => __( 'Removes inline styles and layout when importing broadcasts.', 'convertkit' ),
 			)
 		);

--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -179,6 +179,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 			$this->name,
 			array(
 				'name'        => 'enabled',
+				'label_for'	  => 'enabled',
 				'label'       => __( 'Enables automatic publication of ConvertKit Broadcasts to WordPress Posts.', 'convertkit' ),
 				'description' => $enabled_description,
 			)
@@ -203,6 +204,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 			$this->name,
 			array(
 				'name'        => 'category_id',
+				'label_for'	  => 'category_id',
 				'description' => __( 'The category to assign imported broadcasts to.', 'convertkit' ),
 			)
 		);
@@ -215,6 +217,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 			$this->name,
 			array(
 				'name'        => 'published_at_min_date',
+				'label_for'	  => 'published_at_min_date',
 				'description' => __( 'The earliest date to import broadcasts from, based on the broadcast\'s published date and time.', 'convertkit' ),
 			)
 		);
@@ -227,6 +230,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 			$this->name,
 			array(
 				'name'        => 'no_styles',
+				'label_for'	  => 'no_styles',
 				'description' => __( 'Removes inline styles and layout when importing broadcasts.', 'convertkit' ),
 			)
 		);

--- a/tests/acceptance/broadcasts/import/BroadcastsToPostsSettingsCest.php
+++ b/tests/acceptance/broadcasts/import/BroadcastsToPostsSettingsCest.php
@@ -39,7 +39,7 @@ class BroadcastsToPostsSettingsCest
 		$I->seeInSource('<label for="enabled">');
 		$I->seeInSource('<label for="category_id">');
 		$I->seeInSource('<label for="published_at_min_date">');
-		$I->seeInSource('<label for="no_styles">');	
+		$I->seeInSource('<label for="no_styles">');
 	}
 
 	/**

--- a/tests/acceptance/broadcasts/import/BroadcastsToPostsSettingsCest.php
+++ b/tests/acceptance/broadcasts/import/BroadcastsToPostsSettingsCest.php
@@ -24,6 +24,25 @@ class BroadcastsToPostsSettingsCest
 	}
 
 	/**
+	 * Test that the Settings > ConvertKit > Broadcasts screen has expected a11y output, such as label[for].
+	 *
+	 * @since   2.3.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAccessibility(AcceptanceTester $I)
+	{
+		// Go to the Plugin's Broadcasts Screen.
+		$I->loadConvertKitSettingsBroadcastsScreen($I);
+
+		// Confirm that settings have label[for] attributes.
+		$I->seeInSource('<label for="enabled">');
+		$I->seeInSource('<label for="category_id">');
+		$I->seeInSource('<label for="published_at_min_date">');
+		$I->seeInSource('<label for="no_styles">');	
+	}
+
+	/**
 	 * Tests that enabling and disabling Broadcasts works with no errors,
 	 * and that other form fields show / hide depending on the setting.
 	 *

--- a/tests/acceptance/forms/general/CategoryFormCest.php
+++ b/tests/acceptance/forms/general/CategoryFormCest.php
@@ -35,6 +35,9 @@ class CategoryFormCest
 		// Navigate to Posts > Categories.
 		$I->amOnAdminPage('edit-tags.php?taxonomy=category');
 
+		// Confirm that settings have label[for] attributes.
+		$I->seeInSource('<label for="wp-convertkit-form">');
+
 		// Create Category.
 		$I->fillField('tag-name', 'ConvertKit: Create Category');
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
@@ -110,6 +113,9 @@ class CategoryFormCest
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that settings have label[for] attributes.
+		$I->seeInSource('<label for="wp-convertkit-form">');
 
 		// Check the order of the Form resources are alphabetical, with the Default option prepending the Forms.
 		$I->checkSelectFormOptionOrder(

--- a/tests/acceptance/restrict-content/RestrictContentSettingsCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentSettingsCest.php
@@ -39,7 +39,7 @@ class RestrictContentSettingsCest
 		$I->seeInSource('<label for="email_text">');
 		$I->seeInSource('<label for="email_button_label">');
 		$I->seeInSource('<label for="email_check_text">');
-		$I->seeInSource('<label for="no_access_text">');	
+		$I->seeInSource('<label for="no_access_text">');
 	}
 
 	/**

--- a/tests/acceptance/restrict-content/RestrictContentSettingsCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentSettingsCest.php
@@ -20,6 +20,27 @@ class RestrictContentSettingsCest
 		$I->setupConvertKitPlugin($I);
 	}
 
+	/**
+	 * Test that the Settings > ConvertKit > Member Content screen has expected a11y output, such as label[for].
+	 *
+	 * @since   2.3.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAccessibility(AcceptanceTester $I)
+	{
+		// Go to the Plugin's Member Content Screen.
+		$I->loadConvertKitSettingsRestrictContentScreen($I);
+
+		// Confirm that settings have label[for] attributes.
+		$I->seeInSource('<label for="enabled">');
+		$I->seeInSource('<label for="subscribe_text">');
+		$I->seeInSource('<label for="subscribe_button_label">');
+		$I->seeInSource('<label for="email_text">');
+		$I->seeInSource('<label for="email_button_label">');
+		$I->seeInSource('<label for="email_check_text">');
+		$I->seeInSource('<label for="no_access_text">');	
+	}
 
 	/**
 	 * Tests that enabling and disabling Restrict Content works with no errors,

--- a/views/backend/term/fields-add.php
+++ b/views/backend/term/fields-add.php
@@ -8,7 +8,7 @@
 
 ?>
 <div class="form-field term-description-wrap">
-	<label for="tag-description"><?php esc_html_e( 'ConvertKit Form', 'convertkit' ); ?></label>
+	<label for="wp-convertkit-form"><?php esc_html_e( 'ConvertKit Form', 'convertkit' ); ?></label>
 
 	<div class="convertkit-select2-container convertkit-select2-container-grid">
 		<select name="wp-convertkit[form]" id="wp-convertkit-form" class="convertkit-select2">

--- a/views/backend/term/fields-edit.php
+++ b/views/backend/term/fields-edit.php
@@ -9,7 +9,7 @@
 ?>
 <tr class="form-field">
 	<th scope="row">
-		<label for="description"><?php esc_html_e( 'ConvertKit Form', 'convertkit' ); ?></label>
+		<label for="wp-convertkit-form"><?php esc_html_e( 'ConvertKit Form', 'convertkit' ); ?></label>
 	</th>
 	<td>
 		<div class="convertkit-select2-container convertkit-select2-container-grid">


### PR DESCRIPTION
## Summary

Adds missing `for` attributes on `label` elements in the Plugin's Member Content and Broadcasts settings screens.

Fixes an incorrect `for` attribute value when creating or editing a WordPress Category.

## Testing

- `BroadcastsToPostsSettingsCest:testAccessibility`: Tests that the expected `for` attributes on `label` elements exist when viewing the Broadcasts settings screen.
- `RestrictContentSettingsCest:testAccessibility`: Tests that the expected `for` attributes on `label` elements exist when viewing the Member Content settings screen.
- `CategoryFormCest`: Updated tests to confirm the correct `for` attribute on the `label` element when creating or editing a WordPress Category.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)