### PR TITLE
PHPStan: Remove `ignoreErrors`

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -24,10 +24,3 @@ parameters:
     # Should not need to edit anything below here
     # Rule Level: https://phpstan.org/user-guide/rule-levels
     level: 5
-
-    # Ignore the following errors, as PHPStan and PHPStan for WordPress haven't registered symbols for them yet,
-    # so they're false positives.
-    ignoreErrors:
-        - '#Multi_Value_Field_Table#'
-        - '#Method CK_Widget_Form#'
-        - '#code above always terminates#'


### PR DESCRIPTION
## Summary

Removes the `ignoreErrors` directive for PHPStan static analysis, introduced for WordPress 6.4, as these are resolved in 6.4.1.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)