### PR TITLE
Don't attempt to append Forms to unsupported Post Types

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       DB_USER: root
       DB_PASS: root
       DB_HOST: localhost
-      INSTALL_PLUGINS: "admin-menu-editor contact-form-7 classic-editor disable-welcome-messages-and-tips elementor forminator woocommerce wordpress-seo wpforms-lite litespeed-cache wp-crontrol wp-super-cache w3-total-cache wp-fastest-cache wp-optimize" # Don't include this repository's Plugin here.
+      INSTALL_PLUGINS: "admin-menu-editor contact-form-7 classic-editor custom-post-type-ui disable-welcome-messages-and-tips elementor forminator woocommerce wordpress-seo wpforms-lite litespeed-cache wp-crontrol wp-super-cache w3-total-cache wp-fastest-cache wp-optimize" # Don't include this repository's Plugin here.
       INSTALL_PLUGINS_URLS: "https://downloads.wordpress.org/plugin/convertkit-for-woocommerce.1.6.4.zip" # URLs to specific third party Plugins
       CONVERTKIT_API_KEY: ${{ secrets.CONVERTKIT_API_KEY }} # ConvertKit API Key, stored in the repository's Settings > Secrets
       CONVERTKIT_API_SECRET: ${{ secrets.CONVERTKIT_API_SECRET }} # ConvertKit API Secret, stored in the repository's Settings > Secrets

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -176,8 +176,8 @@ class ConvertKit_Output {
 	 */
 	public function append_form_to_content( $content ) {
 
-		// Bail if not a singular Post Type.
-		if ( ! is_singular() ) {
+		// Bail if not a singular Post Type supported by ConvertKit.
+		if ( ! is_singular( convertkit_get_supported_post_types() ) ) {
 			return $content;
 		}
 

--- a/tests/_support/Helper/Acceptance/CustomPostType.php
+++ b/tests/_support/Helper/Acceptance/CustomPostType.php
@@ -1,0 +1,62 @@
+<?php
+namespace Helper\Acceptance;
+
+/**
+ * Helper methods and actions related to registering Custom Post Types in WordPress.
+ *
+ * @since   2.3.5
+ */
+class CustomPostType extends \Codeception\Module
+{
+	/**
+	 * Registers a Custom Post Type in WordPress
+	 *
+	 * @since   2.3.5
+	 *
+	 * @param   AcceptanceTester $I             Acceptance Tester.
+	 * @param   string           $slug          Post Type Slug.
+	 * @param   string           $singularLabel Singular Label.
+	 * @param   string           $pluralLabel   Plural Label.
+	 */
+	public function registerCustomPostType($I, $slug, $singularLabel, $pluralLabel)
+	{
+		// Activate CPT UI Plugin.
+		$I->activateThirdPartyPlugin($I, 'custom-post-type-ui');
+
+		// Navigate to the CPT UI Plugin screen.
+		$I->amOnAdminPage('admin.php?page=cptui_manage_post_types');
+
+		// Add the Post Type.
+		$I->fillField('cpt_custom_post_type[name]', $slug);
+		$I->fillField('cpt_custom_post_type[label]', $pluralLabel);
+		$I->fillField('cpt_custom_post_type[singular_label]', $singularLabel);
+		$I->click('Add Post Type');
+
+		// Confirm the Post Type was created.
+		$I->see($slug . ' has been successfully added');
+	}
+
+	/**
+	 * Unregisters an existing Custom Post Type in WordPress
+	 *
+	 * @since   2.3.5
+	 *
+	 * @param   AcceptanceTester $I             Acceptance Tester.
+	 * @param   string           $slug          Post Type Slug.
+	 */
+	public function unregisterCustomPostType($I, $slug)
+	{
+		// Navigate to the CPT UI Plugin screen.
+		$I->amOnAdminPage('admin.php?page=cptui_manage_post_types&action=edit');
+
+		// Select the Post Type.
+		$I->selectOption('#post_type', $slug);
+
+		// Click the Delete button.
+		$I->click('Delete Post Type');
+
+		// Confirm deletion.
+		$I->waitForElementVisible('div.wp-dialog');
+		$I->click('OK', 'div.wp-dialog');
+	}
+}

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -22,6 +22,7 @@ modules:
         # Our helper classes, which contain functions used across multiple tests.
         # If you created a new file in tests/_support/Helper/Acceptance, add its namespace and class below,
         - \Helper\Acceptance\ConvertKitAPI
+        - \Helper\Acceptance\CustomPostType
         - \Helper\Acceptance\Email
         - \Helper\Acceptance\Plugin
         - \Helper\Acceptance\Select2

--- a/tests/acceptance/forms/general/CPTFormCest.php
+++ b/tests/acceptance/forms/general/CPTFormCest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Tests for WordPress Custom Post Types.
+ *
+ * @since   2.3.5
+ */
+class CPTFormCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   2.3.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		// Activate ConvertKit plugin.
+		$I->activateConvertKitPlugin($I);
+
+		// Create a Custom Post Type using the Custom Post Type UI Plugin.
+		// @TODO.
+	}
+
+	/**
+	 * Tests that:
+	 * - no ConvertKit options are displayed when adding a new Custom Post Type,
+	 * - no debug output is displayed when viewing a Custom Post Type.
+	 * 
+	 * @since 	2.3.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testNoOptionsOrOutputOnCustomPostType(AcceptanceTester $I)
+	{
+		
+	}
+
+	/**
+	 * Tests that no ConvertKit options are display when quick or bulk editing in a Custom Post Type.
+	 * 
+	 * @since 	2.3.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testNoBulkOrQuickEditOptionsOnCustomPostType(AcceptanceTester $I)
+	{
+
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
+	}
+}

--- a/tests/acceptance/forms/general/CPTFormCest.php
+++ b/tests/acceptance/forms/general/CPTFormCest.php
@@ -18,34 +18,72 @@ class CPTFormCest
 		// Activate ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
 
-		// Create a Custom Post Type using the Custom Post Type UI Plugin.
-		// @TODO.
+		// Setup ConvertKit plugin .
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET']);
+		$I->setupConvertKitPluginResources($I);
+
+		// Create a Custom Post Type called Articles, using the Custom Post Type UI Plugin.
+		$I->registerCustomPostType($I, 'article', 'Articles', 'Article');
 	}
 
 	/**
 	 * Tests that:
 	 * - no ConvertKit options are displayed when adding a new Custom Post Type,
 	 * - no debug output is displayed when viewing a Custom Post Type.
-	 * 
-	 * @since 	2.3.5
+	 *
+	 * @since   2.3.5
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testNoOptionsOrOutputOnCustomPostType(AcceptanceTester $I)
 	{
-		
+		// Add an Article using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'article', 'ConvertKit: Article: Form: None');
+
+		// Check that the metabox is not displayed.
+		$I->dontSeeElementInDOM('#wp-convertkit-meta-box');
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that no ConvertKit Form is displayed.
+		$I->dontSeeElementInDOM('form[data-sv-form]');
+
+		// Confirm that no debug data is output, as this isn't a supported Post Type.
+		$I->dontSeeInSource('<!-- ConvertKit append_form_to_content()');
 	}
 
 	/**
 	 * Tests that no ConvertKit options are display when quick or bulk editing in a Custom Post Type.
-	 * 
-	 * @since 	2.3.5
+	 *
+	 * @since   2.3.5
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testNoBulkOrQuickEditOptionsOnCustomPostType(AcceptanceTester $I)
 	{
+		// Programmatically create two Articles.
+		$postIDs = array(
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'article',
+					'post_title' => 'ConvertKit: Article: #1',
+				]
+			),
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'article',
+					'post_title' => 'ConvertKit: Article: #2',
+				]
+			),
+		);
 
+		// Navigate to Articles.
+		$I->amOnAdminPage('edit.php?post_type=article');
+
+		// Confirm no Bulk or Quick Edit settings are available.
+		$I->dontSeeElementInDOM('#convertkit-bulk-edit');
+		$I->dontSeeElementInDOM('#convertkit-quick-edit');
 	}
 
 	/**
@@ -59,6 +97,7 @@ class CPTFormCest
 	 */
 	public function _passed(AcceptanceTester $I)
 	{
+		$I->unregisterCustomPostType($I, 'article');
 		$I->deactivateConvertKitPlugin($I);
 		$I->resetConvertKitPlugin($I);
 	}


### PR DESCRIPTION
## Summary

Checks if the Post's type being viewed supports appending a ConvertKit Form to the content before running further logic.

Fixes [this issue](https://convertkit.atlassian.net/jira/software/c/projects/T3/boards/27?quickFilter=45&selectedIssue=T3-598), where Envira Gallery refuses to output a gallery if any output is detected (i.e. HTML comments when debugging in the ConvertKit Plugin is enabled).

## Testing

- `CPTFormCest`: Checks that no options are displayed in the WordPress Administration UI on a custom Post Type, and checks that `append_form_to_content()` does not output on a custom Post Type when the `Debug` setting is enabled.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)