### PR TITLE
Improve reliability of WooCommerce tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,11 +48,24 @@ jobs:
       fail-fast: false
       matrix:
         wp-versions: [ 'latest' ] #[ '6.1.1', 'latest' ]
-        php-versions: [ '8.1', '8.2' ] #[ '7.4', '8.0', '8.1' ]
+        php-versions: [ '7.4', '8.0', '8.1', '8.2' ] #[ '7.4', '8.0', '8.1' ]
 
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
-          'acceptance/integrations/woocommerce'
+          'acceptance/broadcasts/blocks',
+          'acceptance/broadcasts/shortcodes',
+          'acceptance/broadcasts/import',
+          'acceptance/forms/blocks',
+          'acceptance/forms/general',
+          'acceptance/forms/shortcodes',
+          'acceptance/general',
+          'acceptance/integrations/elementor',
+          'acceptance/integrations/other',
+          'acceptance/integrations/wlm',
+          'acceptance/integrations/woocommerce',
+          'acceptance/products',
+          'acceptance/restrict-content',
+          'acceptance/tags',
         ]
 
     # Steps to install, configure and run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,24 +48,11 @@ jobs:
       fail-fast: false
       matrix:
         wp-versions: [ 'latest' ] #[ '6.1.1', 'latest' ]
-        php-versions: [ '7.4', '8.0', '8.1', '8.2' ] #[ '7.4', '8.0', '8.1' ]
+        php-versions: [ '8.1', '8.2' ] #[ '7.4', '8.0', '8.1' ]
 
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
-          'acceptance/broadcasts/blocks',
-          'acceptance/broadcasts/shortcodes',
-          'acceptance/broadcasts/import',
-          'acceptance/forms/blocks',
-          'acceptance/forms/general',
-          'acceptance/forms/shortcodes',
-          'acceptance/general',
-          'acceptance/integrations/elementor',
-          'acceptance/integrations/other',
-          'acceptance/integrations/wlm',
-          'acceptance/integrations/woocommerce',
-          'acceptance/products',
-          'acceptance/restrict-content',
-          'acceptance/tags',
+          'acceptance/integrations/woocommerce'
         ]
 
     # Steps to install, configure and run tests

--- a/tests/_support/Helper/Acceptance/WPBulkEdit.php
+++ b/tests/_support/Helper/Acceptance/WPBulkEdit.php
@@ -43,6 +43,9 @@ class WPBulkEdit extends \Codeception\Module
 			}
 		}
 
+		// Scroll so that the Update button is in the viewport.
+		$I->scrollTo('#bulk-edit .inline-edit-wrapper:last-child');
+
 		// Click Update.
 		$I->click('#bulk_edit');
 

--- a/tests/_support/Helper/Acceptance/WPClassicEditor.php
+++ b/tests/_support/Helper/Acceptance/WPClassicEditor.php
@@ -255,6 +255,9 @@ class WPClassicEditor extends \Codeception\Module
 		// Scroll to Publish meta box, so its buttons are not hidden.
 		$I->scrollTo('#submitdiv');
 
+		// Wait for the Publish button to change its state from disabled (WordPress disables it for a moment when auto-saving).
+		$I->waitForElementVisible('input#publish:not(:disabled)');
+
 		// Click the Publish button.
 		$I->click('input#publish');
 

--- a/tests/acceptance/integrations/woocommerce/WooCommerceProductFormCest.php
+++ b/tests/acceptance/integrations/woocommerce/WooCommerceProductFormCest.php
@@ -40,9 +40,6 @@ class WooCommerceProductFormCest
 		// Define a Product Title.
 		$I->fillField('#title', 'ConvertKit: Product: Form: Default: None');
 
-		// Wait, otherwise publishing will fail in WooCommerce.
-		$I->wait(1);
-
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewClassicEditorPage($I);
 
@@ -69,9 +66,6 @@ class WooCommerceProductFormCest
 
 		// Define a Product Title.
 		$I->fillField('#title', 'ConvertKit: Product: Form: Default');
-
-		// Wait, otherwise publishing will fail in WooCommerce.
-		$I->wait(1);
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewClassicEditorPage($I);
@@ -107,9 +101,6 @@ class WooCommerceProductFormCest
 		// Define a Product Title.
 		$I->fillField('#title', 'ConvertKit: Product: Form: None');
 
-		// Wait, otherwise publishing will fail in WooCommerce.
-		$I->wait(1);
-
 		// Publish and view the Product.
 		$I->publishAndViewClassicEditorPage($I);
 
@@ -142,9 +133,6 @@ class WooCommerceProductFormCest
 
 		// Define a Product Title.
 		$I->fillField('#title', 'ConvertKit: Product: Form: Defined');
-
-		// Wait, otherwise publishing will fail in WooCommerce.
-		$I->wait(1);
 
 		// Publish and view the Product.
 		$I->publishAndViewClassicEditorPage($I);


### PR DESCRIPTION
## Summary

Improves the reliability of WooCommerce tests by:
- waiting for the WooCommerce Product publish button to be enabled before clicking it,
- scrolling the Bulk Edit view to ensure the Update button is visible and therefore can be clicked.
- removing unnecessary `wait` calls, as the above changes are a better way to check the UI before interacting with it

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)