### PR TITLE
Restrict Content Wizard: Add support for Tags

### DIFF
--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php
@@ -51,6 +51,15 @@ class ConvertKit_Admin_Setup_Wizard_Restrict_Content extends ConvertKit_Admin_Se
 	public $products = false;
 
 	/**
+	 * Holds the ConvertKit Tags resource class.
+	 *
+	 * @since   2.3.3
+	 *
+	 * @var     bool|ConvertKit_Resource_Tags
+	 */
+	public $tags = false;
+
+	/**
 	 * Holds the Pages created by this setup wizard.
 	 *
 	 * @since   2.1.0
@@ -249,8 +258,9 @@ class ConvertKit_Admin_Setup_Wizard_Restrict_Content extends ConvertKit_Admin_Se
 						break;
 				}
 
-				// Fetch Products.
+				// Fetch Products and Tags.
 				$this->products = new ConvertKit_Resource_Products( 'restrict_content_wizard' );
+				$this->tags     = new ConvertKit_Resource_Tags( 'restrict_content_wizard' );
 				break;
 
 			case 1:

--- a/tests/acceptance/restrict-content/RestrictContentSetupCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentSetupCest.php
@@ -134,13 +134,14 @@ class RestrictContentSetupCest
 	}
 
 	/**
-	 * Test that the Add New Member Content > Downloads generates the expected Pages.
+	 * Test that the Add New Member Content > Downloads generates the expected Page
+	 * and restricts content by the selected Product.
 	 *
 	 * @since   2.1.0
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testAddNewMemberContentDownloads(AcceptanceTester $I)
+	public function testAddNewMemberContentDownloadsByProduct(AcceptanceTester $I)
 	{
 		// Setup Plugin and navigate to Add New Member Content screen.
 		$this->_setupAndLoadAddNewMemberContentScreen($I);
@@ -188,12 +189,13 @@ class RestrictContentSetupCest
 
 	/**
 	 * Test that the Add New Member Content > Course generates the expected Pages.
+	 * and restricts content by the selected Product.
 	 *
 	 * @since   2.1.0
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testAddNewMemberContentCourse(AcceptanceTester $I)
+	public function testAddNewMemberContentCourseByProduct(AcceptanceTester $I)
 	{
 		// Setup Plugin and navigate to Add New Member Content screen.
 		$this->_setupAndLoadAddNewMemberContentScreen($I);
@@ -273,6 +275,154 @@ class RestrictContentSetupCest
 		$I->click('Previous Lesson');
 		$I->waitForElementVisible('body.page-template-default');
 		$I->see('ConvertKit: Member Content: Course: 1/3');
+		$I->see('Some introductory text about lesson 1');
+		$I->see('Lesson 1 content (that is available when the visitor has paid for the ConvertKit product) goes here');
+	}
+
+	/**
+	 * Test that the Add New Member Content > Downloads generates the expected Page
+	 * and restricts content by the selected Tag.
+	 *
+	 * @since   2.3.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewMemberContentDownloadsByTag(AcceptanceTester $I)
+	{
+		// Setup Plugin and navigate to Add New Member Content screen.
+		$this->_setupAndLoadAddNewMemberContentScreen($I);
+
+		// Click Downloads button.
+		$I->click('Download');
+
+		// Confirm the Configure Download screen is displayed.
+		$I->see('Configure Download');
+
+		// Enter a title and description.
+		$I->fillField('title', 'ConvertKit: Member Content: Download: Tag');
+		$I->fillField('description', 'Visible content.');
+
+		// Confirm that the limit option is not visible, as this is only for courses.
+		$I->dontSee('How many lessons does this course consist of?');
+
+		// Restrict by Tag.
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-restrict_content-container', $_ENV['CONVERTKIT_API_TAG_NAME']);
+
+		// Click submit button.
+		$I->click('Submit');
+
+		// Wait for the WP_List_Table of Pages to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Confirm that one Page is listed in the WP_List_Table.
+		$I->see('ConvertKit: Member Content: Download: Tag');
+		$I->seeInSource('<span class="post-state">ConvertKit Member Content</span>');
+
+		// Hover mouse over Post's table row.
+		$I->moveMouseOver('tr.iedit');
+
+		// Get link to Page.
+		$url = $I->grabAttributeFrom('tr.iedit span.view a', 'href');
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentByTagOnFrontend(
+			$I,
+			$url,
+			$I->generateEmailAddress(),
+			'Visible content.',
+			'The downloadable content (that is available when the visitor has paid for the ConvertKit product) goes here.'
+		);
+	}
+
+	/**
+	 * Test that the Add New Member Content > Course generates the expected Pages
+	 * and restricts content by the selected Tag.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewMemberContentCourseByTag(AcceptanceTester $I)
+	{
+		// Setup Plugin and navigate to Add New Member Content screen.
+		$this->_setupAndLoadAddNewMemberContentScreen($I);
+
+		// Click Course button.
+		$I->click('Course');
+
+		// Confirm the Configure Course screen is displayed.
+		$I->see('Configure Course');
+
+		// Enter a title, description and lesson count.
+		$I->fillField('title', 'ConvertKit: Member Content: Course: Tag');
+		$I->fillField('description', 'Visible content.');
+		$I->fillField('number_of_pages', '3');
+
+		// Restrict by Product.
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-restrict_content-container', $_ENV['CONVERTKIT_API_TAG_NAME']);
+
+		// Click submit button.
+		$I->click('Submit');
+
+		// Wait for the WP_List_Table of Pages to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Confirm that four Pages are listed in the WP_List_Table.
+		$I->see('ConvertKit: Member Content: Course: Tag');
+		$I->see('— ConvertKit: Member Content: Course: Tag: 1/3');
+		$I->see('— ConvertKit: Member Content: Course: Tag: 2/3');
+		$I->see('— ConvertKit: Member Content: Course: Tag: 3/3');
+		$I->see('ConvertKit Member Content | Parent Page: ConvertKit: Member Content: Course: Tag');
+
+		// Hover mouse over Post's table row.
+		$I->moveMouseOver('tr.iedit:first-child');
+
+		// Wait for View link to be visible.
+		$I->waitForElementVisible('tr.iedit:first-child span.view a');
+
+		// Click View link.
+		$I->click('tr.iedit:first-child span.view a');
+
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible('body.page-template-default');
+
+		// Confirm the Start Course button exists.
+		$I->see('Start Course');
+
+		// Get URL to first restricted content page.
+		$url = $I->grabAttributeFrom('.wp-block-button a', 'href');
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentByTagOnFrontend(
+			$I,
+			$url,
+			$I->generateEmailAddress(),
+			'Some introductory text about lesson 1',
+			'Lesson 1 content (that is available when the visitor has paid for the ConvertKit product) goes here.'
+		);
+
+		// Test Next / Previous links.
+		$I->click('Next Lesson');
+		$I->waitForElementVisible('body.page-template-default');
+		$I->see('ConvertKit: Member Content: Course: Tag: 2/3');
+		$I->see('Some introductory text about lesson 2');
+		$I->see('Lesson 2 content (that is available when the visitor has paid for the ConvertKit product) goes here');
+
+		$I->click('Next Lesson');
+		$I->waitForElementVisible('body.page-template-default');
+		$I->see('ConvertKit: Member Content: Course: Tag: 3/3');
+		$I->see('Some introductory text about lesson 3');
+		$I->see('Lesson 3 content (that is available when the visitor has paid for the ConvertKit product) goes here');
+
+		$I->click('Previous Lesson');
+		$I->waitForElementVisible('body.page-template-default');
+		$I->see('ConvertKit: Member Content: Course: Tag: 2/3');
+		$I->see('Some introductory text about lesson 2');
+		$I->see('Lesson 2 content (that is available when the visitor has paid for the ConvertKit product) goes here');
+
+		$I->click('Previous Lesson');
+		$I->waitForElementVisible('body.page-template-default');
+		$I->see('ConvertKit: Member Content: Course: Tag: 1/3');
 		$I->see('Some introductory text about lesson 1');
 		$I->see('Lesson 1 content (that is available when the visitor has paid for the ConvertKit product) goes here');
 	}

--- a/views/backend/setup-wizard/convertkit-restrict-content-setup/content-1.php
+++ b/views/backend/setup-wizard/convertkit-restrict-content-setup/content-1.php
@@ -12,13 +12,14 @@
 <p>
 	<?php
 	printf(
-		/* translators: Link to ConvertKit Products */
-		esc_html__( 'This will generate content that visitors can access once they purchase a %s.', 'convertkit' ),
+		/* translators: %1$s: Link to ConvertKit Products, %2$s: ConvertKit Tag */
+		esc_html__( 'This will generate content that visitors can access once they purchase a %1$s or subscribe to a %2$s.', 'convertkit' ),
 		sprintf(
 			'<a href="%1$s" target="_blank">%2$s</a>',
 			esc_attr( 'https://app.convertkit.com/products' ),
 			esc_html__( 'ConvertKit product', 'convertkit' )
-		)
+		),
+		esc_html__( 'ConvertKit tag', 'convertkit' )
 	);
 	?>
 </p>
@@ -33,7 +34,7 @@
 			<?php esc_html_e( 'Download', 'convertkit' ); ?>
 		</a>
 		<span class="description">
-			<?php esc_html_e( 'Require visitors to purchase a ConvertKit product, granting access to a single Page\'s content, which includes downloadable assets.', 'convertkit' ); ?>
+			<?php esc_html_e( 'Require visitors to purchase a ConvertKit product, or subscribe to a ConvertKit tag, granting access to a single Page\'s content, which includes downloadable assets.', 'convertkit' ); ?>
 		</span>
 	</div>
 
@@ -42,7 +43,7 @@
 			<?php esc_html_e( 'Course', 'convertkit' ); ?>
 		</a>
 		<span class="description">
-			<?php esc_html_e( 'Require visitors to purchase a ConvertKit product, granting access to a sequential series of Pages, such as a course, lessons or tutorials.', 'convertkit' ); ?>
+			<?php esc_html_e( 'Require visitors to purchase a ConvertKit product, or subscribe to a ConvertKit tag, granting access to a sequential series of Pages, such as a course, lessons or tutorials.', 'convertkit' ); ?>
 		</span>
 	</div>
 </div>

--- a/views/backend/setup-wizard/convertkit-restrict-content-setup/content-2.php
+++ b/views/backend/setup-wizard/convertkit-restrict-content-setup/content-2.php
@@ -53,12 +53,27 @@ if ( $this->type === 'course' ) {
 
 <div>
 	<label for="wp-convertkit-restrict_content">
-		<?php esc_html_e( 'The ConvertKit Product the visitor must purchase to see the content.', 'convertkit' ); ?>
+		<?php esc_html_e( 'The ConvertKit Product or Tag the visitor must subscribe to, in order to see the content', 'convertkit' ); ?>
 	</label>
 
 	<div class="convertkit-select2-container">
 		<select name="restrict_content" id="wp-convertkit-restrict_content" class="convertkit-select2 widefat">
 			<?php
+			// Tags.
+			if ( $this->tags->exist() ) {
+				?>
+				<optgroup label="<?php esc_attr_e( 'Tags', 'convertkit' ); ?>">
+					<?php
+					foreach ( $this->tags->get() as $convertkit_tag ) {
+						?>
+						<option value="tag_<?php echo esc_attr( $convertkit_tag['id'] ); ?>"><?php echo esc_attr( $convertkit_tag['name'] ); ?></option>
+						<?php
+					}
+					?>
+				</optgroup>
+				<?php
+			}
+
 			// Products.
 			if ( $this->products->exist() ) {
 				?>


### PR DESCRIPTION
## Summary

Allows the user to restrict content by Tag in the Add New Member Content setup wizard.

![Screenshot 2023-10-12 at 14 57 42](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/d4e9e762-eeeb-4780-8722-bfad333f8cb9)

## Testing

- `testAddNewMemberContentDownloadsByTag`: Test that the Add New Member Content > Downloads generates the expected Page and restricts content by the selected Tag.
- `testAddNewMemberContentCourseByTag`: Test that the Add New Member Content > Course generates the expected Pages and restricts content by the selected Tag.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)