### PR TITLE
Member Content: Restrict Content by Tag

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,17 @@ jobs:
 
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
+          'acceptance/broadcasts/blocks',
+          'acceptance/broadcasts/shortcodes',
+          'acceptance/broadcasts/import',
+          'acceptance/forms/blocks',
+          'acceptance/forms/general',
+          'acceptance/forms/shortcodes',
+          'acceptance/general',
+          'acceptance/integrations/elementor',
+          'acceptance/integrations/other',
+          'acceptance/integrations/woocommerce',
+          'acceptance/products',
           'acceptance/restrict-content'
         ]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,19 +51,7 @@ jobs:
 
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
-          'acceptance/broadcasts/blocks',
-          'acceptance/broadcasts/shortcodes',
-          'acceptance/broadcasts/import',
-          'acceptance/forms/blocks',
-          'acceptance/forms/general',
-          'acceptance/forms/shortcodes',
-          'acceptance/general',
-          'acceptance/integrations/elementor',
-          'acceptance/integrations/other',
-          'acceptance/integrations/woocommerce',
-          'acceptance/products',
-          'acceptance/restrict-content',
-          'acceptance/tags'
+          'acceptance/restrict-content'
         ]
 
     # Steps to install, configure and run tests

--- a/admin/class-convertkit-admin-restrict-content.php
+++ b/admin/class-convertkit-admin-restrict-content.php
@@ -228,7 +228,7 @@ class ConvertKit_Admin_Restrict_Content {
 
 		// Fetch Products and Tags.
 		$this->products = new ConvertKit_Resource_Products();
-		$this->tags = new ConvertKit_Resource_Tags();
+		$this->tags     = new ConvertKit_Resource_Tags();
 
 		// Don't display filter if no Tags and no Products exist.
 		if ( ! $this->products->exist() && ! $this->tags->exist() ) {

--- a/admin/class-convertkit-admin-restrict-content.php
+++ b/admin/class-convertkit-admin-restrict-content.php
@@ -18,6 +18,15 @@
 class ConvertKit_Admin_Restrict_Content {
 
 	/**
+	 * Holds the ConvertKit Tags resource class.
+	 *
+	 * @since   2.3.2
+	 *
+	 * @var     bool|ConvertKit_Resource_Tags
+	 */
+	public $tags = false;
+
+	/**
 	 * Holds the ConvertKit Products resource class.
 	 *
 	 * @since   2.1.0
@@ -217,11 +226,12 @@ class ConvertKit_Admin_Restrict_Content {
 			return;
 		}
 
-		// Fetch Products.
+		// Fetch Products and Tags.
 		$this->products = new ConvertKit_Resource_Products();
+		$this->tags = new ConvertKit_Resource_Tags();
 
-		// Don't display filter if no Products exist.
-		if ( ! $this->products->exist() ) {
+		// Don't display filter if no Tags and no Products exist.
+		if ( ! $this->products->exist() && ! $this->tags->exist() ) {
 			return;
 		}
 

--- a/includes/class-convertkit-output-restrict-content.php
+++ b/includes/class-convertkit-output-restrict-content.php
@@ -673,7 +673,7 @@ class ConvertKit_Output_Restrict_Content {
 				}
 
 				// If no tags exist, there's no access.
-				if ( ! $tags || ! count( $tags ) ) {
+				if ( ! count( $tags ) ) {
 					return false;
 				}
 

--- a/includes/class-convertkit-output-restrict-content.php
+++ b/includes/class-convertkit-output-restrict-content.php
@@ -312,7 +312,7 @@ class ConvertKit_Output_Restrict_Content {
 
 		// If here, the subscriber has subscribed to the product.
 		// Show the full Post Content.
-		return $content;
+		return 'subscriber id = ' . $subscriber_id . $content;
 
 	}
 

--- a/includes/class-convertkit-output-restrict-content.php
+++ b/includes/class-convertkit-output-restrict-content.php
@@ -312,7 +312,7 @@ class ConvertKit_Output_Restrict_Content {
 
 		// If here, the subscriber has subscribed to the product.
 		// Show the full Post Content.
-		return 'subscriber id = ' . $subscriber_id . $content;
+		return $content;
 
 	}
 

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -1004,9 +1004,6 @@ class Plugin extends \Codeception\Module
 	 */
 	public function testRestrictedContentByTagOnFrontend($I, $urlOrPageID, $emailAddress, $visibleContent = 'Visible content.', $memberContent = 'Member only content.')
 	{
-		// Reset cookie.
-		$I->resetCookie('ck_subscriber_id');
-
 		// Get default settings.
 		$textItems = $this->getRestrictedContentDefaultSettings();
 
@@ -1016,6 +1013,10 @@ class Plugin extends \Codeception\Module
 		} else {
 			$I->amOnUrl($urlOrPageID);
 		}
+
+		// Clear any existing cookie from a previous test and reload.
+		$I->resetCookie('ck_subscriber_id');
+		$I->reloadPage();
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -998,15 +998,15 @@ class Plugin extends \Codeception\Module
 	 *
 	 * @param   AcceptanceTester $I                  Tester.
 	 * @param   string|int       $urlOrPageID        URL or ID of Restricted Content Page.
+	 * @param   string           $emailAddress       Email Address.
 	 * @param   string           $visibleContent     Content that should always be visible.
 	 * @param   string           $memberContent      Content that should only be available to authenticated subscribers.
-	 * @param   bool|array       $textItems          Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
 	 */
 	public function testRestrictedContentByTagOnFrontend($I, $urlOrPageID, $emailAddress, $visibleContent = 'Visible content.', $memberContent = 'Member only content.')
 	{
 		// Get default settings.
 		$textItems = $this->getRestrictedContentDefaultSettings();
-		
+
 		// Navigate to the page.
 		if ( is_numeric( $urlOrPageID ) ) {
 			$I->amOnPage('?p=' . $urlOrPageID);
@@ -1028,7 +1028,7 @@ class Plugin extends \Codeception\Module
 		$I->seeElementInDOM('#convertkit-restrict-content');
 		$I->see($textItems['subscribe_text']);
 		$I->see($textItems['subscribe_button_label']);
-		
+
 		// Enter the email address and submit the form.
 		$I->fillField('convertkit_email', $emailAddress);
 		$I->click('input.wp-block-button__link');

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -1004,6 +1004,9 @@ class Plugin extends \Codeception\Module
 	 */
 	public function testRestrictedContentByTagOnFrontend($I, $urlOrPageID, $emailAddress, $visibleContent = 'Visible content.', $memberContent = 'Member only content.')
 	{
+		// Reset cookie.
+		$I->resetCookie('ck_subscriber_id');
+
 		// Get default settings.
 		$textItems = $this->getRestrictedContentDefaultSettings();
 

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -924,7 +924,7 @@ class Plugin extends \Codeception\Module
 	}
 
 	/**
-	 * Run frontend tests for restricted content, to confirm that visible and member's content
+	 * Run frontend tests for restricted content by ConvertKit Product, to confirm that visible and member's content
 	 * is / is not displayed when logging in with valid and invalid subscriber email addresses.
 	 *
 	 * @since   2.1.0
@@ -935,7 +935,7 @@ class Plugin extends \Codeception\Module
 	 * @param   string           $memberContent      Content that should only be available to authenticated subscribers.
 	 * @param   bool|array       $textItems          Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
 	 */
-	public function testRestrictedContentOnFrontend($I, $urlOrPageID, $visibleContent = 'Visible content.', $memberContent = 'Member only content.', $textItems = false)
+	public function testRestrictedContentByProductOnFrontend($I, $urlOrPageID, $visibleContent = 'Visible content.', $memberContent = 'Member only content.', $textItems = false)
 	{
 		// Define expected text and labels if not supplied.
 		if ( ! $textItems ) {
@@ -988,6 +988,56 @@ class Plugin extends \Codeception\Module
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// as if we entered the code sent in the email.
 		$this->testRestrictedContentShowsContentWithValidSubscriberID($I, $urlOrPageID, $visibleContent, $memberContent);
+	}
+
+	/**
+	 * Run frontend tests for restricted content by ConvertKit Product, to confirm that visible and member's content
+	 * is / is not displayed when logging in with valid and invalid subscriber email addresses.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I                  Tester.
+	 * @param   string|int       $urlOrPageID        URL or ID of Restricted Content Page.
+	 * @param   string           $visibleContent     Content that should always be visible.
+	 * @param   string           $memberContent      Content that should only be available to authenticated subscribers.
+	 * @param   bool|array       $textItems          Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 */
+	public function testRestrictedContentByTagOnFrontend($I, $urlOrPageID, $emailAddress, $visibleContent = 'Visible content.', $memberContent = 'Member only content.')
+	{
+		// Get default settings.
+		$textItems = $this->getRestrictedContentDefaultSettings();
+		
+		// Navigate to the page.
+		if ( is_numeric( $urlOrPageID ) ) {
+			$I->amOnPage('?p=' . $urlOrPageID);
+		} else {
+			$I->amOnUrl($urlOrPageID);
+		}
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm Restrict Content CSS is output.
+		$I->seeInSource('<link rel="stylesheet" id="convertkit-restrict-content-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/restrict-content.css');
+
+		// Confirm that the visible text displays, hidden text does not display and the CTA displays.
+		$I->see($visibleContent);
+		$I->dontSee($memberContent);
+
+		// Confirm that the CTA displays with the expected text.
+		$I->seeElementInDOM('#convertkit-restrict-content');
+		$I->see($textItems['subscribe_text']);
+		$I->see($textItems['subscribe_button_label']);
+		
+		// Enter the email address and submit the form.
+		$I->fillField('convertkit_email', $emailAddress);
+		$I->click('input.wp-block-button__link');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the restricted content is now displayed.
+		$I->testRestrictContentDisplaysContent($I, $visibleContent, $memberContent);
 	}
 
 	/**

--- a/tests/acceptance/restrict-content/RestrictContentSettingsCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentSettingsCest.php
@@ -128,7 +128,7 @@ class RestrictContentSettingsCest
 		);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentOnFrontend($I, $pageID, $visibleContent, $memberContent);
+		$I->testRestrictedContentByProductOnFrontend($I, $pageID, $visibleContent, $memberContent);
 	}
 
 	/**
@@ -175,7 +175,7 @@ class RestrictContentSettingsCest
 		);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentOnFrontend($I, $pageID, $visibleContent, $memberContent);
+		$I->testRestrictedContentByProductOnFrontend($I, $pageID, $visibleContent, $memberContent);
 	}
 
 	/**
@@ -221,7 +221,7 @@ class RestrictContentSettingsCest
 		);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentOnFrontend($I, $pageID, $visibleContent, $memberContent, $settings);
+		$I->testRestrictedContentByProductOnFrontend($I, $pageID, $visibleContent, $memberContent, $settings);
 	}
 
 	/**

--- a/tests/acceptance/restrict-content/RestrictContentSetupCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentSetupCest.php
@@ -199,7 +199,7 @@ class RestrictContentSetupCest
 		$url = $I->grabAttributeFrom('tr.iedit span.view a', 'href');
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentOnFrontend(
+		$I->testRestrictedContentByProductOnFrontend(
 			$I,
 			$url,
 			'Visible content.',
@@ -265,7 +265,7 @@ class RestrictContentSetupCest
 		$url = $I->grabAttributeFrom('.wp-block-button a', 'href');
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentOnFrontend(
+		$I->testRestrictedContentByProductOnFrontend(
 			$I,
 			$url,
 			'Some introductory text about lesson 1',

--- a/tests/acceptance/restrict-content/RestrictContentTagCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentTagCest.php
@@ -28,36 +28,6 @@ class RestrictContentTagCest
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testRestrictContentWhenDisabled(AcceptanceTester $I)
-	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Restrict Content: Tag');
-
-		// Confirm no option is displayed to restrict content.
-		$I->dontSeeElementInDOM('#wp-convertkit-restrict_content');
-
-		// Add blocks.
-		$I->addGutenbergParagraphBlock($I, 'Visible content.');
-		$I->addGutenbergBlock($I, 'More', 'more');
-		$I->addGutenbergParagraphBlock($I, 'Member only content.');
-
-		// Publish Page.
-		$url = $I->publishGutenbergPage($I);
-
-		// Confirm that all content is displayed.
-		$I->amOnUrl($url);
-		$I->see('Visible content.');
-		$I->see('Member only content.');
-	}
-
-	/**
-	 * Test that restricting content by a Tag specified in the Page Settings works when
-	 * creating and viewing a new WordPress Page.
-	 *
-	 * @since   2.3.2
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 */
 	public function testRestrictContentByTag(AcceptanceTester $I)
 	{
 		// Enable Restricted Content.

--- a/tests/acceptance/restrict-content/RestrictContentTagCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentTagCest.php
@@ -1,15 +1,15 @@
 <?php
 /**
- * Tests Restrict Content by Product functionality.
+ * Tests Restrict Content by Tag functionality.
  *
- * @since   2.1.0
+ * @since   2.3.2
  */
-class RestrictContentProductCest
+class RestrictContentTagCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
 	 *
-	 * @since   2.1.0
+	 * @since   2.3.2
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
@@ -21,17 +21,17 @@ class RestrictContentProductCest
 	}
 
 	/**
-	 * Test that restricting content by a Product specified in the Page Settings works when
+	 * Test that restricting content by a Tag specified in the Page Settings works when
 	 * creating and viewing a new WordPress Page.
 	 *
-	 * @since   2.1.0
+	 * @since   2.3.2
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testRestrictContentWhenDisabled(AcceptanceTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Restrict Content: Product');
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Restrict Content: Tag');
 
 		// Confirm no option is displayed to restrict content.
 		$I->dontSeeElementInDOM('#wp-convertkit-restrict_content');
@@ -51,14 +51,14 @@ class RestrictContentProductCest
 	}
 
 	/**
-	 * Test that restricting content by a Product specified in the Page Settings works when
+	 * Test that restricting content by a Tag specified in the Page Settings works when
 	 * creating and viewing a new WordPress Page.
 	 *
-	 * @since   2.1.0
+	 * @since   2.3.2
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testRestrictContentByProduct(AcceptanceTester $I)
+	public function testRestrictContentByTag(AcceptanceTester $I)
 	{
 		// Enable Restricted Content.
 		$I->setupConvertKitPluginRestrictContent(
@@ -69,15 +69,15 @@ class RestrictContentProductCest
 		);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Restrict Content: Product');
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Restrict Content: Tag');
 
-		// Configure metabox's Restrict Content setting = Product name.
+		// Configure metabox's Restrict Content setting = Tag name.
 		$I->configureMetaboxSettings(
 			$I,
 			'wp-convertkit-meta-box',
 			[
 				'form'             => [ 'select2', 'None' ],
-				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
 			]
 		);
 
@@ -90,23 +90,24 @@ class RestrictContentProductCest
 		$url = $I->publishGutenbergPage($I);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentByProductOnFrontend(
+		$I->testRestrictedContentByTagOnFrontend(
 			$I,
 			$url,
+			$I->generateEmailAddress(),
 			'Visible content.',
 			'Member only content.'
 		);
 	}
 
 	/**
-	 * Test that restricting content by a Product specified in the Page Settings works when
+	 * Test that restricting content by a Tag specified in the Page Settings works when
 	 * using the Quick Edit functionality.
 	 *
-	 * @since   2.1.0
+	 * @since   2.3.2
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testRestrictContentByProductUsingQuickEdit(AcceptanceTester $I)
+	public function testRestrictContentByTagUsingQuickEdit(AcceptanceTester $I)
 	{
 		// Enable Restricted Content.
 		$I->setupConvertKitPluginRestrictContent(
@@ -117,7 +118,7 @@ class RestrictContentProductCest
 		);
 
 		// Programmatically create a Page.
-		$pageID = $I->createRestrictedContentPage($I, 'ConvertKit: Page: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Quick Edit');
+		$pageID = $I->createRestrictedContentPage($I, 'ConvertKit: Page: Restrict Content: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Quick Edit');
 
 		// Quick Edit the Page in the Pages WP_List_Table.
 		$I->quickEdit(
@@ -125,23 +126,23 @@ class RestrictContentProductCest
 			'page',
 			$pageID,
 			[
-				'restrict_content' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+				'restrict_content' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
 			]
 		);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentByProductOnFrontend($I, $pageID);
+		$I->testRestrictedContentByTagOnFrontend($I, $pageID, $I->generateEmailAddress());
 	}
 
 	/**
-	 * Test that restricting content by a Product specified in the Page Settings works when
+	 * Test that restricting content by a Tag specified in the Page Settings works when
 	 * using the Bulk Edit functionality.
 	 *
-	 * @since   2.1.0
+	 * @since   2.3.2
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testRestrictContentByProductUsingBulkEdit(AcceptanceTester $I)
+	public function testRestrictContentByTagUsingBulkEdit(AcceptanceTester $I)
 	{
 		// Enable Restricted Content.
 		$I->setupConvertKitPluginRestrictContent(
@@ -153,8 +154,8 @@ class RestrictContentProductCest
 
 		// Programmatically create two Pages.
 		$pageIDs = array(
-			$I->createRestrictedContentPage($I, 'ConvertKit: Page: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Bulk Edit #1'),
-			$I->createRestrictedContentPage($I, 'ConvertKit: Page: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Bulk Edit #2'),
+			$I->createRestrictedContentPage($I, 'ConvertKit: Page: Restrict Content: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit #1'),
+			$I->createRestrictedContentPage($I, 'ConvertKit: Page: Restrict Content: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit #2'),
 		);
 
 		// Bulk Edit the Pages in the Pages WP_List_Table.
@@ -163,23 +164,23 @@ class RestrictContentProductCest
 			'page',
 			$pageIDs,
 			[
-				'restrict_content' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+				'restrict_content' => [ 'select', $_ENV['CONVERTKIT_API_TAG_NAME'] ],
 			]
 		);
 
 		// Iterate through Pages to run frontend tests.
 		foreach ($pageIDs as $pageID) {
 			// Test Restrict Content functionality.
-			$I->testRestrictedContentByProductOnFrontend($I, $pageID);
+			$I->testRestrictedContentByTagOnFrontend($I, $pageID, $I->generateEmailAddress());
 			$I->resetCookie('ck_subscriber_id');
 		}
 	}
 
 	/**
-	 * Test that no option to restrict content by a Product is displayed when disabled and using
+	 * Test that no option to restrict content by a Tag is displayed when disabled and using
 	 * the Bulk and Quick Edit functionality.
 	 *
-	 * @since   2.1.0
+	 * @since   2.3.2
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
@@ -215,7 +216,7 @@ class RestrictContentProductCest
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
 	 *
-	 * @since   2.1.0
+	 * @since   2.3.2
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */

--- a/tests/acceptance/restrict-content/RestrictContentTagCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentTagCest.php
@@ -142,7 +142,6 @@ class RestrictContentTagCest
 		foreach ($pageIDs as $pageID) {
 			// Test Restrict Content functionality.
 			$I->testRestrictedContentByTagOnFrontend($I, $pageID, $I->generateEmailAddress());
-			$I->resetCookie('ck_subscriber_id');
 		}
 	}
 

--- a/views/backend/post/bulk-edit.php
+++ b/views/backend/post/bulk-edit.php
@@ -88,6 +88,21 @@
 					<option value="0" data-preserve-on-refresh="1"><?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?></option>
 
 					<?php
+					// Tags.
+					if ( $convertkit_tags->exist() ) {
+						?>
+						<optgroup label="<?php esc_attr_e( 'Tags', 'convertkit' ); ?>">
+							<?php
+							foreach ( $convertkit_tags->get() as $convertkit_tag ) {
+								?>
+								<option value="tag_<?php echo esc_attr( $convertkit_tag['id'] ); ?>"><?php echo esc_attr( $convertkit_tag['name'] ); ?></option>
+								<?php
+							}
+							?>
+						</optgroup>
+						<?php
+					}
+
 					// Products.
 					if ( $convertkit_products->exist() ) {
 						?>

--- a/views/backend/post/meta-box.php
+++ b/views/backend/post/meta-box.php
@@ -147,6 +147,20 @@
 							<option value="0"<?php selected( '', $convertkit_post->get_restrict_content() ); ?> data-preserve-on-refresh="1"><?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?></option>
 
 							<?php
+							if ( $convertkit_tags->exist() ) {
+								?>
+								<optgroup label="<?php esc_attr_e( 'Tags', 'convertkit' ); ?>">
+									<?php
+									foreach ( $convertkit_tags->get() as $tag ) {
+										?>
+										<option value="tag_<?php echo esc_attr( $tag['id'] ); ?>"<?php selected( 'tag_' . $tag['id'], $convertkit_post->get_restrict_content() ); ?>><?php echo esc_attr( $tag['name'] ); ?></option>
+										<?php
+									}
+									?>
+								</optgroup>
+								<?php
+							}
+
 							if ( $convertkit_products->exist() ) {
 								?>
 								<optgroup label="<?php esc_attr_e( 'Products', 'convertkit' ); ?>">

--- a/views/backend/post/meta-box.php
+++ b/views/backend/post/meta-box.php
@@ -180,7 +180,9 @@
 							<span class="dashicons dashicons-update"></span>
 						</button>
 						<p class="description">
-							<?php esc_html_e( 'Select the ConvertKit product that the visitor must be subscribed to, permitting them access to view this members only content.', 'convertkit' ); ?>
+							<?php esc_html_e( 'Select the ConvertKit tag or product that the visitor must be subscribed to, permitting them access to view this members only content.', 'convertkit' ); ?>
+							<br />
+							<?php esc_html_e( 'If a tag is selected, a subscription form will be displayed. On submission, the email address will be subscribed to the selected tag, granting access to the members only content.', 'convertkit' ); ?>
 						</p>
 					</div>
 				</td>

--- a/views/backend/post/meta-box.php
+++ b/views/backend/post/meta-box.php
@@ -151,9 +151,9 @@
 								?>
 								<optgroup label="<?php esc_attr_e( 'Tags', 'convertkit' ); ?>">
 									<?php
-									foreach ( $convertkit_tags->get() as $tag ) {
+									foreach ( $convertkit_tags->get() as $convertkit_tag ) {
 										?>
-										<option value="tag_<?php echo esc_attr( $tag['id'] ); ?>"<?php selected( 'tag_' . $tag['id'], $convertkit_post->get_restrict_content() ); ?>><?php echo esc_attr( $tag['name'] ); ?></option>
+										<option value="tag_<?php echo esc_attr( $convertkit_tag['id'] ); ?>"<?php selected( 'tag_' . $convertkit_tag['id'], $convertkit_post->get_restrict_content() ); ?>><?php echo esc_attr( $convertkit_tag['name'] ); ?></option>
 										<?php
 									}
 									?>

--- a/views/backend/post/quick-edit.php
+++ b/views/backend/post/quick-edit.php
@@ -64,6 +64,21 @@
 					<option value="0" data-preserve-on-refresh="1"><?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?></option>
 
 					<?php
+					// Tags.
+					if ( $convertkit_tags->exist() ) {
+						?>
+						<optgroup label="<?php esc_attr_e( 'Tags', 'convertkit' ); ?>">
+							<?php
+							foreach ( $convertkit_tags->get() as $convertkit_tag ) {
+								?>
+								<option value="tag_<?php echo esc_attr( $convertkit_tag['id'] ); ?>"><?php echo esc_attr( $convertkit_tag['name'] ); ?></option>
+								<?php
+							}
+							?>
+						</optgroup>
+						<?php
+					}
+
 					// Products.
 					if ( $convertkit_products->exist() ) {
 						?>

--- a/views/backend/post/wp-list-table-filter.php
+++ b/views/backend/post/wp-list-table-filter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Outputs a dropdown filter comprising of Forms, Tags and Products
+ * Outputs a dropdown filter comprising of Tags and Products
  *
  * @package ConvertKit
  * @author ConvertKit
@@ -11,6 +11,21 @@
 	<option value="0"><?php esc_html_e( 'All content', 'convertkit' ); ?></option>
 
 	<?php
+	// Tags.
+	if ( $this->tags->exist() ) {
+		?>
+		<optgroup label="<?php esc_attr_e( 'Tags', 'convertkit' ); ?>">
+			<?php
+			foreach ( $this->tags->get() as $convertkit_tag ) {
+				?>
+				<option value="tag_<?php echo esc_attr( $convertkit_tag['id'] ); ?>"<?php selected( 'tag_' . $convertkit_tag['id'], $this->restrict_content_filter ); ?>><?php echo esc_attr( $convertkit_tag['name'] ); ?></option>
+				<?php
+			}
+			?>
+		</optgroup>
+		<?php
+	}
+
 	// Products.
 	if ( $this->products->exist() ) {
 		?>

--- a/views/frontend/restrict-content/product.php
+++ b/views/frontend/restrict-content/product.php
@@ -37,7 +37,9 @@
 			</div>
 			<div>
 				<input type="submit" class="wp-block-button__link wp-block-button__link" value="<?php echo esc_attr( $this->restrict_content_settings->get_by_key( 'email_button_label' ) ); ?>" />
-
+				<input type="hidden" name="convertkit_resource_type" value="<?php echo esc_attr( $resource_type ); ?>" />
+           		<input type="hidden" name="convertkit_resource_id" value="<?php echo esc_attr( $resource_id ); ?>" />
+				
 				<?php wp_nonce_field( 'convertkit_restrict_content_login' ); ?>
 			</div>
 		</form>

--- a/views/frontend/restrict-content/product.php
+++ b/views/frontend/restrict-content/product.php
@@ -38,7 +38,7 @@
 			<div>
 				<input type="submit" class="wp-block-button__link wp-block-button__link" value="<?php echo esc_attr( $this->restrict_content_settings->get_by_key( 'email_button_label' ) ); ?>" />
 				<input type="hidden" name="convertkit_resource_type" value="<?php echo esc_attr( $resource_type ); ?>" />
-           		<input type="hidden" name="convertkit_resource_id" value="<?php echo esc_attr( $resource_id ); ?>" />
+					<input type="hidden" name="convertkit_resource_id" value="<?php echo esc_attr( $resource_id ); ?>" />
 				
 				<?php wp_nonce_field( 'convertkit_restrict_content_login' ); ?>
 			</div>

--- a/views/frontend/restrict-content/product.php
+++ b/views/frontend/restrict-content/product.php
@@ -38,7 +38,7 @@
 			<div>
 				<input type="submit" class="wp-block-button__link wp-block-button__link" value="<?php echo esc_attr( $this->restrict_content_settings->get_by_key( 'email_button_label' ) ); ?>" />
 				<input type="hidden" name="convertkit_resource_type" value="<?php echo esc_attr( $resource_type ); ?>" />
-					<input type="hidden" name="convertkit_resource_id" value="<?php echo esc_attr( $resource_id ); ?>" />
+				<input type="hidden" name="convertkit_resource_id" value="<?php echo esc_attr( $resource_id ); ?>" />
 				
 				<?php wp_nonce_field( 'convertkit_restrict_content_login' ); ?>
 			</div>

--- a/views/frontend/restrict-content/tag.php
+++ b/views/frontend/restrict-content/tag.php
@@ -12,25 +12,25 @@
 ?>
 
 <div id="convertkit-restrict-content">
-   <?php
-   require 'notices.php';
-   ?>
+	<?php
+	require 'notices.php';
+	?>
 
-   <div class="convertkit-restrict-content-actions">
-      <p><?php echo esc_html( $this->restrict_content_settings->get_by_key( 'subscribe_text' ) ); ?></p>
+	<div class="convertkit-restrict-content-actions">
+		<p><?php echo esc_html( $this->restrict_content_settings->get_by_key( 'subscribe_text' ) ); ?></p>
 
 
-      <form class="convertkit-restrict-content-login" action="<?php echo esc_attr( add_query_arg( array( 'convertkit_login' => 1 ), get_permalink( $post_id ) ) ); ?>#convertkit-restrict-content" method="post">
-         <div>
-            <input type="email" name="convertkit_email" id="convertkit_email" value="" placeholder="example@convertkit.com" />
-         </div>
-         <div>
-            <input type="submit" class="wp-block-button__link wp-block-button__link" value="<?php echo esc_attr( $this->restrict_content_settings->get_by_key( 'subscribe_button_label' ) ); ?>" />
-            <input type="hidden" name="convertkit_resource_type" value="<?php echo esc_attr( $resource_type ); ?>" />
-            <input type="hidden" name="convertkit_resource_id" value="<?php echo esc_attr( $resource_id ); ?>" />
-            
-            <?php wp_nonce_field( 'convertkit_restrict_content_login' ); ?>
-         </div>
-      </form>
-   </div>
+		<form class="convertkit-restrict-content-login" action="<?php echo esc_attr( add_query_arg( array( 'convertkit_login' => 1 ), get_permalink( $post_id ) ) ); ?>#convertkit-restrict-content" method="post">
+		<div>
+			<input type="email" name="convertkit_email" id="convertkit_email" value="" placeholder="example@convertkit.com" />
+		</div>
+		<div>
+			<input type="submit" class="wp-block-button__link wp-block-button__link" value="<?php echo esc_attr( $this->restrict_content_settings->get_by_key( 'subscribe_button_label' ) ); ?>" />
+			<input type="hidden" name="convertkit_resource_type" value="<?php echo esc_attr( $resource_type ); ?>" />
+			<input type="hidden" name="convertkit_resource_id" value="<?php echo esc_attr( $resource_id ); ?>" />
+			
+			<?php wp_nonce_field( 'convertkit_restrict_content_login' ); ?>
+		</div>
+		</form>
+	</div>
 </div>

--- a/views/frontend/restrict-content/tag.php
+++ b/views/frontend/restrict-content/tag.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Outputs the restricted content product message,
+ * and a form for the subscriber to enter their
+ * email address if they've already subscribed
+ * to the ConvertKit Product.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+?>
+
+<div id="convertkit-restrict-content">
+   <?php
+   require 'notices.php';
+   ?>
+
+   <div class="convertkit-restrict-content-actions">
+      <p><?php echo esc_html( $this->restrict_content_settings->get_by_key( 'subscribe_text' ) ); ?></p>
+
+
+      <form class="convertkit-restrict-content-login" action="<?php echo esc_attr( add_query_arg( array( 'convertkit_login' => 1 ), get_permalink( $post_id ) ) ); ?>#convertkit-restrict-content" method="post">
+         <div>
+            <input type="email" name="convertkit_email" id="convertkit_email" value="" placeholder="example@convertkit.com" />
+         </div>
+         <div>
+            <input type="submit" class="wp-block-button__link wp-block-button__link" value="<?php echo esc_attr( $this->restrict_content_settings->get_by_key( 'subscribe_button_label' ) ); ?>" />
+            <input type="hidden" name="convertkit_resource_type" value="<?php echo esc_attr( $resource_type ); ?>" />
+            <input type="hidden" name="convertkit_resource_id" value="<?php echo esc_attr( $resource_id ); ?>" />
+            
+            <?php wp_nonce_field( 'convertkit_restrict_content_login' ); ?>
+         </div>
+      </form>
+   </div>
+</div>


### PR DESCRIPTION
## Summary

As requested [here](https://twitter.com/brendanaw/status/1704484890841137157), extends the existing Member Content functionality, adding an option to require that the subscriber be assigned to a specified Tag to view the member only content.

![Screenshot 2023-09-27 at 16 08 52](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/346203a4-bad9-417f-af32-ca737ef71e55)

![Screenshot 2023-09-27 at 16 08 18](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/db09c7d7-0fb8-4de8-8ae6-3b0d9f3e54ec)

If the entered email address is not a subscriber, they will be subscribed and tagged, granting access to the member only content.
If the entered email address is subscribed, but not yet tagged to the specified tag, they will be tagged, again granting access to the member only content.

Demonstration video:

https://www.loom.com/share/1a0af441535d45c4be19501db7bfde46?sid=8ab56a77-f2e2-41de-8447-6dadaa858b86

## Testing

- `RestrictContentTagCest`: Adds tests to confirm Restrict Content functionality works with tags

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)