### PR TITLE
Restrict Content: Add Filters

### DIFF
--- a/includes/class-convertkit-output-restrict-content.php
+++ b/includes/class-convertkit-output-restrict-content.php
@@ -840,11 +840,11 @@ class ConvertKit_Output_Restrict_Content {
 		/**
 		 * Define the output for the content preview when the visitor is not
 		 * an authenticated subscriber.
-		 * 
-		 * @since 	2.4.1
-		 * 
-		 * @param 	string 	$content_preview 	Content preview.
-		 * @param 	int 	$post_id 			Post ID.
+		 *
+		 * @since   2.4.1
+		 *
+		 * @param   string  $content_preview    Content preview.
+		 * @param   int     $post_id            Post ID.
 		 */
 		$content_preview = apply_filters( 'convertkit_output_restrict_content_content_preview', $content_preview, $this->post_id );
 
@@ -854,11 +854,11 @@ class ConvertKit_Output_Restrict_Content {
 		/**
 		 * Define the output for the call to action, displayed below the content preview,
 		 * when the visitor is not an authenticated subscriber.
-		 * 
-		 * @since 	2.4.1
-		 * 
-		 * @param 	string 	$call_to_action 	Call to Action.
-		 * @param 	int 	$post_id 			Post ID.
+		 *
+		 * @since   2.4.1
+		 *
+		 * @param   string  $call_to_action     Call to Action.
+		 * @param   int     $post_id            Post ID.
 		 */
 		$call_to_action = apply_filters( 'convertkit_output_restrict_content_call_to_action', $call_to_action, $this->post_id );
 

--- a/includes/class-convertkit-output-restrict-content.php
+++ b/includes/class-convertkit-output-restrict-content.php
@@ -834,7 +834,36 @@ class ConvertKit_Output_Restrict_Content {
 			return $content;
 		}
 
-		return $this->get_content_preview( $content ) . $this->get_call_to_action( $this->post_id );
+		// Fetch the content preview.
+		$content_preview = $this->get_content_preview( $content );
+
+		/**
+		 * Define the output for the content preview when the visitor is not
+		 * an authenticated subscriber.
+		 * 
+		 * @since 	2.4.1
+		 * 
+		 * @param 	string 	$content_preview 	Content preview.
+		 * @param 	int 	$post_id 			Post ID.
+		 */
+		$content_preview = apply_filters( 'convertkit_output_restrict_content_content_preview', $content_preview, $this->post_id );
+
+		// Fetch the call to action.
+		$call_to_action = $this->get_call_to_action( $this->post_id );
+
+		/**
+		 * Define the output for the call to action, displayed below the content preview,
+		 * when the visitor is not an authenticated subscriber.
+		 * 
+		 * @since 	2.4.1
+		 * 
+		 * @param 	string 	$call_to_action 	Call to Action.
+		 * @param 	int 	$post_id 			Post ID.
+		 */
+		$call_to_action = apply_filters( 'convertkit_output_restrict_content_call_to_action', $call_to_action, $this->post_id );
+
+		// Return the content preview and its call to action.
+		return $content_preview . $call_to_action;
 
 	}
 


### PR DESCRIPTION
## Summary

Adds `convertkit_output_restrict_content_content_preview` and `convertkit_output_restrict_content_call_to_action` filter hooks, that might be useful for developers wishing the modify the preview content output and/or call to action displayed when using Member Content functionality (e.g. [this discussion](https://n7studios-workspace.slack.com/archives/C02KFR6N1GF/p1702572004086039?thread_ts=1702571153.834759&cid=C02KFR6N1GF)).

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)