### PR TITLE
Restrict Content: Force `padding` property on buttons

### DIFF
--- a/resources/frontend/css/restrict-content.css
+++ b/resources/frontend/css/restrict-content.css
@@ -49,7 +49,7 @@
 	line-height: 42px;
 	font-size: 15px;
 	margin: 0;
-	padding: 0 20px;
+	padding: 0 20px !important;
 	border: none;
 	border-radius: 3px;
 }
@@ -75,7 +75,7 @@
 	line-height: 42px;
 	font-size: 15px;
 	margin: 0;
-	padding: 0 20px;
+	padding: 0 20px !important;
 	border: none;
 	border-radius: 3px;
 }


### PR DESCRIPTION
## Summary

When selecting a style in a WordPress supplied block theme at `Apperance > Editor > Styles`, WordPress defines its own `!important` declarations on button padding, resulting in button layouts breaking in the Restrict Content functionality:

![Screenshot 2023-11-06 at 16 09 45](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/0be0b043-bb0f-45d0-ac0e-0f9bd5e770f5)

![Screenshot 2023-11-06 at 16 10 03](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/7bdee075-255d-4f15-b9e3-df690e7350f5)

This doesn't happen if the default theme style is selected.

This PR resolves by doing the same - but if there's a better way to do this without using `!important`, I'm open to trying it.

![Screenshot 2023-11-06 at 16 10 10](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/2d327391-b670-4e47-a946-36c5495fb6f5)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)