### PR TITLE
Fix WP-Browser login failures

### DIFF
--- a/tests/acceptance/broadcasts/import/BroadcastsToPostsSettingsCest.php
+++ b/tests/acceptance/broadcasts/import/BroadcastsToPostsSettingsCest.php
@@ -119,6 +119,7 @@ class BroadcastsToPostsSettingsCest
 		$I->checkOption('#enabled');
 		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_broadcasts_category_id-container', 'ConvertKit Broadcasts to Posts');
 		$I->fillField('_wp_convertkit_settings_broadcasts[published_at_min_date]', '01/01/2023');
+		$I->checkOption('#no_styles');
 
 		// Click the Save Changes button.
 		$I->click('Save Changes');
@@ -130,6 +131,7 @@ class BroadcastsToPostsSettingsCest
 		$I->seeCheckboxIsChecked('#enabled');
 		$I->seeInField('_wp_convertkit_settings_broadcasts[category_id]', 'ConvertKit Broadcasts to Posts');
 		$I->seeInField('_wp_convertkit_settings_broadcasts[published_at_min_date]', '2023-01-01');
+		$I->seeCheckboxIsChecked('#no_styles');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Tweaking a test to see if WP-Browser login failures are fixed.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)