### PR TITLE
Broadcasts: Export Post to Broadcast: Classic Editor Action

### DIFF
--- a/admin/class-convertkit-admin-broadcasts-exporter.php
+++ b/admin/class-convertkit-admin-broadcasts-exporter.php
@@ -33,18 +33,18 @@ class ConvertKit_Admin_Broadcasts_Exporter {
 
 	/**
 	 * Holds the Broadcasts Settings class.
-	 * 
+	 *
 	 * @since 2.4.0
-	 * 
+	 *
 	 * @var   bool|ConvertKit_Broadcasts_Settings
 	 */
 	private $broadcasts_settings = false;
 
 	/**
 	 * Holds the Settings class.
-	 * 
+	 *
 	 * @since 2.4.0
-	 * 
+	 *
 	 * @var   bool|ConvertKit_Settings
 	 */
 	private $settings = false;
@@ -215,7 +215,7 @@ class ConvertKit_Admin_Broadcasts_Exporter {
 		$content = WP_ConvertKit()->get_class( 'broadcasts_importer' )->get_permitted_html( $content, $this->broadcasts_settings->no_styles() );
 
 		// Initialize the API.
-		$api      = new ConvertKit_API( $this->settings->get_api_key(), $this->settings->get_api_secret(), $this->settings->debug_enabled() );
+		$api = new ConvertKit_API( $this->settings->get_api_key(), $this->settings->get_api_secret(), $this->settings->debug_enabled() );
 
 		// Create draft Broadcast in ConvertKit.
 		return $api->broadcast_create(

--- a/admin/class-convertkit-admin-broadcasts-exporter.php
+++ b/admin/class-convertkit-admin-broadcasts-exporter.php
@@ -32,6 +32,24 @@ class ConvertKit_Admin_Broadcasts_Exporter {
 	private $broadcast_id = false;
 
 	/**
+	 * Holds the Broadcasts Settings class.
+	 * 
+	 * @since 2.4.0
+	 * 
+	 * @var   bool|ConvertKit_Broadcasts_Settings
+	 */
+	private $broadcasts_settings = false;
+
+	/**
+	 * Holds the Settings class.
+	 * 
+	 * @since 2.4.0
+	 * 
+	 * @var   bool|ConvertKit_Settings
+	 */
+	private $settings = false;
+
+	/**
 	 * Constructor
 	 *
 	 * @since   2.4.0
@@ -39,14 +57,14 @@ class ConvertKit_Admin_Broadcasts_Exporter {
 	public function __construct() {
 
 		// Bail if no API credentials have been set.
-		$settings = new ConvertKit_Settings();
-		if ( ! $settings->has_api_key_and_secret() ) {
+		$this->settings = new ConvertKit_Settings();
+		if ( ! $this->settings->has_api_key_and_secret() ) {
 			return;
 		}
 
 		// Bail if the Enable Export Actions setting is not enabled.
-		$broadcasts_settings = new ConvertKit_Settings_Broadcasts();
-		if ( ! $broadcasts_settings->enabled_export() ) {
+		$this->broadcasts_settings = new ConvertKit_Settings_Broadcasts();
+		if ( ! $this->broadcasts_settings->enabled_export() ) {
 			return;
 		}
 
@@ -194,11 +212,10 @@ class ConvertKit_Admin_Broadcasts_Exporter {
 		$content = apply_filters( 'the_content', $post->post_content );
 
 		// Remove HTML tags that are not supported in ConvertKit Broadcasts.
-		$content = WP_ConvertKit()->get_class( 'broadcasts_importer' )->get_permitted_html( $content );
+		$content = WP_ConvertKit()->get_class( 'broadcasts_importer' )->get_permitted_html( $content, $this->broadcasts_settings->no_styles() );
 
 		// Initialize the API.
-		$settings = new ConvertKit_Settings();
-		$api      = new ConvertKit_API( $settings->get_api_key(), $settings->get_api_secret(), $settings->debug_enabled() );
+		$api      = new ConvertKit_API( $this->settings->get_api_key(), $this->settings->get_api_secret(), $this->settings->debug_enabled() );
 
 		// Create draft Broadcast in ConvertKit.
 		return $api->broadcast_create(

--- a/admin/class-convertkit-admin-broadcasts-exporter.php
+++ b/admin/class-convertkit-admin-broadcasts-exporter.php
@@ -36,7 +36,7 @@ class ConvertKit_Admin_Broadcasts_Exporter {
 	 *
 	 * @since 2.4.0
 	 *
-	 * @var   bool|ConvertKit_Broadcasts_Settings
+	 * @var   bool|ConvertKit_Settings_Broadcasts
 	 */
 	private $broadcasts_settings = false;
 

--- a/admin/class-convertkit-admin-broadcasts-exporter.php
+++ b/admin/class-convertkit-admin-broadcasts-exporter.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * ConvertKit Broadcasts Exporter class.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Class to create ConvertKit Broadcasts from WordPress Posts.
+ *
+ * @since   2.4.0
+ */
+class ConvertKit_Admin_Broadcasts_Exporter {
+
+	/**
+	 * Holds the action name in the WP_List_Table.
+	 *
+	 * @since 2.4.0
+	 *
+	 * @var   string
+	 */
+	private $action_name = 'broadcast-export';
+
+	/**
+	 * Holds the Broadcast ID that was created on ConvertKit.
+	 *
+	 * @since 2.4.0
+	 *
+	 * @var   bool|int
+	 */
+	private $broadcast_id = false;
+
+	/**
+	 * Constructor
+	 *
+	 * @since   2.4.0
+	 */
+	public function __construct() {
+
+		// Bail if no API credentials have been set.
+		$settings = new ConvertKit_Settings();
+		if ( ! $settings->has_api_key_and_secret() ) {
+			return;
+		}
+
+		// Bail if the Enable Export Actions setting is not enabled.
+		$broadcasts_settings = new ConvertKit_Settings_Broadcasts();
+		if ( ! $broadcasts_settings->enabled_export() ) {
+			return;
+		}
+
+		// Run action, if selected.
+		add_action( 'init', array( $this, 'run_row_action' ) );
+
+		// Add action below Post Title in WP_List_Table classes.
+		add_filter( 'post_row_actions', array( $this, 'add_row_action' ), 10, 2 );
+
+	}
+
+	/**
+	 * Checks if a Plugin row action was clicked by the User, and if so performs that action.
+	 *
+	 * @since   2.4.0
+	 */
+	public function run_row_action() {
+
+		// Bail if no nonce exists or fails verification.
+		if ( ! array_key_exists( 'nonce', $_REQUEST ) ) {
+			return;
+		}
+		if ( ! wp_verify_nonce( $_REQUEST['nonce'], 'action-convertkit-' . $this->action_name ) ) {
+			return;
+		}
+
+		// If no action specified, return.
+		if ( ! isset( $_REQUEST['convertkit-action'] ) ) {
+			return;
+		}
+
+		// Fetch action and post ID.
+		$action  = sanitize_text_field( $_REQUEST['convertkit-action'] );
+		$post_id = absint( $_REQUEST['id'] );
+
+		// Bail if the action isn't for exporting a post.
+		if ( $action !== $this->action_name ) {
+			return;
+		}
+
+		// Export Post to a draft ConvertKit Broadcast.
+		$result = $this->export_post_to_broadcast( $post_id );
+
+		// If an error occured, display an error message.
+		if ( is_wp_error( $result ) ) {
+			wp_die( esc_html( $result->get_error_message() ) );
+		}
+
+		// Store Broadcast ID for success notice.
+		$this->broadcast_id = $result['id'];
+
+		// Display a success notice with a link to editing the Broadcast on ConvertKit.
+		add_action( 'admin_notices', array( $this, 'output_success_notice' ) );
+
+	}
+
+	/**
+	 * Outputs a success notice in the WordPress Administration interface that the Post was
+	 * successfully created in ConvertKit as a Broadcast, with a link to edit in ConvertKit.
+	 *
+	 * @since   2.4.0
+	 */
+	public function output_success_notice() {
+
+		// Bail if no Broadcast ID specified.
+		if ( ! $this->broadcast_id ) {
+			return;
+		}
+
+		// Output success notice.
+		?>
+		<div class="notice notice-success is-dismissible">
+			<p>
+				<?php
+				printf(
+					'%s <a href="%s" target="_blank">%s</a> %s',
+					esc_html__( 'Successfully created ConvertKit Broadcast from Post.', 'convertkit' ),
+					esc_url( convertkit_get_edit_broadcast_url( $this->broadcast_id ) ),
+					esc_html__( 'Click here', 'convertkit' ),
+					esc_html__( 'to edit and send the broadcast in ConvertKit.', 'convertkit' )
+				);
+				?>
+			</p>
+		</div>
+		<?php
+
+	}
+
+	/**
+	 * Adds a 'Create ConvertKit Broadcast' action below the Post Title in WP_List_Table classes.
+	 *
+	 * @since   2.4.0
+	 *
+	 * @param   array   $actions    Row Actions.
+	 * @param   WP_Post $post       WordPress Post.
+	 * @return  array                   Row Actions
+	 */
+	public function add_row_action( $actions, $post ) {
+
+		// Build URL.
+		$url = add_query_arg(
+			array(
+				'convertkit-action' => 'broadcast-export',
+				'id'                => $post->ID,
+				'nonce'             => wp_create_nonce( 'action-convertkit-broadcast-export' ),
+			),
+			'edit.php'
+		);
+
+		// Add action.
+		$actions['convertkit_broadcast_export'] = '<a href="' . esc_url( $url ) . '">' . esc_html__( 'Create as ConvertKit Broadcast', 'convertkit' ) . '</a>';
+
+		// Return.
+		return $actions;
+
+	}
+
+	/**
+	 * Creates a draft Broadcast in ConvertKit from the given WordPress Post ID.
+	 *
+	 * @since   2.4.0
+	 *
+	 * @param   int $post_id    Post ID.
+	 * @return  WP_Error|array
+	 */
+	private function export_post_to_broadcast( $post_id ) {
+
+		// Get Post.
+		$post = get_post( $post_id );
+
+		// Return an error if the Post could not be fetched.
+		if ( ! $post ) {
+			return new WP_Error(
+				'convertkit_admin_broadcasts_exporter_export_post_to_broadcast',
+				sprintf(
+					/* translators: WordPress Post ID */
+					esc_html__( 'Could not fetch Post ID %s.', 'convertkit' ),
+					$post_id
+				)
+			);
+		}
+
+		// Fetch post's content by running it through the_content filter.
+		// This will convert e.g. page builders and blocks to HTML.
+		$content = apply_filters( 'the_content', $post->post_content );
+
+		// Remove HTML tags that are not supported in ConvertKit Broadcasts.
+		$content = WP_ConvertKit()->get_class( 'broadcasts_importer' )->get_permitted_html( $content );
+
+		// Initialize the API.
+		$settings = new ConvertKit_Settings();
+		$api      = new ConvertKit_API( $settings->get_api_key(), $settings->get_api_secret(), $settings->debug_enabled() );
+
+		// Create draft Broadcast in ConvertKit.
+		return $api->broadcast_create(
+			$post->post_title,
+			$content,
+			$post->post_excerpt
+		);
+
+	}
+
+}

--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -229,9 +229,9 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 			$this->settings_key,
 			$this->name,
 			array(
-				'name'        => 'enabled_export',
-				'label_for'   => 'enabled_export',
-				'label'       => __( 'Enables options in WordPress to create draft broadcasts from existing WordPress posts.', 'convertkit' ),
+				'name'      => 'enabled_export',
+				'label_for' => 'enabled_export',
+				'label'     => __( 'Enables options in WordPress to create draft broadcasts from existing WordPress posts.', 'convertkit' ),
 			)
 		);
 

--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -29,7 +29,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 
 		// Define the programmatic name, Title and Tab Text.
 		$this->name     = 'broadcasts';
-		$this->title    = __( 'Broadcasts to Posts', 'convertkit' );
+		$this->title    = __( 'Broadcasts', 'convertkit' );
 		$this->tab_text = __( 'Broadcasts', 'convertkit' );
 
 		// Identify that this is beta functionality.
@@ -173,14 +173,14 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 
 		add_settings_field(
 			'enabled',
-			__( 'Enable', 'convertkit' ),
+			__( 'Enable Automatic Import', 'convertkit' ),
 			array( $this, 'enable_callback' ),
 			$this->settings_key,
 			$this->name,
 			array(
 				'name'        => 'enabled',
 				'label_for'   => 'enabled',
-				'label'       => __( 'Enables automatic publication of ConvertKit Broadcasts to WordPress Posts.', 'convertkit' ),
+				'label'       => __( 'Enables automatic publication of public ConvertKit Broadcasts as WordPress Posts.', 'convertkit' ),
 				'description' => $enabled_description,
 			)
 		);
@@ -223,6 +223,19 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 		);
 
 		add_settings_field(
+			'enabled_export',
+			__( 'Enable Export Options', 'convertkit' ),
+			array( $this, 'enable_export_callback' ),
+			$this->settings_key,
+			$this->name,
+			array(
+				'name'        => 'enabled_export',
+				'label_for'   => 'enabled_export',
+				'label'       => __( 'Enables options in WordPress to create draft broadcasts from existing WordPress posts.', 'convertkit' ),
+			)
+		);
+
+		add_settings_field(
 			'no_styles',
 			__( 'Disable Styles', 'convertkit' ),
 			array( $this, 'no_styles_callback' ),
@@ -231,7 +244,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 			array(
 				'name'        => 'no_styles',
 				'label_for'   => 'no_styles',
-				'description' => __( 'Removes inline styles and layout when importing broadcasts.', 'convertkit' ),
+				'description' => __( 'Removes inline styles and layout when importing broadcasts and exporting posts.', 'convertkit' ),
 			)
 		);
 
@@ -246,7 +259,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 
 		?>
 		<span class="convertkit-beta-label"><?php esc_html_e( 'Beta', 'convertkit' ); ?></span>
-		<p class="description"><?php esc_html_e( 'Defines whether public broadcasts created in ConvertKit should automatically be published on this site as WordPress Posts.', 'convertkit' ); ?></p>
+		<p class="description"><?php esc_html_e( 'Defines whether public broadcasts created in ConvertKit should automatically be published on this site as WordPress Posts, and whether to enable options to create draft ConvertKit Broadcasts from WordPress Posts.', 'convertkit' ); ?></p>
 		<?php
 
 	}
@@ -357,6 +370,25 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 	}
 
 	/**
+	 * Renders the input for the Enable Export setting.
+	 *
+	 * @since   2.4.0
+	 *
+	 * @param   array $args   Setting field arguments (name,description).
+	 */
+	public function enable_export_callback( $args ) {
+
+		// Output field.
+		echo $this->get_checkbox_field( // phpcs:ignore WordPress.Security.EscapeOutput
+			$args['name'],
+			'on',
+			$this->settings->enabled_export(), // phpcs:ignore WordPress.Security.EscapeOutput
+			$args['label']  // phpcs:ignore WordPress.Security.EscapeOutput
+		);
+
+	}
+
+	/**
 	 * Renders the input for the No Styles setting.
 	 *
 	 * @since   2.2.9
@@ -370,11 +402,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 			$args['name'],
 			'on',
 			$this->settings->no_styles(), // phpcs:ignore WordPress.Security.EscapeOutput
-			$args['description'], // phpcs:ignore WordPress.Security.EscapeOutput
-			'',
-			array(
-				'enabled',
-			)
+			$args['description'] // phpcs:ignore WordPress.Security.EscapeOutput
 		);
 
 	}

--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -224,14 +224,14 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 
 		add_settings_field(
 			'enabled_export',
-			__( 'Enable Export Options', 'convertkit' ),
+			__( 'Enable Export Actions', 'convertkit' ),
 			array( $this, 'enable_export_callback' ),
 			$this->settings_key,
 			$this->name,
 			array(
 				'name'      => 'enabled_export',
 				'label_for' => 'enabled_export',
-				'label'     => __( 'Enables options in WordPress to create draft broadcasts from existing WordPress posts.', 'convertkit' ),
+				'label'     => __( 'Displays actions in WordPress to create draft broadcasts from existing WordPress posts.', 'convertkit' ),
 			)
 		);
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "convertkit/convertkit-wordpress-libraries": "dev-broadcast-create"
     },
     "require-dev": {
-        "lucatume/wp-browser": "3.2.0",
+        "lucatume/wp-browser": "3.1.10",
         "codeception/module-asserts": "^1.3",                                      
         "codeception/module-phpbrowser": "^1.0",                                   
         "codeception/module-webdriver": "^1.0",                                    

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "1.3.8"
+        "convertkit/convertkit-wordpress-libraries": "dev-broadcast-create"
     },
     "require-dev": {
         "lucatume/wp-browser": "^3.0",

--- a/includes/class-convertkit-broadcasts-importer.php
+++ b/includes/class-convertkit-broadcasts-importer.php
@@ -363,7 +363,7 @@ class ConvertKit_Broadcasts_Importer {
 		);
 
 		// If Disable Styles is false, include layout tags.
-		if ( $disable_styles ) {
+		if ( ! $disable_styles ) {
 			$permitted_html_tags = array_merge(
 				$permitted_html_tags,
 				array(

--- a/includes/class-convertkit-settings-broadcasts.php
+++ b/includes/class-convertkit-settings-broadcasts.php
@@ -143,6 +143,19 @@ class ConvertKit_Settings_Broadcasts {
 	}
 
 	/**
+	 * Returns whether exporting Posts to Broadcasts is enabled in the Plugin settings.
+	 *
+	 * @since   2.4.0
+	 *
+	 * @return  bool
+	 */
+	public function enabled_export() {
+
+		return ( $this->settings['enabled_export'] === 'on' ? true : false );
+
+	}
+
+	/**
 	 * Returns whether Broadcasts should have their styles imported.
 	 *
 	 * @since   2.2.9
@@ -200,7 +213,7 @@ class ConvertKit_Settings_Broadcasts {
 			// By default, only import Broadcasts as Posts for the last 30 days.
 			'published_at_min_date' => gmdate( 'Y-m-d', strtotime( '-30 days' ) ),
 
-			'restrict_content'      => '',
+			'enabled_export'        => '',
 			'no_styles'             => '',
 		);
 

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -64,6 +64,7 @@ class WP_ConvertKit {
 			return;
 		}
 
+		$this->classes['admin_broadcasts_exporter']           = new ConvertKit_Admin_Broadcasts_Exporter();
 		$this->classes['admin_bulk_edit']                     = new ConvertKit_Admin_Bulk_Edit();
 		$this->classes['admin_cache_plugins']                 = new ConvertKit_Admin_Cache_Plugins();
 		$this->classes['admin_category']                      = new ConvertKit_Admin_Category();

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -406,6 +406,30 @@ function convertkit_get_new_broadcast_url() {
 }
 
 /**
+ * Helper method to return the URL the user needs to visit on the ConvertKit app to edit a draft Broadcast.
+ *
+ * @since   2.4.0
+ *
+ * @param   int $broadcast_id   ConvertKit Broadcast ID.
+ * @return  string                  ConvertKit App URL.
+ */
+function convertkit_get_edit_broadcast_url( $broadcast_id ) {
+
+	return add_query_arg(
+		array(
+			'utm_source'  => 'wordpress',
+			'utm_term'    => get_locale(),
+			'utm_content' => 'convertkit',
+		),
+		sprintf(
+			'https://app.convertkit.com/campaigns/%s/draft',
+			$broadcast_id
+		)
+	);
+
+}
+
+/**
  * Helper method to return the URL the user needs to visit on the ConvertKit app to create a new Product.
  *
  * @since   2.2.3

--- a/resources/backend/js/settings-conditional-display.js
+++ b/resources/backend/js/settings-conditional-display.js
@@ -16,7 +16,7 @@ jQuery( document ).ready(
 	function ( $ ) {
 
 		// Update settings and refresh UI when a setting is changed.
-		$( 'input[type=checkbox]' ).on(
+		$( 'input#enabled' ).on(
 			'change',
 			function () {
 
@@ -25,7 +25,6 @@ jQuery( document ).ready(
 			}
 		);
 
-		// Restrict Content.
 		convertKitConditionallyDisplaySettings( 'enabled', $( 'input#enabled' ).prop( 'checked' ) );
 
 	}

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -113,6 +113,38 @@ class ConvertKitAPI extends \Codeception\Module
 	}
 
 	/**
+	 * Fetches the given broadcast from ConvertKit.
+	 *
+	 * @since   2.4.0
+	 *
+	 * @param   int $broadcastID    Broadcast ID.
+	 */
+	public function apiGetBroadcast($broadcastID)
+	{
+		// Run request.
+		return $this->apiRequest(
+			'broadcasts/' . $broadcastID,
+			'GET'
+		);
+	}
+
+	/**
+	 * Deletes the given broadcast from ConvertKit.
+	 *
+	 * @since   2.4.0
+	 *
+	 * @param   int $broadcastID    Broadcast ID.
+	 */
+	public function apiDeleteBroadcast($broadcastID)
+	{
+		// Run request.
+		$this->apiRequest(
+			'broadcasts/' . $broadcastID,
+			'DELETE'
+		);
+	}
+
+	/**
 	 * Sends a request to the ConvertKit API, typically used to read an endpoint to confirm
 	 * that data in an Acceptance Test was added/edited/deleted successfully.
 	 *

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -398,7 +398,7 @@ class Plugin extends \Codeception\Module
 	 * @param   AcceptanceTester $I          AcceptanceTester.
 	 * @param   bool|array       $settings   Array of key/value settings. If not defined, uses expected defaults.
 	 */
-	public function setupConvertKitPluginBroadcastsToPosts($I, $settings = false)
+	public function setupConvertKitPluginBroadcasts($I, $settings = false)
 	{
 		// Go to the Plugin's Broadcasts screen.
 		$I->loadConvertKitSettingsBroadcastsScreen($I);
@@ -408,6 +408,7 @@ class Plugin extends \Codeception\Module
 			foreach ( $settings as $key => $value ) {
 				switch ( $key ) {
 					case 'enabled':
+					case 'enabled_export':
 					case 'no_styles':
 						if ( $value ) {
 							$I->checkOption('_wp_convertkit_settings_broadcasts[' . $key . ']');

--- a/tests/acceptance/broadcasts/export/BroadcastsExportPostRowActionCest.php
+++ b/tests/acceptance/broadcasts/export/BroadcastsExportPostRowActionCest.php
@@ -44,11 +44,8 @@ class BroadcastsExportPostRowActionCest
 		// Navigate to the Posts WP_List_Table.
 		$I->amOnAdminPage('edit.php');
 
-		// Hover mouse over Post's table row.
-		$I->moveMouseOver('tr.iedit:first-child');
-
 		// Confirm that no action to export the Post is displayed.
-
+		$I->dontSeeInSource('span.convertkit_broadcast_export');
 	}
 
 	/**
@@ -74,7 +71,7 @@ class BroadcastsExportPostRowActionCest
 			[
 				'post_type'    => 'post',
 				'post_title'   => 'ConvertKit: Export Post to Broadcast',
-				'post_content' => 'ConvertKit: Export Post to Broadcast: Content',
+				'post_content' => '<p class="style-test">ConvertKit: Export Post to Broadcast: Content</p>',
 				'post_excerpt' => 'ConvertKit: Export Post to Broadcast: Excerpt',
 			]
 		);
@@ -85,12 +82,27 @@ class BroadcastsExportPostRowActionCest
 		// Hover mouse over Post's table row.
 		$I->moveMouseOver('tr.iedit:first-child');
 
+		// Wait for export link to be visible.
+		$I->waitForElementVisible('tr.iedit:first-child span.convertkit_broadcast_export a');
+
 		// Click the export action.
+		$I->click('tr.iedit:first-child span.convertkit_broadcast_export a');
 
 		// Confirm that a success message displays.
+		$I->waitForElementVisible('.notice-success');
+		$I->see('Successfully created ConvertKit Broadcast from Post');
+
+		// Get Broadcast ID from 'Click here' link.
+		$broadcastID = (int) filter_var($I->grabAttributeFrom('.notice-success p a', 'href'), FILTER_SANITIZE_NUMBER_INT);
+
+		// Fetch Broadcast from the API.
+		$broadcast = $I->apiGetBroadcast($broadcastID);
 
 		// Delete Broadcast.
-		
+		$I->apiDeleteBroadcast($broadcastID);
+
+		// Confirm styles were included in the Broadcast.
+		$I->assertStringContainsString('class="style-test"', $broadcast['broadcast']['content']);
 	}
 
 	/**
@@ -103,7 +115,52 @@ class BroadcastsExportPostRowActionCest
 	 */
 	public function testBroadcastsExportActionWithDisableStylesEnabled(AcceptanceTester $I)
 	{
+		// Enable Export Actions for Posts.
+		$I->setupConvertKitPluginBroadcasts(
+			$I,
+			[
+				'enabled_export' => true,
+				'no_styles'      => true,
+			]
+		);
 
+		// Programmatically create a Post.
+		$postID = $I->havePostInDatabase(
+			[
+				'post_type'    => 'post',
+				'post_title'   => 'ConvertKit: Export Post to Broadcast: Disable Styles',
+				'post_content' => '<p class="style-test">ConvertKit: Export Post to Broadcast: Disable Styles: Content</p>',
+				'post_excerpt' => 'ConvertKit: Export Post to Broadcast: Disable Styles: Excerpt',
+			]
+		);
+
+		// Navigate to the Posts WP_List_Table.
+		$I->amOnAdminPage('edit.php');
+
+		// Hover mouse over Post's table row.
+		$I->moveMouseOver('tr.iedit:first-child');
+
+		// Wait for export link to be visible.
+		$I->waitForElementVisible('tr.iedit:first-child span.convertkit_broadcast_export a');
+
+		// Click the export action.
+		$I->click('tr.iedit:first-child span.convertkit_broadcast_export a');
+
+		// Confirm that a success message displays.
+		$I->waitForElementVisible('.notice-success');
+		$I->see('Successfully created ConvertKit Broadcast from Post');
+
+		// Get Broadcast ID from 'Click here' link.
+		$broadcastID = (int) filter_var($I->grabAttributeFrom('.notice-success p a', 'href'), FILTER_SANITIZE_NUMBER_INT);
+
+		// Fetch Broadcast from the API.
+		$broadcast = $I->apiGetBroadcast($broadcastID);
+
+		// Delete Broadcast.
+		$I->apiDeleteBroadcast($broadcastID);
+
+		// Confirm styles were not included in the Broadcast.
+		$I->assertStringNotContainsString('class="style-test"', $broadcast['broadcast']['content']);
 	}
 
 	/**

--- a/tests/acceptance/broadcasts/export/BroadcastsExportPostRowActionCest.php
+++ b/tests/acceptance/broadcasts/export/BroadcastsExportPostRowActionCest.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Tests Post export to Broadcast functionality.
+ *
+ * @since   2.4.0
+ */
+class BroadcastsExportPostRowActionCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   2.4.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		// Activate ConvertKit Plugin.
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+	}
+
+	/**
+	 * Tests that no action is displayed in the Posts table when the 'Enable Export Actions' is disabled
+	 * in the Plugin's settings.
+	 *
+	 * @since   2.4.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsExportRowActionWhenDisabled(AcceptanceTester $I)
+	{
+		// Programmatically create a Post.
+		$postID = $I->havePostInDatabase(
+			[
+				'post_type'    => 'post',
+				'post_title'   => 'ConvertKit: Export Post to Broadcast',
+				'post_content' => 'ConvertKit: Export Post to Broadcast: Content',
+				'post_excerpt' => 'ConvertKit: Export Post to Broadcast: Excerpt',
+			]
+		);
+
+		// Navigate to the Posts WP_List_Table.
+		$I->amOnAdminPage('edit.php');
+
+		// Hover mouse over Post's table row.
+		$I->moveMouseOver('tr.iedit:first-child');
+
+		// Confirm that no action to export the Post is displayed.
+
+	}
+
+	/**
+	 * Tests that an action is displayed in the Posts table when the 'Enable Export Actions' is enabled
+	 * in the Plugin's settings, and a Broadcast is created in ConvertKit when clicked.
+	 *
+	 * @since   2.4.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsExportRowActionWhenEnabled(AcceptanceTester $I)
+	{
+		// Enable Export Actions for Posts.
+		$I->setupConvertKitPluginBroadcasts(
+			$I,
+			[
+				'enabled_export' => true,
+			]
+		);
+
+		// Programmatically create a Post.
+		$postID = $I->havePostInDatabase(
+			[
+				'post_type'    => 'post',
+				'post_title'   => 'ConvertKit: Export Post to Broadcast',
+				'post_content' => 'ConvertKit: Export Post to Broadcast: Content',
+				'post_excerpt' => 'ConvertKit: Export Post to Broadcast: Excerpt',
+			]
+		);
+
+		// Navigate to the Posts WP_List_Table.
+		$I->amOnAdminPage('edit.php');
+
+		// Hover mouse over Post's table row.
+		$I->moveMouseOver('tr.iedit:first-child');
+
+		// Click the export action.
+
+		// Confirm that a success message displays.
+
+		// Delete Broadcast.
+		
+	}
+
+	/**
+	 * Tests that the 'Disable Styles' setting is honored when enabled in the Plugin's settings, and a
+	 * Broadcast is created in ConvertKit.
+	 *
+	 * @since   2.4.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsExportActionWithDisableStylesEnabled(AcceptanceTester $I)
+	{
+
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   2.4.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
+	}
+}

--- a/tests/acceptance/broadcasts/import/BroadcastsToPostsCest.php
+++ b/tests/acceptance/broadcasts/import/BroadcastsToPostsCest.php
@@ -66,7 +66,7 @@ class BroadcastsToPostsCest
 	public function testBroadcastsImportWhenDisabled(AcceptanceTester $I)
 	{
 		// Enable Broadcasts to Posts.
-		$I->setupConvertKitPluginBroadcastsToPosts(
+		$I->setupConvertKitPluginBroadcasts(
 			$I,
 			[
 				'enabled' => false,
@@ -101,7 +101,7 @@ class BroadcastsToPostsCest
 	public function testBroadcastsImportWhenEnabled(AcceptanceTester $I)
 	{
 		// Enable Broadcasts to Posts.
-		$I->setupConvertKitPluginBroadcastsToPosts(
+		$I->setupConvertKitPluginBroadcasts(
 			$I,
 			[
 				'enabled'               => true,
@@ -165,7 +165,7 @@ class BroadcastsToPostsCest
 	public function testBroadcastsManualImportWhenEnabled(AcceptanceTester $I)
 	{
 		// Enable Broadcasts to Posts.
-		$I->setupConvertKitPluginBroadcastsToPosts(
+		$I->setupConvertKitPluginBroadcasts(
 			$I,
 			[
 				'enabled'               => true,
@@ -227,7 +227,7 @@ class BroadcastsToPostsCest
 	public function testBroadcastsImportWithCategoryEnabled(AcceptanceTester $I)
 	{
 		// Enable Broadcasts to Posts.
-		$I->setupConvertKitPluginBroadcastsToPosts(
+		$I->setupConvertKitPluginBroadcasts(
 			$I,
 			[
 				'enabled'               => true,
@@ -278,7 +278,7 @@ class BroadcastsToPostsCest
 	public function testBroadcastsImportWithEarliestDate(AcceptanceTester $I)
 	{
 		// Enable Broadcasts to Posts.
-		$I->setupConvertKitPluginBroadcastsToPosts(
+		$I->setupConvertKitPluginBroadcasts(
 			$I,
 			[
 				'enabled'               => true,
@@ -324,7 +324,7 @@ class BroadcastsToPostsCest
 		);
 
 		// Enable Broadcasts to Posts.
-		$I->setupConvertKitPluginBroadcastsToPosts(
+		$I->setupConvertKitPluginBroadcasts(
 			$I,
 			[
 				'enabled'               => true,
@@ -373,7 +373,7 @@ class BroadcastsToPostsCest
 	public function testBroadcastsImportWithDisableStylesEnabled(AcceptanceTester $I)
 	{
 		// Enable Broadcasts to Posts.
-		$I->setupConvertKitPluginBroadcastsToPosts(
+		$I->setupConvertKitPluginBroadcasts(
 			$I,
 			[
 				'enabled'               => true,

--- a/tests/acceptance/broadcasts/import/BroadcastsToPostsSettingsCest.php
+++ b/tests/acceptance/broadcasts/import/BroadcastsToPostsSettingsCest.php
@@ -43,14 +43,14 @@ class BroadcastsToPostsSettingsCest
 	}
 
 	/**
-	 * Tests that enabling and disabling Broadcasts works with no errors,
+	 * Tests that enabling and disabling the import option works with no errors,
 	 * and that other form fields show / hide depending on the setting.
 	 *
 	 * @since   2.2.8
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testEnableDisable(AcceptanceTester $I)
+	public function testEnableDisableImport(AcceptanceTester $I)
 	{
 		// Go to the Plugin's Broadcasts Screen.
 		$I->loadConvertKitSettingsBroadcastsScreen($I);
@@ -75,7 +75,6 @@ class BroadcastsToPostsSettingsCest
 		$I->seeElement('table.form-table tbody tr td a.button');
 		$I->seeElement('div.convertkit-select2-container');
 		$I->seeElement('input#published_at_min_date');
-		$I->seeElement('input#no_styles');
 
 		// Check the next import date and time is displayed.
 		$I->see('Broadcasts will next import at approximately');
@@ -97,7 +96,6 @@ class BroadcastsToPostsSettingsCest
 		$I->dontSeeElement('table.form-table tbody tr td a.button');
 		$I->dontSeeElement('div.convertkit-select2-container');
 		$I->dontSeeElement('input#published_at_min_date');
-		$I->dontSeeElement('input#no_styles');
 
 		// Check the next import date and time is not displayed.
 		$I->dontSee('Broadcasts will next import at approximately');
@@ -119,6 +117,8 @@ class BroadcastsToPostsSettingsCest
 		$I->checkOption('#enabled');
 		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_broadcasts_category_id-container', 'ConvertKit Broadcasts to Posts');
 		$I->fillField('_wp_convertkit_settings_broadcasts[published_at_min_date]', '01/01/2023');
+		$I->checkOption('#enabled_export');
+		$I->checkOption('#no_styles');
 
 		// Click the Save Changes button.
 		$I->click('Save Changes');
@@ -130,6 +130,8 @@ class BroadcastsToPostsSettingsCest
 		$I->seeCheckboxIsChecked('#enabled');
 		$I->seeInField('_wp_convertkit_settings_broadcasts[category_id]', 'ConvertKit Broadcasts to Posts');
 		$I->seeInField('_wp_convertkit_settings_broadcasts[published_at_min_date]', '2023-01-01');
+		$I->seeCheckboxIsChecked('#enabled_export');
+		$I->seeCheckboxIsChecked('#no_styles');
 	}
 
 	/**

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -100,6 +100,7 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/woocommerce/class-
 
 // Load files that are only used in the WordPress Administration interface.
 if ( is_admin() ) {
+	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-broadcasts-exporter.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-bulk-edit.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-quick-edit.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-cache-plugins.php';


### PR DESCRIPTION
## Summary

Adds a pre-publish action to new and draft WordPress Posts, allowing the user to send the WordPress Post to ConvertKit as a draft Broadcast.

![Screenshot_2023-09-26_at_14_01_33](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/90459faf-f2a7-459a-a859-ce4cc22b76c3)

## Testing

- `BroadcastsExportPostClassicEditorCest`: Adds tests to confirm the option is displayed (or not displayed) when the Classic Editor is used, depending on the Plugin's configuration, and that a draft ConvertKit Broadcast is created when enabled. 

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)