### PR TITLE
Tests: Refactor `seeBroadcastsOutput` method

### DIFF
--- a/tests/acceptance/broadcasts/blocks/PageBlockBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/blocks/PageBlockBroadcastsCest.php
@@ -307,6 +307,7 @@ class PageBlockBroadcastsCest
 			$I,
 			[
 				'number_posts' => $_ENV['CONVERTKIT_API_BROADCAST_COUNT'],
+				'see_grid'     => true,
 				'see_image'    => true,
 			]
 		);

--- a/tests/acceptance/broadcasts/blocks/PageBlockBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/blocks/PageBlockBroadcastsCest.php
@@ -45,7 +45,12 @@ class PageBlockBroadcastsCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the block displays correctly with the expected number of Broadcasts.
-		$I->seeBroadcastsOutput($I, $_ENV['CONVERTKIT_API_BROADCAST_COUNT']);
+		$I->seeBroadcastsOutput(
+			$I,
+			[
+				'number_posts' => $_ENV['CONVERTKIT_API_BROADCAST_COUNT'],
+			]
+		);
 	}
 
 	/**
@@ -133,7 +138,12 @@ class PageBlockBroadcastsCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the block displays correctly with the expected number of Broadcasts.
-		$I->seeBroadcastsOutput($I, $_ENV['CONVERTKIT_API_BROADCAST_COUNT']);
+		$I->seeBroadcastsOutput(
+			$I,
+			[
+				'number_posts' => $_ENV['CONVERTKIT_API_BROADCAST_COUNT'],
+			]
+		);
 	}
 
 	/**
@@ -159,7 +169,12 @@ class PageBlockBroadcastsCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the block displays correctly with the expected number of Broadcasts.
-		$I->seeBroadcastsOutput($I, $_ENV['CONVERTKIT_API_BROADCAST_COUNT']);
+		$I->seeBroadcastsOutput(
+			$I,
+			[
+				'number_posts' => $_ENV['CONVERTKIT_API_BROADCAST_COUNT'],
+			]
+		);
 
 		// Confirm that the default date format is as expected.
 		$I->seeInSource('<time datetime="' . date( 'Y-m-d', strtotime( $_ENV['CONVERTKIT_API_BROADCAST_FIRST_DATE'] ) ) . '">' . date( 'F j, Y', strtotime( $_ENV['CONVERTKIT_API_BROADCAST_FIRST_DATE'] ) ) . '</time>');
@@ -203,10 +218,10 @@ class PageBlockBroadcastsCest
 		// Confirm that the block displays correctly with the expected number of Broadcasts in the grid format.
 		$I->seeBroadcastsOutput(
 			$I,
-			$_ENV['CONVERTKIT_API_BROADCAST_COUNT'], // Confirm expected number of broadcasts are output.
-			false, // Don't check previous pagination label.
-			false, // Don't check next pagination label.
-			true // Confirm grid mode is set.
+			[
+				'number_posts' => $_ENV['CONVERTKIT_API_BROADCAST_COUNT'],
+				'see_grid'     => true,
+			]
 		);
 	}
 
@@ -240,7 +255,12 @@ class PageBlockBroadcastsCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the block displays correctly with the expected number of Broadcasts.
-		$I->seeBroadcastsOutput($I, $_ENV['CONVERTKIT_API_BROADCAST_COUNT']);
+		$I->seeBroadcastsOutput(
+			$I,
+			[
+				'number_posts' => $_ENV['CONVERTKIT_API_BROADCAST_COUNT'],
+			]
+		);
 
 		// Confirm that the date format is as expected.
 		$I->seeInSource('<time datetime="' . date( 'Y-m-d', strtotime( $_ENV['CONVERTKIT_API_BROADCAST_FIRST_DATE'] ) ) . '">' . date( 'Y-m-d', strtotime( $_ENV['CONVERTKIT_API_BROADCAST_FIRST_DATE'] ) ) . '</time>');
@@ -285,11 +305,10 @@ class PageBlockBroadcastsCest
 		// Confirm that the block displays correctly with the expected number of Broadcasts in the grid format.
 		$I->seeBroadcastsOutput(
 			$I,
-			$_ENV['CONVERTKIT_API_BROADCAST_COUNT'], // Confirm expected number of broadcasts are output.
-			false, // Don't check previous pagination label.
-			false, // Don't check next pagination label.
-			true, // Confirm grid mode is set.
-			true // Confirm images are displayed.
+			[
+				'number_posts' => $_ENV['CONVERTKIT_API_BROADCAST_COUNT'],
+				'see_image'    => true,
+			]
 		);
 	}
 
@@ -325,12 +344,10 @@ class PageBlockBroadcastsCest
 		// Confirm that the block displays correctly with the expected number of Broadcasts in the grid format.
 		$I->seeBroadcastsOutput(
 			$I,
-			$_ENV['CONVERTKIT_API_BROADCAST_COUNT'], // Confirm expected number of broadcasts are output.
-			false, // Don't check previous pagination label.
-			false, // Don't check next pagination label.
-			false, // Confirm grid mode is not set.
-			false, // Confirm images are not displayed.
-			true // Confirm description is displayed.
+			[
+				'number_posts'    => $_ENV['CONVERTKIT_API_BROADCAST_COUNT'],
+				'see_description' => true,
+			]
 		);
 	}
 
@@ -367,13 +384,10 @@ class PageBlockBroadcastsCest
 		// Confirm that the block displays correctly with the expected number of Broadcasts in the grid format.
 		$I->seeBroadcastsOutput(
 			$I,
-			$_ENV['CONVERTKIT_API_BROADCAST_COUNT'], // Confirm expected number of broadcasts are output.
-			false, // Don't check previous pagination label.
-			false, // Don't check next pagination label.
-			false, // Confirm grid mode is not set.
-			false, // Confirm images are not displayed.
-			false, // Confirm description is not displayed.
-			'Continue reading' // Confirm read more link is displayed with correct text.
+			[
+				'number_posts'  => $_ENV['CONVERTKIT_API_BROADCAST_COUNT'],
+				'see_read_more' => 'Continue reading',
+			]
 		);
 	}
 
@@ -407,7 +421,12 @@ class PageBlockBroadcastsCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the block displays correctly with the expected number of Broadcasts.
-		$I->seeBroadcastsOutput($I, 2);
+		$I->seeBroadcastsOutput(
+			$I,
+			[
+				'number_posts' => 2,
+			]
+		);
 
 		// Confirm that the expected Broadcast name is displayed first links to the expected URL, with UTM parameters.
 		$I->assertEquals(
@@ -448,7 +467,12 @@ class PageBlockBroadcastsCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the block displays correctly with the expected number of Broadcasts.
-		$I->seeBroadcastsOutput($I, 1);
+		$I->seeBroadcastsOutput(
+			$I,
+			[
+				'number_posts' => 1,
+			]
+		);
 
 		// Confirm that the expected Broadcast name is displayed first links to the expected URL, with UTM parameters.
 		$I->assertEquals(
@@ -601,7 +625,12 @@ class PageBlockBroadcastsCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the block displays correctly with the expected number of Broadcasts.
-		$I->seeBroadcastsOutput($I, $_ENV['CONVERTKIT_API_BROADCAST_COUNT']);
+		$I->seeBroadcastsOutput(
+			$I,
+			[
+				'number_posts' => $_ENV['CONVERTKIT_API_BROADCAST_COUNT'],
+			]
+		);
 
 		// Confirm that our stylesheet loaded.
 		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
@@ -648,7 +677,12 @@ class PageBlockBroadcastsCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the block displays correctly with the expected number of Broadcasts.
-		$I->seeBroadcastsOutput($I, $_ENV['CONVERTKIT_API_BROADCAST_COUNT']);
+		$I->seeBroadcastsOutput(
+			$I,
+			[
+				'number_posts' => $_ENV['CONVERTKIT_API_BROADCAST_COUNT'],
+			]
+		);
 
 		// Confirm that our stylesheet loaded.
 		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');

--- a/tests/acceptance/broadcasts/shortcodes/PageShortcodeBroadcastsCest.php
+++ b/tests/acceptance/broadcasts/shortcodes/PageShortcodeBroadcastsCest.php
@@ -45,7 +45,12 @@ class PageShortcodeBroadcastsCest
 		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the shortcode displays correctly with the expected number of Broadcasts.
-		$I->seeBroadcastsOutput($I, $_ENV['CONVERTKIT_API_BROADCAST_COUNT']);
+		$I->seeBroadcastsOutput(
+			$I,
+			[
+				'number_posts' => $_ENV['CONVERTKIT_API_BROADCAST_COUNT'],
+			]
+		);
 
 		// Confirm that the default date format is as expected.
 		$I->seeInSource('<time datetime="' . date( 'Y-m-d', strtotime( $_ENV['CONVERTKIT_API_BROADCAST_FIRST_DATE'] ) ) . '">' . date( 'F j, Y', strtotime( $_ENV['CONVERTKIT_API_BROADCAST_FIRST_DATE'] ) ) . '</time>');
@@ -85,10 +90,10 @@ class PageShortcodeBroadcastsCest
 		// Confirm that the shortcode displays correctly with the expected number of Broadcasts in the grid format.
 		$I->seeBroadcastsOutput(
 			$I,
-			$_ENV['CONVERTKIT_API_BROADCAST_COUNT'], // Confirm expected number of broadcasts are output.
-			false, // Don't check previous pagination label.
-			false, // Don't check next pagination label.
-			true // Confirm grid mode is set.
+			[
+				'number_posts' => $_ENV['CONVERTKIT_API_BROADCAST_COUNT'],
+				'see_grid'     => true,
+			]
 		);
 	}
 
@@ -119,7 +124,12 @@ class PageShortcodeBroadcastsCest
 		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the shortcode displays correctly with the expected number of Broadcasts.
-		$I->seeBroadcastsOutput($I, $_ENV['CONVERTKIT_API_BROADCAST_COUNT']);
+		$I->seeBroadcastsOutput(
+			$I,
+			[
+				'number_posts' => $_ENV['CONVERTKIT_API_BROADCAST_COUNT'],
+			]
+		);
 
 		// Confirm that the default date format is as expected.
 		$I->seeInSource('<time datetime="' . date( 'Y-m-d', strtotime( $_ENV['CONVERTKIT_API_BROADCAST_FIRST_DATE'] ) ) . '">' . date( 'Y-m-d', strtotime( $_ENV['CONVERTKIT_API_BROADCAST_FIRST_DATE'] ) ) . '</time>');
@@ -159,11 +169,10 @@ class PageShortcodeBroadcastsCest
 		// Confirm that the shortcode displays correctly with the expected number of Broadcasts in the grid format.
 		$I->seeBroadcastsOutput(
 			$I,
-			$_ENV['CONVERTKIT_API_BROADCAST_COUNT'], // Confirm expected number of broadcasts are output.
-			false, // Don't check previous pagination label.
-			false, // Don't check next pagination label.
-			false, // Confirm grid mode is not set.
-			true // Confirm images are displayed.
+			[
+				'number_posts' => $_ENV['CONVERTKIT_API_BROADCAST_COUNT'],
+				'see_image'    => true,
+			]
 		);
 	}
 
@@ -195,12 +204,10 @@ class PageShortcodeBroadcastsCest
 		// Confirm that the shortcode displays correctly with the expected number of Broadcasts in the grid format.
 		$I->seeBroadcastsOutput(
 			$I,
-			$_ENV['CONVERTKIT_API_BROADCAST_COUNT'], // Confirm expected number of broadcasts are output.
-			false, // Don't check previous pagination label.
-			false, // Don't check next pagination label.
-			false, // Confirm grid mode is not set.
-			false, // Confirm images are not displayed.
-			true // Confirm description is displayed.
+			[
+				'number_posts'    => $_ENV['CONVERTKIT_API_BROADCAST_COUNT'],
+				'see_description' => true,
+			]
 		);
 	}
 
@@ -233,13 +240,10 @@ class PageShortcodeBroadcastsCest
 		// Confirm that the shortcode displays correctly with the expected number of Broadcasts in the grid format.
 		$I->seeBroadcastsOutput(
 			$I,
-			$_ENV['CONVERTKIT_API_BROADCAST_COUNT'], // Confirm expected number of broadcasts are output.
-			false, // Don't check previous pagination label.
-			false, // Don't check next pagination label.
-			false, // Confirm grid mode is not set.
-			false, // Confirm images are not displayed.
-			false, // Confirm description is not displayed.
-			'Continue reading' // Confirm read more link is displayed with correct text.
+			[
+				'number_posts'  => $_ENV['CONVERTKIT_API_BROADCAST_COUNT'],
+				'see_read_more' => 'Continue reading',
+			]
 		);
 	}
 
@@ -270,7 +274,12 @@ class PageShortcodeBroadcastsCest
 		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the shortcode output displays.
-		$I->seeBroadcastsOutput($I, 2);
+		$I->seeBroadcastsOutput(
+			$I,
+			[
+				'number_posts' => 2,
+			]
+		);
 
 		// Confirm that the expected Broadcast name is displayed first links to the expected URL, with UTM parameters.
 		$I->assertEquals(
@@ -412,7 +421,12 @@ class PageShortcodeBroadcastsCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the shortcode displays correctly with the expected number of Broadcasts.
-		$I->seeBroadcastsOutput($I, 1);
+		$I->seeBroadcastsOutput(
+			$I,
+			[
+				'number_posts' => 1,
+			]
+		);
 
 		// Confirm that our stylesheet loaded.
 		$I->seeInSource('<link rel="stylesheet" id="convertkit-broadcasts-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/broadcasts.css');
@@ -453,7 +467,12 @@ class PageShortcodeBroadcastsCest
 		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the shortcode displays correctly with the expected number of Broadcasts.
-		$I->seeBroadcastsOutput($I, $_ENV['CONVERTKIT_API_BROADCAST_COUNT']);
+		$I->seeBroadcastsOutput(
+			$I,
+			[
+				'number_posts' => $_ENV['CONVERTKIT_API_BROADCAST_COUNT'],
+			]
+		);
 
 		// Confirm that the default date format is as expected.
 		$I->seeInSource('<time datetime="' . date( 'Y-m-d', strtotime( $_ENV['CONVERTKIT_API_BROADCAST_FIRST_DATE'] ) ) . '">' . date( 'F j, Y', strtotime( $_ENV['CONVERTKIT_API_BROADCAST_FIRST_DATE'] ) ) . '</time>');
@@ -491,10 +510,10 @@ class PageShortcodeBroadcastsCest
 		// Confirm that the shortcode displays correctly with the expected number of Broadcasts in the grid format.
 		$I->seeBroadcastsOutput(
 			$I,
-			$_ENV['CONVERTKIT_API_BROADCAST_COUNT'], // Confirm expected number of broadcasts are output.
-			false, // Don't check previous pagination label.
-			false, // Don't check next pagination label.
-			true // Confirm grid mode is set.
+			[
+				'number_posts' => $_ENV['CONVERTKIT_API_BROADCAST_COUNT'],
+				'see_grid'     => true,
+			]
 		);
 	}
 
@@ -525,7 +544,12 @@ class PageShortcodeBroadcastsCest
 		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the shortcode displays correctly with the expected number of Broadcasts.
-		$I->seeBroadcastsOutput($I, $_ENV['CONVERTKIT_API_BROADCAST_COUNT']);
+		$I->seeBroadcastsOutput(
+			$I,
+			[
+				'number_posts' => $_ENV['CONVERTKIT_API_BROADCAST_COUNT'],
+			]
+		);
 
 		// Confirm that the default date format is as expected.
 		$I->seeInSource('<time datetime="' . date( 'Y-m-d', strtotime( $_ENV['CONVERTKIT_API_BROADCAST_FIRST_DATE'] ) ) . '">' . date( 'Y-m-d', strtotime( $_ENV['CONVERTKIT_API_BROADCAST_FIRST_DATE'] ) ) . '</time>');
@@ -560,11 +584,10 @@ class PageShortcodeBroadcastsCest
 		// Confirm that the block displays correctly with the expected number of Broadcasts in the grid format.
 		$I->seeBroadcastsOutput(
 			$I,
-			$_ENV['CONVERTKIT_API_BROADCAST_COUNT'], // Confirm expected number of broadcasts are output.
-			false, // Don't check previous pagination label.
-			false, // Don't check next pagination label.
-			false, // Confirm grid mode is not set.
-			true // Confirm images are displayed.
+			[
+				'number_posts' => $_ENV['CONVERTKIT_API_BROADCAST_COUNT'],
+				'see_image'    => true,
+			]
 		);
 	}
 
@@ -597,12 +620,10 @@ class PageShortcodeBroadcastsCest
 		// Confirm that the block displays correctly with the expected number of Broadcasts in the grid format.
 		$I->seeBroadcastsOutput(
 			$I,
-			$_ENV['CONVERTKIT_API_BROADCAST_COUNT'], // Confirm expected number of broadcasts are output.
-			false, // Don't check previous pagination label.
-			false, // Don't check next pagination label.
-			false, // Confirm grid mode is not set.
-			false, // Confirm images are not displayed.
-			true // Confirm description is displayed.
+			[
+				'number_posts'    => $_ENV['CONVERTKIT_API_BROADCAST_COUNT'],
+				'see_description' => true,
+			]
 		);
 	}
 
@@ -636,13 +657,10 @@ class PageShortcodeBroadcastsCest
 		// Confirm that the block displays correctly with the expected number of Broadcasts in the grid format.
 		$I->seeBroadcastsOutput(
 			$I,
-			$_ENV['CONVERTKIT_API_BROADCAST_COUNT'], // Confirm expected number of broadcasts are output.
-			false, // Don't check previous pagination label.
-			false, // Don't check next pagination label.
-			false, // Confirm grid mode is not set.
-			false, // Confirm images are not displayed.
-			false, // Confirm description is not displayed.
-			'Continue reading' // Confirm read more link is displayed with correct text.
+			[
+				'number_posts'  => $_ENV['CONVERTKIT_API_BROADCAST_COUNT'],
+				'see_read_more' => 'Continue reading',
+			]
 		);
 	}
 
@@ -673,7 +691,12 @@ class PageShortcodeBroadcastsCest
 		$I->publishAndViewClassicEditorPage($I);
 
 		// Confirm that the shortcode displays correctly with the expected number of Broadcasts.
-		$I->seeBroadcastsOutput($I, 2);
+		$I->seeBroadcastsOutput(
+			$I,
+			[
+				'number_posts' => 2,
+			]
+		);
 
 		// Confirm that the default date format is as expected.
 		$I->seeInSource('<time datetime="' . date( 'Y-m-d', strtotime( $_ENV['CONVERTKIT_API_BROADCAST_FIRST_DATE'] ) ) . '">' . date( 'F j, Y', strtotime( $_ENV['CONVERTKIT_API_BROADCAST_FIRST_DATE'] ) ) . '</time>');


### PR DESCRIPTION
## Summary

Refactors the `seeBroadcastsOutput` method by accepting an array of named key/value pairs.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)