### PR TITLE
Match Button Blocks Output in Editor and Frontend

### DIFF
--- a/includes/blocks/class-convertkit-block-form-trigger.php
+++ b/includes/blocks/class-convertkit-block-form-trigger.php
@@ -215,6 +215,11 @@ class ConvertKit_Block_Form_Trigger extends ConvertKit_Block {
 			'color'      => array(
 				'background' => true,
 				'text'       => true,
+
+				// Don't apply styles to the block editor's div element.
+				// This ensures what's rendered in the Gutenberg editor matches the frontend output for styling.
+				// See: https://github.com/WordPress/gutenberg/issues/32417
+				'__experimentalSkipSerialization' => true,
 			),
 			'typography' => array(
 				'fontSize' => true,

--- a/includes/blocks/class-convertkit-block-form-trigger.php
+++ b/includes/blocks/class-convertkit-block-form-trigger.php
@@ -213,12 +213,12 @@ class ConvertKit_Block_Form_Trigger extends ConvertKit_Block {
 		return array(
 			'className'  => true,
 			'color'      => array(
-				'background' => true,
-				'text'       => true,
+				'background'                      => true,
+				'text'                            => true,
 
 				// Don't apply styles to the block editor's div element.
 				// This ensures what's rendered in the Gutenberg editor matches the frontend output for styling.
-				// See: https://github.com/WordPress/gutenberg/issues/32417
+				// See: https://github.com/WordPress/gutenberg/issues/32417.
 				'__experimentalSkipSerialization' => true,
 			),
 			'typography' => array(

--- a/includes/blocks/class-convertkit-block-product.php
+++ b/includes/blocks/class-convertkit-block-product.php
@@ -237,12 +237,12 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 		return array(
 			'className'  => true,
 			'color'      => array(
-				'background' => true,
-				'text'       => true,
+				'background'                      => true,
+				'text'                            => true,
 
 				// Don't apply styles to the block editor's div element.
 				// This ensures what's rendered in the Gutenberg editor matches the frontend output for styling.
-				// See: https://github.com/WordPress/gutenberg/issues/32417
+				// See: https://github.com/WordPress/gutenberg/issues/32417.
 				'__experimentalSkipSerialization' => true,
 			),
 			'typography' => array(

--- a/includes/blocks/class-convertkit-block-product.php
+++ b/includes/blocks/class-convertkit-block-product.php
@@ -239,6 +239,11 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 			'color'      => array(
 				'background' => true,
 				'text'       => true,
+
+				// Don't apply styles to the block editor's div element.
+				// This ensures what's rendered in the Gutenberg editor matches the frontend output for styling.
+				// See: https://github.com/WordPress/gutenberg/issues/32417
+				'__experimentalSkipSerialization' => true,
 			),
 			'typography' => array(
 				'fontSize' => true,

--- a/resources/backend/js/gutenberg-block-broadcasts.js
+++ b/resources/backend/js/gutenberg-block-broadcasts.js
@@ -20,7 +20,10 @@ function convertKitGutenbergBroadcastsBlockRenderPreview( block, props ) {
 		{
 			block: 'convertkit/' + block.name,
 			attributes: props.attributes,
-			className: 'convertkit-' + block.name,
+
+			// This is only output in the Gutenberg editor, so must be slightly different from the inner class name used to
+			// apply styles with i.e. convertkit-block.name.
+			className: 'convertkit-ssr-' + block.name,
 		}
 	);
 

--- a/resources/backend/js/gutenberg-block-form-trigger.js
+++ b/resources/backend/js/gutenberg-block-form-trigger.js
@@ -27,7 +27,10 @@ function convertKitGutenbergFormTriggerBlockRenderPreview( block, props ) {
 		{
 			block: 'convertkit/' + block.name,
 			attributes: props.attributes,
-			className: 'convertkit-' + block.name,
+
+			// This is only output in the Gutenberg editor, so must be slightly different from the inner class name used to
+			// apply styles with i.e. convertkit-block.name.
+			className: 'convertkit-ssr-' + block.name,
 		}
 	);
 

--- a/resources/backend/js/gutenberg-block-form.js
+++ b/resources/backend/js/gutenberg-block-form.js
@@ -81,7 +81,10 @@ function convertKitGutenbergFormBlockRenderPreview( block, props ) {
 		{
 			block: 'convertkit/' + block.name,
 			attributes: props.attributes,
-			className: 'convertkit-' + block.name,
+
+			// This is only output in the Gutenberg editor, so must be slightly different from the inner class name used to
+			// apply styles with i.e. convertkit-block.name.
+			className: 'convertkit-ssr-' + block.name,
 		}
 	);
 

--- a/resources/backend/js/gutenberg-block-product.js
+++ b/resources/backend/js/gutenberg-block-product.js
@@ -49,7 +49,10 @@ function convertKitGutenbergProductBlockRenderPreview( block, props ) {
 		{
 			block: 'convertkit/' + block.name,
 			attributes: props.attributes,
-			className: 'convertkit-' + block.name,
+
+			// This is only output in the Gutenberg editor, so must be slightly different from the inner class name used to
+			// apply styles with i.e. convertkit-block.name.
+			className: 'convertkit-ssr-' + block.name,
 		}
 	);
 


### PR DESCRIPTION
## Summary

Fixes an issue where applying a background color to a Form Trigger or Product button block would result in different output between the editor and frontend, due to the color being applied to the editor `div` element, resulting in the border radius not showing.

Frontend output (before and after, always correct):
![frontend](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/4b1e6534-c275-46c9-81dc-ac07c0268eb0)

Before (editor):
![before](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/e4e7809f-c0a0-4378-b0c4-87d987294432)

After (editor):
![after](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/e9fca017-cbac-4826-8952-45717d3922d1)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)