### PR TITLE
Member Content: Remove `Enable` option

### DIFF
--- a/admin/class-convertkit-admin-cache-plugins.php
+++ b/admin/class-convertkit-admin-cache-plugins.php
@@ -54,12 +54,6 @@ class ConvertKit_Admin_Cache_Plugins {
 	 */
 	public function maybe_configure_cache_plugins() {
 
-		// Bail if Restrict Content is disabled.
-		$restrict_content_settings = new ConvertKit_Settings_Restrict_Content();
-		if ( ! $restrict_content_settings->enabled() ) {
-			return;
-		}
-
 		$this->litespeed_cache();
 		$this->w3_total_cache();
 		$this->wp_fastest_cache();

--- a/admin/class-convertkit-admin-restrict-content.php
+++ b/admin/class-convertkit-admin-restrict-content.php
@@ -52,14 +52,6 @@ class ConvertKit_Admin_Restrict_Content {
 	 */
 	public function __construct() {
 
-		// Initialize classes that will be used.
-		$this->restrict_content_settings = new ConvertKit_Settings_Restrict_Content();
-
-		// Bail if Restrict Content isn't enabled.
-		if ( ! $this->restrict_content_settings->enabled() ) {
-			return;
-		}
-
 		// Add New Member Content button.
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts_and_css' ) );
 		foreach ( convertkit_get_supported_restrict_content_post_types() as $post_type ) {

--- a/admin/class-convertkit-admin-settings-restrict-content.php
+++ b/admin/class-convertkit-admin-settings-restrict-content.php
@@ -66,19 +66,6 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 	public function register_fields() {
 
 		add_settings_field(
-			'enabled',
-			__( 'Enable', 'convertkit' ),
-			array( $this, 'enable_callback' ),
-			$this->settings_key,
-			$this->name,
-			array(
-				'name'        => 'enabled',
-				'label_for'   => 'enabled',
-				'description' => __( 'Enables the Member Content functionality, displaying configuration options on pages to require a subscription to a ConvertKit product', 'convertkit' ),
-			)
-		);
-
-		add_settings_field(
 			'subscribe_text',
 			__( 'Subscribe Text', 'convertkit' ),
 			array( $this, 'text_callback' ),
@@ -210,25 +197,6 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 	}
 
 	/**
-	 * Renders the input for the Enable setting.
-	 *
-	 * @since   2.1.0
-	 *
-	 * @param   array $args   Setting field arguments (name,description).
-	 */
-	public function enable_callback( $args ) {
-
-		// Output field.
-		echo $this->get_checkbox_field( // phpcs:ignore WordPress.Security.EscapeOutput
-			$args['name'],
-			'on',
-			$this->settings->enabled(), // phpcs:ignore WordPress.Security.EscapeOutput
-			$args['description'] // phpcs:ignore WordPress.Security.EscapeOutput
-		);
-
-	}
-
-	/**
 	 * Renders the input for the text setting.
 	 *
 	 * @since   2.1.0
@@ -244,7 +212,6 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 			$args['description'], // phpcs:ignore WordPress.Security.EscapeOutput
 			array(
 				'widefat',
-				'enabled',
 			)
 		);
 

--- a/includes/class-convertkit-output-restrict-content.php
+++ b/includes/class-convertkit-output-restrict-content.php
@@ -99,11 +99,6 @@ class ConvertKit_Output_Restrict_Content {
 		$this->settings                  = new ConvertKit_Settings();
 		$this->restrict_content_settings = new ConvertKit_Settings_Restrict_Content();
 
-		// Bail if Restrict Content isn't enabled.
-		if ( ! $this->restrict_content_settings->enabled() ) {
-			return;
-		}
-
 		add_action( 'init', array( $this, 'maybe_run_subscriber_authentication' ), 1 );
 		add_action( 'init', array( $this, 'maybe_run_subscriber_verification' ), 2 );
 		add_filter( 'the_content', array( $this, 'maybe_restrict_content' ) );

--- a/includes/class-convertkit-settings-restrict-content.php
+++ b/includes/class-convertkit-settings-restrict-content.php
@@ -90,19 +90,6 @@ class ConvertKit_Settings_Restrict_Content {
 	}
 
 	/**
-	 * Returns whether Restrict Content is enabled in the Plugin settings.
-	 *
-	 * @since   2.1.0
-	 *
-	 * @return  bool
-	 */
-	public function enabled() {
-
-		return ( $this->settings['enabled'] === 'on' ? true : false );
-
-	}
-
-	/**
 	 * The default settings, used when the ConvertKit Restrict Content Settings haven't been saved
 	 * e.g. on a new installation.
 	 *
@@ -113,7 +100,6 @@ class ConvertKit_Settings_Restrict_Content {
 	public function get_defaults() {
 
 		$defaults = array(
-			'enabled'                => '',
 			'subscribe_text'         => __( 'This content is only available to premium subscribers', 'convertkit' ),
 			'subscribe_button_label' => __( 'Subscribe', 'convertkit' ),
 			'email_text'             => __( 'Already a premium subscriber? Enter the email address used when purchasing below, to receive a login link to access.', 'convertkit' ),

--- a/tests/acceptance/restrict-content/RestrictContentCacheCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentCacheCest.php
@@ -38,14 +38,6 @@ class RestrictContentCacheCest
 		$I->activateConvertKitPlugin($I);
 		$I->setupConvertKitPlugin($I);
 
-		// Enable Restricted Content.
-		$I->setupConvertKitPluginRestrictContent(
-			$I,
-			[
-				'enabled' => 'on',
-			]
-		);
-
 		// Clear up any cache configuration files that might exist from previous tests.
 		$I->deleteWPCacheConfigFiles($I);
 		$I->resetCookie('ck_subscriber_id');

--- a/tests/acceptance/restrict-content/RestrictContentFilterCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentFilterCest.php
@@ -73,12 +73,6 @@ class RestrictContentFilterCest
 	{
 		// Setup Plugin using API keys that have no resources.
 		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
-		$I->setupConvertKitPluginRestrictContent(
-			$I,
-			[
-				'enabled' => 'on',
-			]
-		);
 
 		// Navigate to Pages.
 		$I->amOnAdminPage('edit.php?post_type=page');
@@ -101,12 +95,6 @@ class RestrictContentFilterCest
 	{
 		// Setup Plugin.
 		$I->setupConvertKitPlugin($I);
-		$I->setupConvertKitPluginRestrictContent(
-			$I,
-			[
-				'enabled' => 'on',
-			]
-		);
 
 		// Create Page, set to restrict content to a Product.
 		$I->createRestrictedContentPage(

--- a/tests/acceptance/restrict-content/RestrictContentFilterCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentFilterCest.php
@@ -39,29 +39,6 @@ class RestrictContentFilterCest
 	}
 
 	/**
-	 * Test that no dropdown filter on the Pages screen is displayed when Restrict
-	 * Content is disabled.
-	 *
-	 * @since   2.1.0
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 */
-	public function testNoFilterDisplayedWhenRestrictContentDisabled(AcceptanceTester $I)
-	{
-		// Setup Plugin using API keys that have no resources.
-		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET']);
-
-		// Navigate to Pages.
-		$I->amOnAdminPage('edit.php?post_type=page');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Check no filter is displayed, as the ConvertKit account has no resources.
-		$I->dontSeeElementInDOM('#wp-convertkit-restrict-content-filter');
-	}
-
-	/**
 	 * Test that no dropdown filter on the Pages screen is displayed when the ConvertKit
 	 * account has no Forms, Tag and Products.
 	 *

--- a/tests/acceptance/restrict-content/RestrictContentProductCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentProductCest.php
@@ -32,9 +32,6 @@ class RestrictContentProductCest
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Restrict Content: Product');
 
-		// Confirm no option is displayed to restrict content.
-		$I->dontSeeElementInDOM('#wp-convertkit-restrict_content');
-
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
 		$I->addGutenbergBlock($I, 'More', 'more');
@@ -172,41 +169,6 @@ class RestrictContentProductCest
 			$I->testRestrictedContentOnFrontend($I, $pageID);
 			$I->resetCookie('ck_subscriber_id');
 		}
-	}
-
-	/**
-	 * Test that no option to restrict content by a Product is displayed when disabled and using
-	 * the Bulk and Quick Edit functionality.
-	 *
-	 * @since   2.1.0
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 */
-	public function testRestrictContentBulkQuickEditWhenDisabled(AcceptanceTester $I)
-	{
-		// Programmatically create two Pages.
-		$pageIDs = array(
-			$I->createRestrictedContentPage($I, 'ConvertKit: Page: Restrict Content: Disabled: Bulk Edit #1'),
-			$I->createRestrictedContentPage($I, 'ConvertKit: Page: Restrict Content: Disabled: Bulk Edit #2'),
-		);
-
-		// Navigate to Pages > Edit.
-		$I->amOnAdminPage('edit.php?post_type=page');
-
-		// Open Quick Edit form for the Page.
-		$I->openQuickEdit($I, 'page', $pageIDs[0]);
-
-		// Confirm no option exists to restrict content.
-		$I->dontSeeElementInDOM('#convertkit-quick-edit #wp-convertkit-quick-edit-restrict_content');
-
-		// Cancel Quick Edit.
-		$I->click('Cancel');
-
-		// Open Bulk Edit form for the Pages.
-		$I->openBulkEdit($I, 'page', $pageIDs);
-
-		// Confirm no option exists to restrict content.
-		$I->dontSeeElementInDOM('#convertkit-bulk-edit #wp-convertkit-bulk-edit-restrict_content');
 	}
 
 	/**

--- a/tests/acceptance/restrict-content/RestrictContentProductCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentProductCest.php
@@ -21,8 +21,7 @@ class RestrictContentProductCest
 	}
 
 	/**
-	 * Test that restricting content by a Product specified in the Page Settings works when
-	 * creating and viewing a new WordPress Page.
+	 * Test that content is not restricted when not configured on a WordPress Page.
 	 *
 	 * @since   2.1.0
 	 *

--- a/tests/acceptance/restrict-content/RestrictContentSettingsCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentSettingsCest.php
@@ -33,62 +33,12 @@ class RestrictContentSettingsCest
 		$I->loadConvertKitSettingsRestrictContentScreen($I);
 
 		// Confirm that settings have label[for] attributes.
-		$I->seeInSource('<label for="enabled">');
 		$I->seeInSource('<label for="subscribe_text">');
 		$I->seeInSource('<label for="subscribe_button_label">');
 		$I->seeInSource('<label for="email_text">');
 		$I->seeInSource('<label for="email_button_label">');
 		$I->seeInSource('<label for="email_check_text">');
 		$I->seeInSource('<label for="no_access_text">');
-	}
-
-	/**
-	 * Tests that enabling and disabling Restrict Content works with no errors,
-	 * and that other form fields show / hide depending on the setting.
-	 *
-	 * @since   2.1.0
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 */
-	public function testEnableDisable(AcceptanceTester $I)
-	{
-		// Go to the Plugin's Member Content Screen.
-		$I->loadConvertKitSettingsRestrictContentScreen($I);
-
-		// Confirm that additional fields are hidden, because the 'Enable' option is not checked.
-		$I->dontSeeElement('input.enabled');
-
-		// Enable Member Content.
-		$I->checkOption('#enabled');
-
-		// Confirm that additional fields are now displayed.
-		$I->waitForElementVisible('input.enabled');
-
-		// Click the Save Changes button.
-		$I->click('Save Changes');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm that settings saved and additional fields remain displayed.
-		$I->seeCheckboxIsChecked('#enabled');
-		$I->seeElement('input.enabled');
-
-		// Disable Member Content.
-		$I->uncheckOption('#enabled');
-
-		// Confirm that additional fields are hidden, because the 'Enable' option is not checked.
-		$I->waitForElementNotVisible('input.enabled');
-
-		// Click the Save Changes button.
-		$I->click('Save Changes');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm that settings saved and additional fields are hidden, because the 'Enable' option is not checked.
-		$I->dontSeeCheckboxIsChecked('#enabled');
-		$I->dontSeeElement('input.enabled');
 	}
 
 	/**
@@ -105,12 +55,7 @@ class RestrictContentSettingsCest
 		$memberContent  = 'Member only content.';
 
 		// Save settings.
-		$this->_setupConvertKitPluginRestrictContent(
-			$I,
-			[
-				'enabled' => true,
-			]
-		);
+		$this->_setupConvertKitPluginRestrictContent($I);
 
 		// Confirm default values were saved and display in the form fields.
 		$defaults = $I->getRestrictedContentDefaultSettings();
@@ -147,7 +92,6 @@ class RestrictContentSettingsCest
 
 		// Define settings.
 		$settings = array(
-			'enabled'                => true,
 			'subscribe_text'         => '',
 			'subscribe_button_label' => '',
 			'email_text'             => '',
@@ -194,7 +138,6 @@ class RestrictContentSettingsCest
 
 		// Define settings.
 		$settings = array(
-			'enabled'                => true,
 			'subscribe_text'         => 'Subscribe Text',
 			'subscribe_button_label' => 'Subscribe Button Label',
 			'email_text'             => 'Email Text',
@@ -233,14 +176,6 @@ class RestrictContentSettingsCest
 	 */
 	public function testDisableCSSSetting(AcceptanceTester $I)
 	{
-		// Enable Restrict Content.
-		$this->_setupConvertKitPluginRestrictContent(
-			$I,
-			[
-				'enabled' => true,
-			]
-		);
-
 		// Disable CSS.
 		$I->loadConvertKitSettingsGeneralScreen($I);
 		$I->checkOption('#no_css');
@@ -275,18 +210,7 @@ class RestrictContentSettingsCest
 		// Complete fields.
 		if ( $settings ) {
 			foreach ( $settings as $key => $value ) {
-				switch ( $key ) {
-					case 'enabled':
-						if ( $value ) {
-							$I->checkOption('_wp_convertkit_settings_restrict_content[' . $key . ']');
-						} else {
-							$I->uncheckOption('_wp_convertkit_settings_restrict_content[' . $key . ']');
-						}
-						break;
-					default:
-						$I->fillField('_wp_convertkit_settings_restrict_content[' . $key . ']', $value);
-						break;
-				}
+				$I->fillField('_wp_convertkit_settings_restrict_content[' . $key . ']', $value);
 			}
 		}
 

--- a/tests/acceptance/restrict-content/RestrictContentSetupCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentSetupCest.php
@@ -26,32 +26,8 @@ class RestrictContentSetupCest
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testAddNewMemberContentButtonNotDisplayedWhenDisabled(AcceptanceTester $I)
-	{
-		// Navigate to Pages.
-		$I->amOnAdminPage('edit.php?post_type=page');
-
-		// Check the button isn't displayed.
-		$I->dontSeeElementInDOM('a.convertkit-action page-title-action');
-	}
-
-	/**
-	 * Test that the Add New Member Content button does not display on the Pages screen when no API keys are configured.
-	 *
-	 * @since   2.1.0
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 */
 	public function testAddNewMemberContentButtonNotDisplayedWhenNoAPIKeys(AcceptanceTester $I)
 	{
-		// Enable Restrict Content.
-		$I->setupConvertKitPluginRestrictContent(
-			$I,
-			[
-				'enabled' => 'on',
-			]
-		);
-
 		// Navigate to Pages.
 		$I->amOnAdminPage('edit.php?post_type=page');
 
@@ -69,14 +45,6 @@ class RestrictContentSetupCest
 	 */
 	public function testAddNewMemberContentButtonNotDisplayedWhenNoResources(AcceptanceTester $I)
 	{
-		// Enable Restrict Content.
-		$I->setupConvertKitPluginRestrictContent(
-			$I,
-			[
-				'enabled' => 'on',
-			]
-		);
-
 		// Setup Plugin using API keys that have no resources.
 		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
 
@@ -102,14 +70,6 @@ class RestrictContentSetupCest
 
 		// Setup Plugin.
 		$I->setupConvertKitPlugin($I);
-
-		// Enable Restrict Content.
-		$I->setupConvertKitPluginRestrictContent(
-			$I,
-			[
-				'enabled' => 'on',
-			]
-		);
 
 		// Navigate to Admin Menu Editor's settings.
 		$I->amOnAdminPage('options-general.php?page=menu_editor');
@@ -309,14 +269,6 @@ class RestrictContentSetupCest
 	{
 		// Setup Plugin.
 		$I->setupConvertKitPlugin($I);
-
-		// Enable Restrict Content.
-		$I->setupConvertKitPluginRestrictContent(
-			$I,
-			[
-				'enabled' => 'on',
-			]
-		);
 
 		// Navigate to Pages.
 		$I->amOnAdminPage('edit.php?post_type=page');

--- a/views/backend/post/bulk-edit.php
+++ b/views/backend/post/bulk-edit.php
@@ -69,49 +69,44 @@
 		</button>
 	</div>
 
-	<?php
-	if ( $restrict_content_settings->enabled() ) {
-		?>
-		<!-- Restrict Content -->
-		<div>
-			<label for="wp-convertkit-bulk-edit-restrict_content">
-				<span class="title convertkit-icon-restrict-content"><?php esc_html_e( 'Member', 'convertkit' ); ?></span>
-				<select name="wp-convertkit[restrict_content]" id="wp-convertkit-bulk-edit-restrict_content" size="1">
-					<?php
-					// For Bulk Edit, the 'No Change' value is -1. However, because this Plugin has historically used -1
-					// to mean that the Default form for the Post Type should be displayed, using -1 as 'No Change' in Bulk Edit
-					// would result in Posts/Pages having (or not having) the Form setting updated, when the user may/may not
-					// have selected the 'Default' option.
-					// Therefore, we use -2 to denote 'No Change', even though this setting is for the Tag, so we're at least consistent.
-					?>
-					<option value="-2" data-preserve-on-refresh="1"><?php esc_html_e( '— No Change —', 'convertkit' ); ?></option>
-					<option value="0" data-preserve-on-refresh="1"><?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?></option>
+	<!-- Restrict Content -->
+	<div>
+		<label for="wp-convertkit-bulk-edit-restrict_content">
+			<span class="title convertkit-icon-restrict-content"><?php esc_html_e( 'Member', 'convertkit' ); ?></span>
+			<select name="wp-convertkit[restrict_content]" id="wp-convertkit-bulk-edit-restrict_content" size="1">
+				<?php
+				// For Bulk Edit, the 'No Change' value is -1. However, because this Plugin has historically used -1
+				// to mean that the Default form for the Post Type should be displayed, using -1 as 'No Change' in Bulk Edit
+				// would result in Posts/Pages having (or not having) the Form setting updated, when the user may/may not
+				// have selected the 'Default' option.
+				// Therefore, we use -2 to denote 'No Change', even though this setting is for the Tag, so we're at least consistent.
+				?>
+				<option value="-2" data-preserve-on-refresh="1"><?php esc_html_e( '— No Change —', 'convertkit' ); ?></option>
+				<option value="0" data-preserve-on-refresh="1"><?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?></option>
 
-					<?php
-					// Products.
-					if ( $convertkit_products->exist() ) {
-						?>
-						<optgroup label="<?php esc_attr_e( 'Products', 'convertkit' ); ?>">
-							<?php
-							foreach ( $convertkit_products->get() as $product ) {
-								?>
-								<option value="product_<?php echo esc_attr( $product['id'] ); ?>"><?php echo esc_attr( $product['name'] ); ?></option>
-								<?php
-							}
-							?>
-						</optgroup>
+				<?php
+				// Products.
+				if ( $convertkit_products->exist() ) {
+					?>
+					<optgroup label="<?php esc_attr_e( 'Products', 'convertkit' ); ?>">
 						<?php
-					}
-					?>
-				</select>
-			</label>
-			<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Products from ConvertKit account', 'convertkit' ); ?>" data-resource="products" data-field="#wp-convertkit-bulk-edit-restrict_content">
-				<span class="dashicons dashicons-update"></span>
-			</button>
-		</div>
-		<?php
-	}
-
+						foreach ( $convertkit_products->get() as $product ) {
+							?>
+							<option value="product_<?php echo esc_attr( $product['id'] ); ?>"><?php echo esc_attr( $product['name'] ); ?></option>
+							<?php
+						}
+						?>
+					</optgroup>
+					<?php
+				}
+				?>
+			</select>
+		</label>
+		<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Products from ConvertKit account', 'convertkit' ); ?>" data-resource="products" data-field="#wp-convertkit-bulk-edit-restrict_content">
+			<span class="dashicons dashicons-update"></span>
+		</button>
+	</div>
+	<?php
 	wp_nonce_field( 'wp-convertkit-save-meta', 'wp-convertkit-save-meta-nonce' );
 	?>
 </div>

--- a/views/backend/post/meta-box.php
+++ b/views/backend/post/meta-box.php
@@ -134,46 +134,40 @@
 			</td>
 		</tr>
 
-		<?php
-		if ( $restrict_content_settings->enabled() ) {
-			?>
-			<tr valign="top">
-				<th scope="row">
-					<label for="wp-convertkit-restrict_content"><?php esc_html_e( 'Member Content', 'convertkit' ); ?></label>
-				</th>
-				<td>
-					<div class="convertkit-select2-container convertkit-select2-container-grid">
-						<select name="wp-convertkit[restrict_content]" id="wp-convertkit-restrict_content" class="convertkit-select2">
-							<option value="0"<?php selected( '', $convertkit_post->get_restrict_content() ); ?> data-preserve-on-refresh="1"><?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?></option>
+		<tr valign="top">
+			<th scope="row">
+				<label for="wp-convertkit-restrict_content"><?php esc_html_e( 'Member Content', 'convertkit' ); ?></label>
+			</th>
+			<td>
+				<div class="convertkit-select2-container convertkit-select2-container-grid">
+					<select name="wp-convertkit[restrict_content]" id="wp-convertkit-restrict_content" class="convertkit-select2">
+						<option value="0"<?php selected( '', $convertkit_post->get_restrict_content() ); ?> data-preserve-on-refresh="1"><?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?></option>
 
-							<?php
-							if ( $convertkit_products->exist() ) {
-								?>
-								<optgroup label="<?php esc_attr_e( 'Products', 'convertkit' ); ?>">
-									<?php
-									foreach ( $convertkit_products->get() as $product ) {
-										?>
-										<option value="product_<?php echo esc_attr( $product['id'] ); ?>"<?php selected( 'product_' . $product['id'], $convertkit_post->get_restrict_content() ); ?>><?php echo esc_attr( $product['name'] ); ?></option>
-										<?php
-									}
-									?>
-								</optgroup>
-								<?php
-							}
+						<?php
+						if ( $convertkit_products->exist() ) {
 							?>
-						</select>
-						<button class="wp-convertkit-refresh-resources" class="button button-secondary hide-if-no-js" title="<?php esc_attr_e( 'Refresh Products Pages from ConvertKit account', 'convertkit' ); ?>" data-resource="products" data-field="#wp-convertkit-restrict_content">
-							<span class="dashicons dashicons-update"></span>
-						</button>
-						<p class="description">
-							<?php esc_html_e( 'Select the ConvertKit product that the visitor must be subscribed to, permitting them access to view this members only content.', 'convertkit' ); ?>
-						</p>
-					</div>
-				</td>
-			</tr>
-			<?php
-		}
-		?>
+							<optgroup label="<?php esc_attr_e( 'Products', 'convertkit' ); ?>">
+								<?php
+								foreach ( $convertkit_products->get() as $product ) {
+									?>
+									<option value="product_<?php echo esc_attr( $product['id'] ); ?>"<?php selected( 'product_' . $product['id'], $convertkit_post->get_restrict_content() ); ?>><?php echo esc_attr( $product['name'] ); ?></option>
+									<?php
+								}
+								?>
+							</optgroup>
+							<?php
+						}
+						?>
+					</select>
+					<button class="wp-convertkit-refresh-resources" class="button button-secondary hide-if-no-js" title="<?php esc_attr_e( 'Refresh Products Pages from ConvertKit account', 'convertkit' ); ?>" data-resource="products" data-field="#wp-convertkit-restrict_content">
+						<span class="dashicons dashicons-update"></span>
+					</button>
+					<p class="description">
+						<?php esc_html_e( 'Select the ConvertKit product that the visitor must be subscribed to, permitting them access to view this members only content.', 'convertkit' ); ?>
+					</p>
+				</div>
+			</td>
+		</tr>
 	</tbody>
 </table>
 

--- a/views/backend/post/quick-edit.php
+++ b/views/backend/post/quick-edit.php
@@ -53,41 +53,36 @@
 		</button>
 	</div>
 
-	<?php
-	if ( $restrict_content_settings->enabled() ) {
-		?>
-		<!-- Restrict Content -->
-		<div>
-			<label for="wp-convertkit-quick-edit-restrict_content">
-				<span class="title convertkit-icon-restrict-content"><?php esc_html_e( 'Member', 'convertkit' ); ?></span>
-				<select name="wp-convertkit[restrict_content]" id="wp-convertkit-quick-edit-restrict_content" size="1">
-					<option value="0" data-preserve-on-refresh="1"><?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?></option>
+	<!-- Restrict Content -->
+	<div>
+		<label for="wp-convertkit-quick-edit-restrict_content">
+			<span class="title convertkit-icon-restrict-content"><?php esc_html_e( 'Member', 'convertkit' ); ?></span>
+			<select name="wp-convertkit[restrict_content]" id="wp-convertkit-quick-edit-restrict_content" size="1">
+				<option value="0" data-preserve-on-refresh="1"><?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?></option>
 
-					<?php
-					// Products.
-					if ( $convertkit_products->exist() ) {
-						?>
-						<optgroup label="<?php esc_attr_e( 'Products', 'convertkit' ); ?>">
-							<?php
-							foreach ( $convertkit_products->get() as $product ) {
-								?>
-								<option value="product_<?php echo esc_attr( $product['id'] ); ?>"><?php echo esc_attr( $product['name'] ); ?></option>
-								<?php
-							}
-							?>
-						</optgroup>
-						<?php
-					}
+				<?php
+				// Products.
+				if ( $convertkit_products->exist() ) {
 					?>
-				</select>
-			</label>
-			<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Products from ConvertKit account', 'convertkit' ); ?>" data-resource="products" data-field="#wp-convertkit-quick-edit-restrict_content">
-				<span class="dashicons dashicons-update"></span>
-			</button>
-		</div>
-		<?php
-	}
-
+					<optgroup label="<?php esc_attr_e( 'Products', 'convertkit' ); ?>">
+						<?php
+						foreach ( $convertkit_products->get() as $product ) {
+							?>
+							<option value="product_<?php echo esc_attr( $product['id'] ); ?>"><?php echo esc_attr( $product['name'] ); ?></option>
+							<?php
+						}
+						?>
+					</optgroup>
+					<?php
+				}
+				?>
+			</select>
+		</label>
+		<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Products from ConvertKit account', 'convertkit' ); ?>" data-resource="products" data-field="#wp-convertkit-quick-edit-restrict_content">
+			<span class="dashicons dashicons-update"></span>
+		</button>
+	</div>
+	<?php
 	wp_nonce_field( 'wp-convertkit-save-meta', 'wp-convertkit-save-meta-nonce' );
 	?>
 </div>


### PR DESCRIPTION
## Summary

Removes the `Enable` option at `Settings > ConvertKit > Member Content`, ensuring Member Content options in the WordPress Administration UI are always loaded, and functionality runs (if required) on a given Post or Page.

This [prevents confusion](https://twitter.com/RGWords/status/1707404101967909280) when Broadcasts to Posts functionality is used, and paid Broadcasts are not gated, due to Member Content's `Enable` setting not being checked.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)