### PR TITLE
Broadcasts: Export Post to Broadcast: Gutenberg Action

### DIFF
--- a/includes/class-convertkit-broadcasts-exporter.php
+++ b/includes/class-convertkit-broadcasts-exporter.php
@@ -11,7 +11,7 @@
  *
  * @since   2.4.0
  */
-class ConvertKit_Admin_Broadcasts_Exporter {
+class ConvertKit_Broadcasts_Exporter {
 
 	/**
 	 * Holds the action name in the WP_List_Table.
@@ -199,7 +199,7 @@ class ConvertKit_Admin_Broadcasts_Exporter {
 		// Return an error if the Post could not be fetched.
 		if ( ! $post ) {
 			return new WP_Error(
-				'convertkit_admin_broadcasts_exporter_export_post_to_broadcast',
+				'convertkit_broadcasts_exporter_export_post_to_broadcast',
 				sprintf(
 					/* translators: WordPress Post ID */
 					esc_html__( 'Could not fetch Post ID %s.', 'convertkit' ),

--- a/includes/class-convertkit-gutenberg.php
+++ b/includes/class-convertkit-gutenberg.php
@@ -145,10 +145,14 @@ class ConvertKit_Gutenberg {
 		// Get blocks and block toolbar buttons.
 		$blocks           = convertkit_get_blocks();
 		$block_formatters = convertkit_get_block_formatters();
-
+		$pre_publish_actions = convertkit_get_pre_publish_actions();
+		
 		// Enqueue Gutenberg Javascript, and set the blocks data.
 		wp_enqueue_script( 'convertkit-gutenberg', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/gutenberg.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
 		wp_localize_script( 'convertkit-gutenberg', 'convertkit_blocks', $blocks );
+		if ( count( $pre_publish_actions ) ) {
+			wp_localize_script( 'convertkit-gutenberg', 'convertkit_pre_publish_actions', $pre_publish_actions );
+		}
 		wp_localize_script(
 			'convertkit-gutenberg',
 			'convertkit_gutenberg',

--- a/includes/class-convertkit-gutenberg.php
+++ b/includes/class-convertkit-gutenberg.php
@@ -143,10 +143,10 @@ class ConvertKit_Gutenberg {
 		$settings = new ConvertKit_Settings();
 
 		// Get blocks and block toolbar buttons.
-		$blocks           = convertkit_get_blocks();
-		$block_formatters = convertkit_get_block_formatters();
+		$blocks              = convertkit_get_blocks();
+		$block_formatters    = convertkit_get_block_formatters();
 		$pre_publish_actions = convertkit_get_pre_publish_actions();
-		
+
 		// Enqueue Gutenberg Javascript, and set the blocks data.
 		wp_enqueue_script( 'convertkit-gutenberg', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/gutenberg.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
 		wp_localize_script( 'convertkit-gutenberg', 'convertkit_blocks', $blocks );

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -170,7 +170,7 @@ class WP_ConvertKit {
 		$this->classes['block_formatter_form_link']           = new ConvertKit_Block_Formatter_Form_Link();
 		$this->classes['block_formatter_product_link']        = new ConvertKit_Block_Formatter_Product_Link();
 		$this->classes['pre_publish_action_broadcast_export'] = new ConvertKit_Pre_Publish_Action_Broadcast_Export();
-		$this->classes['broadcasts_exporter']           	  = new ConvertKit_Broadcasts_Exporter();
+		$this->classes['broadcasts_exporter']                 = new ConvertKit_Broadcasts_Exporter();
 		$this->classes['broadcasts_importer']                 = new ConvertKit_Broadcasts_Importer();
 		$this->classes['elementor']                           = new ConvertKit_Elementor();
 		$this->classes['gutenberg']                           = new ConvertKit_Gutenberg();

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -64,7 +64,6 @@ class WP_ConvertKit {
 			return;
 		}
 
-		$this->classes['admin_broadcasts_exporter']           = new ConvertKit_Admin_Broadcasts_Exporter();
 		$this->classes['admin_bulk_edit']                     = new ConvertKit_Admin_Bulk_Edit();
 		$this->classes['admin_cache_plugins']                 = new ConvertKit_Admin_Cache_Plugins();
 		$this->classes['admin_category']                      = new ConvertKit_Admin_Category();
@@ -171,6 +170,7 @@ class WP_ConvertKit {
 		$this->classes['block_formatter_form_link']           = new ConvertKit_Block_Formatter_Form_Link();
 		$this->classes['block_formatter_product_link']        = new ConvertKit_Block_Formatter_Product_Link();
 		$this->classes['pre_publish_action_broadcast_export'] = new ConvertKit_Pre_Publish_Action_Broadcast_Export();
+		$this->classes['broadcasts_exporter']           	  = new ConvertKit_Broadcasts_Exporter();
 		$this->classes['broadcasts_importer']                 = new ConvertKit_Broadcasts_Importer();
 		$this->classes['elementor']                           = new ConvertKit_Elementor();
 		$this->classes['gutenberg']                           = new ConvertKit_Gutenberg();

--- a/includes/pre-publish-actions/class-convertkit-pre-publish-action-broadcast-export.php
+++ b/includes/pre-publish-actions/class-convertkit-pre-publish-action-broadcast-export.php
@@ -47,7 +47,7 @@ class ConvertKit_Pre_Publish_Action_Broadcast_Export extends ConvertKit_Pre_Publ
 	 */
 	public function export_broadcast( $post ) {
 
-		$broadcasts_exporter = WP_ConvertKit()->get_class( 'admin_broadcasts_exporter' );
+		$broadcasts_exporter = WP_ConvertKit()->get_class( 'broadcasts_exporter' );
 		$broadcasts_exporter->export_post_to_broadcast( $post->ID );
 
 	}

--- a/includes/pre-publish-actions/class-convertkit-pre-publish-action.php
+++ b/includes/pre-publish-actions/class-convertkit-pre-publish-action.php
@@ -50,9 +50,29 @@ class ConvertKit_Pre_Publish_Action {
 
 		// Perform pre-publish action.
 		add_action( 'transition_post_status', array( $this, 'run' ), 10, 3 );
+		add_action( 'rest_after_insert_post', array( $this, 'rest_api_post_publish' ), 10, 1 );
+		add_action( 'wp_after_insert_post', array( $this, 'wp_after_insert_post' ), 10, 4 );
 
 		// Save whether to run the pre-publish action when the Post is saved.
 		add_action( 'save_post', array( $this, 'save_post_meta' ) );
+
+	}
+
+	public function rest_api_post_publish( $post ) {
+
+		error_log( '---' );
+		error_log( 'rest_after_insert_post' );
+		error_log( 'enabled = ' . $this->is_enabled( $post->ID ) );
+
+	}
+
+	public function wp_after_insert_post( $post_id, $post, $update, $post_before ) {
+
+		error_log( '---' );
+		error_log( 'wp_after_insert_post' );
+		error_log( 'enabled = ' . $this->is_enabled( $post->ID ) );
+		error_log( 'update = ' . $update );
+		error_log( print_r( $post_before, true ) );
 
 	}
 
@@ -109,6 +129,11 @@ class ConvertKit_Pre_Publish_Action {
 	 * @param   WP_Post $post           Post.
 	 */
 	public function run( $new_status, $old_status, $post ) {
+
+		error_log( '---' );
+		error_log( $new_status );
+		error_log( $old_status );
+		error_log( 'enabled = ' . $this->is_enabled( $post->ID ) );
 
 		// Ignore if the Post is not transitioning to published.
 		if ( $new_status !== 'publish' ) {

--- a/includes/pre-publish-actions/class-convertkit-pre-publish-action.php
+++ b/includes/pre-publish-actions/class-convertkit-pre-publish-action.php
@@ -90,9 +90,9 @@ class ConvertKit_Pre_Publish_Action {
 			'post',
 			$this->meta_key,
 			array(
-				'show_in_rest' => true,
-				'single'       => true,
-				'type'         => 'boolean',
+				'show_in_rest'  => true,
+				'single'        => true,
+				'type'          => 'boolean',
 				'auth_callback' => '__return_true',
 			)
 		);
@@ -113,7 +113,7 @@ class ConvertKit_Pre_Publish_Action {
 		// Remove actions registered by this Plugin.
 		// This ensures that when Page Builders call trigger actions via AJAX, we don't run this multiple times.
 		remove_action( 'wp_insert_post', array( $this, 'classic_editor_post_published' ), 999 );
-		remove_action( 'rest_after_insert_' . $post->post_type, array( $this, 'rest_api_post_published' ), 10, 3 );
+		remove_action( 'rest_after_insert_' . $post->post_type, array( $this, 'rest_api_post_published' ), 10 );
 
 		// Ignore if the Post is not transitioning to published.
 		if ( $new_status !== 'publish' ) {
@@ -142,12 +142,12 @@ class ConvertKit_Pre_Publish_Action {
 
 	/**
 	 * Called when a Post is created or updated using the Classic Editor.
-	 * 
-	 * @since 	2.4.0
-	 * 
-	 * @param 	int     $post_id Post ID.
-	 * @param 	WP_Post $post    Post object.
-	 * @param 	bool    $update  Whether this is an existing post being updated.
+	 *
+	 * @since   2.4.0
+	 *
+	 * @param   int     $post_id Post ID.
+	 * @param   WP_Post $post    Post object.
+	 * @param   bool    $update  Whether this is an existing post being updated.
 	 */
 	public function classic_editor_post_published( $post_id, $post, $update ) {
 
@@ -171,21 +171,21 @@ class ConvertKit_Pre_Publish_Action {
 		 */
 		do_action( 'convertkit_pre_publish_action_run_' . $this->get_name(), $post );
 
-	} 
+	}
 
 	/**
 	 * Called when a Post is created or updated via the REST API, including Gutenberg.
-	 * 
-	 * @since 	2.4.0
-	 * 
-	 * @param 	WP_Post         $post     Inserted or updated post object.
-	 * @param 	WP_REST_Request $request  Request object.
-	 * @param 	bool            $creating True when creating a post, false when updating.
+	 *
+	 * @since   2.4.0
+	 *
+	 * @param   WP_Post         $post     Inserted or updated post object.
+	 * @param   WP_REST_Request $request  Request object.
+	 * @param   bool            $creating True when creating a post, false when updating.
 	 */
-	public function rest_api_post_publish( $post, $request, $publishing ) {
+	public function rest_api_post_publish( $post, $request, $creating ) {
 
 		// If the Post is not being published (i.e. it's an update), don't do anything.
-		if ( ! $publishing ) {
+		if ( ! $creating ) {
 			return;
 		}
 
@@ -243,6 +243,19 @@ class ConvertKit_Pre_Publish_Action {
 
 		// Save setting.
 		update_post_meta( $post_id, $this->meta_key, true );
+
+	}
+
+	/**
+	 * Deletes the action's meta key and value from the given Post.
+	 *
+	 * @since   2.4.0
+	 *
+	 * @param   int $post_id    Post ID.
+	 */
+	public function delete_post_meta( $post_id ) {
+
+		delete_post_meta( $post_id, $this->meta_key );
 
 	}
 

--- a/includes/pre-publish-actions/class-convertkit-pre-publish-action.php
+++ b/includes/pre-publish-actions/class-convertkit-pre-publish-action.php
@@ -45,6 +45,9 @@ class ConvertKit_Pre_Publish_Action {
 		// Register this as a pre-publish action in the ConvertKit Plugin.
 		add_filter( 'convertkit_get_pre_publish_actions', array( $this, 'register' ) );
 
+		// Register meta key for Gutenberg.
+		add_action( 'init', array( $this, 'register_meta_key' ) );
+
 		// Perform pre-publish action.
 		add_action( 'transition_post_status', array( $this, 'run' ), 10, 3 );
 
@@ -70,6 +73,29 @@ class ConvertKit_Pre_Publish_Action {
 		);
 
 		return $pre_publish_actions;
+
+	}
+
+	/**
+	 * Registers the action's meta key in WordPress.
+	 * This is required for Gutenberg to save the '_convertkit_action_{$name}'
+	 * meta key/value pair when a Post is saved.
+	 *
+	 * @since   2.4.0
+	 */
+	public function register_meta_key() {
+
+		// Register action as a meta key.
+		register_post_meta(
+			'post',
+			$this->meta_key,
+			array(
+				'show_in_rest' => true,
+				'single'       => true,
+				'type'         => 'boolean',
+				'auth_callback' => '__return_true',
+			)
+		);
 
 	}
 

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -18,6 +18,11 @@ if ( typeof wp !== 'undefined' &&
 		convertKitGutenbergRegisterBlock( convertkit_blocks[ block ] );
 	}
 
+	// Register ConvertKit Pre-publish actions in Gutenberg.
+	if ( typeof convertkit_pre_publish_actions !== 'undefined' ) {
+		convertKitGutenbergRegisterPrePublishActions( convertkit_pre_publish_actions );
+	}
+
 }
 
 /**
@@ -674,6 +679,97 @@ function convertKitGutenbergRegisterBlock( block ) {
 		window.wp.blockEditor,
 		window.wp.element,
 		window.wp.components
+	) );
+
+}
+
+/**
+ * Registers pre-publish actions in Gutenberg's pre-publish checks panel.
+ *
+ * @since 	2.4.0
+ *
+ * @param 	object 	actions 	Pre-publish actions.
+ */
+function convertKitGutenbergRegisterPrePublishActions( actions ) {
+
+	( function ( plugins, editPost, element, components, data ) {
+
+		// Define some constants for the various items we'll use.
+		const el                 		 = element.createElement;
+		const { ToggleControl }          = components;
+		const { registerPlugin } 		 = plugins;
+		const { PluginPrePublishPanel }  = editPost;
+		const { useSelect, useDispatch } = data;
+
+		/**
+		 * Returns a PluginPrePublishPanel for this Plugin, comprising of all
+		 * pre-publish actions.
+		 *
+		 * @since   2.4.0
+		 *
+		 * @return  PluginPrePublishPanel
+		 */
+		const renderPanel = function () {
+
+			// Build rows.
+			let rows = [];
+			for ( const [ name, action ] of Object.entries( actions ) ) {
+
+				const key = '_convertkit_action_' + action.name;
+				const { meta } = useSelect( function( select ) {
+					return {
+						meta: select( 'core/editor' ).getEditedPostAttribute( 'meta' ),
+					};
+				} );
+				const { editPost } = useDispatch( 'core/editor', [ meta[ key ] ] );
+
+				// Add row.
+			    rows.push(
+					el(
+						ToggleControl,
+						{
+							id:  		'convertkit_action_' + action.name,
+							label: 		action.label,
+							help: 		action.description,
+							value:      true, // @TODO is this right?
+							checked: 	meta[ key ],
+							onChange: 	function ( value ) {
+								editPost( {
+						            meta: { [ key ]: value },
+						        } );
+							}
+						}
+					)
+				);
+			}
+
+			// Return actions in the pre-publish panel.
+			return el(
+		        PluginPrePublishPanel,
+		        {   
+		            className: 'convertkit-pre-publish-actions',
+		            title: 'ConvertKit',
+		            initialOpen: true,
+		        },
+		        rows
+		    );
+
+		}
+
+		// Register pre-publish action.
+		registerPlugin(
+			'convertkit-pre-publish-actions',
+			{
+				render: renderPanel
+			}
+		);
+
+	} (
+		window.wp.plugins,
+		window.wp.editPost,
+		window.wp.element,
+		window.wp.components,
+		window.wp.data
 	) );
 
 }

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -695,10 +695,10 @@ function convertKitGutenbergRegisterPrePublishActions( actions ) {
 	( function ( plugins, editPost, element, components, data ) {
 
 		// Define some constants for the various items we'll use.
-		const el                 		 = element.createElement;
-		const { ToggleControl }          = components;
-		const { registerPlugin } 		 = plugins;
-		const { PluginPrePublishPanel }  = editPost;
+		const el                                 = element.createElement;
+		const { ToggleControl }                  = components;
+		const { registerPlugin }                 = plugins;
+		const { PluginPrePublishPanel }          = editPost;
 		const { useSelect, useDispatch, select } = data;
 
 		/**

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -699,7 +699,7 @@ function convertKitGutenbergRegisterPrePublishActions( actions ) {
 		const { ToggleControl }          = components;
 		const { registerPlugin } 		 = plugins;
 		const { PluginPrePublishPanel }  = editPost;
-		const { useSelect, useDispatch } = data;
+		const { useSelect, useDispatch, select } = data;
 
 		/**
 		 * Returns a PluginPrePublishPanel for this Plugin, comprising of all
@@ -710,6 +710,11 @@ function convertKitGutenbergRegisterPrePublishActions( actions ) {
 		 * @return  PluginPrePublishPanel
 		 */
 		const renderPanel = function () {
+
+			// Bail if the Post Type isn't a Post.
+			if ( select( 'core/editor' ).getCurrentPostType() !== 'post' ) {
+				return;
+			}
 
 			// Build rows.
 			let rows = [];
@@ -760,7 +765,7 @@ function convertKitGutenbergRegisterPrePublishActions( actions ) {
 
 		}
 
-		// Register pre-publish action.
+		// Register pre-publish actions.
 		registerPlugin(
 			'convertkit-pre-publish-actions',
 			{

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -715,28 +715,32 @@ function convertKitGutenbergRegisterPrePublishActions( actions ) {
 			let rows = [];
 			for ( const [ name, action ] of Object.entries( actions ) ) {
 
-				const key = '_convertkit_action_' + action.name;
-				const { meta } = useSelect( function( select ) {
-					return {
-						meta: select( 'core/editor' ).getEditedPostAttribute( 'meta' ),
-					};
-				} );
+				const key          = '_convertkit_action_' + action.name;
+				const { meta }     = useSelect(
+					function ( select ) {
+						return {
+							meta: select( 'core/editor' ).getEditedPostAttribute( 'meta' ),
+						};
+					}
+				);
 				const { editPost } = useDispatch( 'core/editor', [ meta[ key ] ] );
 
 				// Add row.
-			    rows.push(
+				rows.push(
 					el(
 						ToggleControl,
 						{
 							id:  		'convertkit_action_' + action.name,
 							label: 		action.label,
 							help: 		action.description,
-							value:      true, // @TODO is this right?
+							value:      true,
 							checked: 	meta[ key ],
 							onChange: 	function ( value ) {
-								editPost( {
-						            meta: { [ key ]: value },
-						        } );
+								editPost(
+									{
+										meta: { [ key ]: value },
+									}
+								);
 							}
 						}
 					)
@@ -745,14 +749,14 @@ function convertKitGutenbergRegisterPrePublishActions( actions ) {
 
 			// Return actions in the pre-publish panel.
 			return el(
-		        PluginPrePublishPanel,
-		        {   
-		            className: 'convertkit-pre-publish-actions',
-		            title: 'ConvertKit',
-		            initialOpen: true,
-		        },
-		        rows
-		    );
+				PluginPrePublishPanel,
+				{
+					className: 'convertkit-pre-publish-actions',
+					title: 'ConvertKit',
+					initialOpen: true,
+				},
+				rows
+			);
 
 		}
 

--- a/tests/_support/Helper/Acceptance/WPGutenberg.php
+++ b/tests/_support/Helper/Acceptance/WPGutenberg.php
@@ -331,7 +331,21 @@ class WPGutenberg extends \Codeception\Module
 		// Click the Publish button.
 		$I->click('.editor-post-publish-button__button');
 
-		// When the pre-publish panel displays, click Publish again.
+		// Click the Publish button on the pre-publish Panel.
+		return $I->clickPublishOnPrePublishChecksForGutenbergPage($I);
+	}
+
+	/**
+	 * Clicks the Publish button the pre-publish checks sidebar, confirming the Page, Post or Custom Post Type
+	 * published and returning its URL.
+	 *
+	 * @since   2.4.0
+	 *
+	 * @param   AcceptanceTester $I                      Acceptance Tester.
+	 */
+	public function clickPublishOnPrePublishChecksForGutenbergPage($I)
+	{
+		// Click publish on the pre-publish panel.
 		$I->waitForElementVisible('.editor-post-publish-panel__header-publish-button');
 		$I->performOn(
 			'.editor-post-publish-panel__header-publish-button',

--- a/tests/acceptance/broadcasts/export/BroadcastsExportPostCest.php
+++ b/tests/acceptance/broadcasts/export/BroadcastsExportPostCest.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Tests Post export to Broadcast functionality in Gutenberg.
+ *
+ * @since   2.4.0
+ */
+class BroadcastsExportPostCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   2.4.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		// Activate ConvertKit Plugin.
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+	}
+
+	/**
+	 * Tests that no "Create Broadcast" option is displayed when creating a Post and the 'Enable Export Actions' is disabled
+	 * in the Plugin's settings.
+	 *
+	 * @since   2.4.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testCreateBroadcastNotDisplayedWhenDisabledInPlugin(AcceptanceTester $I)
+	{
+		// Add a Post using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Broadcast: Export: Disabled in Plugin');
+
+		// Click the Publish button.
+		$I->click('.editor-post-publish-button__button');
+
+		// When the pre-publish panel displays, confirm no Create Broadcast option exists.
+		$I->waitForElementVisible('.editor-post-publish-panel__header-publish-button');
+
+		// Confirm no Create Broadcast option is displayed.
+		$I->dontSeeElementInDOM('.convertkit-pre-publish-actions');
+
+		// Publish the page, to prevent an alert when navigating away for the next test.
+		$I->clickPublishOnPrePublishChecksForGutenbergPage($I);
+	}
+
+	/**
+	 * Tests that no "Create Broadcast" option is displayed when creating a Page and the 'Enable Export Actions' is enabled
+	 * in the Plugin's settings.
+	 *
+	 * @since   2.4.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testCreateBroadcastNotDisplayedOnPages(AcceptanceTester $I)
+	{
+		// Enable Export Actions for Posts.
+		$I->setupConvertKitPluginBroadcasts(
+			$I,
+			[
+				'enabled_export' => true,
+			]
+		);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Broadcast: Export: Disabled in Plugin');
+
+		// Click the Publish button.
+		$I->click('.editor-post-publish-button__button');
+
+		// When the pre-publish panel displays, confirm no Create Broadcast option exists.
+		$I->waitForElementVisible('.editor-post-publish-panel__header-publish-button');
+
+		// Confirm no Create Broadcast option is displayed.
+		$I->dontSeeElementInDOM('.convertkit-pre-publish-actions');
+
+		// Publish the page, to prevent an alert when navigating away for the next test.
+		$I->clickPublishOnPrePublishChecksForGutenbergPage($I);
+	}
+
+	/**
+	 * Tests that:
+	 * - the "Create Broadcast" option is displayed when creating a Post,
+	 * - the Broadcast is not created in ConvertKit when the "Create Broadcast" option is not enabled on the Post.
+	 *
+	 * @since   2.4.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testCreateBroadcastWhenDisabledInPost(AcceptanceTester $I)
+	{
+		// Enable Export Actions for Posts.
+		$I->setupConvertKitPluginBroadcasts(
+			$I,
+			[
+				'enabled_export' => true,
+			]
+		);
+
+		// Add a Post using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Broadcast: Export: Disabled in Post');
+
+		// Publish Post.
+		$I->publishGutenbergPage($I);
+
+		// Get Post ID.
+		$postID = $I->grabValueFrom('post_ID');
+
+		// Confirm Broadcast was not created in ConvertKit.
+		$I->dontSeePostMetaInDatabase(
+			array(
+				'post_id'  => $postID,
+				'meta_key' => '_convertkit_broadcast_export_id',
+			)
+		);
+	}
+
+	/**
+	 * Tests that:
+	 * - the "Create Broadcast" option is displayed when creating a Post,
+	 * - the Broadcast is created in ConvertKit when the "Create Broadcast" option is enabled on the Post.
+	 *
+	 * @since   2.4.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testCreateBroadcastWhenEnabledInPost(AcceptanceTester $I)
+	{
+		// Enable Export Actions for Posts.
+		$I->setupConvertKitPluginBroadcasts(
+			$I,
+			[
+				'enabled_export' => true,
+			]
+		);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'post', 'ConvertKit: Page: Broadcast: Export: Enabled in Post');
+
+		// Click the Publish button.
+		$I->click('.editor-post-publish-button__button');
+
+		// When the pre-publish panel displays, confirm no Create Broadcast option exists.
+		$I->waitForElementVisible('.editor-post-publish-panel__header-publish-button');
+
+		// Enable the Create Broadcast option.
+		$I->click('.convertkit-pre-publish-actions #inspector-toggle-control-0');
+
+		// Publish the Post.
+		$I->clickPublishOnPrePublishChecksForGutenbergPage($I);
+
+		// Get Post ID.
+		$postID = $I->grabValueFrom('post_ID');
+
+		// Confirm Broadcast was created in ConvertKit.
+		$I->seePostMetaInDatabase(
+			array(
+				'post_id'  => $postID,
+				'meta_key' => '_convertkit_broadcast_export_id',
+			)
+		);
+
+		// Get Broadcast ID.
+		$broadcastID = $I->grabPostMetaFromDatabase($postID, '_convertkit_broadcast_export_id', true);
+
+		// Fetch Broadcast from the API.
+		$broadcast = $I->apiGetBroadcast($broadcastID);
+
+		// Delete Broadcast.
+		$I->apiDeleteBroadcast($broadcastID);
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   2.4.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
+	}
+}

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -46,6 +46,7 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/cron-functions.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/functions.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-wp-convertkit.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-ajax.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-broadcasts-exporter.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-broadcasts-importer.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-cron.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-gutenberg.php';
@@ -102,7 +103,6 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/woocommerce/class-
 
 // Load files that are only used in the WordPress Administration interface.
 if ( is_admin() ) {
-	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-broadcasts-exporter.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-bulk-edit.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-quick-edit.php';
 	require_once CONVERTKIT_PLUGIN_PATH . '/admin/class-convertkit-admin-cache-plugins.php';


### PR DESCRIPTION
## Summary

Adds a pre-publish action to new and draft WordPress Posts, allowing the user to send the WordPress Post to ConvertKit as a draft Broadcast when using the Gutenberg / Block Editor.

<img width="1822" alt="Screenshot_2023-09-29_at_13_10_02" src="https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/2fa01aa0-af3e-41a7-887b-f17babf455d3">

## Testing

- `BroadcastsExportPostCest`: Adds tests to confirm the option is displayed (or not displayed) when Gutenberg is used, depending on the Plugin's configuration, and that a draft ConvertKit Broadcast is created when enabled. 

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)