### PR TITLE
Broadcasts: Don't display next import date/time when event running

### DIFF
--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -157,8 +157,9 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 
 		// Define description for the 'Enabled' setting.
 		// If enabled, include the next scheduled date and time the Plugin will import broadcasts.
+		// If the next scheduled timestamp is 1, the event is running now.
 		$enabled_description = '';
-		if ( $this->settings->enabled() && $posts->get_cron_event_next_scheduled() ) {
+		if ( $this->settings->enabled() && $posts->get_cron_event_next_scheduled() && $posts->get_cron_event_next_scheduled() > 1 ) {
 			$enabled_description = sprintf(
 				'%s %s',
 				esc_html__( 'Broadcasts will next import at approximately ', 'convertkit' ),

--- a/tests/acceptance/broadcasts/import/BroadcastsToPostsCest.php
+++ b/tests/acceptance/broadcasts/import/BroadcastsToPostsCest.php
@@ -185,6 +185,9 @@ class BroadcastsToPostsCest
 		// Confirm a success message displays.
 		$I->see('Broadcasts import started. Check the Posts screen shortly to confirm Broadcasts imported successfully.');
 
+		// Confirm the next scheduled date/time is not displayed, as the event is running.
+		$I->dontSee('Broadcasts will next import at approximately');
+
 		// Wait a few seconds for the Cron event to complete importing Broadcasts.
 		$I->wait(7);
 


### PR DESCRIPTION
## Summary

When the scheduled event to import ConvertKit Broadcasts to WordPress Posts is running, the timestamp for the next scheduled event is `1`, resulting in incorrect output on the description:

<img width="868" alt="Screenshot 2023-11-17 at 13 17 01" src="https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/132f5e53-ea8f-4fe3-b402-aa5674db16c8">

This PR resolves by not outputting the next scheduled date/time when the event is running:

<img width="837" alt="Screenshot 2023-11-17 at 13 17 10" src="https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/0aa39d18-8083-4231-8eb5-a01fb8f7e2a8">

When the event is not running, the next scheduled date/time displays in the description.

## Testing

- `BroadcastsToPostsCest:testBroadcastsManualImportWhenEnabled`: Test that the description does not display when using the manual import functionality.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)