### PR TITLE
Broadcasts to Posts: Add Post Status Setting

### DIFF
--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -197,6 +197,19 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 		}
 
 		add_settings_field(
+			'post_status',
+			__( 'Status', 'convertkit' ),
+			array( $this, 'post_status_callback' ),
+			$this->settings_key,
+			$this->name,
+			array(
+				'name'        => 'post_status',
+				'label_for'   => 'post_status',
+				'description' => __( 'The WordPress Post status to assign imported broadcasts to.', 'convertkit' ),
+			)
+		);
+
+		add_settings_field(
 			'category_id',
 			__( 'Category', 'convertkit' ),
 			array( $this, 'category_callback' ),
@@ -316,6 +329,32 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 		);
 
 		echo '<a href="' . esc_url( $import_url ) . '" class="button button-secondary enabled">' . esc_html__( 'Import now', 'convertkit' ) . '</a>';
+
+	}
+
+	/**
+	 * Renders the input for the status setting.
+	 *
+	 * @since   2.3.4
+	 *
+	 * @param   array $args   Setting field arguments (name,description).
+	 */
+	public function post_status_callback( $args ) {
+
+		// Build field.
+		$select_field = $this->get_select_field(
+			$args['name'],
+			$this->settings->post_status(),
+			get_post_statuses(),
+			$args['description'],
+			array(
+				'enabled',
+				'convertkit-select2',
+			)
+		);
+
+		// Output field.
+		echo '<div class="convertkit-select2-container">' . $select_field . '</div>'; // phpcs:ignore WordPress.Security.EscapeOutput
 
 	}
 

--- a/includes/class-convertkit-broadcasts-importer.php
+++ b/includes/class-convertkit-broadcasts-importer.php
@@ -146,11 +146,11 @@ class ConvertKit_Broadcasts_Importer {
 			// If the Broadcast has an image, save it to the Media Library and link it to the Post.
 			$this->add_broadcast_image_to_post( $broadcast, $post_id );
 
-			// Publish the draft Post, now that the image has been added to it.
+			// Transition the Post to the defined Post Status in the settings, now that the image has been added to it.
 			$post_id = wp_update_post(
 				array(
 					'ID'          => $post_id,
-					'post_status' => 'publish',
+					'post_status' => $this->broadcasts_settings->post_status(),
 				),
 				true
 			);

--- a/includes/class-convertkit-settings-broadcasts.php
+++ b/includes/class-convertkit-settings-broadcasts.php
@@ -116,6 +116,19 @@ class ConvertKit_Settings_Broadcasts {
 	}
 
 	/**
+	 * Returns the WordPress Post Status to assign to Posts created from imported Broadcasts.
+	 *
+	 * @since   2.3.4
+	 *
+	 * @return  int
+	 */
+	public function post_status() {
+
+		return $this->settings['post_status'];
+
+	}
+
+	/**
 	 * Returns the WordPress Category ID to assign imported Broadcasts to.
 	 *
 	 * @since   2.2.9
@@ -208,6 +221,7 @@ class ConvertKit_Settings_Broadcasts {
 		$defaults = array(
 			'enabled'               => '',
 			'author_id'             => get_current_user_id(),
+			'post_status'			=> 'publish',
 			'category_id'           => '',
 
 			// By default, only import Broadcasts as Posts for the last 30 days.

--- a/includes/class-convertkit-settings-broadcasts.php
+++ b/includes/class-convertkit-settings-broadcasts.php
@@ -120,7 +120,7 @@ class ConvertKit_Settings_Broadcasts {
 	 *
 	 * @since   2.3.4
 	 *
-	 * @return  int
+	 * @return  string
 	 */
 	public function post_status() {
 
@@ -221,7 +221,7 @@ class ConvertKit_Settings_Broadcasts {
 		$defaults = array(
 			'enabled'               => '',
 			'author_id'             => get_current_user_id(),
-			'post_status'			=> 'publish',
+			'post_status'           => 'publish',
 			'category_id'           => '',
 
 			// By default, only import Broadcasts as Posts for the last 30 days.

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -417,8 +417,8 @@ class Plugin extends \Codeception\Module
 						}
 						break;
 
+					case 'post_status':
 					case 'category_id':
-					case 'restrict_content':
 						$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_broadcasts_' . $key . '-container', $value);
 
 						break;

--- a/tests/acceptance/broadcasts/import/BroadcastsToPostsCest.php
+++ b/tests/acceptance/broadcasts/import/BroadcastsToPostsCest.php
@@ -228,6 +228,63 @@ class BroadcastsToPostsCest
 	}
 
 	/**
+	 * Tests that Broadcasts import when enabled in the Plugin's settings,
+	 * a Post Status is defined and the Post Status is assigned to the created
+	 * WordPress Posts.
+	 *
+	 * @since   2.3.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsImportWithPostStatusEnabled(AcceptanceTester $I)
+	{
+		// Enable Broadcasts to Posts.
+		$I->setupConvertKitPluginBroadcasts(
+			$I,
+			[
+				'enabled'               => true,
+				'post_status'           => 'private',
+				'category_id'           => $this->categoryName,
+				'published_at_min_date' => '01/01/2020',
+			]
+		);
+
+		// Run the WordPress Cron event to import Broadcasts to WordPress Posts.
+		$I->runCronEvent($I, $this->cronEventName);
+
+		// Wait a few seconds for the Cron event to complete importing Broadcasts.
+		$I->wait(7);
+
+		// Load the Posts screen.
+		$I->amOnAdminPage('edit.php');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm expected Broadcasts exist as Posts.
+		$I->see($_ENV['CONVERTKIT_API_BROADCAST_FIRST_TITLE']);
+		$I->see($_ENV['CONVERTKIT_API_BROADCAST_SECOND_TITLE']);
+		$I->see($_ENV['CONVERTKIT_API_BROADCAST_THIRD_TITLE']);
+
+		// Get created Post IDs.
+		$postIDs = [
+			(int) str_replace('post-', '', $I->grabAttributeFrom('tbody#the-list > tr:nth-child(1)', 'id')),
+			(int) str_replace('post-', '', $I->grabAttributeFrom('tbody#the-list > tr:nth-child(2)', 'id')),
+			(int) str_replace('post-', '', $I->grabAttributeFrom('tbody#the-list > tr:nth-child(3)', 'id')),
+		];
+
+		// Confirm each Post's status is private.
+		foreach ($postIDs as $postID) {
+			$I->seePostInDatabase(
+				[
+					'ID'          => $postID,
+					'post_status' => 'private',
+				]
+			);
+		}
+	}
+
+	/**
 	 * Tests that Broadcasts import when enabled in the Plugin's settings
 	 * a Category is defined and the Category is assigned to the created
 	 * WordPress Posts.

--- a/tests/acceptance/broadcasts/import/BroadcastsToPostsCest.php
+++ b/tests/acceptance/broadcasts/import/BroadcastsToPostsCest.php
@@ -331,6 +331,15 @@ class BroadcastsToPostsCest
 
 		// Confirm each Post is assigned to the Category.
 		foreach ($postIDs as $postID) {
+			// Confirm the Post is published.
+			$I->seePostInDatabase(
+				[
+					'ID'          => $postID,
+					'post_status' => 'publish',
+				]
+			);
+
+			// Confirm the Post is assigned to the Category.
 			$I->seePostWithTermInDatabase($postID, $this->categoryID, null, 'category');
 		}
 	}

--- a/tests/acceptance/broadcasts/import/BroadcastsToPostsSettingsCest.php
+++ b/tests/acceptance/broadcasts/import/BroadcastsToPostsSettingsCest.php
@@ -37,6 +37,7 @@ class BroadcastsToPostsSettingsCest
 
 		// Confirm that settings have label[for] attributes.
 		$I->seeInSource('<label for="enabled">');
+		$I->seeInSource('<label for="post_status">');
 		$I->seeInSource('<label for="category_id">');
 		$I->seeInSource('<label for="published_at_min_date">');
 		$I->seeInSource('<label for="no_styles">');
@@ -73,6 +74,8 @@ class BroadcastsToPostsSettingsCest
 		// Confirm that settings saved and additional fields remain displayed.
 		$I->seeCheckboxIsChecked('#enabled');
 		$I->seeElement('table.form-table tbody tr td a.button');
+		$I->seeElement('span[aria-labelledby="select2-_wp_convertkit_settings_broadcasts_post_status-container"]');
+		$I->seeElement('span[aria-labelledby="select2-_wp_convertkit_settings_broadcasts_category_id-container"]');
 		$I->seeElement('div.convertkit-select2-container');
 		$I->seeElement('input#published_at_min_date');
 
@@ -94,7 +97,8 @@ class BroadcastsToPostsSettingsCest
 		// Confirm that settings saved and additional fields are hidden, because the 'Enable' option is not checked.
 		$I->dontSeeCheckboxIsChecked('#enabled');
 		$I->dontSeeElement('table.form-table tbody tr td a.button');
-		$I->dontSeeElement('div.convertkit-select2-container');
+		$I->dontSeeElement('span[aria-labelledby="select2-_wp_convertkit_settings_broadcasts_post_status-container"]');
+		$I->dontSeeElement('span[aria-labelledby="select2-_wp_convertkit_settings_broadcasts_category_id-container"]');
 		$I->dontSeeElement('input#published_at_min_date');
 
 		// Check the next import date and time is not displayed.
@@ -115,6 +119,7 @@ class BroadcastsToPostsSettingsCest
 
 		// Enable Broadcasts to Posts, and modify settings.
 		$I->checkOption('#enabled');
+		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_broadcasts_post_status-container', 'Draft');
 		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_broadcasts_category_id-container', 'ConvertKit Broadcasts to Posts');
 		$I->fillField('_wp_convertkit_settings_broadcasts[published_at_min_date]', '01/01/2023');
 		$I->checkOption('#enabled_export');
@@ -128,6 +133,7 @@ class BroadcastsToPostsSettingsCest
 
 		// Confirm that settings saved.
 		$I->seeCheckboxIsChecked('#enabled');
+		$I->seeInField('_wp_convertkit_settings_broadcasts[post_status]', 'Draft');
 		$I->seeInField('_wp_convertkit_settings_broadcasts[category_id]', 'ConvertKit Broadcasts to Posts');
 		$I->seeInField('_wp_convertkit_settings_broadcasts[published_at_min_date]', '2023-01-01');
 		$I->seeCheckboxIsChecked('#enabled_export');


### PR DESCRIPTION
## Summary

As requested [here](https://twitter.com/RobbyMiles/status/1714688969445962225), adds an option to specify the WordPress Post status to assign imported ConvertKit Broadcasts to.

![Screenshot 2023-10-20 at 14 08 25](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/625f6954-cc26-4f80-a258-585f66e8a075)

## Testing

- `BroadcastsToPostsSettingsCest`: Updated tests to include the Post Status setting field.
- `testBroadcastsImportWithCategoryEnabled`: Test that the Post Status is set to published for each imported Broadcast
- `testBroadcastsImportWithPostStatusEnabled`: Test that the Post Status is set to private for each imported Broadcast

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)