### PR TITLE
Fix `output` Class Error

### DIFF
--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -306,6 +306,13 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource {
 				}
 			);
 
+			// Sanity check we're not in the WordPress Admin interface.
+			// Some third party REST API Plugins seem to load frontend Posts, which would result in a wp_die() as
+			// the output Plugin class (rightly) isn't initialized in the backend.
+			if ( is_admin() ) {
+				return '';
+			}
+
 			// Don't output the global non-inline form, if defined, because
 			// a non-inline form was specified at either Post/Page default level, Post/Page level
 			// or Post Category level.


### PR DESCRIPTION
## Summary

Resolves [this reported issue](https://convertkit.atlassian.net/jira/software/c/projects/T3/boards/27?search=wordpress&selectedIssue=T3-665), by checking if the request is for the WordPress Administration interface before deciding whether to remove the global non-inline form action, introduced in [this PR](https://github.com/ConvertKit/convertkit-wordpress/pull/591).

![0f26f6b0-2fbd-4927-9677-7d7933dab37f](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/52d78a8c-c332-4501-a78e-deb45ca5e983)

It's unclear why the creator can replicate this issue, given manual testing does not (see https://www.loom.com/share/e834f819d67f453a8ddc6a936b5d407e?sid=ca8029e4-6668-4669-a35c-f6cc118e032c) 

## Testing

Currently no test, as no clear steps to accurately replicate.  Existing tests pass, to confirm this change does not break non-inline forms.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)