### PR TITLE
Member Content: Display Filters and Settings on Posts

### DIFF
--- a/admin/class-convertkit-admin-restrict-content.php
+++ b/admin/class-convertkit-admin-restrict-content.php
@@ -60,11 +60,9 @@ class ConvertKit_Admin_Restrict_Content {
 			return;
 		}
 
-		// Add New Member Content button.
+		// Add New Member Content Wizard button to Pages.
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts_and_css' ) );
-		foreach ( convertkit_get_supported_restrict_content_post_types() as $post_type ) {
-			add_filter( 'views_edit-' . $post_type, array( $this, 'output_wp_list_table_buttons' ) );
-		}
+		add_filter( 'views_edit-page', array( $this, 'output_wp_list_table_buttons' ) );
 
 		// Filter WP_List_Table by Restrict Content setting.
 		add_action( 'pre_get_posts', array( $this, 'filter_wp_list_table_output' ) );
@@ -186,7 +184,7 @@ class ConvertKit_Admin_Restrict_Content {
 		$url = add_query_arg(
 			array(
 				'page'         => 'convertkit-restrict-content-setup',
-				'ck_post_type' => 'page',
+				'ck_post_type' => $post_type,
 			),
 			admin_url( 'options.php' )
 		);

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -136,6 +136,7 @@ function convertkit_get_supported_restrict_content_post_types() {
 
 	$post_types = array(
 		'page',
+		'post',
 	);
 
 	/**

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -892,13 +892,14 @@ class Plugin extends \Codeception\Module
 	 * @since   2.1.0
 	 *
 	 * @param   AcceptanceTester $I                          Tester.
+	 * @param 	string 			 $postType 					 Post Type.
 	 * @param   string           $title                      Title.
 	 * @param   string           $visibleContent             Content that should always be visible.
 	 * @param   string           $memberContent              Content that should only be available to authenticated subscribers.
 	 * @param   string           $restrictContentSetting     Restrict Content setting.
 	 * @return  int                                          Page ID.
 	 */
-	public function createRestrictedContentPage($I, $title, $visibleContent = 'Visible content.', $memberContent = 'Member only content.', $restrictContentSetting = '')
+	public function createRestrictedContentPage($I, $postType, $title, $visibleContent = 'Visible content.', $memberContent = 'Member only content.', $restrictContentSetting = '')
 	{
 		return $I->havePostInDatabase(
 			[

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -903,7 +903,7 @@ class Plugin extends \Codeception\Module
 	{
 		return $I->havePostInDatabase(
 			[
-				'post_type'    => 'page',
+				'post_type'    => $postType,
 				'post_title'   => $title,
 
 				// Emulate Gutenberg content with visible and members only content sections.

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -892,7 +892,7 @@ class Plugin extends \Codeception\Module
 	 * @since   2.1.0
 	 *
 	 * @param   AcceptanceTester $I                          Tester.
-	 * @param 	string 			 $postType 					 Post Type.
+	 * @param   string           $postType                   Post Type.
 	 * @param   string           $title                      Title.
 	 * @param   string           $visibleContent             Content that should always be visible.
 	 * @param   string           $memberContent              Content that should only be available to authenticated subscribers.

--- a/tests/acceptance/restrict-content/RestrictContentCacheCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentCacheCest.php
@@ -71,6 +71,7 @@ class RestrictContentCacheCest
 		// Create Restricted Content Page.
 		$pageID = $I->createRestrictedContentPage(
 			$I,
+			'page',
 			'ConvertKit: Restrict Content: Product: LiteSpeed Cache',
 			$this->visibleContent,
 			$this->memberContent,
@@ -120,6 +121,7 @@ class RestrictContentCacheCest
 		// Create Restricted Content Page.
 		$pageID = $I->createRestrictedContentPage(
 			$I,
+			'page',
 			'ConvertKit: Restrict Content: Product: W3 Total Cache',
 			$this->visibleContent,
 			$this->memberContent,
@@ -167,6 +169,7 @@ class RestrictContentCacheCest
 		// Create Restricted Content Page.
 		$pageID = $I->createRestrictedContentPage(
 			$I,
+			'page',
 			'ConvertKit: Restrict Content: Product: WP Fastest Cache',
 			$this->visibleContent,
 			$this->memberContent,
@@ -214,6 +217,7 @@ class RestrictContentCacheCest
 		// Create Restricted Content Page.
 		$pageID = $I->createRestrictedContentPage(
 			$I,
+			'page',
 			'ConvertKit: Restrict Content: Product: WP-Optimize',
 			$this->visibleContent,
 			$this->memberContent,
@@ -261,6 +265,7 @@ class RestrictContentCacheCest
 		// Create Restricted Content Page.
 		$pageID = $I->createRestrictedContentPage(
 			$I,
+			'page',
 			'ConvertKit: Restrict Content: Product: WP Super Cache',
 			$this->visibleContent,
 			$this->memberContent,

--- a/tests/acceptance/restrict-content/RestrictContentFilterPageCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentFilterPageCest.php
@@ -4,7 +4,7 @@
  *
  * @since   2.1.0
  */
-class RestrictContentFilterCest
+class RestrictContentFilterPageCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
@@ -111,6 +111,7 @@ class RestrictContentFilterCest
 		// Create Page, set to restrict content to a Product.
 		$I->createRestrictedContentPage(
 			$I,
+			'page'
 			'ConvertKit: Page: Restricted Content: Product: Filter Test',
 			'Visible content.',
 			'Member only content.',

--- a/tests/acceptance/restrict-content/RestrictContentFilterPageCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentFilterPageCest.php
@@ -111,7 +111,7 @@ class RestrictContentFilterPageCest
 		// Create Page, set to restrict content to a Product.
 		$I->createRestrictedContentPage(
 			$I,
-			'page'
+			'page',
 			'ConvertKit: Page: Restricted Content: Product: Filter Test',
 			'Visible content.',
 			'Member only content.',

--- a/tests/acceptance/restrict-content/RestrictContentFilterPostCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentFilterPostCest.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Tests the filter dropdown for Restrict Content in the Posts WP_List_Table.
+ *
+ * @since   2.3.2
+ */
+class RestrictContentFilterPostCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   2.3.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		// Activate ConvertKit plugin.
+		$I->activateConvertKitPlugin($I);
+	}
+
+	/**
+	 * Test that no dropdown filter on the Posts screen is displayed when no API keys are configured.
+	 *
+	 * @since   2.3.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testNoFilterDisplayedWhenNoAPIKeys(AcceptanceTester $I)
+	{
+		// Navigate to Posts.
+		$I->amOnAdminPage('edit.php?post_type=post');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check no filter is displayed, as the Plugin isn't configured.
+		$I->dontSeeElementInDOM('#wp-convertkit-restrict-content-filter');
+	}
+
+	/**
+	 * Test that no dropdown filter on the Posts screen is displayed when Restrict
+	 * Content is disabled.
+	 *
+	 * @since   2.3.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testNoFilterDisplayedWhenRestrictContentDisabled(AcceptanceTester $I)
+	{
+		// Setup Plugin using API keys that have no resources.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET']);
+
+		// Navigate to Posts.
+		$I->amOnAdminPage('edit.php?post_type=post');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check no filter is displayed, as the ConvertKit account has no resources.
+		$I->dontSeeElementInDOM('#wp-convertkit-restrict-content-filter');
+	}
+
+	/**
+	 * Test that no dropdown filter on the Posts screen is displayed when the ConvertKit
+	 * account has no Forms, Tag and Products.
+	 *
+	 * @since   2.3.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testNoFilterDisplayedWhenNoResources(AcceptanceTester $I)
+	{
+		// Setup Plugin using API keys that have no resources.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
+		$I->setupConvertKitPluginRestrictContent(
+			$I,
+			[
+				'enabled' => 'on',
+			]
+		);
+
+		// Navigate to Posts.
+		$I->amOnAdminPage('edit.php?post_type=post');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check no filter is displayed, as the ConvertKit account has no resources.
+		$I->dontSeeElementInDOM('#wp-convertkit-restrict-content-filter');
+	}
+
+	/**
+	 * Test that filtering by Product works on the Posts screen.
+	 *
+	 * @since   2.3.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFilterByProduct(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginRestrictContent(
+			$I,
+			[
+				'enabled' => 'on',
+			]
+		);
+
+		// Create Post, set to restrict content to a Product.
+		$I->createRestrictedContentPage(
+			$I,
+			'post'
+			'ConvertKit: Post: Restricted Content: Product: Filter Test',
+			'Visible content.',
+			'Member only content.',
+			'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+		);
+
+		// Navigate to Posts.
+		$I->amOnAdminPage('edit.php?post_type=post');
+
+		// Wait for the WP_List_Table of Posts to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Post is listed, and has the 'ConvertKit Member Content' label.
+		$I->see('ConvertKit: Post: Restricted Content: Product: Filter Test');
+		$I->see('ConvertKit Member Content');
+
+		// Filter by Product.
+		$I->selectOption('#wp-convertkit-restrict-content-filter', $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
+		$I->click('Filter');
+
+		// Wait for the WP_List_Table of Posts to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Post is still listed, and has the 'ConvertKit Member Content' label.
+		$I->see('ConvertKit: Post: Restricted Content: Product: Filter Test');
+		$I->see('ConvertKit Member Content');
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   2.3.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
+	}
+}

--- a/tests/acceptance/restrict-content/RestrictContentFilterPostCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentFilterPostCest.php
@@ -111,7 +111,7 @@ class RestrictContentFilterPostCest
 		// Create Post, set to restrict content to a Product.
 		$I->createRestrictedContentPage(
 			$I,
-			'post'
+			'post',
 			'ConvertKit: Post: Restricted Content: Product: Filter Test',
 			'Visible content.',
 			'Member only content.',

--- a/tests/acceptance/restrict-content/RestrictContentProductPageCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentProductPageCest.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * Tests Restrict Content by Product functionality on WordPress Pages.
+ *
+ * @since   2.1.0
+ */
+class RestrictContentProductPageCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		// Activate and Setup ConvertKit plugin.
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+	}
+
+	/**
+	 * Test that restricting content by a Product specified in the Page Settings works when
+	 * creating and viewing a new WordPress Page.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentWhenDisabled(AcceptanceTester $I)
+	{
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Restrict Content: Product');
+
+		// Confirm no option is displayed to restrict content.
+		$I->dontSeeElementInDOM('#wp-convertkit-restrict_content');
+
+		// Add blocks.
+		$I->addGutenbergParagraphBlock($I, 'Visible content.');
+		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergParagraphBlock($I, 'Member only content.');
+
+		// Publish Page.
+		$url = $I->publishGutenbergPage($I);
+
+		// Confirm that all content is displayed.
+		$I->amOnUrl($url);
+		$I->see('Visible content.');
+		$I->see('Member only content.');
+	}
+
+	/**
+	 * Test that restricting content by a Product specified in the Page Settings works when
+	 * creating and viewing a new WordPress Page.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentByProduct(AcceptanceTester $I)
+	{
+		// Enable Restricted Content.
+		$I->setupConvertKitPluginRestrictContent(
+			$I,
+			[
+				'enabled' => 'on',
+			]
+		);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Restrict Content: Product');
+
+		// Configure metabox's Restrict Content setting = Product name.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form'             => [ 'select2', 'None' ],
+				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+			]
+		);
+
+		// Add blocks.
+		$I->addGutenbergParagraphBlock($I, 'Visible content.');
+		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergParagraphBlock($I, 'Member only content.');
+
+		// Publish Page.
+		$url = $I->publishGutenbergPage($I);
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentOnFrontend(
+			$I,
+			$url,
+			'Visible content.',
+			'Member only content.'
+		);
+	}
+
+	/**
+	 * Test that restricting content by a Product specified in the Page Settings works when
+	 * using the Quick Edit functionality.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentByProductUsingQuickEdit(AcceptanceTester $I)
+	{
+		// Enable Restricted Content.
+		$I->setupConvertKitPluginRestrictContent(
+			$I,
+			[
+				'enabled' => 'on',
+			]
+		);
+
+		// Programmatically create a Page.
+		$pageID = $I->createRestrictedContentPage($I, 'page', 'ConvertKit: Page: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Quick Edit');
+
+		// Quick Edit the Page in the Pages WP_List_Table.
+		$I->quickEdit(
+			$I,
+			'page',
+			$pageID,
+			[
+				'restrict_content' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+			]
+		);
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentOnFrontend($I, $pageID);
+	}
+
+	/**
+	 * Test that restricting content by a Product specified in the Page Settings works when
+	 * using the Bulk Edit functionality.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentByProductUsingBulkEdit(AcceptanceTester $I)
+	{
+		// Enable Restricted Content.
+		$I->setupConvertKitPluginRestrictContent(
+			$I,
+			[
+				'enabled' => 'on',
+			]
+		);
+
+		// Programmatically create two Pages.
+		$pageIDs = array(
+			$I->createRestrictedContentPage($I, 'page', 'ConvertKit: Page: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Bulk Edit #1'),
+			$I->createRestrictedContentPage($I, 'page', 'ConvertKit: Page: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Bulk Edit #2'),
+		);
+
+		// Bulk Edit the Pages in the Pages WP_List_Table.
+		$I->bulkEdit(
+			$I,
+			'page',
+			$pageIDs,
+			[
+				'restrict_content' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+			]
+		);
+
+		// Iterate through Pages to run frontend tests.
+		foreach ($pageIDs as $pageID) {
+			// Test Restrict Content functionality.
+			$I->testRestrictedContentOnFrontend($I, $pageID);
+			$I->resetCookie('ck_subscriber_id');
+		}
+	}
+
+	/**
+	 * Test that no option to restrict content by a Product is displayed when disabled and using
+	 * the Bulk and Quick Edit functionality.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentBulkQuickEditWhenDisabled(AcceptanceTester $I)
+	{
+		// Programmatically create two Pages.
+		$pageIDs = array(
+			$I->createRestrictedContentPage($I, 'page', 'ConvertKit: Page: Restrict Content: Disabled: Bulk Edit #1'),
+			$I->createRestrictedContentPage($I, 'page', 'ConvertKit: Page: Restrict Content: Disabled: Bulk Edit #2'),
+		);
+
+		// Navigate to Pages > Edit.
+		$I->amOnAdminPage('edit.php?post_type=page');
+
+		// Open Quick Edit form for the Page.
+		$I->openQuickEdit($I, 'page', $pageIDs[0]);
+
+		// Confirm no option exists to restrict content.
+		$I->dontSeeElementInDOM('#convertkit-quick-edit #wp-convertkit-quick-edit-restrict_content');
+
+		// Cancel Quick Edit.
+		$I->click('Cancel');
+
+		// Open Bulk Edit form for the Pages.
+		$I->openBulkEdit($I, 'page', $pageIDs);
+
+		// Confirm no option exists to restrict content.
+		$I->dontSeeElementInDOM('#convertkit-bulk-edit #wp-convertkit-bulk-edit-restrict_content');
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->resetCookie('ck_subscriber_id');
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
+	}
+}

--- a/tests/acceptance/restrict-content/RestrictContentProductPostCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentProductPostCest.php
@@ -1,15 +1,15 @@
 <?php
 /**
- * Tests Restrict Content by Product functionality.
+ * Tests Restrict Content by Product functionality on WordPress Posts.
  *
- * @since   2.1.0
+ * @since   2.3.2
  */
-class RestrictContentProductCest
+class RestrictContentProductPostCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
 	 *
-	 * @since   2.1.0
+	 * @since   2.3.2
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
@@ -21,17 +21,17 @@ class RestrictContentProductCest
 	}
 
 	/**
-	 * Test that restricting content by a Product specified in the Page Settings works when
-	 * creating and viewing a new WordPress Page.
+	 * Test that restricting content by a Product specified in the Post Settings works when
+	 * creating and viewing a new WordPress Post.
 	 *
-	 * @since   2.1.0
+	 * @since   2.3.2
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testRestrictContentWhenDisabled(AcceptanceTester $I)
 	{
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Restrict Content: Product');
+		// Add a Post using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Restrict Content: Product');
 
 		// Confirm no option is displayed to restrict content.
 		$I->dontSeeElementInDOM('#wp-convertkit-restrict_content');
@@ -41,7 +41,7 @@ class RestrictContentProductCest
 		$I->addGutenbergBlock($I, 'More', 'more');
 		$I->addGutenbergParagraphBlock($I, 'Member only content.');
 
-		// Publish Page.
+		// Publish Post.
 		$url = $I->publishGutenbergPage($I);
 
 		// Confirm that all content is displayed.
@@ -51,10 +51,10 @@ class RestrictContentProductCest
 	}
 
 	/**
-	 * Test that restricting content by a Product specified in the Page Settings works when
-	 * creating and viewing a new WordPress Page.
+	 * Test that restricting content by a Product specified in the Post Settings works when
+	 * creating and viewing a new WordPress Post.
 	 *
-	 * @since   2.1.0
+	 * @since   2.3.2
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
@@ -68,8 +68,8 @@ class RestrictContentProductCest
 			]
 		);
 
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Restrict Content: Product');
+		// Add a Post using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Restrict Content: Product');
 
 		// Configure metabox's Restrict Content setting = Product name.
 		$I->configureMetaboxSettings(
@@ -86,7 +86,7 @@ class RestrictContentProductCest
 		$I->addGutenbergBlock($I, 'More', 'more');
 		$I->addGutenbergParagraphBlock($I, 'Member only content.');
 
-		// Publish Page.
+		// Publish Post.
 		$url = $I->publishGutenbergPage($I);
 
 		// Test Restrict Content functionality.
@@ -99,10 +99,10 @@ class RestrictContentProductCest
 	}
 
 	/**
-	 * Test that restricting content by a Product specified in the Page Settings works when
+	 * Test that restricting content by a Product specified in the Post Settings works when
 	 * using the Quick Edit functionality.
 	 *
-	 * @since   2.1.0
+	 * @since   2.3.2
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
@@ -116,28 +116,32 @@ class RestrictContentProductCest
 			]
 		);
 
-		// Programmatically create a Page.
-		$pageID = $I->createRestrictedContentPage($I, 'ConvertKit: Page: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Quick Edit');
+		// Programmatically create a Post.
+		$postID = $I->createRestrictedContentPage(
+			$I,
+			'post',
+			'ConvertKit: Post: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Quick Edit'
+		);
 
-		// Quick Edit the Page in the Pages WP_List_Table.
+		// Quick Edit the Post in the Posts WP_List_Table.
 		$I->quickEdit(
 			$I,
-			'page',
-			$pageID,
+			'post',
+			$postID,
 			[
 				'restrict_content' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			]
 		);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentOnFrontend($I, $pageID);
+		$I->testRestrictedContentOnFrontend($I, $postID);
 	}
 
 	/**
-	 * Test that restricting content by a Product specified in the Page Settings works when
+	 * Test that restricting content by a Product specified in the Post Settings works when
 	 * using the Bulk Edit functionality.
 	 *
-	 * @since   2.1.0
+	 * @since   2.3.2
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
@@ -151,26 +155,26 @@ class RestrictContentProductCest
 			]
 		);
 
-		// Programmatically create two Pages.
-		$pageIDs = array(
-			$I->createRestrictedContentPage($I, 'ConvertKit: Page: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Bulk Edit #1'),
-			$I->createRestrictedContentPage($I, 'ConvertKit: Page: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Bulk Edit #2'),
+		// Programmatically create two Posts.
+		$postIDs = array(
+			$I->createRestrictedContentPage($I, 'post', 'ConvertKit: Post: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Bulk Edit #1'),
+			$I->createRestrictedContentPage($I, 'post', 'ConvertKit: Post: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Bulk Edit #2'),
 		);
 
-		// Bulk Edit the Pages in the Pages WP_List_Table.
+		// Bulk Edit the Posts in the Posts WP_List_Table.
 		$I->bulkEdit(
 			$I,
-			'page',
-			$pageIDs,
+			'post',
+			$postIDs,
 			[
 				'restrict_content' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			]
 		);
 
-		// Iterate through Pages to run frontend tests.
-		foreach ($pageIDs as $pageID) {
+		// Iterate through Posts to run frontend tests.
+		foreach ($postIDs as $postID) {
 			// Test Restrict Content functionality.
-			$I->testRestrictedContentOnFrontend($I, $pageID);
+			$I->testRestrictedContentOnFrontend($I, $postID);
 			$I->resetCookie('ck_subscriber_id');
 		}
 	}
@@ -179,23 +183,23 @@ class RestrictContentProductCest
 	 * Test that no option to restrict content by a Product is displayed when disabled and using
 	 * the Bulk and Quick Edit functionality.
 	 *
-	 * @since   2.1.0
+	 * @since   2.3.2
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testRestrictContentBulkQuickEditWhenDisabled(AcceptanceTester $I)
 	{
-		// Programmatically create two Pages.
-		$pageIDs = array(
-			$I->createRestrictedContentPage($I, 'ConvertKit: Page: Restrict Content: Disabled: Bulk Edit #1'),
-			$I->createRestrictedContentPage($I, 'ConvertKit: Page: Restrict Content: Disabled: Bulk Edit #2'),
+		// Programmatically create two Posts.
+		$postIDs = array(
+			$I->createRestrictedContentPage($I, 'post', 'ConvertKit: Post: Restrict Content: Disabled: Bulk Edit #1'),
+			$I->createRestrictedContentPage($I, 'post', 'ConvertKit: Post: Restrict Content: Disabled: Bulk Edit #2'),
 		);
 
-		// Navigate to Pages > Edit.
-		$I->amOnAdminPage('edit.php?post_type=page');
+		// Navigate to Posts > Edit.
+		$I->amOnAdminPage('edit.php?post_type=post');
 
-		// Open Quick Edit form for the Page.
-		$I->openQuickEdit($I, 'page', $pageIDs[0]);
+		// Open Quick Edit form for the Post.
+		$I->openQuickEdit($I, 'post', $postIDs[0]);
 
 		// Confirm no option exists to restrict content.
 		$I->dontSeeElementInDOM('#convertkit-quick-edit #wp-convertkit-quick-edit-restrict_content');
@@ -203,8 +207,8 @@ class RestrictContentProductCest
 		// Cancel Quick Edit.
 		$I->click('Cancel');
 
-		// Open Bulk Edit form for the Pages.
-		$I->openBulkEdit($I, 'page', $pageIDs);
+		// Open Bulk Edit form for the Posts.
+		$I->openBulkEdit($I, 'post', $postIDs);
 
 		// Confirm no option exists to restrict content.
 		$I->dontSeeElementInDOM('#convertkit-bulk-edit #wp-convertkit-bulk-edit-restrict_content');
@@ -215,7 +219,7 @@ class RestrictContentProductCest
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
 	 *
-	 * @since   2.1.0
+	 * @since   2.3.2
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */

--- a/tests/acceptance/restrict-content/RestrictContentSettingsCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentSettingsCest.php
@@ -121,6 +121,7 @@ class RestrictContentSettingsCest
 		// Create Restricted Content Page.
 		$pageID = $I->createRestrictedContentPage(
 			$I,
+			'page',
 			'ConvertKit: Restrict Content: Settings',
 			$visibleContent,
 			$memberContent,
@@ -168,6 +169,7 @@ class RestrictContentSettingsCest
 		// Create Restricted Content Page.
 		$pageID = $I->createRestrictedContentPage(
 			$I,
+			'page',
 			'ConvertKit: Restrict Content: Settings: Blank',
 			$visibleContent,
 			$memberContent,
@@ -214,6 +216,7 @@ class RestrictContentSettingsCest
 		// Create Restricted Content Page.
 		$pageID = $I->createRestrictedContentPage(
 			$I,
+			'page',
 			'ConvertKit: Restrict Content: Settings: Custom',
 			$visibleContent,
 			$memberContent,
@@ -249,6 +252,7 @@ class RestrictContentSettingsCest
 		// Create Restricted Content Page.
 		$pageID = $I->createRestrictedContentPage(
 			$I,
+			'page',
 			'ConvertKit: Restrict Content: Settings: Custom',
 			'Visible content.',
 			'Member only content.',

--- a/tests/acceptance/restrict-content/RestrictContentSetupCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentSetupCest.php
@@ -88,6 +88,33 @@ class RestrictContentSetupCest
 	}
 
 	/**
+	 * Test that the Add New Member Content button does not display on the Posts screen.
+	 *
+	 * @since   2.3.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewMemberContentButtonNotDisplayedOnPosts(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Enable Restrict Content.
+		$I->setupConvertKitPluginRestrictContent(
+			$I,
+			[
+				'enabled' => 'on',
+			]
+		);
+
+		// Navigate to Posts.
+		$I->amOnAdminPage('edit.php?post_type=post');
+
+		// Check the button isn't displayed.
+		$I->dontSeeElementInDOM('a.convertkit-action');
+	}
+
+	/**
 	 * Test that the Dashboard submenu item for this wizard does not display when a
 	 * third party Admin Menu editor type Plugin is installed and active.
 	 *


### PR DESCRIPTION
## Summary

Adds options to:
- define the Member Content setting for WordPress Posts,
- filter WordPress Posts by a ConvertKit Product.

![Screenshot 2023-09-29 at 14 58 30](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/13478859-5827-489e-8868-979f0bcce471)
<img width="1822" alt="Screenshot 2023-09-29 at 14 58 44" src="https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/7db9d3a0-1d6d-4c78-bb4f-2dc818a18e73">

With the introduction of ConvertKit Broadcasts to WordPress Posts functionality, ConvertKit paid posts are correctly gated when viewed as WordPress Posts.  However, the admin UI to define/filter by ConvertKit Product on WordPress Posts was not displaying, as it was set to only display on WordPress Pages.

## Testing

- `RestrictContentFilterPostCest`: Tests that the filter dropdown displays on the WordPress Posts screen, and filters Posts by ConvertKit Product
- `RestrictContentProductPostCest`: Tests that the Member Content functionality works when a ConvertKit Product is assigned as the Member Content option for a WordPress Post
- `RestrictContentSetupCest:testAddNewMemberContentButtonNotDisplayedOnPosts`: Test that the `Add New Member Content` button isn't display on the Posts screen.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)