### PR TITLE
Resources: Forms: Add `select` dropdown methods

### DIFF
--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -356,7 +356,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 	public function post_status_callback( $args ) {
 
 		// Build field.
-		$select_field = $this->get_select_field_all(
+		$select_field = $this->get_select_field(
 			$args['name'],
 			$this->settings->post_status(),
 			get_post_statuses(),

--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -356,7 +356,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 	public function post_status_callback( $args ) {
 
 		// Build field.
-		$select_field = $this->get_select_field(
+		$select_field = $this->get_select_field_all(
 			$args['name'],
 			$this->settings->post_status(),
 			get_post_statuses(),

--- a/admin/section/class-convertkit-settings-base.php
+++ b/admin/section/class-convertkit-settings-base.php
@@ -461,7 +461,7 @@ abstract class ConvertKit_Settings_Base {
 		}
 
 		// Return description lines in a paragraph, using breaklines for each description entry in the array.
-		return '<p class="description">' . implode( '<br />', $description );
+		return '<p class="description">' . implode( '<br />', $description ) . '</p>';
 
 	}
 

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -457,8 +457,8 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 
 		// Build field.
 		$select_field = $this->forms->get_select_field(
-			$this->settings_key . '[' . $args['post_type'] . '_form' . ']',
-			$this->settings_key . '_' . $args['post_type'] . '_form' ,
+			$this->settings_key . '[' . $args['post_type'] . '_form]',
+			$this->settings_key . '_' . $args['post_type'] . '_form',
 			array(
 				'convertkit-select2',
 				'convertkit-preview-output-link',

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -456,7 +456,7 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 		}
 
 		// Build field.
-		$select_field = $this->forms->get_select_field(
+		$select_field = $this->forms->get_select_field_all(
 			$this->settings_key . '[' . $args['post_type'] . '_form]',
 			$this->settings_key . '_' . $args['post_type'] . '_form',
 			array(
@@ -496,14 +496,6 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 			return;
 		}
 
-		// Build array of select options.
-		$options = array(
-			'' => esc_html__( 'None', 'convertkit' ),
-		);
-		foreach ( $this->forms->get_non_inline() as $form ) {
-			$options[ esc_attr( $form['id'] ) ] = esc_html( $form['name'] );
-		}
-
 		// Build description with preview link.
 		$preview_url = WP_ConvertKit()->get_class( 'preview_output' )->get_preview_form_home_url();
 		$description = sprintf(
@@ -514,19 +506,22 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 		);
 
 		// Build field.
-		$select_field = $this->get_select_field(
-			'non_inline_form',
-			$this->settings->get_non_inline_form(),
-			$options,
-			$description,
+		$select_field = $this->forms->get_select_field_non_inline(
+			$this->settings_key . '[non_inline_form]',
+			$this->settings_key . '_non_inline_form',
 			array(
 				'convertkit-select2',
 				'convertkit-preview-output-link',
 			),
+			$this->settings->get_non_inline_form(),
+			array(
+				'' => esc_html__( 'None', 'convertkit' ),
+			),
 			array(
 				'data-target' => '#convertkit-preview-non-inline-form',
-				'data-link'   => esc_url( $preview_url ) . '&convertkit_form_id=',
-			)
+				'data-link'   => esc_attr( $preview_url ) . '&convertkit_form_id=',
+			),
+			$description
 		);
 
 		// Output field.

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -431,14 +431,6 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 			return;
 		}
 
-		// Build array of select options.
-		$options = array(
-			'default' => esc_html__( 'None', 'convertkit' ),
-		);
-		foreach ( $this->forms->get() as $form ) {
-			$options[ esc_attr( $form['id'] ) ] = esc_html( $form['name'] );
-		}
-
 		// Build description with preview link.
 		$description = false;
 		$preview_url = WP_ConvertKit()->get_class( 'preview_output' )->get_preview_form_url( $args['post_type'] );
@@ -464,19 +456,22 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 		}
 
 		// Build field.
-		$select_field = $this->get_select_field(
-			$args['post_type'] . '_form',
-			$this->settings->get_default_form( $args['post_type'] ),
-			$options,
-			$description,
+		$select_field = $this->forms->get_select_field(
+			$this->settings_key . '[' . $args['post_type'] . '_form' . ']',
+			$this->settings_key . '_' . $args['post_type'] . '_form' ,
 			array(
 				'convertkit-select2',
 				'convertkit-preview-output-link',
 			),
+			$this->settings->get_default_form( $args['post_type'] ),
+			array(
+				'default' => esc_html__( 'None', 'convertkit' ),
+			),
 			array(
 				'data-target' => '#convertkit-preview-form-' . esc_attr( $args['post_type'] ),
 				'data-link'   => esc_attr( $preview_url ) . '&convertkit_form_id=',
-			)
+			),
+			$description
 		);
 
 		// Output field.

--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -125,7 +125,7 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource {
 		if ( $prepend_options ) {
 			foreach ( $prepend_options as $value => $label ) {
 				$html .= sprintf(
-					'<option value="%s"%s>%s</option>',
+					'<option value="%s" data-preserve-on-refresh="1"%s>%s</option>',
 					esc_attr( $value ),
 					selected( $selected_option, $value, false ),
 					esc_attr( $label )
@@ -133,14 +133,16 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource {
 			}
 		}
 
-		// Iterate through resources, building <option> elements.
-		foreach ( $this->get() as $form ) {
-			$html .= sprintf(
-				'<option value="%s"%s>%s</option>',
-				esc_attr( $form['id'] ),
-				selected( $selected_option, $form['id'], false ),
-				esc_attr( $form['name'] )
-			);
+		// Iterate through resources, if they exist, building <option> elements.
+		if ( $this->exist() ) {
+			foreach ( $this->get() as $form ) {
+				$html .= sprintf(
+					'<option value="%s"%s>%s</option>',
+					esc_attr( $form['id'] ),
+					selected( $selected_option, $form['id'], false ),
+					esc_attr( $form['name'] )
+				);
+			}
 		}
 
 		// Close select.

--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -94,9 +94,17 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource {
 
 	/**
 	 * Returns a <select> field populated with the resources, based on the given parameters.
-	 * 
-	 * @since 	2.3.9
-	 * 
+	 *
+	 * @since   2.3.9
+	 *
+	 * @param   string            $name            Name.
+	 * @param   string            $id              ID.
+	 * @param   bool|array        $css_classes     <select> CSS class(es).
+	 * @param   string            $selected_option <option> value to mark as selected.
+	 * @param   bool|array        $prepend_options <option> elements to prepend before resources.
+	 * @param   bool|array        $attributes      <select> attributes.
+	 * @param   bool|string|array $description     Description.
+	 * @return  string                             HTML Select Field
 	 */
 	public function get_select_field( $name, $id, $css_classes, $selected_option, $prepend_options = false, $attributes = false, $description = false ) {
 

--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -93,7 +93,7 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource {
 	}
 
 	/**
-	 * Returns a <select> field populated with the resources, based on the given parameters.
+	 * Returns a <select> field populated with all forms, based on the given parameters.
 	 *
 	 * @since   2.3.9
 	 *
@@ -106,7 +106,66 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource {
 	 * @param   bool|string|array $description     Description.
 	 * @return  string                             HTML Select Field
 	 */
-	public function get_select_field( $name, $id, $css_classes, $selected_option, $prepend_options = false, $attributes = false, $description = false ) {
+	public function get_select_field_all( $name, $id, $css_classes, $selected_option, $prepend_options = false, $attributes = false, $description = false ) {
+
+		return $this->get_select_field(
+			$this->get(),
+			$name,
+			$id,
+			$css_classes,
+			$selected_option,
+			$prepend_options,
+			$attributes,
+			$description
+		);
+
+	}
+
+	/**
+	 * Returns a <select> field populated with all non-inline forms, based on the given parameters.
+	 *
+	 * @since   2.3.9
+	 *
+	 * @param   string            $name            Name.
+	 * @param   string            $id              ID.
+	 * @param   bool|array        $css_classes     <select> CSS class(es).
+	 * @param   string            $selected_option <option> value to mark as selected.
+	 * @param   bool|array        $prepend_options <option> elements to prepend before resources.
+	 * @param   bool|array        $attributes      <select> attributes.
+	 * @param   bool|string|array $description     Description.
+	 * @return  string                             HTML Select Field
+	 */
+	public function get_select_field_non_inline( $name, $id, $css_classes, $selected_option, $prepend_options = false, $attributes = false, $description = false ) {
+
+		return $this->get_select_field(
+			$this->get_non_inline(),
+			$name,
+			$id,
+			$css_classes,
+			$selected_option,
+			$prepend_options,
+			$attributes,
+			$description
+		);
+
+	}
+
+	/**
+	 * Returns a <select> field populated with the resources, based on the given parameters.
+	 *
+	 * @since   2.3.9
+	 *
+	 * @param   array             $forms           Forms.
+	 * @param   string            $name            Name.
+	 * @param   string            $id              ID.
+	 * @param   bool|array        $css_classes     <select> CSS class(es).
+	 * @param   string            $selected_option <option> value to mark as selected.
+	 * @param   bool|array        $prepend_options <option> elements to prepend before resources.
+	 * @param   bool|array        $attributes      <select> attributes.
+	 * @param   bool|string|array $description     Description.
+	 * @return  string                             HTML Select Field
+	 */
+	private function get_select_field( $forms, $name, $id, $css_classes, $selected_option, $prepend_options = false, $attributes = false, $description = false ) {
 
 		$html = sprintf(
 			'<select name="%s" id="%s" class="%s"',
@@ -142,8 +201,8 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource {
 		}
 
 		// Iterate through resources, if they exist, building <option> elements.
-		if ( $this->exist() ) {
-			foreach ( $this->get() as $form ) {
+		if ( $forms ) {
+			foreach ( $forms as $form ) {
 				$html .= sprintf(
 					'<option value="%s"%s>%s</option>',
 					esc_attr( $form['id'] ),

--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -226,7 +226,7 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource {
 		}
 
 		// Return description lines in a paragraph, using breaklines for each description entry in the array.
-		return $html . '<p class="description">' . implode( '<br />', $description );
+		return $html . '<p class="description">' . implode( '<br />', $description ) . '</p>';
 
 	}
 

--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -171,7 +171,7 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource {
 			'<select name="%s" id="%s" class="%s"',
 			esc_attr( $name ),
 			esc_attr( $id ),
-			esc_attr( ( is_array( $css_classes ) ? implode( ' ', $css_classes ) : '' ) ),
+			esc_attr( ( is_array( $css_classes ) ? implode( ' ', $css_classes ) : '' ) )
 		);
 
 		// Append any attributes.

--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -93,6 +93,75 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource {
 	}
 
 	/**
+	 * Returns a <select> field populated with the resources, based on the given parameters.
+	 * 
+	 * @since 	2.3.9
+	 * 
+	 */
+	public function get_select_field( $name, $id, $css_classes, $selected_option, $prepend_options = false, $attributes = false, $description = false ) {
+
+		$html = sprintf(
+			'<select name="%s" id="%s" class="%s"',
+			esc_attr( $name ),
+			esc_attr( $id ),
+			esc_attr( ( is_array( $css_classes ) ? implode( ' ', $css_classes ) : '' ) ),
+		);
+
+		// Append any attributes.
+		if ( $attributes ) {
+			foreach ( $attributes as $key => $value ) {
+				$html .= sprintf(
+					' %s="%s"',
+					esc_attr( $key ),
+					esc_attr( $value )
+				);
+			}
+		}
+
+		// Close select tag.
+		$html .= '>';
+
+		// If any prepended options exist, add them now.
+		if ( $prepend_options ) {
+			foreach ( $prepend_options as $value => $label ) {
+				$html .= sprintf(
+					'<option value="%s"%s>%s</option>',
+					esc_attr( $value ),
+					selected( $selected_option, $value, false ),
+					esc_attr( $label )
+				);
+			}
+		}
+
+		// Iterate through resources, building <option> elements.
+		foreach ( $this->get() as $form ) {
+			$html .= sprintf(
+				'<option value="%s"%s>%s</option>',
+				esc_attr( $form['id'] ),
+				selected( $selected_option, $form['id'], false ),
+				esc_attr( $form['name'] )
+			);
+		}
+
+		// Close select.
+		$html .= '</select>';
+
+		// If no description is provided, return the select field now.
+		if ( ! $description ) {
+			return $html;
+		}
+
+		// Append description before returning field.
+		if ( ! is_array( $description ) ) {
+			return $html . '<p class="description">' . $description . '</p>';
+		}
+
+		// Return description lines in a paragraph, using breaklines for each description entry in the array.
+		return $html . '<p class="description">' . implode( '<br />', $description );
+
+	}
+
+	/**
 	 * Returns the HTML/JS markup for the given Form ID.
 	 *
 	 * Legacy Forms will return HTML.

--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
@@ -135,8 +135,8 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 			$table_row = array(
 				'title' => $cf7_form['name'],
 				'form'  => $forms->get_select_field_all(
-					$cf7_form['id'] . '_form',
-					$cf7_form['id'] . '_form',
+					'_wp_convertkit_integration_contactform7_settings[' . $cf7_form['id'] . '_form]',
+					'_wp_convertkit_integration_contactform7_settings_' . $cf7_form['id'] . '_form',
 					false,
 					(string) $this->settings->get_convertkit_form_id_by_cf7_form_id( $cf7_form['id'] ),
 					array(

--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
@@ -134,7 +134,7 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 			// Build row.
 			$table_row = array(
 				'title' => $cf7_form['name'],
-				'form'  => $forms->get_select_field(
+				'form'  => $forms->get_select_field_all(
 					$cf7_form['id'] . '_form',
 					$cf7_form['id'] . '_form',
 					false,

--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
@@ -108,14 +108,6 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 			return;
 		}
 
-		// Build array of select options.
-		$options = array(
-			'default' => __( 'None', 'convertkit' ),
-		);
-		foreach ( $forms->get() as $form ) {
-			$options[ esc_attr( $form['id'] ) ] = esc_html( $form['name'] );
-		}
-
 		// Get Creator Network Recommendations script.
 		$creator_network_recommendations_enabled = $creator_network_recommendations->enabled();
 
@@ -142,10 +134,14 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 			// Build row.
 			$table_row = array(
 				'title' => $cf7_form['name'],
-				'form'  => $this->get_select_field(
-					$cf7_form['id'],
+				'form'  => $forms->get_select_field(
+					$cf7_form['id'] . '_form',
+					$cf7_form['id'] . '_form',
+					false,
 					(string) $this->settings->get_convertkit_form_id_by_cf7_form_id( $cf7_form['id'] ),
-					$options
+					array(
+						'default' => __( 'None', 'convertkit' ),
+					)
 				),
 				'email' => 'your-email',
 				'name'  => 'your-name',

--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
@@ -135,8 +135,8 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 			$table_row = array(
 				'title' => $cf7_form['name'],
 				'form'  => $forms->get_select_field_all(
-					'_wp_convertkit_integration_contactform7_settings[' . $cf7_form['id'] . '_form]',
-					'_wp_convertkit_integration_contactform7_settings_' . $cf7_form['id'] . '_form',
+					'_wp_convertkit_integration_contactform7_settings[' . $cf7_form['id'] . ']',
+					'_wp_convertkit_integration_contactform7_settings_' . $cf7_form['id'],
 					false,
 					(string) $this->settings->get_convertkit_form_id_by_cf7_form_id( $cf7_form['id'] ),
 					array(

--- a/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
+++ b/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
@@ -132,8 +132,8 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 			$table_row = array(
 				'title' => $forminator_form['name'],
 				'form'  => $forms->get_select_field_all(
-					$forminator_form['id'] . '_form',
-					$forminator_form['id'] . '_form',
+					'_wp_convertkit_integration_forminator_settings[' . $wlm_level['id'] . ']',
+					'_wp_convertkit_integration_forminator_settings_' . $wlm_level['id'] . '',
 					false,
 					(string) $this->settings->get_convertkit_form_id_by_forminator_form_id( $forminator_form['id'] ),
 					array(

--- a/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
+++ b/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
@@ -107,14 +107,6 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 			return;
 		}
 
-		// Build array of select options.
-		$options = array(
-			'default' => __( 'None', 'convertkit' ),
-		);
-		foreach ( $forms->get() as $form ) {
-			$options[ esc_attr( $form['id'] ) ] = esc_html( $form['name'] );
-		}
-
 		// Get Creator Network Recommendations script.
 		$creator_network_recommendations_enabled = $creator_network_recommendations->enabled();
 
@@ -139,10 +131,14 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 			// Build row.
 			$table_row = array(
 				'title' => $forminator_form['name'],
-				'form'  => $this->get_select_field(
-					$forminator_form['id'],
+				'form'  => $forms->get_select_field(
+					$forminator_form['id'] . '_form',
+					$forminator_form['id'] . '_form',
+					false,
 					(string) $this->settings->get_convertkit_form_id_by_forminator_form_id( $forminator_form['id'] ),
-					$options
+					array(
+						'default' => __( 'None', 'convertkit' ),
+					)
 				),
 			);
 

--- a/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
+++ b/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
@@ -131,7 +131,7 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 			// Build row.
 			$table_row = array(
 				'title' => $forminator_form['name'],
-				'form'  => $forms->get_select_field(
+				'form'  => $forms->get_select_field_all(
 					$forminator_form['id'] . '_form',
 					$forminator_form['id'] . '_form',
 					false,

--- a/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
+++ b/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
@@ -132,8 +132,8 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 			$table_row = array(
 				'title' => $forminator_form['name'],
 				'form'  => $forms->get_select_field_all(
-					'_wp_convertkit_integration_forminator_settings[' . $wlm_level['id'] . ']',
-					'_wp_convertkit_integration_forminator_settings_' . $wlm_level['id'] . '',
+					'_wp_convertkit_integration_forminator_settings[' . $forminator_form['id'] . ']',
+					'_wp_convertkit_integration_forminator_settings_' . $forminator_form['id'] . '',
 					false,
 					(string) $this->settings->get_convertkit_form_id_by_forminator_form_id( $forminator_form['id'] ),
 					array(

--- a/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php
@@ -140,8 +140,8 @@ class ConvertKit_Wishlist_Admin_Settings extends ConvertKit_Settings_Base {
 				array(
 					'title'       => $wlm_level['name'],
 					'form'        => $forms->get_select_field_all(
-						$wlm_level['id'] . '_form',
-						$wlm_level['id'] . '_form',
+						'_wp_convertkit_integration_wishlistmember_settings[' . $wlm_level['id'] . '_form]',
+						'_wp_convertkit_integration_wishlistmember_settings_' . $wlm_level['id'] . '_form',
 						false,
 						(string) $this->settings->get_convertkit_form_id_by_wishlist_member_level_id( $wlm_level['id'] ),
 						array(

--- a/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php
@@ -119,14 +119,6 @@ class ConvertKit_Wishlist_Admin_Settings extends ConvertKit_Settings_Base {
 			return;
 		}
 
-		// Build array of select options for Forms.
-		$form_options = array(
-			'default' => __( 'None', 'convertkit' ),
-		);
-		foreach ( $forms->get() as $form ) {
-			$form_options[ esc_attr( $form['id'] ) ] = esc_html( $form['name'] );
-		}
-
 		// Build array of select options for Tags.
 		$tag_options = array(
 			'0' => __( 'None', 'convertkit' ),
@@ -147,10 +139,14 @@ class ConvertKit_Wishlist_Admin_Settings extends ConvertKit_Settings_Base {
 			$table->add_item(
 				array(
 					'title'       => $wlm_level['name'],
-					'form'        => $this->get_select_field(
+					'form'        => $forms->get_select_field(
 						$wlm_level['id'] . '_form',
+						$wlm_level['id'] . '_form',
+						false,
 						(string) $this->settings->get_convertkit_form_id_by_wishlist_member_level_id( $wlm_level['id'] ),
-						$form_options
+						array(
+							'default' => __( 'None', 'convertkit' ),
+						)
 					),
 					'unsubscribe' => $this->get_select_field(
 						$wlm_level['id'] . '_unsubscribe',

--- a/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php
@@ -139,7 +139,7 @@ class ConvertKit_Wishlist_Admin_Settings extends ConvertKit_Settings_Base {
 			$table->add_item(
 				array(
 					'title'       => $wlm_level['name'],
-					'form'        => $forms->get_select_field(
+					'form'        => $forms->get_select_field_all(
 						$wlm_level['id'] . '_form',
 						$wlm_level['id'] . '_form',
 						false,

--- a/includes/widgets/class-ck-widget-form.php
+++ b/includes/widgets/class-ck-widget-form.php
@@ -77,15 +77,16 @@ class CK_Widget_Form extends WP_Widget {
 		</p>
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'form' ) ); ?>"><?php esc_html_e( 'Form', 'convertkit' ); ?></label>
-			<select name="<?php echo esc_attr( $this->get_field_name( 'form' ) ); ?>" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'form' ) ); ?>" size="1">
-				<?php
-				foreach ( $forms->get() as $form ) {
-					?>
-					<option value="<?php echo esc_attr( $form['id'] ); ?>"<?php selected( $form['id'], $instance['form'] ); ?>><?php echo esc_attr( $form['name'] ); ?></option>
-					<?php
-				}
-				?>
-			</select>
+			<?php
+			echo $forms->get_select_field(
+				$this->get_field_name( 'form' ),
+				$this->get_field_id( 'form' ),
+				array(
+					'widefat',
+				),
+				$instance['form']
+			);
+			?>
 		</p>
 		<?php
 

--- a/includes/widgets/class-ck-widget-form.php
+++ b/includes/widgets/class-ck-widget-form.php
@@ -78,7 +78,7 @@ class CK_Widget_Form extends WP_Widget {
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'form' ) ); ?>"><?php esc_html_e( 'Form', 'convertkit' ); ?></label>
 			<?php
-			echo $forms->get_select_field( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo $forms->get_select_field_all( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				esc_attr( $this->get_field_name( 'form' ) ),
 				esc_attr( $this->get_field_id( 'form' ) ),
 				array(

--- a/includes/widgets/class-ck-widget-form.php
+++ b/includes/widgets/class-ck-widget-form.php
@@ -78,13 +78,13 @@ class CK_Widget_Form extends WP_Widget {
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'form' ) ); ?>"><?php esc_html_e( 'Form', 'convertkit' ); ?></label>
 			<?php
-			echo $forms->get_select_field(
-				$this->get_field_name( 'form' ),
-				$this->get_field_id( 'form' ),
+			echo $forms->get_select_field( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				esc_attr( $this->get_field_name( 'form' ) ),
+				esc_attr( $this->get_field_id( 'form' ) ),
 				array(
 					'widefat',
 				),
-				$instance['form']
+				esc_attr( $instance['form'] )
 			);
 			?>
 		</p>

--- a/views/backend/post/bulk-edit.php
+++ b/views/backend/post/bulk-edit.php
@@ -19,7 +19,7 @@
 			// would result in Posts/Pages having (or not having) the Form setting updated, when the user may/may not
 			// have selected the 'Default' option.
 			// Therefore, we use -2 to denote 'No Change'.
-			echo $convertkit_forms->get_select_field( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo $convertkit_forms->get_select_field_all( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				'wp-convertkit[form]',
 				'wp-convertkit-bulk-edit-form',
 				false,

--- a/views/backend/post/bulk-edit.php
+++ b/views/backend/post/bulk-edit.php
@@ -12,27 +12,25 @@
 	<div>
 		<label for="wp-convertkit-bulk-edit-form">
 			<span class="title convertkit-icon-form"><?php esc_html_e( 'Form', 'convertkit' ); ?></span>
-			<select name="wp-convertkit[form]" id="wp-convertkit-bulk-edit-form" size="1">
-				<?php
-				// For Bulk Edit, the 'No Change' value is -1. However, because this Plugin has historically used -1
-				// to mean that the Default form for the Post Type should be displayed, using -1 as 'No Change' in Bulk Edit
-				// would result in Posts/Pages having (or not having) the Form setting updated, when the user may/may not
-				// have selected the 'Default' option.
-				// Therefore, we use -2 to denote 'No Change'.
-				?>
-				<option value="-2" data-preserve-on-refresh="1"><?php esc_html_e( '— No Change —', 'convertkit' ); ?></option>
-				<option value="-1" data-preserve-on-refresh="1"><?php esc_html_e( 'Default', 'convertkit' ); ?></option>
-				<option value="0" data-preserve-on-refresh="1"><?php esc_html_e( 'None', 'convertkit' ); ?></option>
-				<?php
-				if ( $convertkit_forms->exist() ) {
-					foreach ( $convertkit_forms->get() as $form ) {
-						?>
-						<option value="<?php echo esc_attr( $form['id'] ); ?>"><?php echo esc_attr( $form['name'] ); ?></option>
-						<?php
-					}
-				}
-				?>
-			</select>
+
+			<?php
+			// For Bulk Edit, the 'No Change' value is -1. However, because this Plugin has historically used -1
+			// to mean that the Default form for the Post Type should be displayed, using -1 as 'No Change' in Bulk Edit
+			// would result in Posts/Pages having (or not having) the Form setting updated, when the user may/may not
+			// have selected the 'Default' option.
+			// Therefore, we use -2 to denote 'No Change'.
+			echo $convertkit_forms->get_select_field(
+				'wp-convertkit[form]',
+				'wp-convertkit-bulk-edit-form',
+				false,
+				false,
+				array(
+					'-2' => esc_html__( '— No Change —', 'convertkit' ),
+					'-1' => esc_html__( 'Default', 'convertkit' ),
+					'0' => esc_html__( 'None', 'convertkit' ),
+				)
+			);
+			?>
 		</label>
 		<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Forms from ConvertKit account', 'convertkit' ); ?>" data-resource="forms" data-field="#wp-convertkit-bulk-edit-form">
 			<span class="dashicons dashicons-update"></span>

--- a/views/backend/post/bulk-edit.php
+++ b/views/backend/post/bulk-edit.php
@@ -19,7 +19,7 @@
 			// would result in Posts/Pages having (or not having) the Form setting updated, when the user may/may not
 			// have selected the 'Default' option.
 			// Therefore, we use -2 to denote 'No Change'.
-			echo $convertkit_forms->get_select_field(
+			echo $convertkit_forms->get_select_field( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				'wp-convertkit[form]',
 				'wp-convertkit-bulk-edit-form',
 				false,
@@ -27,7 +27,7 @@
 				array(
 					'-2' => esc_html__( '— No Change —', 'convertkit' ),
 					'-1' => esc_html__( 'Default', 'convertkit' ),
-					'0' => esc_html__( 'None', 'convertkit' ),
+					'0'  => esc_html__( 'None', 'convertkit' ),
 				)
 			);
 			?>

--- a/views/backend/post/meta-box.php
+++ b/views/backend/post/meta-box.php
@@ -17,17 +17,17 @@
 			<td>
 				<div class="convertkit-select2-container convertkit-select2-container-grid">
 					<?php
-					echo $convertkit_forms->get_select_field(
+					echo $convertkit_forms->get_select_field( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 						'wp-convertkit[form]',
 						'wp-convertkit-form',
 						array(
 							'convertkit-select2',
 							'widefat',
 						),
-						$convertkit_post->get_form(),
+						esc_attr( $convertkit_post->get_form() ),
 						array(
 							'-1' => esc_html__( 'Default', 'convertkit' ),
-							'0' => esc_html__( 'None', 'convertkit' ),
+							'0'  => esc_html__( 'None', 'convertkit' ),
 						)
 					);
 					?>

--- a/views/backend/post/meta-box.php
+++ b/views/backend/post/meta-box.php
@@ -16,19 +16,21 @@
 			</th>
 			<td>
 				<div class="convertkit-select2-container convertkit-select2-container-grid">
-					<select name="wp-convertkit[form]" id="wp-convertkit-form" class="convertkit-select2 widefat">
-						<option value="-1"<?php selected( - 1, $convertkit_post->get_form() ); ?> data-preserve-on-refresh="1"><?php esc_html_e( 'Default', 'convertkit' ); ?></option>
-						<option value="0"<?php selected( 0, $convertkit_post->get_form() ); ?> data-preserve-on-refresh="1"><?php esc_html_e( 'None', 'convertkit' ); ?></option>
-						<?php
-						if ( $convertkit_forms->exist() ) {
-							foreach ( $convertkit_forms->get() as $form ) {
-								?>
-								<option value="<?php echo esc_attr( $form['id'] ); ?>"<?php selected( $form['id'], $convertkit_post->get_form() ); ?>><?php echo esc_attr( $form['name'] ); ?></option>
-								<?php
-							}
-						}
-						?>
-					</select>
+					<?php
+					echo $convertkit_forms->get_select_field(
+						'wp-convertkit[form]',
+						'wp-convertkit-form',
+						array(
+							'convertkit-select2',
+							'widefat',
+						),
+						$convertkit_post->get_form(),
+						array(
+							'-1' => esc_html__( 'Default', 'convertkit' ),
+							'0' => esc_html__( 'None', 'convertkit' ),
+						)
+					);
+					?>
 					<button class="wp-convertkit-refresh-resources" class="button button-secondary hide-if-no-js" title="<?php esc_attr_e( 'Refresh Forms from ConvertKit account', 'convertkit' ); ?>" data-resource="forms" data-field="#wp-convertkit-form">
 						<span class="dashicons dashicons-update"></span>
 					</button>

--- a/views/backend/post/meta-box.php
+++ b/views/backend/post/meta-box.php
@@ -17,7 +17,7 @@
 			<td>
 				<div class="convertkit-select2-container convertkit-select2-container-grid">
 					<?php
-					echo $convertkit_forms->get_select_field( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					echo $convertkit_forms->get_select_field_all( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 						'wp-convertkit[form]',
 						'wp-convertkit-form',
 						array(

--- a/views/backend/post/quick-edit.php
+++ b/views/backend/post/quick-edit.php
@@ -12,19 +12,19 @@
 	<div>
 		<label for="wp-convertkit-quick-edit-form">
 			<span class="title convertkit-icon-form"><?php esc_html_e( 'Form', 'convertkit' ); ?></span>
-			<select name="wp-convertkit[form]" id="wp-convertkit-quick-edit-form" size="1">
-				<option value="-1" data-preserve-on-refresh="1"><?php esc_html_e( 'Default', 'convertkit' ); ?></option>
-				<option value="0" data-preserve-on-refresh="1"><?php esc_html_e( 'None', 'convertkit' ); ?></option>
-				<?php
-				if ( $convertkit_forms->exist() ) {
-					foreach ( $convertkit_forms->get() as $form ) {
-						?>
-						<option value="<?php echo esc_attr( $form['id'] ); ?>"><?php echo esc_attr( $form['name'] ); ?></option>
-						<?php
-					}
-				}
-				?>
-			</select>
+
+			<?php
+			echo $convertkit_forms->get_select_field(
+				'wp-convertkit[form]',
+				'wp-convertkit-quick-edit-form',
+				false,
+				false,
+				array(
+					'-1' => esc_html__( 'Default', 'convertkit' ),
+					'0' => esc_html__( 'None', 'convertkit' ),
+				)
+			);
+			?>
 		</label>
 		<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Forms from ConvertKit account', 'convertkit' ); ?>" data-resource="forms" data-field="#wp-convertkit-quick-edit-form">
 			<span class="dashicons dashicons-update"></span>

--- a/views/backend/post/quick-edit.php
+++ b/views/backend/post/quick-edit.php
@@ -14,14 +14,14 @@
 			<span class="title convertkit-icon-form"><?php esc_html_e( 'Form', 'convertkit' ); ?></span>
 
 			<?php
-			echo $convertkit_forms->get_select_field(
+			echo $convertkit_forms->get_select_field( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				'wp-convertkit[form]',
 				'wp-convertkit-quick-edit-form',
 				false,
 				false,
 				array(
 					'-1' => esc_html__( 'Default', 'convertkit' ),
-					'0' => esc_html__( 'None', 'convertkit' ),
+					'0'  => esc_html__( 'None', 'convertkit' ),
 				)
 			);
 			?>

--- a/views/backend/post/quick-edit.php
+++ b/views/backend/post/quick-edit.php
@@ -14,7 +14,7 @@
 			<span class="title convertkit-icon-form"><?php esc_html_e( 'Form', 'convertkit' ); ?></span>
 
 			<?php
-			echo $convertkit_forms->get_select_field( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo $convertkit_forms->get_select_field_all( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				'wp-convertkit[form]',
 				'wp-convertkit-quick-edit-form',
 				false,

--- a/views/backend/setup-wizard/convertkit-setup/content-3.php
+++ b/views/backend/setup-wizard/convertkit-setup/content-3.php
@@ -49,16 +49,26 @@ if ( ! $this->forms->exist() ) {
 		<label for="wp-convertkit-form-posts">
 			<?php esc_html_e( 'Which form would you like to display below all blog posts?', 'convertkit' ); ?>
 		</label>
-		<select name="post_form" id="wp-convertkit-form-posts" class="convertkit-select2 convertkit-preview-output-link widefat" data-target="#convertkit-preview-form-post" data-link="<?php echo esc_attr( $this->preview_post_url ); ?>&convertkit_form_id=">
-			<option value="0"><?php esc_html_e( 'Don\'t display an email subscription form on posts.', 'convertkit' ); ?></option>	
-			<?php
-			foreach ( $this->forms->get() as $form ) {
-				?>
-				<option value="<?php echo esc_attr( $form['id'] ); ?>"<?php selected( $this->settings->get_default_form( 'post' ), $form['id'] ); ?>><?php echo esc_attr( $form['name'] ); ?></option>
-				<?php
-			}
-			?>
-		</select>
+
+		<?php
+		echo $this->forms->get_select_field(
+			'post_form',
+			'wp-convertkit-form-posts',
+			array(
+				'convertkit-select2',
+				'convertkit-preview-output-link',
+				'widefat',
+			),
+			$this->settings->get_default_form( 'post' ),
+			array(
+				'0' => esc_html__( 'Don\'t display an email subscription form on posts.', 'convertkit' ),
+			),
+			array(
+				'data-target' => '#convertkit-preview-form-post',
+				'data-link'   => esc_attr( $this->preview_post_url ) . '&convertkit_form_id=',
+			)
+		);
+		?>
 
 		<p class="description">
 			<?php
@@ -80,16 +90,26 @@ if ( ! $this->forms->exist() ) {
 		<label for="wp-convertkit-form-pages">
 			<?php esc_html_e( 'Which form would you like to display below all Pages?', 'convertkit' ); ?>
 		</label>
-		<select name="page_form" id="wp-convertkit-form-pages" class="convertkit-select2 convertkit-preview-output-link widefat" data-target="#convertkit-preview-form-page" data-link="<?php echo esc_attr( $this->preview_page_url ); ?>&convertkit_form_id=">	
-			<option value="0"><?php esc_html_e( 'Don\'t display an email subscription form on pages.', 'convertkit' ); ?></option>
-			<?php
-			foreach ( $this->forms->get() as $form ) {
-				?>
-				<option value="<?php echo esc_attr( $form['id'] ); ?>"<?php selected( $this->settings->get_default_form( 'page' ), $form['id'] ); ?>><?php echo esc_attr( $form['name'] ); ?></option>
-				<?php
-			}
-			?>
-		</select>
+
+		<?php
+		echo $this->forms->get_select_field(
+			'page_form',
+			'wp-convertkit-form-pages',
+			array(
+				'convertkit-select2',
+				'convertkit-preview-output-link',
+				'widefat',
+			),
+			$this->settings->get_default_form( 'page' ),
+			array(
+				'0' => esc_html__( 'Don\'t display an email subscription form on pages.', 'convertkit' ),
+			),
+			array(
+				'data-target' => '#convertkit-preview-form-page',
+				'data-link'   => esc_attr( $this->preview_post_url ) . '&convertkit_form_id=',
+			)
+		);
+		?>
 
 		<p class="description">
 			<?php

--- a/views/backend/setup-wizard/convertkit-setup/content-3.php
+++ b/views/backend/setup-wizard/convertkit-setup/content-3.php
@@ -51,7 +51,7 @@ if ( ! $this->forms->exist() ) {
 		</label>
 
 		<?php
-		echo $this->forms->get_select_field( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $this->forms->get_select_field_all( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			'post_form',
 			'wp-convertkit-form-posts',
 			array(
@@ -92,7 +92,7 @@ if ( ! $this->forms->exist() ) {
 		</label>
 
 		<?php
-		echo $this->forms->get_select_field( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $this->forms->get_select_field_all( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			'page_form',
 			'wp-convertkit-form-pages',
 			array(

--- a/views/backend/setup-wizard/convertkit-setup/content-3.php
+++ b/views/backend/setup-wizard/convertkit-setup/content-3.php
@@ -51,7 +51,7 @@ if ( ! $this->forms->exist() ) {
 		</label>
 
 		<?php
-		echo $this->forms->get_select_field(
+		echo $this->forms->get_select_field( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			'post_form',
 			'wp-convertkit-form-posts',
 			array(
@@ -59,7 +59,7 @@ if ( ! $this->forms->exist() ) {
 				'convertkit-preview-output-link',
 				'widefat',
 			),
-			$this->settings->get_default_form( 'post' ),
+			esc_attr( $this->settings->get_default_form( 'post' ) ),
 			array(
 				'0' => esc_html__( 'Don\'t display an email subscription form on posts.', 'convertkit' ),
 			),
@@ -92,7 +92,7 @@ if ( ! $this->forms->exist() ) {
 		</label>
 
 		<?php
-		echo $this->forms->get_select_field(
+		echo $this->forms->get_select_field( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			'page_form',
 			'wp-convertkit-form-pages',
 			array(
@@ -100,7 +100,7 @@ if ( ! $this->forms->exist() ) {
 				'convertkit-preview-output-link',
 				'widefat',
 			),
-			$this->settings->get_default_form( 'page' ),
+			esc_attr( $this->settings->get_default_form( 'page' ) ),
 			array(
 				'0' => esc_html__( 'Don\'t display an email subscription form on pages.', 'convertkit' ),
 			),

--- a/views/backend/term/fields-add.php
+++ b/views/backend/term/fields-add.php
@@ -12,7 +12,7 @@
 
 	<div class="convertkit-select2-container convertkit-select2-container-grid">
 		<?php
-		echo $convertkit_forms->get_select_field(
+		echo $convertkit_forms->get_select_field( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			'wp-convertkit[form]',
 			'wp-convertkit-form',
 			array(

--- a/views/backend/term/fields-add.php
+++ b/views/backend/term/fields-add.php
@@ -12,7 +12,7 @@
 
 	<div class="convertkit-select2-container convertkit-select2-container-grid">
 		<?php
-		echo $convertkit_forms->get_select_field( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $convertkit_forms->get_select_field_all( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			'wp-convertkit[form]',
 			'wp-convertkit-form',
 			array(

--- a/views/backend/term/fields-add.php
+++ b/views/backend/term/fields-add.php
@@ -11,18 +11,20 @@
 	<label for="wp-convertkit-form"><?php esc_html_e( 'ConvertKit Form', 'convertkit' ); ?></label>
 
 	<div class="convertkit-select2-container convertkit-select2-container-grid">
-		<select name="wp-convertkit[form]" id="wp-convertkit-form" class="convertkit-select2">
-			<option value="0" data-preserve-on-refresh="1" selected><?php esc_html_e( 'Default', 'convertkit' ); ?></option>
-			<?php
-			if ( $convertkit_forms->exist() ) {
-				foreach ( $convertkit_forms->get() as $convertkit_form ) {
-					?>
-					<option value="<?php echo esc_attr( $convertkit_form['id'] ); ?>"><?php echo esc_html( $convertkit_form['name'] ); ?></option>
-					<?php
-				}
-			}
-			?>
-		</select>
+		<?php
+		echo $convertkit_forms->get_select_field(
+			'wp-convertkit[form]',
+			'wp-convertkit-form',
+			array(
+				'convertkit-select2',
+			),
+			'0',
+			array(
+				'0' => esc_html__( 'Default', 'convertkit' ),
+			)
+		);
+		?>
+
 		<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Forms from ConvertKit account', 'convertkit' ); ?>" data-resource="forms" data-field="#wp-convertkit-form">
 			<span class="dashicons dashicons-update"></span>
 		</button>

--- a/views/backend/term/fields-edit.php
+++ b/views/backend/term/fields-edit.php
@@ -13,18 +13,20 @@
 	</th>
 	<td>
 		<div class="convertkit-select2-container convertkit-select2-container-grid">
-			<select name="wp-convertkit[form]" id="wp-convertkit-form" class="convertkit-select2">
-				<option value="0"<?php selected( 0, $convertkit_term->get_form() ); ?> data-preserve-on-refresh="1"><?php esc_html_e( 'Default', 'convertkit' ); ?></option>
-				<?php
-				if ( $convertkit_forms->exist() ) {
-					foreach ( $convertkit_forms->get() as $convertkit_form ) {
-						?>
-						<option value="<?php echo esc_attr( $convertkit_form['id'] ); ?>"<?php selected( $convertkit_form['id'], $convertkit_term->get_form() ); ?>><?php echo esc_html( $convertkit_form['name'] ); ?></option>
-						<?php
-					}
-				}
-				?>
-			</select>
+			<?php
+			echo $convertkit_forms->get_select_field(
+				'wp-convertkit[form]',
+				'wp-convertkit-form',
+				array(
+					'convertkit-select2',
+				),
+				$convertkit_term->get_form(),
+				array(
+					'0' => esc_html__( 'Default', 'convertkit' ),
+				)
+			);
+			?>
+
 			<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Forms from ConvertKit account', 'convertkit' ); ?>" data-resource="forms" data-field="#wp-convertkit-form">
 				<span class="dashicons dashicons-update"></span>
 			</button>

--- a/views/backend/term/fields-edit.php
+++ b/views/backend/term/fields-edit.php
@@ -14,13 +14,13 @@
 	<td>
 		<div class="convertkit-select2-container convertkit-select2-container-grid">
 			<?php
-			echo $convertkit_forms->get_select_field(
+			echo $convertkit_forms->get_select_field( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				'wp-convertkit[form]',
 				'wp-convertkit-form',
 				array(
 					'convertkit-select2',
 				),
-				$convertkit_term->get_form(),
+				esc_attr( $convertkit_term->get_form() ),
 				array(
 					'0' => esc_html__( 'Default', 'convertkit' ),
 				)

--- a/views/backend/term/fields-edit.php
+++ b/views/backend/term/fields-edit.php
@@ -14,7 +14,7 @@
 	<td>
 		<div class="convertkit-select2-container convertkit-select2-container-grid">
 			<?php
-			echo $convertkit_forms->get_select_field( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo $convertkit_forms->get_select_field_all( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				'wp-convertkit[form]',
 				'wp-convertkit-form',
 				array(


### PR DESCRIPTION
## Summary

Replaces multiple instances of `<select>` elements, used to select a ConvertKit Form, with two methods in the resource class:
- `get_select_field_all()`: Returns all Forms in a `<select>` dropdown
- `get_select_field_non_inline()`: Returns all non-inline Forms in a `<select>` dropdown

These will later be used (specifically `get_select_field_non_inline()`) to ensure that non-inline Forms in a `<select>` dropdown also display the inline form type (sticky bar, modal etc), where such a change can be made in one place and apply to all dropdowns.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)