### PR TITLE
Restrict Content: Generate / Display Excerpt

### DIFF
--- a/includes/class-convertkit-output-restrict-content.php
+++ b/includes/class-convertkit-output-restrict-content.php
@@ -821,13 +821,13 @@ class ConvertKit_Output_Restrict_Content {
 
 	/**
 	 * Returns the excerpt for the given Post.
-	 * 
+	 *
 	 * If no excerpt is defined, generates one from the Post's content.
-	 * 
-	 * @since 	2.3.5
-	 * 
-	 * @param 	int 	$post_id 	Post ID.
-	 * @return 	string 				Post excerpt.
+	 *
+	 * @since   2.3.5
+	 *
+	 * @param   int $post_id    Post ID.
+	 * @return  string              Post excerpt.
 	 */
 	private function get_excerpt( $post_id ) {
 
@@ -840,7 +840,7 @@ class ConvertKit_Output_Restrict_Content {
 
 		// Restore filters so other functions and Plugins aren't affected.
 		add_filter( 'the_content', array( $this, 'maybe_restrict_content' ) );
-		
+
 		// Return the excerpt.
 		return wpautop( $excerpt );
 

--- a/includes/class-convertkit-output-restrict-content.php
+++ b/includes/class-convertkit-output-restrict-content.php
@@ -778,10 +778,10 @@ class ConvertKit_Output_Restrict_Content {
 	 * - A single <!--more--> tag being placed between WordPress paragraphs when using the Classic Editor.
 	 * Content before the tag will be returned as the preview, unless 'noteaser' is enabled.
 	 * - A single 'Read More' block being placed between WordPress blocks when using the Gutenberg Editor.
-	 * Content before the Read More block will be returned as the preview, unless 'Hide th excerpt
+	 * Content before the Read More block will be returned as the preview, unless 'Hide the excerpt
 	 * on the full content page' is enabled.
 	 *
-	 * No preview content is returned if the above conditions are not met.
+	 * If no more tag or Read More block is present, returns the Post's excerpt.
 	 *
 	 * @since   2.1.0
 	 *
@@ -814,8 +814,35 @@ class ConvertKit_Output_Restrict_Content {
 			return $content_breakdown[0];
 		}
 
-		// If here, there is no preview content available. Don't return any content.
-		return '';
+		// If here, there is no preview content available. Use the Post's excerpt.
+		return $this->get_excerpt( $post->ID );
+
+	}
+
+	/**
+	 * Returns the excerpt for the given Post.
+	 * 
+	 * If no excerpt is defined, generates one from the Post's content.
+	 * 
+	 * @since 	2.3.5
+	 * 
+	 * @param 	int 	$post_id 	Post ID.
+	 * @return 	string 				Post excerpt.
+	 */
+	private function get_excerpt( $post_id ) {
+
+		// Remove 'the_content' filter, as if the Post contains no defined excerpt, WordPress
+		// will invoke the Post's content to build an excerpt, resulting in an infinite loop.
+		remove_filter( 'the_content', array( $this, 'maybe_restrict_content' ) );
+
+		// Generate the Post's excerpt.
+		$excerpt = get_the_excerpt( $post_id );
+
+		// Restore filters so other functions and Plugins aren't affected.
+		add_filter( 'the_content', array( $this, 'maybe_restrict_content' ) );
+		
+		// Return the excerpt.
+		return wpautop( $excerpt );
 
 	}
 

--- a/tests/_support/Helper/Acceptance/WPGutenberg.php
+++ b/tests/_support/Helper/Acceptance/WPGutenberg.php
@@ -187,6 +187,19 @@ class WPGutenberg extends \Codeception\Module
 	}
 
 	/**
+	 * Adds the given text as the excerpt in the Gutenberg editor.
+	 * 
+	 * @since 	2.3.5
+	 * 
+	 * @param   AcceptanceTester $I      	Acceptance Tester.
+	 * @param   string           $excerpt   Post excerpt.
+	 */
+	public function addGutenbergExcerpt($I, $excerpt)
+	{
+		// @TODO.
+	}
+
+	/**
 	 * Helper method to insert a link into the selected element, by:
 	 * - clicking the link button in the selected block's toolbar,
 	 * - searching for the Page, Post or Custom Post Type,

--- a/tests/_support/Helper/Acceptance/WPGutenberg.php
+++ b/tests/_support/Helper/Acceptance/WPGutenberg.php
@@ -188,15 +188,22 @@ class WPGutenberg extends \Codeception\Module
 
 	/**
 	 * Adds the given text as the excerpt in the Gutenberg editor.
-	 * 
-	 * @since 	2.3.5
-	 * 
-	 * @param   AcceptanceTester $I      	Acceptance Tester.
+	 *
+	 * @since   2.3.5
+	 *
+	 * @param   AcceptanceTester $I         Acceptance Tester.
 	 * @param   string           $excerpt   Post excerpt.
 	 */
 	public function addGutenbergExcerpt($I, $excerpt)
 	{
-		// @TODO.
+		// Click the Post tab.
+		$I->click('button[aria-label="Post"]');
+
+		// Click the Excerpt tab.
+		$I->click('Excerpt');
+
+		// Insert the excerpt into the field.
+		$I->fillField('.editor-post-excerpt textarea', $excerpt);
 	}
 
 	/**

--- a/tests/acceptance/restrict-content/RestrictContentProductPageCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentProductPageCest.php
@@ -87,6 +87,50 @@ class RestrictContentProductPageCest
 	}
 
 	/**
+	 * Test that restricting content by a Product specified in the Page Settings works when
+	 * creating and viewing a new WordPress Page, and that the WordPress generated Page Excerpt
+	 * is displayed when no more tag exists.
+	 *
+	 * @since   2.3.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentByProductWithGeneratedExcerpt(AcceptanceTester $I)
+	{
+		// Define visible content and member only content.
+		$visibleContent = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at velit purus. Nam gravida tempor tellus, sit amet euismod arcu. Mauris sed mattis leo. Mauris viverra eget tellus sit amet vehicula. Nulla eget sapien quis felis euismod pellentesque. Quisque elementum et diam nec eleifend. Sed ornare quam eget augue consequat, in maximus quam fringilla. Morbi';
+		$memberOnlyContent = 'Member only content';
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Restrict Content: Product: Generated Excerpt');
+
+		// Configure metabox's Restrict Content setting = Product name.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form'             => [ 'select2', 'None' ],
+				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+			]
+		);
+
+		// Add blocks.
+		$I->addGutenbergParagraphBlock($I, $visibleContent);
+		$I->addGutenbergParagraphBlock($I, $memberOnlyContent);
+
+		// Publish Page.
+		$url = $I->publishGutenbergPage($I);
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentByProductOnFrontend(
+			$I,
+			$url,
+			$visibleContent,
+			$memberOnlyContent
+		);
+	}
+
+	/**
 	 * Test that restricting content by a Product that does not exist does not output
 	 * a fatal error and instead displays all of the Page's content.
 	 *

--- a/tests/acceptance/restrict-content/RestrictContentProductPageCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentProductPageCest.php
@@ -98,7 +98,7 @@ class RestrictContentProductPageCest
 	public function testRestrictContentByProductWithGeneratedExcerpt(AcceptanceTester $I)
 	{
 		// Define visible content and member only content.
-		$visibleContent = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at velit purus. Nam gravida tempor tellus, sit amet euismod arcu. Mauris sed mattis leo. Mauris viverra eget tellus sit amet vehicula. Nulla eget sapien quis felis euismod pellentesque. Quisque elementum et diam nec eleifend. Sed ornare quam eget augue consequat, in maximus quam fringilla. Morbi';
+		$visibleContent    = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at velit purus. Nam gravida tempor tellus, sit amet euismod arcu. Mauris sed mattis leo. Mauris viverra eget tellus sit amet vehicula. Nulla eget sapien quis felis euismod pellentesque. Quisque elementum et diam nec eleifend. Sed ornare quam eget augue consequat, in maximus quam fringilla. Morbi';
 		$memberOnlyContent = 'Member only content';
 
 		// Add a Page using the Gutenberg editor.

--- a/tests/acceptance/restrict-content/RestrictContentProductPostCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentProductPostCest.php
@@ -87,6 +87,97 @@ class RestrictContentProductPostCest
 	}
 
 	/**
+	 * Test that restricting content by a Product specified in the Post Settings works when
+	 * creating and viewing a new WordPress Post, and that the WordPress generated Post Excerpt
+	 * is displayed when no more tag exists.
+	 *
+	 * @since   2.3.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentByProductWithGeneratedExcerpt(AcceptanceTester $I)
+	{
+		// Define visible content and member only content.
+		$visibleContent = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at velit purus. Nam gravida tempor tellus, sit amet euismod arcu. Mauris sed mattis leo. Mauris viverra eget tellus sit amet vehicula. Nulla eget sapien quis felis euismod pellentesque. Quisque elementum et diam nec eleifend. Sed ornare quam eget augue consequat, in maximus quam fringilla. Morbi';
+		$memberOnlyContent = 'Member only content';
+
+		// Add a Post using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Restrict Content: Product: Generated Excerpt');
+
+		// Configure metabox's Restrict Content setting = Product name.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form'             => [ 'select2', 'None' ],
+				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+			]
+		);
+
+		// Add blocks.
+		$I->addGutenbergParagraphBlock($I, $visibleContent);
+		$I->addGutenbergParagraphBlock($I, $memberOnlyContent);
+
+		// Publish Page.
+		$url = $I->publishGutenbergPage($I);
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentByProductOnFrontend(
+			$I,
+			$url,
+			$visibleContent,
+			$memberOnlyContent
+		);
+	}
+
+	/**
+	 * Test that restricting content by a Product specified in the Post Settings works when
+	 * creating and viewing a new WordPress Post, and that the Excerpt defined in the Post
+	 * is displayed when no more tag exists.
+	 *
+	 * @since   2.3.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentByProductWithDefinedExcerpt(AcceptanceTester $I)
+	{
+		// Define visible content and member only content.
+		$visibleContent = 'This is a defined excerpt';
+		$memberOnlyContent = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at velit purus. Nam gravida tempor tellus, sit amet euismod arcu. Mauris sed mattis leo. Mauris viverra eget tellus sit amet vehicula. Nulla eget sapien quis felis euismod pellentesque. Quisque elementum et diam nec eleifend. Sed ornare quam eget augue consequat, in maximus quam fringilla. Morbi';
+		
+		// Add a Post using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Restrict Content: Product: Defined Excerpt');
+
+		// Configure metabox's Restrict Content setting = Product name.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form'             => [ 'select2', 'None' ],
+				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+			]
+		);
+
+		// Add member content only as a block.
+		// Visible content will be defined in the excerpt.
+		$I->addGutenbergParagraphBlock($I, $memberOnlyContent);
+
+		// Define excerpt.
+		$I->addGutenbergExcerpt($I, $visibleContent);
+
+		// Publish Post.
+		$url = $I->publishGutenbergPage($I);
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentByProductOnFrontend(
+			$I,
+			$url,
+			$visibleContent,
+			$memberOnlyContent
+		);
+	}
+
+	/**
 	 * Test that restricting content by a Product that does not exist does not output
 	 * a fatal error and instead displays all of the Post's content.
 	 *

--- a/tests/acceptance/restrict-content/RestrictContentProductPostCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentProductPostCest.php
@@ -98,7 +98,7 @@ class RestrictContentProductPostCest
 	public function testRestrictContentByProductWithGeneratedExcerpt(AcceptanceTester $I)
 	{
 		// Define visible content and member only content.
-		$visibleContent = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at velit purus. Nam gravida tempor tellus, sit amet euismod arcu. Mauris sed mattis leo. Mauris viverra eget tellus sit amet vehicula. Nulla eget sapien quis felis euismod pellentesque. Quisque elementum et diam nec eleifend. Sed ornare quam eget augue consequat, in maximus quam fringilla. Morbi';
+		$visibleContent    = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at velit purus. Nam gravida tempor tellus, sit amet euismod arcu. Mauris sed mattis leo. Mauris viverra eget tellus sit amet vehicula. Nulla eget sapien quis felis euismod pellentesque. Quisque elementum et diam nec eleifend. Sed ornare quam eget augue consequat, in maximus quam fringilla. Morbi';
 		$memberOnlyContent = 'Member only content';
 
 		// Add a Post using the Gutenberg editor.
@@ -142,9 +142,9 @@ class RestrictContentProductPostCest
 	public function testRestrictContentByProductWithDefinedExcerpt(AcceptanceTester $I)
 	{
 		// Define visible content and member only content.
-		$visibleContent = 'This is a defined excerpt';
+		$excerpt           = 'This is a defined excerpt';
 		$memberOnlyContent = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at velit purus. Nam gravida tempor tellus, sit amet euismod arcu. Mauris sed mattis leo. Mauris viverra eget tellus sit amet vehicula. Nulla eget sapien quis felis euismod pellentesque. Quisque elementum et diam nec eleifend. Sed ornare quam eget augue consequat, in maximus quam fringilla. Morbi';
-		
+
 		// Add a Post using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Restrict Content: Product: Defined Excerpt');
 
@@ -163,18 +163,25 @@ class RestrictContentProductPostCest
 		$I->addGutenbergParagraphBlock($I, $memberOnlyContent);
 
 		// Define excerpt.
-		$I->addGutenbergExcerpt($I, $visibleContent);
+		$I->addGutenbergExcerpt($I, $excerpt);
 
 		// Publish Post.
 		$url = $I->publishGutenbergPage($I);
 
+		// Navigate to the page.
+		$I->amOnUrl($url);
+
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentByProductOnFrontend(
-			$I,
-			$url,
-			$visibleContent,
-			$memberOnlyContent
-		);
+		// Check content is not displayed, and CTA displays with expected text.
+		$I->testRestrictContentByProductHidesContentWithCTA($I, $excerpt, $memberOnlyContent);
+
+		// Test that the restricted content displays when a valid signed subscriber ID is used,
+		// as if we entered the code sent in the email.
+		// Excerpt should not be displayed, as its an excerpt, and we now show the member content instead.
+		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $url, '', $memberOnlyContent);
+
+		// Assert that the excerpt is no longer displayed.
+		$I->dontSee($excerpt);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

If no `more` tag is present in the Post's content, falls back to displaying text content before the CTA from either:
- a specified Excerpt, if viewing a WordPress Post, and the Post's Excerpt is defined in Gutenberg / Classic Editor:
![Screenshot 2023-11-06 at 15 53 08](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/5909d9cd-29b9-4354-a01d-81b14a28e231)
- a generated Excerpt from the Post's Content, if the Post has no Excerpt defined or it is a WordPress Page (Pages don't provide an Excerpt field)

Before:
![Screenshot 2023-11-06 at 15 52 16](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/25e7a9c3-0028-48b2-a02f-ba7d8a448b82)

After, with specified Excerpt:
![Screenshot 2023-11-06 at 15 53 15](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/511b6ea4-aa5c-45de-a5cf-f8fd35511407)

After, with no specified Excerpt (Excerpt is generated):
![Screenshot 2023-11-06 at 15 52 31](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/fe8d13a1-ebfc-4fc6-b963-51bd6ea51b2d)

## Testing

- `RestrictContentProductPageCest:testRestrictContentByProductWithGeneratedExcerpt`: Test that the generated Page Excerpt is displayed above the CTA when no more tag exists in the content.
- `RestrictContentProductPostCest:testRestrictContentByProductWithGeneratedExcerpt`: Test that the generated Post Excerpt is displayed above the CTA when no more tag exists in the content.
- `RestrictContentProductPostCest:testRestrictContentByProductWithDefinedExcerpt`: Test that the defined Post Excerpt  is displayed above the CTA when no more tag exists in the content.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)