### PR TITLE
Replace `FILTER_SANITIZE_STRING`

### DIFF
--- a/includes/blocks/class-convertkit-block.php
+++ b/includes/blocks/class-convertkit-block.php
@@ -370,7 +370,10 @@ class ConvertKit_Block {
 		}
 
 		// Return false if the context parameter isn't edit.
-		if ( filter_input( INPUT_GET, 'context', FILTER_SANITIZE_STRING ) !== 'edit' ) {
+		if ( ! array_key_exists( 'context', $_REQUEST ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			return false;
+		}
+		if ( sanitize_text_field( $_REQUEST['context'] ) !== 'edit' ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return false;
 		}
 

--- a/includes/blocks/class-convertkit-block.php
+++ b/includes/blocks/class-convertkit-block.php
@@ -370,10 +370,10 @@ class ConvertKit_Block {
 		}
 
 		// Return false if the context parameter isn't edit.
-		if ( ! array_key_exists( 'context', $_REQUEST ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		if ( ! array_key_exists( 'context', $_GET ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return false;
 		}
-		if ( sanitize_text_field( $_REQUEST['context'] ) !== 'edit' ) { // phpcs:ignore WordPress.Security.NonceVerification
+		if ( sanitize_text_field( $_GET['context'] ) !== 'edit' ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return false;
 		}
 


### PR DESCRIPTION
## Summary

Replaces `FILTER_SANITIZE_STRING` (which is deprecated in PHP 8.1+) with `sanitize_text_field`, when checking if the request is from Gutenberg:
![Screenshot 2023-11-10 at 16 26 44](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/6552ce89-aca3-465d-8b9d-cf3e40a82829)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)