### PR TITLE
Restrict Content: Verify nonce on code submission

### DIFF
--- a/includes/class-convertkit-output-restrict-content.php
+++ b/includes/class-convertkit-output-restrict-content.php
@@ -118,7 +118,6 @@ class ConvertKit_Output_Restrict_Content {
 
 		// Bail if the nonce failed validation.
 		if ( ! wp_verify_nonce( sanitize_key( $_REQUEST['_wpnonce'] ), 'convertkit_restrict_content_login' ) ) {
-			$this->error = new WP_Error( 'convertkit_output_restrict_content_error', __( 'Invalid nonce specified. Please try again.', 'convertkit' ) );
 			return;
 		}
 
@@ -195,7 +194,16 @@ class ConvertKit_Output_Restrict_Content {
 	 */
 	public function maybe_run_subscriber_verification() {
 
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		// Bail if no nonce was specified.
+		if ( ! array_key_exists( '_wpnonce', $_REQUEST ) ) {
+			return;
+		}
+
+		// Bail if the nonce failed validation.
+		if ( ! wp_verify_nonce( sanitize_key( $_REQUEST['_wpnonce'] ), 'convertkit_restrict_content_subscriber_code' ) ) {
+			return;
+		}
+
 		// Bail if the expected token and subscriber code is missing.
 		if ( ! array_key_exists( 'token', $_REQUEST ) ) {
 			return;
@@ -220,7 +228,6 @@ class ConvertKit_Output_Restrict_Content {
 			sanitize_text_field( $_REQUEST['token'] ),
 			sanitize_text_field( $_REQUEST['subscriber_code'] )
 		);
-		// phpcs:enable
 
 		// Bail if an error occured.
 		if ( is_wp_error( $subscriber_id ) ) {


### PR DESCRIPTION
## Summary

Check the nonce is valid when submitting the access code for Member Content functionality.

Remove output of error messages when the nonce is invalid, as the same `_wpnonce` field will contain a nonce for either running subscriber authentication or subscriber verification.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)