### PR TITLE
Restrict Content: Check Resource Exists

### DIFF
--- a/tests/acceptance/restrict-content/RestrictContentProductPageCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentProductPageCest.php
@@ -87,6 +87,36 @@ class RestrictContentProductPageCest
 	}
 
 	/**
+	 * Test that restricting content by a Product that does not exist does not output
+	 * a fatal error and instead displays all of the Page's content.
+	 *
+	 * This checks for when a Product is deleted in ConvertKit, but is still specified
+	 * as the Restrict Content setting for a Page.
+	 *
+	 * @since   2.3.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentByInvalidProduct(AcceptanceTester $I)
+	{
+		// Programmatically create a Page.
+		$pageID = $I->createRestrictedContentPage(
+			$I,
+			'page',
+			'ConvertKit: Page: Restrict Content: Invalid Product',
+			'Visible content.',
+			'Member only content.',
+			'product_12345', // A fake Product that does not exist in ConvertKit.
+		);
+
+		// Navigate to the page.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Confirm all content displays, with no errors, as the Product is invalid.
+		$I->testRestrictContentDisplaysContent($I);
+	}
+
+	/**
 	 * Test that restricting content by a Product specified in the Page Settings works when
 	 * using the Quick Edit functionality.
 	 *

--- a/tests/acceptance/restrict-content/RestrictContentProductPageCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentProductPageCest.php
@@ -106,7 +106,7 @@ class RestrictContentProductPageCest
 			'ConvertKit: Page: Restrict Content: Invalid Product',
 			'Visible content.',
 			'Member only content.',
-			'product_12345', // A fake Product that does not exist in ConvertKit.
+			'product_12345' // A fake Product that does not exist in ConvertKit.
 		);
 
 		// Navigate to the page.

--- a/tests/acceptance/restrict-content/RestrictContentProductPostCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentProductPostCest.php
@@ -87,6 +87,36 @@ class RestrictContentProductPostCest
 	}
 
 	/**
+	 * Test that restricting content by a Product that does not exist does not output
+	 * a fatal error and instead displays all of the Post's content.
+	 *
+	 * This checks for when a Product is deleted in ConvertKit, but is still specified
+	 * as the Restrict Content setting for a Post.
+	 *
+	 * @since   2.3.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentByInvalidProduct(AcceptanceTester $I)
+	{
+		// Programmatically create a Page.
+		$postID = $I->createRestrictedContentPage(
+			$I,
+			'post',
+			'ConvertKit: Post: Restrict Content: Invalid Product',
+			'Visible content.',
+			'Member only content.',
+			'product_12345', // A fake Product that does not exist in ConvertKit.
+		);
+
+		// Navigate to the post.
+		$I->amOnPage('?p=' . $postID);
+
+		// Confirm all content displays, with no errors, as the Product is invalid.
+		$I->testRestrictContentDisplaysContent($I);
+	}
+
+	/**
 	 * Test that restricting content by a Product specified in the Post Settings works when
 	 * using the Quick Edit functionality.
 	 *

--- a/tests/acceptance/restrict-content/RestrictContentProductPostCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentProductPostCest.php
@@ -106,7 +106,7 @@ class RestrictContentProductPostCest
 			'ConvertKit: Post: Restrict Content: Invalid Product',
 			'Visible content.',
 			'Member only content.',
-			'product_12345', // A fake Product that does not exist in ConvertKit.
+			'product_12345' // A fake Product that does not exist in ConvertKit.
 		);
 
 		// Navigate to the post.

--- a/tests/acceptance/restrict-content/RestrictContentTagCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentTagCest.php
@@ -81,7 +81,7 @@ class RestrictContentTagCest
 			'ConvertKit: Page: Restrict Content: Invalid Tag',
 			'Visible content.',
 			'Member only content.',
-			'tag_12345', // A fake Tag that does not exist in ConvertKit.
+			'tag_12345' // A fake Tag that does not exist in ConvertKit.
 		);
 
 		// Navigate to the page.

--- a/tests/acceptance/restrict-content/RestrictContentTagCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentTagCest.php
@@ -62,6 +62,36 @@ class RestrictContentTagCest
 	}
 
 	/**
+	 * Test that restricting content by a Tag that does not exist does not output
+	 * a fatal error and instead displays all of the Page's content.
+	 *
+	 * This checks for when a Tag is deleted in ConvertKit, but is still specified
+	 * as the Restrict Content setting for a Page.
+	 *
+	 * @since   2.3.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentByInvalidTag(AcceptanceTester $I)
+	{
+		// Programmatically create a Page.
+		$pageID = $I->createRestrictedContentPage(
+			$I,
+			'page',
+			'ConvertKit: Page: Restrict Content: Invalid Tag',
+			'Visible content.',
+			'Member only content.',
+			'tag_12345', // A fake Tag that does not exist in ConvertKit.
+		);
+
+		// Navigate to the page.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Confirm all content displays, with no errors, as the Tag is invalid.
+		$I->testRestrictContentDisplaysContent($I);
+	}
+
+	/**
 	 * Test that restricting content by a Tag specified in the Page Settings works when
 	 * using the Quick Edit functionality.
 	 *


### PR DESCRIPTION
## Summary

Checks that a resource (Tag or Product) exists before restricting a Page or Post's content.

If the resource does not exist, all content is displayed on the Page / Post.

Fixes this issue where an uncaught WP_Error occurs when a Tag or Product no longer exists in ConvertKit (either deleted or the API Keys have been changed in the Plugin), and a WordPress Page or Post still has its Member Content setting set to the existing resource.

Before:
![Screenshot 2023-10-06 at 14 41 28](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/02d4ed54-f365-4b87-9f53-23b9409c5f50)

After:
![Screenshot 2023-10-06 at 14 41 41](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/3358ab03-11e6-4979-b280-0a730eab7f8b)

## Testing

- `testRestrictContentByInvalidProduct`: Tests that all Page / Post content is displayed when an invalid Product is specified as the Restrict Content setting on a Page / Post.
- `testRestrictContentByInvalidTag`: Tests that all Page / Post content is displayed when an invalid Tag is specified as the Restrict Content setting on a Page / Post.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)