### PR TITLE
Broadcasts to Posts: Remove `get_by_key` method

### DIFF
--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -360,7 +360,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 		// Output field.
 		echo $this->get_date_field( // phpcs:ignore WordPress.Security.EscapeOutput
 			$args['name'],
-			esc_attr( $this->settings->g( $args['name'] ) ),
+			esc_attr( $this->settings->published_at_min_date() ),
 			$args['description'], // phpcs:ignore WordPress.Security.EscapeOutput
 			array(
 				'enabled',

--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -337,7 +337,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 				'name'             => $this->settings_key . '[' . $args['name'] . ']',
 				'id'               => $this->settings_key . '_' . $args['name'],
 				'class'            => 'convertkit-select2 enabled',
-				'selected'         => $this->settings->get_by_key( $args['name'] ),
+				'selected'         => $this->settings->category_id(),
 				'taxonomy'         => 'category',
 				'hide_empty'       => false,
 			)
@@ -360,7 +360,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 		// Output field.
 		echo $this->get_date_field( // phpcs:ignore WordPress.Security.EscapeOutput
 			$args['name'],
-			esc_attr( $this->settings->get_by_key( $args['name'] ) ),
+			esc_attr( $this->settings->g( $args['name'] ) ),
 			$args['description'], // phpcs:ignore WordPress.Security.EscapeOutput
 			array(
 				'enabled',

--- a/includes/class-convertkit-settings-broadcasts.php
+++ b/includes/class-convertkit-settings-broadcasts.php
@@ -65,31 +65,6 @@ class ConvertKit_Settings_Broadcasts {
 	}
 
 	/**
-	 * Returns Broadcasts settings value for the given key.
-	 *
-	 * @since   2.2.9
-	 *
-	 * @param   string $key    Setting Key.
-	 * @return  string          Value
-	 */
-	public function get_by_key( $key ) {
-
-		// If the setting doesn't exist, bail.
-		if ( ! array_key_exists( $key, $this->settings ) ) {
-			return '';
-		}
-
-		// If the setting is empty, fallback to the default.
-		if ( empty( $this->settings[ $key ] ) ) {
-			$defaults = $this->get_defaults();
-			return $defaults[ $key ];
-		}
-
-		return $this->settings[ $key ];
-
-	}
-
-	/**
 	 * Returns whether Broadcasts are enabled in the Plugin settings.
 	 *
 	 * @since   2.2.9


### PR DESCRIPTION
## Summary

Removes the `get_by_key` method for Broadcasts, as named methods are preferred in case array key names change in the future.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)