### PR TITLE
Wizards: Fix Blank Submenu Items and Access

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,19 +51,7 @@ jobs:
 
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
-          'acceptance/broadcasts/blocks',
-          'acceptance/broadcasts/shortcodes',
-          'acceptance/broadcasts/import',
-          'acceptance/forms/blocks',
-          'acceptance/forms/general',
-          'acceptance/forms/shortcodes',
-          'acceptance/general',
-          'acceptance/integrations/elementor',
-          'acceptance/integrations/other',
-          'acceptance/integrations/woocommerce',
-          'acceptance/products',
-          'acceptance/restrict-content',
-          'acceptance/tags'
+          'acceptance/broadcasts/blocks'
         ]
 
     # Steps to install, configure and run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,19 @@ jobs:
 
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
-          'acceptance/broadcasts/blocks'
+          'acceptance/broadcasts/blocks',
+          'acceptance/broadcasts/shortcodes',
+          'acceptance/broadcasts/import',
+          'acceptance/forms/blocks',
+          'acceptance/forms/general',
+          'acceptance/forms/shortcodes',
+          'acceptance/general',
+          'acceptance/integrations/elementor',
+          'acceptance/integrations/other',
+          'acceptance/integrations/woocommerce',
+          'acceptance/products',
+          'acceptance/restrict-content',
+          'acceptance/tags'
         ]
 
     # Steps to install, configure and run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       DB_USER: root
       DB_PASS: root
       DB_HOST: localhost
-      INSTALL_PLUGINS: "contact-form-7 classic-editor disable-welcome-messages-and-tips elementor forminator woocommerce wordpress-seo wpforms-lite litespeed-cache wp-crontrol wp-super-cache w3-total-cache wp-fastest-cache wp-optimize" # Don't include this repository's Plugin here.
+      INSTALL_PLUGINS: "admin-menu-editor contact-form-7 classic-editor disable-welcome-messages-and-tips elementor forminator woocommerce wordpress-seo wpforms-lite litespeed-cache wp-crontrol wp-super-cache w3-total-cache wp-fastest-cache wp-optimize" # Don't include this repository's Plugin here.
       INSTALL_PLUGINS_URLS: "https://downloads.wordpress.org/plugin/convertkit-for-woocommerce.1.6.4.zip" # URLs to specific third party Plugins
       CONVERTKIT_API_KEY: ${{ secrets.CONVERTKIT_API_KEY }} # ConvertKit API Key, stored in the repository's Settings > Secrets
       CONVERTKIT_API_SECRET: ${{ secrets.CONVERTKIT_API_SECRET }} # ConvertKit API Secret, stored in the repository's Settings > Secrets

--- a/admin/class-convertkit-admin-restrict-content.php
+++ b/admin/class-convertkit-admin-restrict-content.php
@@ -188,7 +188,7 @@ class ConvertKit_Admin_Restrict_Content {
 				'page'         => 'convertkit-restrict-content-setup',
 				'ck_post_type' => 'page',
 			),
-			admin_url( 'index.php' )
+			admin_url( 'options.php' )
 		);
 
 		$views['convertkit_restrict_content_setup'] = '<a href="' . esc_attr( $url ) . '" class="convertkit-action page-title-action hidden">' . esc_html__( 'Add New Member Content', 'convertkit' ) . '</a>';

--- a/admin/class-convertkit-admin-restrict-content.php
+++ b/admin/class-convertkit-admin-restrict-content.php
@@ -182,7 +182,13 @@ class ConvertKit_Admin_Restrict_Content {
 			return $views;
 		}
 
-		$views['convertkit_restrict_content_setup'] = '<a href="admin.php?page=convertkit-restrict-content-setup&post_type=' . esc_attr( $post_type ) . '" class="convertkit-action page-title-action hidden">' . esc_html__( 'Add New Member Content', 'convertkit' ) . '</a>';
+		// Build URL for Restrict Content Setup Wizard.
+		$url = add_query_arg( array(
+			'page' => 'convertkit-restrict-content-setup',
+			'ck_post_type' => 'page',
+		), admin_url( 'index.php' ) );
+
+		$views['convertkit_restrict_content_setup'] = '<a href="' . esc_attr( $url ) . '" class="convertkit-action page-title-action hidden">' . esc_html__( 'Add New Member Content', 'convertkit' ) . '</a>';
 		return $views;
 
 	}

--- a/admin/class-convertkit-admin-restrict-content.php
+++ b/admin/class-convertkit-admin-restrict-content.php
@@ -183,10 +183,13 @@ class ConvertKit_Admin_Restrict_Content {
 		}
 
 		// Build URL for Restrict Content Setup Wizard.
-		$url = add_query_arg( array(
-			'page' => 'convertkit-restrict-content-setup',
-			'ck_post_type' => 'page',
-		), admin_url( 'index.php' ) );
+		$url = add_query_arg(
+			array(
+				'page'         => 'convertkit-restrict-content-setup',
+				'ck_post_type' => 'page',
+			),
+			admin_url( 'index.php' )
+		);
 
 		$views['convertkit_restrict_content_setup'] = '<a href="' . esc_attr( $url ) . '" class="convertkit-action page-title-action hidden">' . esc_html__( 'Add New Member Content', 'convertkit' ) . '</a>';
 		return $views;

--- a/admin/class-convertkit-admin-setup-wizard.php
+++ b/admin/class-convertkit-admin-setup-wizard.php
@@ -124,32 +124,21 @@ class ConvertKit_Admin_Setup_Wizard {
 
 		// Define actions to register the setup screen.
 		add_action( 'admin_menu', array( $this, 'register_screen' ) );
-		add_action( 'admin_head', array( $this, 'hide_screen_from_menu' ) );
 		add_action( 'admin_init', array( $this, 'maybe_load_setup_screen' ) );
 
 	}
 
 	/**
-	 * Register the setup screen in WordPress' Dashboard, so that index.php?page={$this->page_name}
+	 * Register the wizard screen in WordPress' Dashboard, so that options.php?page={$this->page_name}
 	 * does not 404 when in the WordPress Admin interface.
+	 * 
+	 * Ensures the WordPress user has the given required_capability to access this screen. 
 	 *
 	 * @since   1.9.8.4
 	 */
 	public function register_screen() {
 
-		add_dashboard_page( '', '', 'edit_posts', $this->page_name, '__return_false' );
-
-	}
-
-	/**
-	 * Hides the menu registered when register_screen() above is called, otherwise
-	 * we would have a blank submenu entry below the Dashboard menu.
-	 *
-	 * @since   1.9.8.4
-	 */
-	public function hide_screen_from_menu() {
-
-		remove_submenu_page( 'index.php', $this->page_name );
+		add_submenu_page( '', '', '', $this->required_capability, $this->page_name, '__return_false' );
 
 	}
 
@@ -247,7 +236,7 @@ class ConvertKit_Admin_Setup_Wizard {
 				'convertkit-modal' => $this->is_modal(),
 				'step'             => $this->step,
 			),
-			admin_url( 'index.php' )
+			admin_url( 'options.php' )
 		);
 
 		// Define the previous step URL if we're not on the first or last step.
@@ -258,7 +247,7 @@ class ConvertKit_Admin_Setup_Wizard {
 					'convertkit-modal' => $this->is_modal(),
 					'step'             => ( $this->step - 1 ),
 				),
-				admin_url( 'index.php' )
+				admin_url( 'options.php' )
 			);
 		}
 
@@ -270,7 +259,7 @@ class ConvertKit_Admin_Setup_Wizard {
 					'convertkit-modal' => $this->is_modal(),
 					'step'             => ( $this->step + 1 ),
 				),
-				admin_url( 'index.php' )
+				admin_url( 'options.php' )
 			);
 		}
 

--- a/admin/class-convertkit-admin-setup-wizard.php
+++ b/admin/class-convertkit-admin-setup-wizard.php
@@ -124,7 +124,12 @@ class ConvertKit_Admin_Setup_Wizard {
 
 		// Define actions to register the setup screen.
 		add_action( 'admin_menu', array( $this, 'register_screen' ) );
-		add_action( 'admin_head', array( $this, 'hide_screen_from_menu' ) );
+
+		// Hide submenu item under Dashboard menu. admin_menu hook is deliberate, to prevent
+		// plugins such as Admin Menu Editor not honoring this setting. 
+		add_action( 'admin_menu', array( $this, 'hide_screen_from_menu' ), 9999 );
+
+		// Determine whether to load a ConvertKit wizard screen.
 		add_action( 'admin_init', array( $this, 'maybe_load_setup_screen' ) );
 
 	}
@@ -137,7 +142,7 @@ class ConvertKit_Admin_Setup_Wizard {
 	 */
 	public function register_screen() {
 
-		add_dashboard_page( '', '', 'edit_posts', $this->page_name, '__return_false' );
+		add_dashboard_page( '', '', $this->required_capability, $this->page_name, '__return_false' );
 
 	}
 

--- a/admin/class-convertkit-admin-setup-wizard.php
+++ b/admin/class-convertkit-admin-setup-wizard.php
@@ -121,7 +121,7 @@ class ConvertKit_Admin_Setup_Wizard {
 		if ( $this->page_name === false ) {
 			return;
 		}
-		
+
 		// Define actions to register the setup screen.
 		add_action( 'admin_menu', array( $this, 'register_screen' ) );
 		add_action( 'admin_init', array( $this, 'maybe_load_setup_screen' ) );
@@ -147,7 +147,7 @@ class ConvertKit_Admin_Setup_Wizard {
 		// doesn't work, because again Admin Menu Editor will re-inject menu items.
 		// Using `admin_menu` with a later priority results in a 'Sorry, you are not allowed to access this page' errpr
 		// when serving the wizard through a modal (as we do for blocks when there are no API credentials specified).
-		$hook_name = get_plugin_page_hookname( $this->page_name, '' );
+		$hook_name                       = get_plugin_page_hookname( $this->page_name, '' );
 		$_registered_pages[ $hook_name ] = true;
 
 	}

--- a/admin/class-convertkit-admin-setup-wizard.php
+++ b/admin/class-convertkit-admin-setup-wizard.php
@@ -124,31 +124,32 @@ class ConvertKit_Admin_Setup_Wizard {
 
 		// Define actions to register the setup screen.
 		add_action( 'admin_menu', array( $this, 'register_screen' ) );
+		add_action( 'admin_head', array( $this, 'hide_screen_from_menu' ) );
 		add_action( 'admin_init', array( $this, 'maybe_load_setup_screen' ) );
 
 	}
 
 	/**
 	 * Register the setup screen in WordPress' Dashboard, so that index.php?page={$this->page_name}
-	 * does not 404 or return a 'Sorry, you are not allowed to access this page' error when in the
-	 * WordPress Admin interface.
+	 * does not 404 when in the WordPress Admin interface.
 	 *
 	 * @since   1.9.8.4
 	 */
 	public function register_screen() {
 
-		global $_registered_pages;
+		add_dashboard_page( '', '', 'edit_posts', $this->page_name, '__return_false' );
 
-		// Ideally we'd use add_dashboard_page() or add_submenu_page(), which registers the screen
-		// with WordPress in this global variable and doesn't add a submenu item because the name is blank.
-		// However, third party plugins, such as Admin Menu Editor, will then present these blank submenu items to
-		// the user, causing confusion.
-		// Use of the documented remove_submenu_page() in the `admin_head` action [https://core.trac.wordpress.org/ticket/18850]
-		// doesn't work, because again Admin Menu Editor will re-inject menu items.
-		// Using `admin_menu` with a later priority results in a 'Sorry, you are not allowed to access this page' errpr
-		// when serving the wizard through a modal (as we do for blocks when there are no API credentials specified).
-		$hook_name                       = get_plugin_page_hookname( $this->page_name, '' );
-		$_registered_pages[ $hook_name ] = true;
+	}
+
+	/**
+	 * Hides the menu registered when register_screen() above is called, otherwise
+	 * we would have a blank submenu entry below the Dashboard menu.
+	 *
+	 * @since   1.9.8.4
+	 */
+	public function hide_screen_from_menu() {
+
+		remove_submenu_page( 'index.php', $this->page_name );
 
 	}
 

--- a/admin/class-convertkit-admin-setup-wizard.php
+++ b/admin/class-convertkit-admin-setup-wizard.php
@@ -131,8 +131,8 @@ class ConvertKit_Admin_Setup_Wizard {
 	/**
 	 * Register the wizard screen in WordPress' Dashboard, so that options.php?page={$this->page_name}
 	 * does not 404 when in the WordPress Admin interface.
-	 * 
-	 * Ensures the WordPress user has the given required_capability to access this screen. 
+	 *
+	 * Ensures the WordPress user has the given required_capability to access this screen.
 	 *
 	 * @since   1.9.8.4
 	 */

--- a/admin/class-convertkit-admin-setup-wizard.php
+++ b/admin/class-convertkit-admin-setup-wizard.php
@@ -126,7 +126,7 @@ class ConvertKit_Admin_Setup_Wizard {
 		add_action( 'admin_menu', array( $this, 'register_screen' ) );
 
 		// Hide submenu item under Dashboard menu. admin_menu hook is deliberate, to prevent
-		// plugins such as Admin Menu Editor not honoring this setting. 
+		// plugins such as Admin Menu Editor not honoring this setting.
 		add_action( 'admin_menu', array( $this, 'hide_screen_from_menu' ), 9999 );
 
 		// Determine whether to load a ConvertKit wizard screen.

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php
@@ -57,6 +57,15 @@ class ConvertKit_Admin_Setup_Wizard_Plugin extends ConvertKit_Admin_Setup_Wizard
 	public $preview_page_url = false;
 
 	/**
+	 * The required user capability to access the setup wizard.
+	 *
+	 * @since   2.3.2
+	 *
+	 * @var     string
+	 */
+	public $required_capability = 'edit_posts';
+
+	/**
 	 * The programmatic name for this wizard.
 	 *
 	 * @since   1.9.8.4

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php
@@ -143,7 +143,7 @@ class ConvertKit_Admin_Setup_Wizard_Plugin extends ConvertKit_Admin_Setup_Wizard
 						array(
 							'page' => $this->page_name,
 						),
-						admin_url( 'index.php' )
+						admin_url( 'options.php' )
 					),
 					__( 'Setup Wizard', 'convertkit' )
 				),
@@ -183,7 +183,7 @@ class ConvertKit_Admin_Setup_Wizard_Plugin extends ConvertKit_Admin_Setup_Wizard
 		}
 
 		// Show the setup screen.
-		wp_safe_redirect( admin_url( 'index.php?page=' . $this->page_name ) );
+		wp_safe_redirect( admin_url( 'options.php?page=' . $this->page_name ) );
 		exit;
 
 	}
@@ -284,7 +284,7 @@ class ConvertKit_Admin_Setup_Wizard_Plugin extends ConvertKit_Admin_Setup_Wizard
 							'page' => $this->page_name,
 							'step' => 3,
 						),
-						admin_url( 'index.php' )
+						admin_url( 'options.php' )
 					);
 				}
 

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php
@@ -257,7 +257,7 @@ class ConvertKit_Admin_Setup_Wizard_Restrict_Content extends ConvertKit_Admin_Se
 				// Define Download and Course button links.
 				$this->download_url = add_query_arg(
 					array(
-						'type'      => 'download',
+						'type'         => 'download',
 						'ck_post_type' => $this->post_type,
 					),
 					$this->next_step_url
@@ -265,8 +265,8 @@ class ConvertKit_Admin_Setup_Wizard_Restrict_Content extends ConvertKit_Admin_Se
 
 				$this->course_url = add_query_arg(
 					array(
-						'type'      	=> 'course',
-						'ck_post_type' 	=> $this->post_type,
+						'type'         => 'course',
+						'ck_post_type' => $this->post_type,
 					),
 					$this->next_step_url
 				);

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php
@@ -210,7 +210,7 @@ class ConvertKit_Admin_Setup_Wizard_Restrict_Content extends ConvertKit_Admin_Se
 		}
 
 		// Bail if the Post Type isn't supported.
-		$this->post_type = isset( $_REQUEST['post_type'] ) ? sanitize_text_field( $_REQUEST['post_type'] ) : 'page'; // phpcs:ignore WordPress.Security.NonceVerification
+		$this->post_type = isset( $_REQUEST['ck_post_type'] ) ? sanitize_text_field( $_REQUEST['ck_post_type'] ) : 'page'; // phpcs:ignore WordPress.Security.NonceVerification
 		if ( ! in_array( $this->post_type, convertkit_get_supported_restrict_content_post_types(), true ) ) {
 			wp_die(
 				sprintf(
@@ -258,15 +258,15 @@ class ConvertKit_Admin_Setup_Wizard_Restrict_Content extends ConvertKit_Admin_Se
 				$this->download_url = add_query_arg(
 					array(
 						'type'      => 'download',
-						'post_type' => $this->post_type,
+						'ck_post_type' => $this->post_type,
 					),
 					$this->next_step_url
 				);
 
 				$this->course_url = add_query_arg(
 					array(
-						'type'      => 'course',
-						'post_type' => $this->post_type,
+						'type'      	=> 'course',
+						'ck_post_type' 	=> $this->post_type,
 					),
 					$this->next_step_url
 				);

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -261,7 +261,7 @@ function convertkit_get_setup_wizard_plugin_link( $query_args = array() ) {
 		)
 	);
 
-	return add_query_arg( $query_args, admin_url( 'index.php' ) );
+	return add_query_arg( $query_args, admin_url( 'options.php' ) );
 
 }
 

--- a/tests/acceptance/forms/shortcodes/PageShortcodeFormCest.php
+++ b/tests/acceptance/forms/shortcodes/PageShortcodeFormCest.php
@@ -389,7 +389,7 @@ class PageShortcodeFormCest
 		$I->switchToNextTab();
 
 		// Confirm the Plugin's setup wizard is displayed.
-		$I->seeInCurrentUrl('index.php?page=convertkit-setup');
+		$I->seeInCurrentUrl('options.php?page=convertkit-setup');
 
 		// Close tab.
 		$I->closeTab();

--- a/tests/acceptance/forms/shortcodes/PageShortcodeFormTriggerCest.php
+++ b/tests/acceptance/forms/shortcodes/PageShortcodeFormTriggerCest.php
@@ -307,7 +307,7 @@ class PageShortcodeFormTriggerCest
 		$I->switchToNextTab();
 
 		// Confirm the Plugin's setup wizard is displayed.
-		$I->seeInCurrentUrl('index.php?page=convertkit-setup');
+		$I->seeInCurrentUrl('options.php?page=convertkit-setup');
 
 		// Close tab.
 		$I->closeTab();

--- a/tests/acceptance/general/PluginSetupWizardCest.php
+++ b/tests/acceptance/general/PluginSetupWizardCest.php
@@ -74,7 +74,7 @@ class PluginSetupWizardCest
 		$I->amOnAdminPage('index.php');
 
 		// Confirm no Dashboard Submenu item exists.
-		$I->dontSeeInSource('<a href="index.php?page=convertkit-setup"></a>');
+		$I->dontSeeInSource('<a href="options.php?page=convertkit-setup"></a>');
 	}
 
 	/**
@@ -272,7 +272,7 @@ class PluginSetupWizardCest
 		);
 
 		// Load Step 3/4.
-		$I->amOnAdminPage('index.php?page=convertkit-setup&step=3');
+		$I->amOnAdminPage('options.php?page=convertkit-setup&step=3');
 
 		// Confirm expected setup wizard screen is displayed.
 		$this->_seeExpectedSetupWizardScreen($I, 3, 'Display an email capture form');
@@ -352,7 +352,7 @@ class PluginSetupWizardCest
 		);
 
 		// Load Step 3/4.
-		$I->amOnAdminPage('index.php?page=convertkit-setup&step=3');
+		$I->amOnAdminPage('options.php?page=convertkit-setup&step=3');
 
 		// Confirm expected setup wizard screen is displayed.
 		$this->_seeExpectedSetupWizardScreen($I, 3, 'Create your first ConvertKit Form', true);
@@ -403,7 +403,7 @@ class PluginSetupWizardCest
 		);
 
 		// Load Step 3/4.
-		$I->amOnAdminPage('index.php?page=convertkit-setup&step=3');
+		$I->amOnAdminPage('options.php?page=convertkit-setup&step=3');
 
 		// Confirm expected setup wizard screen is displayed.
 		$this->_seeExpectedSetupWizardScreen($I, 3, 'Display an email capture form');
@@ -452,7 +452,7 @@ class PluginSetupWizardCest
 
 		// Manually navigate to the Plugin Setup Wizard; this will be performed via a block
 		// in a future PR, so this test can be moved to e.g. PageBlockFormCest.
-		$I->amOnAdminPage('index.php?page=convertkit-setup&convertkit-modal=1');
+		$I->amOnAdminPage('options.php?page=convertkit-setup&convertkit-modal=1');
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -540,7 +540,7 @@ class PluginSetupWizardCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm expected setup wizard screen loaded.
-		$I->seeInCurrentUrl('index.php?page=convertkit-setup');
+		$I->seeInCurrentUrl('options.php?page=convertkit-setup');
 
 		// Confirm expected title is displayed.
 		$I->see($title);

--- a/tests/acceptance/general/PluginSetupWizardCest.php
+++ b/tests/acceptance/general/PluginSetupWizardCest.php
@@ -44,6 +44,40 @@ class PluginSetupWizardCest
 	}
 
 	/**
+	 * Test that the Dashboard submenu item for this wizard does not display when a
+	 * third party Admin Menu editor type Plugin is installed and active.
+	 *
+	 * @since   2.3.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testNoSetupWizardDashboardSubmenuItem(AcceptanceTester $I)
+	{
+		// Activate Admin Menu Editor Plugin.
+		$I->activateThirdPartyPlugin($I, 'admin-menu-editor');
+
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Activate Plugin.
+		$this->_activatePlugin($I);
+
+		// Navigate to Admin Menu Editor's settings.
+		$I->amOnAdminPage('options-general.php?page=menu_editor');
+
+		// Save settings. If hiding submenu items fails in the Plugin, this step
+		// will display those submenu items on subsequent page loads.
+		$I->click('Save Changes');
+
+		// Navigate to Dashboard.
+		$I->amOnAdminPage('index.php');
+
+		// Confirm no Dashboard Submenu item exists.
+		$I->dontSeeInSource('<a href="index.php?page=convertkit-setup"></a>');
+	}
+
+	/**
 	 * Test that the Setup Wizard exit link works.
 	 *
 	 * @since   1.9.8.4

--- a/tests/acceptance/products/PageShortcodeProductCest.php
+++ b/tests/acceptance/products/PageShortcodeProductCest.php
@@ -307,7 +307,7 @@ class PageShortcodeProductCest
 		$I->switchToNextTab();
 
 		// Confirm the Plugin's setup wizard is displayed.
-		$I->seeInCurrentUrl('index.php?page=convertkit-setup');
+		$I->seeInCurrentUrl('options.php?page=convertkit-setup');
 
 		// Close tab.
 		$I->closeTab();

--- a/tests/acceptance/restrict-content/RestrictContentSetupCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentSetupCest.php
@@ -88,6 +88,44 @@ class RestrictContentSetupCest
 	}
 
 	/**
+	 * Test that the Dashboard submenu item for this wizard does not display when a
+	 * third party Admin Menu editor type Plugin is installed and active.
+	 *
+	 * @since   2.3.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testNoMemberContentWizardDashboardSubmenuItem(AcceptanceTester $I)
+	{
+		// Activate Admin Menu Editor Plugin.
+		$I->activateThirdPartyPlugin($I, 'admin-menu-editor');
+
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Enable Restrict Content.
+		$I->setupConvertKitPluginRestrictContent(
+			$I,
+			[
+				'enabled' => 'on',
+			]
+		);
+
+		// Navigate to Admin Menu Editor's settings.
+		$I->amOnAdminPage('options-general.php?page=menu_editor');
+
+		// Save settings. If hiding submenu items fails in the Plugin, this step
+		// will display those submenu items on subsequent page loads.
+		$I->click('Save Changes');
+
+		// Navigate to Dashboard.
+		$I->amOnAdminPage('index.php');
+
+		// Confirm no Member Content Dashboard Submenu item exists.
+		$I->dontSeeInSource('<a href="index.php?page=convertkit-restrict-content-setup"></a>');
+	}
+
+	/**
 	 * Test that the Add New Member Content > Exit wizard link returns to the Pages screen.
 	 *
 	 * @since   2.1.0

--- a/tests/acceptance/restrict-content/RestrictContentSetupCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentSetupCest.php
@@ -122,7 +122,7 @@ class RestrictContentSetupCest
 		$I->amOnAdminPage('index.php');
 
 		// Confirm no Member Content Dashboard Submenu item exists.
-		$I->dontSeeInSource('<a href="index.php?page=convertkit-restrict-content-setup"></a>');
+		$I->dontSeeInSource('<a href="options.php?page=convertkit-restrict-content-setup"></a>');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes:
- Use `add_submenu_page` to register setup wizard routes against `options.php` instead of `index.php`, fixing an issue where blank submenu items would incorrectly display in the WordPress Administration interface when a third party administration menu management plugin (such as Admin Menu Editor) is activated.
- For the Add New Member Content wizard, change the `post_type` request URI parameter to `ck_post_type`, to avoid a WordPress permissions issue.

Before:
![Screenshot 2023-09-18 at 13 49 40](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/0f4fcf3f-b0c6-4ff5-bf27-726df9c0985d)

![Screenshot_2023-09-18_at_14_27_00](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/e491f75f-1bf2-46ca-85f3-22cce8c57aaf)

After:
![Screenshot 2023-09-18 at 14 25 52](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/8d824170-3740-4250-8a3f-1d33a6cb73b1)

![Screenshot 2023-09-18 at 14 26 03](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/d6302abb-2758-43d1-8009-a650594f44c5)

## Testing

- `PluginSetupWizardCest:testNoSetupWizardDashboardSubmenuItem`: Test that no dashboard submenu item is displayed for the Plugin's `Setup Wizard` when the Admin Menu Editor plugin is active and configured.
- `RestrictContentSetupCest:testNoMemberContentWizardDashboardSubmenuItem`: Test that no Member Content submenu item is displayed for the `Add New Member Content` when the Admin Menu Editor plugin is active and configured.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)