### PR TITLE
Add Global Default Non-Inline Form Setting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,19 @@ jobs:
 
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
-          'acceptance/general'
+          'acceptance/broadcasts/blocks',
+          'acceptance/broadcasts/shortcodes',
+          'acceptance/broadcasts/import',
+          'acceptance/forms/blocks',
+          'acceptance/forms/general',
+          'acceptance/forms/shortcodes',
+          'acceptance/general',
+          'acceptance/integrations/elementor',
+          'acceptance/integrations/other',
+          'acceptance/integrations/woocommerce',
+          'acceptance/products',
+          'acceptance/restrict-content',
+          'acceptance/tags',
         ]
 
     # Steps to install, configure and run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,19 +52,7 @@ jobs:
 
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
-          'acceptance/broadcasts/blocks',
-          'acceptance/broadcasts/shortcodes',
-          'acceptance/broadcasts/import',
-          'acceptance/forms/blocks',
-          'acceptance/forms/general',
-          'acceptance/forms/shortcodes',
-          'acceptance/general',
-          'acceptance/integrations/elementor',
-          'acceptance/integrations/other',
-          'acceptance/integrations/woocommerce',
-          'acceptance/products',
-          'acceptance/restrict-content',
-          'acceptance/tags', 
+          'acceptance/general'
         ]
 
     # Steps to install, configure and run tests

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -173,6 +173,17 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 		}
 
 		add_settings_field(
+			'non_inline_form',
+			__( 'Default Non-Inline Form (Global)', 'convertkit' ),
+			array( $this, 'non_inline_form_callback' ),
+			$this->settings_key,
+			$this->name,
+			array(
+				'label_for' => 'non_inline_form',
+			)
+		);
+
+		add_settings_field(
 			'debug',
 			__( 'Debug', 'convertkit' ),
 			array( $this, 'debug_callback' ),
@@ -465,6 +476,61 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 			array(
 				'data-target' => '#convertkit-preview-form-' . esc_attr( $args['post_type'] ),
 				'data-link'   => esc_attr( $preview_url ) . '&convertkit_form_id=',
+			)
+		);
+
+		// Output field.
+		echo '<div class="convertkit-select2-container">' . $select_field . '</div>'; // phpcs:ignore WordPress.Security.EscapeOutput
+
+	}
+
+
+	/**
+	 * Renders the input for the Non-inline Form setting.
+	 *
+	 * @since  2.2.3
+	 *
+	 * @param   array $args  Field arguments.
+	 */
+	public function non_inline_form_callback( $args ) {
+
+		// Bail if no non-inline Forms exist.
+		if ( ! $this->forms->non_inline_exist() ) {
+			esc_html_e( 'No non-inline Forms exist in ConvertKit.', 'convertkit' );
+			echo '<br /><a href="' . esc_url( convertkit_get_new_form_url() ) . '" target="_blank">' . esc_html__( 'Click here to create your first modal, slide in or sticky bar form', 'convertkit' ) . '</a>';
+			return;
+		}
+
+		// Build array of select options.
+		$options = array(
+			'' => esc_html__( 'None', 'convertkit' ),
+		);
+		foreach ( $this->forms->get_non_inline() as $form ) {
+			$options[ esc_attr( $form['id'] ) ] = esc_html( $form['name'] );
+		}
+
+		// Build description with preview link.
+		$preview_url = WP_ConvertKit()->get_class( 'preview_output' )->get_preview_form_home_url();
+		$description = sprintf(
+			'%s %s %s',
+			esc_html__( 'Select a modal, slide in or sticky bar form to automatically display site wide.', 'convertkit' ),
+			'<a href="' . esc_url( $preview_url ) . '" id="convertkit-preview-non-inline-form" target="_blank">' . esc_html__( 'Click here', 'convertkit' ) . '</a>',
+			esc_html__( 'to preview how this will display.', 'convertkit' )
+		);
+
+		// Build field.
+		$select_field = $this->get_select_field(
+			'non_inline_form',
+			$this->settings->get_non_inline_form(),
+			$options,
+			$description,
+			array(
+				'convertkit-select2',
+				'convertkit-preview-output-link',
+			),
+			array(
+				'data-target' => '#convertkit-preview-non-inline-form',
+				'data-link'   => esc_url( $preview_url ) . '&convertkit_form_id=',
 			)
 		);
 

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -69,6 +69,7 @@ class ConvertKit_Output {
 
 		add_action( 'init', array( $this, 'get_subscriber_id_from_request' ), 1 );
 		add_action( 'template_redirect', array( $this, 'output_form' ) );
+		add_action( 'template_redirect', array( $this, 'output_global_non_inline_form' ) );
 		add_action( 'template_redirect', array( $this, 'page_takeover' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 		add_filter( 'the_content', array( $this, 'append_form_to_content' ) );
@@ -407,6 +408,51 @@ class ConvertKit_Output {
 		}
 
 		$this->subscriber_id = $subscriber_id;
+
+	}
+
+	/**
+	 * Outputs a non-inline form if defined in the Plugin's settings >
+	 * Default Non-Inline Form (Global) setting.
+	 *
+	 * @since   2.3.3
+	 */
+	public function output_global_non_inline_form() {
+
+		// Get Settings, if they have not yet been loaded.
+		if ( ! $this->settings ) {
+			$this->settings = new ConvertKit_Settings();
+		}
+
+		// Bail if no non-inline form setting is specified.
+		if ( ! $this->settings->has_non_inline_form() ) {
+			return;
+		}
+
+		// Get form.
+		$convertkit_forms = new ConvertKit_Resource_Forms();
+		$form             = $convertkit_forms->get_by_id( (int) $this->settings->get_non_inline_form() );
+
+		// Bail if the Form doesn't exist (this shouldn't happen, but you never know).
+		if ( ! $form ) {
+			return;
+		}
+
+		// Add the form to the scripts array so it is included in the preview.
+		add_filter(
+			'convertkit_output_scripts_footer',
+			function ( $scripts ) use ( $form ) {
+
+				$scripts[] = array(
+					'async'    => true,
+					'data-uid' => $form['uid'],
+					'src'      => $form['embed_js'],
+				);
+
+				return $scripts;
+
+			}
+		);
 
 	}
 

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -438,7 +438,7 @@ class ConvertKit_Output {
 			return;
 		}
 
-		// Add the form to the scripts array so it is included in the preview.
+		// Add the form to the scripts array so it is included in the output.
 		add_filter(
 			'convertkit_output_scripts_footer',
 			function ( $scripts ) use ( $form ) {

--- a/includes/class-convertkit-settings.php
+++ b/includes/class-convertkit-settings.php
@@ -229,7 +229,7 @@ class ConvertKit_Settings {
 	 */
 	public function has_non_inline_form() {
 
-		return ( ! empty( 'non_inline_form' ) ? true : false );
+		return ( ! empty( $this->settings['non_inline_form'] ) ? true : false );
 
 	}
 

--- a/includes/class-convertkit-settings.php
+++ b/includes/class-convertkit-settings.php
@@ -203,6 +203,37 @@ class ConvertKit_Settings {
 	}
 
 	/**
+	 * Returns the Global non-inline Form Plugin setting.
+	 *
+	 * @since   2.3.3
+	 *
+	 * @return  string|int       Non-inline Form (blank string|form id)
+	 */
+	public function get_non_inline_form() {
+
+		// Return blank string if no inline form is specified.
+		if ( ! $this->has_non_inline_form() ) {
+			return '';
+		}
+
+		return $this->settings['non_inline_form'];
+
+	}
+
+	/**
+	 * Returns whether the Global non-inline Form has been set in the Plugin settings.
+	 *
+	 * @since   2.3.3
+	 *
+	 * @return  bool    Global non-inline Form setting specified in Plugin Settings.
+	 */
+	public function has_non_inline_form() {
+
+		return ( ! empty( 'non_inline_form' ) ? true : false );
+
+	}
+
+	/**
 	 * Returns whether debugging is enabled in the Plugin settings.
 	 *
 	 * @since   1.9.6
@@ -252,11 +283,12 @@ class ConvertKit_Settings {
 	public function get_defaults() {
 
 		$defaults = array(
-			'api_key'    => '', // string.
-			'api_secret' => '', // string.
-			'debug'      => '', // blank|on.
-			'no_scripts' => '', // blank|on.
-			'no_css'     => '', // blank|on.
+			'api_key'         => '', // string.
+			'api_secret'      => '', // string.
+			'non_inline_form' => '', // string.
+			'debug'           => '', // blank|on.
+			'no_scripts'      => '', // blank|on.
+			'no_css'          => '', // blank|on.
 		);
 
 		// Add Post Type Default Forms.

--- a/tests/acceptance/general/ActivateDeactivatePluginCest.php
+++ b/tests/acceptance/general/ActivateDeactivatePluginCest.php
@@ -51,5 +51,9 @@ class ActivateDeactivatePluginCest
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Deactivate Plugins.
+		$I->deactivateConvertKitPlugin($I);
+		$I->deactivateThirdPartyPlugin($I, 'convertkit-for-woocommerce');
 	}
 }

--- a/tests/acceptance/general/PluginSettingsGeneralCest.php
+++ b/tests/acceptance/general/PluginSettingsGeneralCest.php
@@ -356,6 +356,25 @@ class PluginSettingsGeneralCest
 	}
 
 	/**
+	 * Test that no non-inline form displays site wide when not selected in the Plugin's settings.
+	 *
+	 * @since   2.3.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testNoFormWhenNoDefaultNonInlineForm(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// View the home page.
+		$I->amOnPage('/');
+
+		// Confirm that no ConvertKit Form is output in the DOM.
+		$I->dontSeeElementInDOM('form[data-sv-form]');
+	}
+
+	/**
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
 	 * when Debug settings are enabled and disabled.
 	 *

--- a/tests/acceptance/general/PluginSettingsGeneralCest.php
+++ b/tests/acceptance/general/PluginSettingsGeneralCest.php
@@ -272,7 +272,6 @@ class PluginSettingsGeneralCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		// @TODO Check this is correct.
 		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_ID'] . '"]', 1);
 
 		// Close newly opened tab.
@@ -320,6 +319,15 @@ class PluginSettingsGeneralCest
 	 */
 	public function testDefaultNonInlineForm(AcceptanceTester $I)
 	{
+		// Create a Page in the database.
+		$I->havePostInDatabase(
+			[
+				'post_title'  => 'ConvertKit: Default Non Inline Global',
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			]
+		);
+
 		// Setup Plugin.
 		$I->setupConvertKitPlugin($I);
 
@@ -335,11 +343,16 @@ class PluginSettingsGeneralCest
 		// View the home page.
 		$I->amOnPage('/');
 
-		// @TODO Confirm the non-inline form displays.
+		// Confirm that one ConvertKit Form is output in the DOM.
+		// This confirms that there is only one script on the page for this form, which renders the form.
+		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_ID'] . '"]', 1);
 
-		// @TODO View something else.
+		// View another Page.
+		$I->amOnPage('/convertkit-default-non-inline-global');
 
-		// @TOOD Confirm the non-inline form displays.
+		// Confirm that one ConvertKit Form is output in the DOM.
+		// This confirms that there is only one script on the page for this form, which renders the form.
+		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_ID'] . '"]', 1);
 	}
 
 	/**

--- a/tests/acceptance/general/PluginSettingsGeneralCest.php
+++ b/tests/acceptance/general/PluginSettingsGeneralCest.php
@@ -260,6 +260,24 @@ class PluginSettingsGeneralCest
 		// Close newly opened tab.
 		$I->closeTab();
 
+		// Select a non-inline form for the Default non-inline form setting.
+		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_non_inline_form-container', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME']);
+
+		// Open preview.
+		$I->click('a#convertkit-preview-non-inline-form');
+		$I->wait(2); // Required, otherwise switchToNextTab fails.
+
+		// Switch to newly opened tab.
+		$I->switchToNextTab();
+
+		// Confirm that one ConvertKit Form is output in the DOM.
+		// This confirms that there is only one script on the page for this form, which renders the form.
+		// @TODO Check this is correct.
+		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_ID'] . '"]', 1);
+
+		// Close newly opened tab.
+		$I->closeTab();
+
 		// Click the Save Changes button.
 		$I->click('Save Changes');
 
@@ -269,6 +287,7 @@ class PluginSettingsGeneralCest
 		// Check the value of the fields match the inputs provided.
 		$I->seeInField('_wp_convertkit_settings[page_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
 		$I->seeInField('_wp_convertkit_settings[post_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->seeInField('_wp_convertkit_settings[non_inline_form]', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME']);
 	}
 
 	/**
@@ -290,6 +309,37 @@ class PluginSettingsGeneralCest
 		// Confirm no Page or Post preview links exist, because there are no Pages or Posts in WordPress.
 		$I->dontSeeElementInDOM('a#convertkit-preview-form-post');
 		$I->dontSeeElementInDOM('a#convertkit-preview-form-page');
+	}
+
+	/**
+	 * Test that the defined default non-inline form displays site wide.
+	 *
+	 * @since   2.3.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testDefaultNonInlineForm(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsGeneralScreen($I);
+
+		// Select a non-inline form for the Default non-inline form setting.
+		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_non_inline_form-container', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME']);
+
+		// Click the Save Changes button.
+		$I->click('Save Changes');
+
+		// View the home page.
+		$I->amOnPage('/');
+
+		// @TODO Confirm the non-inline form displays.
+
+		// @TODO View something else.
+
+		// @TOOD Confirm the non-inline form displays.
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Based on [this ticket](https://wordpress.org/support/topic/sticky-bar-issues/) (where the customer was trying to manually add the embed script directly into their theme's code to display a sticky bar form site wide), adds a setting to optionally select a modal, slide in or sticky bar (i.e. non-inline) form to display site wide.

![Screenshot_2023-10-16_at_15_12_54](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/316058b6-9317-45ba-9abf-869e6f3a0eff)

![Screenshot 2023-10-16 at 15 13 30](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/7bd5ef31-4ec4-44d9-adf2-2b4a6925c1a0)

## Testing

- `testDefaultNonInlineForm`: Tests that the non-inline form displays site wide when selected
- `testNoFormWhenNoDefaultNonInlineForm`: Tests that no non-inline form displays site wide when no option chosen
- `testChangeDefaultFormSettingAndPreviewFormLinks`: Tests that the preview functionality works for the new non-inline form setting

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)