### PR TITLE
Restrict Content: Wizard: Display options when no Products or Tags exist

### DIFF
--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php
@@ -244,6 +244,31 @@ class ConvertKit_Admin_Setup_Wizard_Restrict_Content extends ConvertKit_Admin_Se
 
 		// Load data depending on the current step.
 		switch ( $step ) {
+			case 1:
+				// Fetch Products and Tags.
+				$this->products = new ConvertKit_Resource_Products( 'restrict_content_wizard' );
+				$this->tags     = new ConvertKit_Resource_Tags( 'restrict_content_wizard' );
+
+				// Refresh Products and Tags resources, in case the user just created their first Product or Tag
+				// in ConvertKit.
+				$this->products->refresh();
+				$this->tags->refresh();
+
+				// If no Products and Tags exist in ConvertKit, change the next button label and make it a link to reload
+				// the screen.
+				if ( ! $this->products->exist() && ! $this->tags->exist() ) {
+					$this->steps[1]['next_button']['label'] = __( 'I\'ve created a Product or Tag in ConvertKit', 'convertkit' );
+					$this->steps[1]['next_button']['link']  = add_query_arg(
+						array(
+							'page' 		   => $this->page_name,
+							'ck_post_type' => $this->post_type,
+							'step' 		   => 1,
+						),
+						admin_url( 'options.php' )
+					);
+				}
+				break;
+
 			case 2:
 				// Define Member Content Type.
 				$this->type = sanitize_text_field( $_REQUEST['type'] ); // phpcs:ignore WordPress.Security.NonceVerification

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php
@@ -87,6 +87,15 @@ class ConvertKit_Admin_Setup_Wizard_Restrict_Content extends ConvertKit_Admin_Se
 	public $course_url = false;
 
 	/**
+	 * Holds the URL to the current setup wizard screen.
+	 *
+	 * @since   2.3.3
+	 *
+	 * @var     bool|string
+	 */
+	public $current_url = false;
+
+	/**
 	 * The required user capability to access the setup wizard.
 	 *
 	 * @since   2.1.0
@@ -257,8 +266,8 @@ class ConvertKit_Admin_Setup_Wizard_Restrict_Content extends ConvertKit_Admin_Se
 				// If no Products and Tags exist in ConvertKit, change the next button label and make it a link to reload
 				// the screen.
 				if ( ! $this->products->exist() && ! $this->tags->exist() ) {
-					$this->steps[1]['next_button']['label'] = __( 'I\'ve created a Product or Tag in ConvertKit', 'convertkit' );
-					$this->steps[1]['next_button']['link']  = add_query_arg(
+					unset( $this->steps[1]['next_button'] );
+					$this->current_url = add_query_arg(
 						array(
 							'page'         => $this->page_name,
 							'ck_post_type' => $this->post_type,

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php
@@ -260,11 +260,28 @@ class ConvertKit_Admin_Setup_Wizard_Restrict_Content extends ConvertKit_Admin_Se
 					$this->steps[1]['next_button']['label'] = __( 'I\'ve created a Product or Tag in ConvertKit', 'convertkit' );
 					$this->steps[1]['next_button']['link']  = add_query_arg(
 						array(
-							'page' 		   => $this->page_name,
+							'page'         => $this->page_name,
 							'ck_post_type' => $this->post_type,
-							'step' 		   => 1,
+							'step'         => 1,
 						),
 						admin_url( 'options.php' )
+					);
+				} else {
+					// Define Download and Course button links.
+					$this->download_url = add_query_arg(
+						array(
+							'type'         => 'download',
+							'ck_post_type' => $this->post_type,
+						),
+						$this->next_step_url
+					);
+
+					$this->course_url = add_query_arg(
+						array(
+							'type'         => 'course',
+							'ck_post_type' => $this->post_type,
+						),
+						$this->next_step_url
 					);
 				}
 				break;
@@ -286,25 +303,6 @@ class ConvertKit_Admin_Setup_Wizard_Restrict_Content extends ConvertKit_Admin_Se
 				// Fetch Products and Tags.
 				$this->products = new ConvertKit_Resource_Products( 'restrict_content_wizard' );
 				$this->tags     = new ConvertKit_Resource_Tags( 'restrict_content_wizard' );
-				break;
-
-			case 1:
-				// Define Download and Course button links.
-				$this->download_url = add_query_arg(
-					array(
-						'type'         => 'download',
-						'ck_post_type' => $this->post_type,
-					),
-					$this->next_step_url
-				);
-
-				$this->course_url = add_query_arg(
-					array(
-						'type'         => 'course',
-						'ck_post_type' => $this->post_type,
-					),
-					$this->next_step_url
-				);
 				break;
 		}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -411,6 +411,26 @@ function convertkit_get_form_editor_url() {
 }
 
 /**
+ * Helper method to return the URL the user needs to visit on the ConvertKit app to create a new Tag.
+ *
+ * @since   2.3.3
+ *
+ * @return  string  ConvertKit App URL.
+ */
+function convertkit_get_new_tag_url() {
+
+	return add_query_arg(
+		array(
+			'utm_source'  => 'wordpress',
+			'utm_term'    => get_locale(),
+			'utm_content' => 'convertkit',
+		),
+		'https://app.convertkit.com/subscribers/'
+	);
+
+}
+
+/**
  * Helper method to return the URL the user needs to visit on the ConvertKit app to create a new Broadcast.
  *
  * @since   2.2.6

--- a/tests/acceptance/restrict-content/RestrictContentSetupCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentSetupCest.php
@@ -36,26 +36,6 @@ class RestrictContentSetupCest
 	}
 
 	/**
-	 * Test that the Add New Member Content button does not display on the Pages screen when the ConvertKit
-	 * account has no Forms, Tag and Products.
-	 *
-	 * @since   2.1.0
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 */
-	public function testAddNewMemberContentButtonNotDisplayedWhenNoResources(AcceptanceTester $I)
-	{
-		// Setup Plugin using API keys that have no resources.
-		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
-
-		// Navigate to Pages.
-		$I->amOnAdminPage('edit.php?post_type=page');
-
-		// Check the button isn't displayed.
-		$I->dontSeeElementInDOM('a.convertkit-action page-title-action');
-	}
-
-	/**
 	 * Test that the Add New Member Content button does not display on the Posts screen.
 	 *
 	 * @since   2.3.2
@@ -102,6 +82,49 @@ class RestrictContentSetupCest
 
 		// Confirm no Member Content Dashboard Submenu item exists.
 		$I->dontSeeInSource('<a href="options.php?page=convertkit-restrict-content-setup"></a>');
+	}
+
+	/**
+	 * Test that the Add New Member Content wizard displays call to actions to add a Product or Tag in ConvertKit
+	 * when the ConvertKit account has no Tags and Products.
+	 *
+	 * @since   2.3.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewMemberContentDisplaysCTAWhenNoResources(AcceptanceTester $I)
+	{
+		// Setup Plugin using API keys that have no resources.
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
+
+		// Navigate to Pages.
+		$I->amOnAdminPage('edit.php?post_type=page');
+
+		// Click Add New Member Content button.
+		$I->click('Add New Member Content');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check that the expected buttons display linking to ConvertKit.
+		$I->see('Create product');
+		$I->see('Create tag');
+		$I->seeInSource('<a href="https://app.convertkit.com/products/new/?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit"');
+		$I->seeInSource('<a href="https://app.convertkit.com/subscribers/?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit"');
+
+		// Update the Plugin to use API keys that have resources.
+		$I->setupConvertKitPlugin($I);
+
+		// Click the button to reload the wizard.
+		$I->click('#convertkit-setup-wizard-footer a.button-primary');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check that the Download and Course buttons now display.
+		$I->see('What type of content are you offering?');
+		$I->see('Download');
+		$I->see('Course');
 	}
 
 	/**

--- a/tests/acceptance/restrict-content/RestrictContentSetupCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentSetupCest.php
@@ -116,7 +116,7 @@ class RestrictContentSetupCest
 		$I->setupConvertKitPlugin($I);
 
 		// Click the button to reload the wizard.
-		$I->click('#convertkit-setup-wizard-footer a.button-primary');
+		$I->click('center a.button-primary');
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);

--- a/views/backend/setup-wizard/convertkit-restrict-content-setup/content-1.php
+++ b/views/backend/setup-wizard/convertkit-restrict-content-setup/content-1.php
@@ -24,26 +24,59 @@
 	?>
 </p>
 
-<hr />
+<?php
+// If no Products and Tags exist on the ConvertKit account, show the user how to add a Product to ConvertKit,
+// with an option to refresh this page so that they can then select the Product to restrict content with.
+if ( ! $this->products->exist() && ! $this->tags->exist() ) {
+	?>
+	<p>
+		<?php
+		esc_html_e( 'To get started, you first need to create a Product or Tag in ConvertKit. Click the button below to get started.', 'convertkit' );
+		?>
+	</p>
 
-<h2><?php esc_html_e( 'What type of content are you offering?', 'convertkit' ); ?></h2>
+	<div class="convertkit-setup-wizard-grid">
+		<div>
+			<a href="<?php echo esc_url( convertkit_get_new_product_url() ); ?>" target="_blank" class="button button-primary button-hero">
+				<?php esc_html_e( 'Create product', 'convertkit' ); ?>
+			</a>
+			<span class="description">
+				<?php esc_html_e( 'Require visitors to purchase a ConvertKit product to access your content.', 'convertkit' ); ?>
+			</span>
+		</div>
 
-<div class="convertkit-setup-wizard-grid">
-	<div>
-		<a href="<?php echo esc_url( $this->download_url ); ?>" class="button button-primary button-hero">
-			<?php esc_html_e( 'Download', 'convertkit' ); ?>
-		</a>
-		<span class="description">
-			<?php esc_html_e( 'Require visitors to purchase a ConvertKit product, or subscribe to a ConvertKit tag, granting access to a single Page\'s content, which includes downloadable assets.', 'convertkit' ); ?>
-		</span>
+		<div>
+			<a href="<?php echo esc_url( convertkit_get_new_tag_url() ); ?>" target="_blank" class="button button-primary button-hero">
+				<?php esc_html_e( 'Create tag', 'convertkit' ); ?>
+			</a>
+			<span class="description">
+				<?php esc_html_e( 'Require visitors to enter their email address, subscribing them to a ConvertKit tag to access your content.', 'convertkit' ); ?>
+			</span>
+		</div>
 	</div>
+	<?php
+} else {
+	?>
+	<h2><?php esc_html_e( 'What type of content are you offering?', 'convertkit' ); ?></h2>
 
-	<div>
-		<a href="<?php echo esc_url( $this->course_url ); ?>" class="button button-primary button-hero">
-			<?php esc_html_e( 'Course', 'convertkit' ); ?>
-		</a>
-		<span class="description">
-			<?php esc_html_e( 'Require visitors to purchase a ConvertKit product, or subscribe to a ConvertKit tag, granting access to a sequential series of Pages, such as a course, lessons or tutorials.', 'convertkit' ); ?>
-		</span>
+	<div class="convertkit-setup-wizard-grid">
+		<div>
+			<a href="<?php echo esc_url( $this->download_url ); ?>" class="button button-primary button-hero">
+				<?php esc_html_e( 'Download', 'convertkit' ); ?>
+			</a>
+			<span class="description">
+				<?php esc_html_e( 'Require visitors to purchase a ConvertKit product, or subscribe to a ConvertKit tag, granting access to a single Page\'s content, which includes downloadable assets.', 'convertkit' ); ?>
+			</span>
+		</div>
+
+		<div>
+			<a href="<?php echo esc_url( $this->course_url ); ?>" class="button button-primary button-hero">
+				<?php esc_html_e( 'Course', 'convertkit' ); ?>
+			</a>
+			<span class="description">
+				<?php esc_html_e( 'Require visitors to purchase a ConvertKit product, or subscribe to a ConvertKit tag, granting access to a sequential series of Pages, such as a course, lessons or tutorials.', 'convertkit' ); ?>
+			</span>
+		</div>
 	</div>
-</div>
+	<?php
+}

--- a/views/backend/setup-wizard/convertkit-restrict-content-setup/content-1.php
+++ b/views/backend/setup-wizard/convertkit-restrict-content-setup/content-1.php
@@ -54,6 +54,12 @@ if ( ! $this->products->exist() && ! $this->tags->exist() ) {
 			</span>
 		</div>
 	</div>
+
+	<center>
+		<a href="<?php echo esc_url( $this->current_url ); ?>" class="button button-primary button-hero">
+			<?php esc_html_e( 'I\'ve created a Product or Tag in ConvertKit', 'convertkit' ); ?>
+		</a>
+	</center>			
 	<?php
 } else {
 	?>


### PR DESCRIPTION
## Summary

Displays call to action buttons with links to ConvertKit to add a Product or Tag, when the ConvertKit account has neither specified.

Prevents users ending up on a screen where they can't proceed, because there are no Products or Tags to choose from.

Before:
![Screenshot 2023-10-13 at 13 22 57](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/63815d1f-b543-4473-a52b-da1442c221fd)

After:
![Screenshot 2023-10-13 at 14 54 10](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/2b939ff8-0026-4548-89bf-fc606c631c3c)

## Testing

- `testAddNewMemberContentButtonNotDisplayedWhenNoResources`: Removed this test, as it failed to check that the `Add New Member Content` button was displayed when a ConvertKit account contains no Products or Tags, due to the incorrect `a.convertkit-action page-title-action` selector that would pass every time. No logic in the Plugin has ever existed to prevent this button from displaying under these conditions.
- `testAddNewMemberContentDisplaysCTAWhenNoResources`: Tests that the wizard screen displays links to creating a Product and Tag on ConvertKit, when the ConvertKit account has no Products and Tags defined.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)