### PR TITLE
Tests: Use `waitForElementVisible` when checking modal content

### DIFF
--- a/tests/acceptance/broadcasts/blocks/PageBlockBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/blocks/PageBlockBroadcastsCest.php
@@ -87,7 +87,7 @@ class PageBlockBroadcastsCest
 		$I->switchToNextTab();
 
 		// Confirm the ConvertKit login screen loaded.
-		$I->seeElementInDOM('input[name="user[email]"]');
+		$I->waitForElementVisible('input[name="user[email]"]');
 
 		// Close tab.
 		$I->closeTab();

--- a/tests/acceptance/forms/blocks/PageBlockFormCest.php
+++ b/tests/acceptance/forms/blocks/PageBlockFormCest.php
@@ -568,7 +568,7 @@ class PageBlockFormCest
 		$I->switchToNextTab();
 
 		// Confirm the ConvertKit login screen loaded.
-		$I->seeElementInDOM('input[name="user[email]"]');
+		$I->waitForElementVisible('input[name="user[email]"]');
 
 		// Close tab.
 		$I->closeTab();

--- a/tests/acceptance/forms/blocks/PageBlockFormTriggerCest.php
+++ b/tests/acceptance/forms/blocks/PageBlockFormTriggerCest.php
@@ -418,7 +418,7 @@ class PageBlockFormTriggerCest
 		$I->switchToNextTab();
 
 		// Confirm the ConvertKit login screen loaded.
-		$I->seeElementInDOM('input[name="user[email]"]');
+		$I->waitForElementVisible('input[name="user[email]"]');
 
 		// Close tab.
 		$I->closeTab();

--- a/tests/acceptance/forms/shortcodes/PageShortcodeFormCest.php
+++ b/tests/acceptance/forms/shortcodes/PageShortcodeFormCest.php
@@ -447,7 +447,7 @@ class PageShortcodeFormCest
 		$I->switchToNextTab();
 
 		// Confirm the ConvertKit login screen loaded.
-		$I->seeElementInDOM('input[name="user[email]"]');
+		$I->waitForElementVisible('input[name="user[email]"]');
 
 		// Close tab.
 		$I->closeTab();

--- a/tests/acceptance/forms/shortcodes/PageShortcodeFormTriggerCest.php
+++ b/tests/acceptance/forms/shortcodes/PageShortcodeFormTriggerCest.php
@@ -365,7 +365,7 @@ class PageShortcodeFormTriggerCest
 		$I->switchToNextTab();
 
 		// Confirm the ConvertKit login screen loaded.
-		$I->seeElementInDOM('input[name="user[email]"]');
+		$I->waitForElementVisible('input[name="user[email]"]');
 
 		// Close tab.
 		$I->closeTab();

--- a/tests/acceptance/products/PageBlockProductCest.php
+++ b/tests/acceptance/products/PageBlockProductCest.php
@@ -323,7 +323,7 @@ class PageBlockProductCest
 		$I->switchToNextTab();
 
 		// Confirm the ConvertKit login screen loaded.
-		$I->seeElementInDOM('input[name="user[email]"]');
+		$I->waitForElementVisible('input[name="user[email]"]');
 
 		// Close tab.
 		$I->closeTab();

--- a/tests/acceptance/products/PageShortcodeProductCest.php
+++ b/tests/acceptance/products/PageShortcodeProductCest.php
@@ -365,7 +365,7 @@ class PageShortcodeProductCest
 		$I->switchToNextTab();
 
 		// Confirm the ConvertKit login screen loaded.
-		$I->seeElementInDOM('input[name="user[email]"]');
+		$I->waitForElementVisible('input[name="user[email]"]');
 
 		// Close tab.
 		$I->closeTab();


### PR DESCRIPTION
## Summary

Improves reliability of tests by waiting for the modal's contents to load, checking the expected element is visible, instead of immediately checking the DOM.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)