### PR TITLE
Tests: Refactor Restrict Content

### DIFF
--- a/tests/_support/Helper/Acceptance/ConvertKitRestrictContent.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitRestrictContent.php
@@ -202,7 +202,26 @@ class ConvertKitRestrictContent extends \Codeception\Module
 		$I->click('input.wp-block-button__link');
 
 		// Confirm that confirmation an email has been sent is displayed.
-		$this->testRestrictContentShowsEmailCodeForm($I, $options);
+		// Confirm that the visible text displays, hidden text does not display and the CTA displays.
+		if ( ! empty($options['visible_content'])) {
+			$I->see($options['visible_content']);
+		}
+		$I->dontSee($options['member_content']);
+
+		// Confirm that the CTA displays with the expected text.
+		$I->seeElementInDOM('#convertkit-restrict-content');
+		$I->seeInSource('<h4>' . $options['text_items']['email_check_heading'] . '</h4>');
+		$I->see($options['text_items']['email_check_text']);
+		$I->seeElementInDOM('input#convertkit_subscriber_code');
+		$I->seeElementInDOM('input.wp-block-button__link');
+
+		// Enter an invalid code.
+		$I->fillField('subscriber_code', '999999');
+		$I->click('Verify');
+
+		// Confirm an inline error message is displayed.
+		$I->seeInSource('<div class="convertkit-restrict-content-notice convertkit-restrict-content-notice-error">The entered code is invalid. Please try again, or click the link sent in the email.</div>');
+		$I->seeInSource('<div id="convertkit-subscriber-code-container" class="convertkit-restrict-content-error">');
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// as if we entered the code sent in the email.
@@ -415,53 +434,6 @@ class ConvertKitRestrictContent extends \Codeception\Module
 		$I->see($options['text_items']['email_text']);
 		$I->seeInSource('<input type="submit" class="wp-block-button__link wp-block-button__link" value="' . $options['text_items']['email_button_label'] . '">');
 		$I->seeInSource('<small>' . $options['text_items']['email_description_text'] . '</small>');
-	}
-
-	/**
-	 * Run frontend tests for restricted content, to confirm that:
-	 * - visible content is displayed,
-	 * - member's content is not displayed,
-	 * - the email code form is displayed with the expected text.
-	 *
-	 * @since   2.1.0
-	 *
-	 * @param   AcceptanceTester $I                  Tester.
-	 * @param   bool|array       $options {
-	 *           Optional. An array of settings.
-	 *
-	 *     @type string $visible_content            Content that should always be visible.
-	 *     @type string $member_content         	Content that should only be available to authenticated subscribers.
-	 *     @type array  $text_items 				Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
-	 * }
-	 */
-	public function testRestrictContentShowsEmailCodeForm($I, $options = false)
-	{
-		// Merge options with defaults.
-		$options = $this->_getRestrictedContentOptionsWithDefaultsMerged($options);
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm that the visible text displays, hidden text does not display and the CTA displays.
-		if ( ! empty($options['visible_content'])) {
-			$I->see($options['visible_content']);
-		}
-		$I->dontSee($options['member_content']);
-
-		// Confirm that the CTA displays with the expected text.
-		$I->seeElementInDOM('#convertkit-restrict-content');
-		$I->seeInSource('<h4>' . $options['text_items']['email_check_heading'] . '</h4>');
-		$I->see($options['text_items']['email_check_text']);
-		$I->seeElementInDOM('input#convertkit_subscriber_code');
-		$I->seeElementInDOM('input.wp-block-button__link');
-
-		// Enter an invalid code.
-		$I->fillField('subscriber_code', '999999');
-		$I->click('Verify');
-
-		// Confirm an inline error message is displayed.
-		$I->seeInSource('<div class="convertkit-restrict-content-notice convertkit-restrict-content-notice-error">The entered code is invalid. Please try again, or click the link sent in the email.</div>');
-		$I->seeInSource('<div id="convertkit-subscriber-code-container" class="convertkit-restrict-content-error">');
 	}
 
 	/**

--- a/tests/_support/Helper/Acceptance/ConvertKitRestrictContent.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitRestrictContent.php
@@ -84,11 +84,11 @@ class ConvertKitRestrictContent extends \Codeception\Module
 	 * @param   bool|array       $options {
 	 *           Optional. An array of settings.
 	 *
-	 *     @type string $post_type            		Post Type.
-	 *     @type string $post_title         		Post Title.
+	 *     @type string $post_type                  Post Type.
+	 *     @type string $post_title                 Post Title.
 	 *     @type string $visible_content            Content that should always be visible.
-	 *     @type string $member_content         	Content that should only be available to authenticated subscribers.
-	 *     @type string $restrict_content_setting 	Restrict Content setting.
+	 *     @type string $member_content             Content that should only be available to authenticated subscribers.
+	 *     @type string $restrict_content_setting   Restrict Content setting.
 	 * }
 	 *
 	 * @return  int                                          Page ID.
@@ -97,10 +97,10 @@ class ConvertKitRestrictContent extends \Codeception\Module
 	{
 		// Define default options.
 		$defaults = [
-			'post_type'       => 'page',
-			'post_title'      => 'Restrict Content',
-			'visible_content' => 'Visible content.',
-			'member_content'  => 'Member only content.',
+			'post_type'                => 'page',
+			'post_title'               => 'Restrict Content',
+			'visible_content'          => 'Visible content.',
+			'member_content'           => 'Member only content.',
 			'restrict_content_setting' => '',
 		];
 
@@ -146,8 +146,8 @@ class ConvertKitRestrictContent extends \Codeception\Module
 	 *           Optional. An array of settings.
 	 *
 	 *     @type string $visible_content            Content that should always be visible.
-	 *     @type string $member_content         	Content that should only be available to authenticated subscribers.
-	 *     @type array  $text_items 				Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 *     @type string $member_content             Content that should only be available to authenticated subscribers.
+	 *     @type array  $text_items                 Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
 	 * }
 	 */
 	public function testRestrictedContentByProductOnFrontend($I, $urlOrPageID, $options = false)
@@ -240,8 +240,8 @@ class ConvertKitRestrictContent extends \Codeception\Module
 	 *           Optional. An array of settings.
 	 *
 	 *     @type string $visible_content            Content that should always be visible.
-	 *     @type string $member_content         	Content that should only be available to authenticated subscribers.
-	 *     @type array  $text_items 				Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 *     @type string $member_content             Content that should only be available to authenticated subscribers.
+	 *     @type array  $text_items                 Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
 	 * }
 	 */
 	public function testRestrictedContentModalByProductOnFrontend($I, $urlOrPageID, $options = false)
@@ -308,8 +308,8 @@ class ConvertKitRestrictContent extends \Codeception\Module
 	 *           Optional. An array of settings.
 	 *
 	 *     @type string $visible_content            Content that should always be visible.
-	 *     @type string $member_content         	Content that should only be available to authenticated subscribers.
-	 *     @type array  $text_items 				Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 *     @type string $member_content             Content that should only be available to authenticated subscribers.
+	 *     @type array  $text_items                 Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
 	 * }
 	 */
 	public function testRestrictedContentByTagOnFrontend($I, $urlOrPageID, $emailAddress, $options = false)
@@ -367,8 +367,8 @@ class ConvertKitRestrictContent extends \Codeception\Module
 	 *           Optional. An array of settings.
 	 *
 	 *     @type string $visible_content            Content that should always be visible.
-	 *     @type string $member_content         	Content that should only be available to authenticated subscribers.
-	 *     @type array  $text_items 				Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 *     @type string $member_content             Content that should only be available to authenticated subscribers.
+	 *     @type array  $text_items                 Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
 	 * }
 	 */
 	public function testRestrictedContentShowsContentWithValidSubscriberID($I, $urlOrPageID, $options = false)
@@ -404,8 +404,8 @@ class ConvertKitRestrictContent extends \Codeception\Module
 	 *           Optional. An array of settings.
 	 *
 	 *     @type string $visible_content            Content that should always be visible.
-	 *     @type string $member_content         	Content that should only be available to authenticated subscribers.
-	 *     @type array  $text_items 				Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 *     @type string $member_content             Content that should only be available to authenticated subscribers.
+	 *     @type array  $text_items                 Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
 	 * }
 	 */
 	public function testRestrictContentByProductHidesContentWithCTA($I, $options = false)
@@ -449,8 +449,8 @@ class ConvertKitRestrictContent extends \Codeception\Module
 	 *           Optional. An array of settings.
 	 *
 	 *     @type string $visible_content            Content that should always be visible.
-	 *     @type string $member_content         	Content that should only be available to authenticated subscribers.
-	 *     @type array  $text_items 				Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 *     @type string $member_content             Content that should only be available to authenticated subscribers.
+	 *     @type array  $text_items                 Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
 	 * }
 	 */
 	public function testRestrictContentDisplaysContent($I, $options = false)
@@ -476,13 +476,12 @@ class ConvertKitRestrictContent extends \Codeception\Module
 	 *
 	 * @since   2.4.1
 	 *
-	 * @param   AcceptanceTester $I                  Tester.
-	 * @param   bool|array       $options {
-	 *           Optional. An array of settings.
+	 * @param   bool|array $options {
+	 *     Optional. An array of settings.
 	 *
 	 *     @type string $visible_content            Content that should always be visible.
-	 *     @type string $member_content         	Content that should only be available to authenticated subscribers.
-	 *     @type array  $text_items 				Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 *     @type string $member_content             Content that should only be available to authenticated subscribers.
+	 *     @type array  $text_items                 Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
 	 * }
 	 */
 	private function _getRestrictedContentOptionsWithDefaultsMerged($options = false)
@@ -491,7 +490,7 @@ class ConvertKitRestrictContent extends \Codeception\Module
 		$defaults = [
 			'visible_content' => 'Visible content.',
 			'member_content'  => 'Member only content.',
-			'text_items' 	  => $this->getRestrictedContentDefaultSettings(),
+			'text_items'      => $this->getRestrictedContentDefaultSettings(),
 		];
 
 		// If supplied options are an array, merge them with the defaults.
@@ -501,6 +500,5 @@ class ConvertKitRestrictContent extends \Codeception\Module
 
 		// Just return defaults.
 		return $defaults;
-
 	}
 }

--- a/tests/_support/Helper/Acceptance/ConvertKitRestrictContent.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitRestrictContent.php
@@ -190,7 +190,7 @@ class ConvertKitRestrictContent extends \Codeception\Module
 		}
 
 		// Confirm an inline error message is displayed.
-		$I->seeInSource('<div class="convertkit-restrict-content-notice convertkit-restrict-content-notice-error">' . $textItems['no_access_text'] . '</div>');
+		$I->seeInSource('<div class="convertkit-restrict-content-notice convertkit-restrict-content-notice-error">' . $options['text_items']['no_access_text'] . '</div>');
 		$I->seeInSource('<div id="convertkit-restrict-content-email-field" class="convertkit-restrict-content-error">');
 
 		// Check content is not displayed, and CTA displays with expected text.
@@ -279,8 +279,8 @@ class ConvertKitRestrictContent extends \Codeception\Module
 
 		// Confirm that confirmation an email has been sent is displayed.
 		$I->waitForElementVisible('input#convertkit_subscriber_code');
-		$I->see($textItems['email_check_heading'], 'h4');
-		$I->see($textItems['email_check_text'], 'p');
+		$I->see($options['text_items']['email_check_heading'], 'h4');
+		$I->see($options['text_items']['email_check_text'], 'p');
 
 		// Enter an invalid code.
 		$I->fillField('subscriber_code', '999999');

--- a/tests/_support/Helper/Acceptance/ConvertKitRestrictContent.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitRestrictContent.php
@@ -81,24 +81,45 @@ class ConvertKitRestrictContent extends \Codeception\Module
 	 * @since   2.1.0
 	 *
 	 * @param   AcceptanceTester $I                          Tester.
-	 * @param   string           $postType                   Post Type.
-	 * @param   string           $title                      Title.
-	 * @param   string           $visibleContent             Content that should always be visible.
-	 * @param   string           $memberContent              Content that should only be available to authenticated subscribers.
-	 * @param   string           $restrictContentSetting     Restrict Content setting.
+	 * @param   bool|array       $options {
+	 *           Optional. An array of settings.
+	 *
+	 *     @type string $post_type            		Post Type.
+	 *     @type string $post_title         		Post Title.
+	 *     @type string $visible_content            Content that should always be visible.
+	 *     @type string $member_content         	Content that should only be available to authenticated subscribers.
+	 *     @type string $restrict_content_setting 	Restrict Content setting.
+	 * }
+	 *
 	 * @return  int                                          Page ID.
 	 */
-	public function createRestrictedContentPage($I, $postType, $title, $visibleContent = 'Visible content.', $memberContent = 'Member only content.', $restrictContentSetting = '')
+	public function createRestrictedContentPage($I, $options = false)
 	{
+		// Define default options.
+		$defaults = [
+			'post_type'       => 'page',
+			'post_title'      => 'Restrict Content',
+			'visible_content' => 'Visible content.',
+			'member_content'  => 'Member only content.',
+			'restrict_content_setting' => '',
+		];
+
+		// If supplied options are an array, merge them with the defaults.
+		if (is_array($options)) {
+			$options = array_merge($defaults, $options);
+		} else {
+			$options = $defaults;
+		}
+
 		return $I->havePostInDatabase(
 			[
-				'post_type'    => $postType,
-				'post_title'   => $title,
+				'post_type'    => $options['post_type'],
+				'post_title'   => $options['post_title'],
 
 				// Emulate Gutenberg content with visible and members only content sections.
-				'post_content' => '<!-- wp:paragraph --><p>' . $visibleContent . '</p><!-- /wp:paragraph -->
+				'post_content' => '<!-- wp:paragraph --><p>' . $options['visible_content'] . '</p><!-- /wp:paragraph -->
 <!-- wp:more --><!--more--><!-- /wp:more -->
-<!-- wp:paragraph -->' . $memberContent . '<!-- /wp:paragraph -->',
+<!-- wp:paragraph -->' . $options['member_content'] . '<!-- /wp:paragraph -->',
 
 				// Don't display a Form on this Page, so we test against Restrict Content's Form.
 				'meta_input'   => [
@@ -106,7 +127,7 @@ class ConvertKitRestrictContent extends \Codeception\Module
 						'form'             => '-1',
 						'landing_page'     => '',
 						'tag'              => '',
-						'restrict_content' => $restrictContentSetting,
+						'restrict_content' => $options['restrict_content_setting'],
 					],
 				],
 			]
@@ -121,16 +142,18 @@ class ConvertKitRestrictContent extends \Codeception\Module
 	 *
 	 * @param   AcceptanceTester $I                  Tester.
 	 * @param   string|int       $urlOrPageID        URL or ID of Restricted Content Page.
-	 * @param   string           $visibleContent     Content that should always be visible.
-	 * @param   string           $memberContent      Content that should only be available to authenticated subscribers.
-	 * @param   bool|array       $textItems          Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 * @param   bool|array       $options {
+	 *           Optional. An array of settings.
+	 *
+	 *     @type string $visible_content            Content that should always be visible.
+	 *     @type string $member_content         	Content that should only be available to authenticated subscribers.
+	 *     @type array  $text_items 				Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 * }
 	 */
-	public function testRestrictedContentByProductOnFrontend($I, $urlOrPageID, $visibleContent = 'Visible content.', $memberContent = 'Member only content.', $textItems = false)
+	public function testRestrictedContentByProductOnFrontend($I, $urlOrPageID, $options = false)
 	{
-		// Define expected text and labels if not supplied.
-		if ( ! $textItems ) {
-			$textItems = $this->getRestrictedContentDefaultSettings();
-		}
+		// Merge options with defaults.
+		$options = $this->_getRestrictedContentOptionsWithDefaultsMerged($options);
 
 		// Navigate to the page.
 		if ( is_numeric( $urlOrPageID ) ) {
@@ -143,7 +166,7 @@ class ConvertKitRestrictContent extends \Codeception\Module
 		$I->seeInSource('<link rel="stylesheet" id="convertkit-restrict-content-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/restrict-content.css');
 
 		// Check content is not displayed, and CTA displays with expected text.
-		$this->testRestrictContentByProductHidesContentWithCTA($I, $visibleContent, $memberContent, $textItems);
+		$this->testRestrictContentByProductHidesContentWithCTA($I, $options);
 
 		// Login as a ConvertKit subscriber who does not exist in ConvertKit.
 		$I->waitForElementVisible('input#convertkit_email');
@@ -155,7 +178,7 @@ class ConvertKitRestrictContent extends \Codeception\Module
 		$I->seeInSource('<div id="convertkit-restrict-content-email-field" class="convertkit-restrict-content-error">');
 
 		// Check content is not displayed, and CTA displays with expected text.
-		$this->testRestrictContentByProductHidesContentWithCTA($I, $visibleContent, $memberContent, $textItems);
+		$this->testRestrictContentByProductHidesContentWithCTA($I, $options);
 
 		// Set cookie with signed subscriber ID and reload the restricted content page, as if we entered the
 		// code sent in the email as a ConvertKit subscriber who has not subscribed to the product.
@@ -171,7 +194,7 @@ class ConvertKitRestrictContent extends \Codeception\Module
 		$I->seeInSource('<div id="convertkit-restrict-content-email-field" class="convertkit-restrict-content-error">');
 
 		// Check content is not displayed, and CTA displays with expected text.
-		$this->testRestrictContentByProductHidesContentWithCTA($I, $visibleContent, $memberContent, $textItems);
+		$this->testRestrictContentByProductHidesContentWithCTA($I, $options);
 
 		// Login as a ConvertKit subscriber who has subscribed to the product.
 		$I->waitForElementVisible('input#convertkit_email');
@@ -179,11 +202,11 @@ class ConvertKitRestrictContent extends \Codeception\Module
 		$I->click('input.wp-block-button__link');
 
 		// Confirm that confirmation an email has been sent is displayed.
-		$this->testRestrictContentShowsEmailCodeForm($I, $visibleContent, $memberContent, $textItems);
+		$this->testRestrictContentShowsEmailCodeForm($I, $options);
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// as if we entered the code sent in the email.
-		$this->testRestrictedContentShowsContentWithValidSubscriberID($I, $urlOrPageID, $visibleContent, $memberContent);
+		$this->testRestrictedContentShowsContentWithValidSubscriberID($I, $urlOrPageID, $options);
 	}
 
 	/**
@@ -194,16 +217,18 @@ class ConvertKitRestrictContent extends \Codeception\Module
 	 *
 	 * @param   AcceptanceTester $I                  Tester.
 	 * @param   string|int       $urlOrPageID        URL or ID of Restricted Content Page.
-	 * @param   string           $visibleContent     Content that should always be visible.
-	 * @param   string           $memberContent      Content that should only be available to authenticated subscribers.
-	 * @param   bool|array       $textItems          Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 * @param   bool|array       $options {
+	 *           Optional. An array of settings.
+	 *
+	 *     @type string $visible_content            Content that should always be visible.
+	 *     @type string $member_content         	Content that should only be available to authenticated subscribers.
+	 *     @type array  $text_items 				Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 * }
 	 */
-	public function testRestrictedContentModalByProductOnFrontend($I, $urlOrPageID, $visibleContent = 'Visible content.', $memberContent = 'Member only content.', $textItems = false)
+	public function testRestrictedContentModalByProductOnFrontend($I, $urlOrPageID, $options = false)
 	{
-		// Define expected text and labels if not supplied.
-		if ( ! $textItems ) {
-			$textItems = $this->getRestrictedContentDefaultSettings();
-		}
+		// Merge options with defaults.
+		$options = $this->_getRestrictedContentOptionsWithDefaultsMerged($options);
 
 		// Navigate to the page.
 		if ( is_numeric( $urlOrPageID ) ) {
@@ -216,7 +241,7 @@ class ConvertKitRestrictContent extends \Codeception\Module
 		$I->seeInSource('<link rel="stylesheet" id="convertkit-restrict-content-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/restrict-content.css');
 
 		// Check content is not displayed, and CTA displays with expected text.
-		$this->testRestrictContentByProductHidesContentWithCTA($I, $visibleContent, $memberContent, $textItems);
+		$this->testRestrictContentByProductHidesContentWithCTA($I, $options);
 
 		// Login as a ConvertKit subscriber who does not exist in ConvertKit.
 		$I->click('a.convertkit-restrict-content-modal-open');
@@ -248,7 +273,7 @@ class ConvertKitRestrictContent extends \Codeception\Module
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// as if we entered the code sent in the email.
-		$this->testRestrictedContentShowsContentWithValidSubscriberID($I, $urlOrPageID, $visibleContent, $memberContent);
+		$this->testRestrictedContentShowsContentWithValidSubscriberID($I, $urlOrPageID, $options);
 	}
 
 	/**
@@ -260,13 +285,18 @@ class ConvertKitRestrictContent extends \Codeception\Module
 	 * @param   AcceptanceTester $I                  Tester.
 	 * @param   string|int       $urlOrPageID        URL or ID of Restricted Content Page.
 	 * @param   string           $emailAddress       Email Address.
-	 * @param   string           $visibleContent     Content that should always be visible.
-	 * @param   string           $memberContent      Content that should only be available to authenticated subscribers.
+	 * @param   bool|array       $options {
+	 *           Optional. An array of settings.
+	 *
+	 *     @type string $visible_content            Content that should always be visible.
+	 *     @type string $member_content         	Content that should only be available to authenticated subscribers.
+	 *     @type array  $text_items 				Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 * }
 	 */
-	public function testRestrictedContentByTagOnFrontend($I, $urlOrPageID, $emailAddress, $visibleContent = 'Visible content.', $memberContent = 'Member only content.')
+	public function testRestrictedContentByTagOnFrontend($I, $urlOrPageID, $emailAddress, $options = false)
 	{
-		// Get default settings.
-		$textItems = $this->getRestrictedContentDefaultSettings();
+		// Merge options with defaults.
+		$options = $this->_getRestrictedContentOptionsWithDefaultsMerged($options);
 
 		// Navigate to the page.
 		if ( is_numeric( $urlOrPageID ) ) {
@@ -286,14 +316,14 @@ class ConvertKitRestrictContent extends \Codeception\Module
 		$I->seeInSource('<link rel="stylesheet" id="convertkit-restrict-content-css" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/restrict-content.css');
 
 		// Confirm that the visible text displays, hidden text does not display and the CTA displays.
-		$I->see($visibleContent);
-		$I->dontSee($memberContent);
+		$I->see($options['visible_content']);
+		$I->dontSee($options['member_content']);
 
 		// Confirm that the CTA displays with the expected headings, text and other elements.
 		$I->seeElementInDOM('#convertkit-restrict-content');
-		$I->seeInSource('<h3>' . $textItems['subscribe_heading_tag'] . '</h3>');
-		$I->see($textItems['subscribe_text_tag']);
-		$I->seeInSource('<input type="submit" class="wp-block-button__link wp-block-button__link" value="' . $textItems['subscribe_button_label'] . '">');
+		$I->seeInSource('<h3>' . $options['text_items']['subscribe_heading_tag'] . '</h3>');
+		$I->see($options['text_items']['subscribe_text_tag']);
+		$I->seeInSource('<input type="submit" class="wp-block-button__link wp-block-button__link" value="' . $options['text_items']['subscribe_button_label'] . '">');
 
 		// Enter the email address and submit the form.
 		$I->fillField('convertkit_email', $emailAddress);
@@ -303,7 +333,7 @@ class ConvertKitRestrictContent extends \Codeception\Module
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the restricted content is now displayed.
-		$I->testRestrictContentDisplaysContent($I, $visibleContent, $memberContent);
+		$I->testRestrictContentDisplaysContent($I, $options);
 	}
 
 	/**
@@ -314,10 +344,15 @@ class ConvertKitRestrictContent extends \Codeception\Module
 	 *
 	 * @param   AcceptanceTester $I                  Tester.
 	 * @param   string|int       $urlOrPageID        URL or ID of Restricted Content Page.
-	 * @param   string           $visibleContent     Content that should always be visible.
-	 * @param   string           $memberContent      Content that should only be available to authenticated subscribers.
+	 * @param   bool|array       $options {
+	 *           Optional. An array of settings.
+	 *
+	 *     @type string $visible_content            Content that should always be visible.
+	 *     @type string $member_content         	Content that should only be available to authenticated subscribers.
+	 *     @type array  $text_items 				Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 * }
 	 */
-	public function testRestrictedContentShowsContentWithValidSubscriberID($I, $urlOrPageID, $visibleContent, $memberContent)
+	public function testRestrictedContentShowsContentWithValidSubscriberID($I, $urlOrPageID, $options = false)
 	{
 		// Set cookie with signed subscriber ID, as if we entered the code sent in the email.
 		$I->setCookie('ck_subscriber_id', $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID']);
@@ -334,7 +369,7 @@ class ConvertKitRestrictContent extends \Codeception\Module
 
 		// Confirm that the restricted content is now displayed, as we've authenticated as a subscriber
 		// who has access to this Product.
-		$I->testRestrictContentDisplaysContent($I, $visibleContent, $memberContent);
+		$I->testRestrictContentDisplaysContent($I, $options);
 	}
 
 	/**
@@ -346,38 +381,40 @@ class ConvertKitRestrictContent extends \Codeception\Module
 	 * @since   2.1.0
 	 *
 	 * @param   AcceptanceTester $I                  Tester.
-	 * @param   string           $visibleContent     Content that should always be visible.
-	 * @param   string           $memberContent      Content that should only be available to authenticated subscribers.
-	 * @param   bool|array       $textItems          Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 * @param   bool|array       $options {
+	 *           Optional. An array of settings.
+	 *
+	 *     @type string $visible_content            Content that should always be visible.
+	 *     @type string $member_content         	Content that should only be available to authenticated subscribers.
+	 *     @type array  $text_items 				Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 * }
 	 */
-	public function testRestrictContentByProductHidesContentWithCTA($I, $visibleContent = 'Visible content.', $memberContent = 'Member only content.', $textItems = false)
+	public function testRestrictContentByProductHidesContentWithCTA($I, $options = false)
 	{
-		// Define expected text and labels if not supplied.
-		if ( ! $textItems ) {
-			$textItems = $this->getRestrictedContentDefaultSettings();
-		}
+		// Merge options with defaults.
+		$options = $this->_getRestrictedContentOptionsWithDefaultsMerged($options);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the visible text displays, hidden text does not display and the CTA displays.
-		if ( ! empty($visibleContent)) {
-			$I->see($visibleContent);
+		if ( ! empty($options['visible_content'])) {
+			$I->see($options['visible_content']);
 		}
-		$I->dontSee($memberContent);
+		$I->dontSee($options['member_content']);
 
 		// Confirm that the CTA displays with the expected headings, text, buttons and other elements.
 		$I->seeElementInDOM('#convertkit-restrict-content');
 
-		$I->seeInSource('<h3>' . $textItems['subscribe_heading'] . '</h3>');
-		$I->see($textItems['subscribe_text']);
+		$I->seeInSource('<h3>' . $options['text_items']['subscribe_heading'] . '</h3>');
+		$I->see($options['text_items']['subscribe_text']);
 
-		$I->see($textItems['subscribe_button_label']);
+		$I->see($options['text_items']['subscribe_button_label']);
 		$I->seeInSource('<a href="' . $_ENV['CONVERTKIT_API_PRODUCT_URL'] . '" class="wp-block-button__link');
 
-		$I->see($textItems['email_text']);
-		$I->seeInSource('<input type="submit" class="wp-block-button__link wp-block-button__link" value="' . $textItems['email_button_label'] . '">');
-		$I->seeInSource('<small>' . $textItems['email_description_text'] . '</small>');
+		$I->see($options['text_items']['email_text']);
+		$I->seeInSource('<input type="submit" class="wp-block-button__link wp-block-button__link" value="' . $options['text_items']['email_button_label'] . '">');
+		$I->seeInSource('<small>' . $options['text_items']['email_description_text'] . '</small>');
 	}
 
 	/**
@@ -389,30 +426,32 @@ class ConvertKitRestrictContent extends \Codeception\Module
 	 * @since   2.1.0
 	 *
 	 * @param   AcceptanceTester $I                  Tester.
-	 * @param   string           $visibleContent     Content that should always be visible.
-	 * @param   string           $memberContent      Content that should only be available to authenticated subscribers.
-	 * @param   bool|array       $textItems          Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 * @param   bool|array       $options {
+	 *           Optional. An array of settings.
+	 *
+	 *     @type string $visible_content            Content that should always be visible.
+	 *     @type string $member_content         	Content that should only be available to authenticated subscribers.
+	 *     @type array  $text_items 				Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 * }
 	 */
-	public function testRestrictContentShowsEmailCodeForm($I, $visibleContent = 'Visible content.', $memberContent = 'Member only content.', $textItems)
+	public function testRestrictContentShowsEmailCodeForm($I, $options = false)
 	{
-		// Define expected text and labels if not supplied.
-		if ( ! $textItems ) {
-			$textItems = $this->getRestrictedContentDefaultSettings();
-		}
+		// Merge options with defaults.
+		$options = $this->_getRestrictedContentOptionsWithDefaultsMerged($options);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the visible text displays, hidden text does not display and the CTA displays.
-		if ( ! empty($visibleContent)) {
-			$I->see($visibleContent);
+		if ( ! empty($options['visible_content'])) {
+			$I->see($options['visible_content']);
 		}
-		$I->dontSee($memberContent);
+		$I->dontSee($options['member_content']);
 
 		// Confirm that the CTA displays with the expected text.
 		$I->seeElementInDOM('#convertkit-restrict-content');
-		$I->seeInSource('<h4>' . $textItems['email_check_heading'] . '</h4>');
-		$I->see($textItems['email_check_text']);
+		$I->seeInSource('<h4>' . $options['text_items']['email_check_heading'] . '</h4>');
+		$I->see($options['text_items']['email_check_text']);
 		$I->seeElementInDOM('input#convertkit_subscriber_code');
 		$I->seeElementInDOM('input.wp-block-button__link');
 
@@ -434,21 +473,62 @@ class ConvertKitRestrictContent extends \Codeception\Module
 	 * @since   2.1.0
 	 *
 	 * @param   AcceptanceTester $I                  Tester.
-	 * @param   string           $visibleContent     Content that should always be visible.
-	 * @param   string           $memberContent      Content that should only be available to authenticated subscribers.
+	 * @param   bool|array       $options {
+	 *           Optional. An array of settings.
+	 *
+	 *     @type string $visible_content            Content that should always be visible.
+	 *     @type string $member_content         	Content that should only be available to authenticated subscribers.
+	 *     @type array  $text_items 				Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 * }
 	 */
-	public function testRestrictContentDisplaysContent($I, $visibleContent = 'Visible content.', $memberContent = 'Member only content.')
+	public function testRestrictContentDisplaysContent($I, $options = false)
 	{
+		// Merge options with defaults.
+		$options = $this->_getRestrictedContentOptionsWithDefaultsMerged($options);
+
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the visible and hidden text displays.
-		if ( ! empty($visibleContent)) {
-			$I->see($visibleContent);
+		if ( ! empty($options['visible_content'])) {
+			$I->see($options['visible_content']);
 		}
-		$I->see($memberContent);
+		$I->see($options['member_content']);
 
 		// Confirm that the CTA is not displayed.
 		$I->dontSeeElementInDOM('#convertkit-restrict-content');
+	}
+
+	/**
+	 * Return an array of Restrict Content strings for tests, based on the optional supplied strings.
+	 *
+	 * @since   2.4.1
+	 *
+	 * @param   AcceptanceTester $I                  Tester.
+	 * @param   bool|array       $options {
+	 *           Optional. An array of settings.
+	 *
+	 *     @type string $visible_content            Content that should always be visible.
+	 *     @type string $member_content         	Content that should only be available to authenticated subscribers.
+	 *     @type array  $text_items 				Expected text for subscribe text, subscribe button label, email text etc. If not defined, uses expected defaults.
+	 * }
+	 */
+	private function _getRestrictedContentOptionsWithDefaultsMerged($options = false)
+	{
+		// Define default options for Restrict Content tests.
+		$defaults = [
+			'visible_content' => 'Visible content.',
+			'member_content'  => 'Member only content.',
+			'text_items' 	  => $this->getRestrictedContentDefaultSettings(),
+		];
+
+		// If supplied options are an array, merge them with the defaults.
+		if (is_array($options)) {
+			return array_merge($defaults, $options);
+		}
+
+		// Just return defaults.
+		return $defaults;
+
 	}
 }

--- a/tests/acceptance/restrict-content/RestrictContentCacheCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentCacheCest.php
@@ -46,7 +46,7 @@ class RestrictContentCacheCest
 		$pageID = $I->createRestrictedContentPage(
 			$I,
 			[
-				'post_title' => 'ConvertKit: Restrict Content: Product: LiteSpeed Cache',
+				'post_title'               => 'ConvertKit: Restrict Content: Product: LiteSpeed Cache',
 				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'],
 			]
 		);
@@ -95,7 +95,7 @@ class RestrictContentCacheCest
 		$pageID = $I->createRestrictedContentPage(
 			$I,
 			[
-				'post_title' => 'ConvertKit: Restrict Content: Product: W3 Total Cache',
+				'post_title'               => 'ConvertKit: Restrict Content: Product: W3 Total Cache',
 				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'],
 			]
 		);
@@ -142,7 +142,7 @@ class RestrictContentCacheCest
 		$pageID = $I->createRestrictedContentPage(
 			$I,
 			[
-				'post_title' => 'ConvertKit: Restrict Content: Product: WP Fastest Cache',
+				'post_title'               => 'ConvertKit: Restrict Content: Product: WP Fastest Cache',
 				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'],
 			]
 		);
@@ -189,7 +189,7 @@ class RestrictContentCacheCest
 		$pageID = $I->createRestrictedContentPage(
 			$I,
 			[
-				'post_title' => 'ConvertKit: Restrict Content: Product: WP-Optimize',
+				'post_title'               => 'ConvertKit: Restrict Content: Product: WP-Optimize',
 				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'],
 			]
 		);
@@ -236,7 +236,7 @@ class RestrictContentCacheCest
 		$pageID = $I->createRestrictedContentPage(
 			$I,
 			[
-				'post_title' => 'ConvertKit: Restrict Content: Product: WP Super Cache',
+				'post_title'               => 'ConvertKit: Restrict Content: Product: WP Super Cache',
 				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'],
 			]
 		);

--- a/tests/acceptance/restrict-content/RestrictContentCacheCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentCacheCest.php
@@ -59,11 +59,11 @@ class RestrictContentCacheCest
 
 		// Test that the restricted content CTA displays when no valid signed subscriber ID is used,
 		// to confirm caching does not show member only content.
-		$I->testRestrictContentByProductHidesContentWithCTA($I, $this->visibleContent, $this->memberContent);
+		$I->testRestrictContentByProductHidesContentWithCTA($I);
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// to confirm caching does not show the incorrect content.
-		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID, $this->visibleContent, $this->memberContent);
+		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID);
 
 		// Deactivate Litespeed Cache Plugin.
 		$I->deactivateThirdPartyPlugin($I, 'litespeed-cache');
@@ -108,11 +108,11 @@ class RestrictContentCacheCest
 
 		// Test that the restricted content CTA displays when no valid signed subscriber ID is used,
 		// to confirm caching does not show member only content.
-		$I->testRestrictContentByProductHidesContentWithCTA($I, $this->visibleContent, $this->memberContent);
+		$I->testRestrictContentByProductHidesContentWithCTA($I);
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// to confirm caching does not show the incorrect content.
-		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID, $this->visibleContent, $this->memberContent);
+		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID);
 
 		// Deactivate W3 Total Cache Plugin.
 		$I->deactivateThirdPartyPlugin($I, 'w3-total-cache');
@@ -155,11 +155,11 @@ class RestrictContentCacheCest
 
 		// Test that the restricted content CTA displays when no valid signed subscriber ID is used,
 		// to confirm caching does not show member only content.
-		$I->testRestrictContentByProductHidesContentWithCTA($I, $this->visibleContent, $this->memberContent);
+		$I->testRestrictContentByProductHidesContentWithCTA($I);
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// to confirm caching does not show the incorrect content.
-		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID, $this->visibleContent, $this->memberContent);
+		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID);
 
 		// Deactivate WP Fastest Cache Plugin.
 		$I->deactivateThirdPartyPlugin($I, 'wp-fastest-cache');
@@ -202,11 +202,11 @@ class RestrictContentCacheCest
 
 		// Test that the restricted content CTA displays when no valid signed subscriber ID is used,
 		// to confirm caching does not show member only content.
-		$I->testRestrictContentByProductHidesContentWithCTA($I, $this->visibleContent, $this->memberContent);
+		$I->testRestrictContentByProductHidesContentWithCTA($I);
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// to confirm caching does not show the incorrect content.
-		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID, $this->visibleContent, $this->memberContent);
+		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID);
 
 		// Deactivate WP-Optimize Cache Plugin.
 		$I->deactivateThirdPartyPlugin($I, 'wp-optimize');
@@ -249,11 +249,11 @@ class RestrictContentCacheCest
 
 		// Test that the restricted content CTA displays when no valid signed subscriber ID is used,
 		// to confirm caching does not show member only content.
-		$I->testRestrictContentByProductHidesContentWithCTA($I, $this->visibleContent, $this->memberContent);
+		$I->testRestrictContentByProductHidesContentWithCTA($I);
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// to confirm caching does not show the incorrect content.
-		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID, $this->visibleContent, $this->memberContent);
+		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $pageID);
 
 		// Deactivate WP Super Cache Plugin.
 		$I->deactivateThirdPartyPlugin($I, 'wp-super-cache');

--- a/tests/acceptance/restrict-content/RestrictContentCacheCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentCacheCest.php
@@ -8,24 +8,6 @@
 class RestrictContentCacheCest
 {
 	/**
-	 * The visible content to all users.
-	 *
-	 * @since   2.2.2
-	 *
-	 * @var     string
-	 */
-	public $visibleContent = 'Visible content';
-
-	/**
-	 * The content only available to authorized users.
-	 *
-	 * @since   2.2.2
-	 *
-	 * @var     string
-	 */
-	public $memberContent = 'Member only content.';
-
-	/**
 	 * Run common actions before running the test functions in this class.
 	 *
 	 * @since   2.2.2
@@ -63,11 +45,10 @@ class RestrictContentCacheCest
 		// Create Restricted Content Page.
 		$pageID = $I->createRestrictedContentPage(
 			$I,
-			'page',
-			'ConvertKit: Restrict Content: Product: LiteSpeed Cache',
-			$this->visibleContent,
-			$this->memberContent,
-			'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+			[
+				'post_title' => 'ConvertKit: Restrict Content: Product: LiteSpeed Cache',
+				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+			]
 		);
 
 		// Log out, so that caching is honored.
@@ -113,11 +94,10 @@ class RestrictContentCacheCest
 		// Create Restricted Content Page.
 		$pageID = $I->createRestrictedContentPage(
 			$I,
-			'page',
-			'ConvertKit: Restrict Content: Product: W3 Total Cache',
-			$this->visibleContent,
-			$this->memberContent,
-			'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+			[
+				'post_title' => 'ConvertKit: Restrict Content: Product: W3 Total Cache',
+				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+			]
 		);
 
 		// Log out, so that caching is honored.
@@ -161,11 +141,10 @@ class RestrictContentCacheCest
 		// Create Restricted Content Page.
 		$pageID = $I->createRestrictedContentPage(
 			$I,
-			'page',
-			'ConvertKit: Restrict Content: Product: WP Fastest Cache',
-			$this->visibleContent,
-			$this->memberContent,
-			'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+			[
+				'post_title' => 'ConvertKit: Restrict Content: Product: WP Fastest Cache',
+				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+			]
 		);
 
 		// Log out, so that caching is honored.
@@ -209,11 +188,10 @@ class RestrictContentCacheCest
 		// Create Restricted Content Page.
 		$pageID = $I->createRestrictedContentPage(
 			$I,
-			'page',
-			'ConvertKit: Restrict Content: Product: WP-Optimize',
-			$this->visibleContent,
-			$this->memberContent,
-			'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+			[
+				'post_title' => 'ConvertKit: Restrict Content: Product: WP-Optimize',
+				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+			]
 		);
 
 		// Log out, so that caching is honored.
@@ -257,11 +235,10 @@ class RestrictContentCacheCest
 		// Create Restricted Content Page.
 		$pageID = $I->createRestrictedContentPage(
 			$I,
-			'page',
-			'ConvertKit: Restrict Content: Product: WP Super Cache',
-			$this->visibleContent,
-			$this->memberContent,
-			'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+			[
+				'post_title' => 'ConvertKit: Restrict Content: Product: WP Super Cache',
+				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+			]
 		);
 
 		// Log out, so that caching is honored.

--- a/tests/acceptance/restrict-content/RestrictContentFilterPageCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentFilterPageCest.php
@@ -76,11 +76,10 @@ class RestrictContentFilterPageCest
 		// Create Page, set to restrict content to a Product.
 		$I->createRestrictedContentPage(
 			$I,
-			'page',
-			'ConvertKit: Page: Restricted Content: Product: Filter Test',
-			'Visible content.',
-			'Member only content.',
-			'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+			[
+				'post_title' => 'ConvertKit: Page: Restricted Content: Product: Filter Test',
+				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+			]
 		);
 
 		// Navigate to Pages.

--- a/tests/acceptance/restrict-content/RestrictContentFilterPageCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentFilterPageCest.php
@@ -77,7 +77,7 @@ class RestrictContentFilterPageCest
 		$I->createRestrictedContentPage(
 			$I,
 			[
-				'post_title' => 'ConvertKit: Page: Restricted Content: Product: Filter Test',
+				'post_title'               => 'ConvertKit: Page: Restricted Content: Product: Filter Test',
 				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'],
 			]
 		);

--- a/tests/acceptance/restrict-content/RestrictContentFilterPostCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentFilterPostCest.php
@@ -76,11 +76,11 @@ class RestrictContentFilterPostCest
 		// Create Post, set to restrict content to a Product.
 		$I->createRestrictedContentPage(
 			$I,
-			'post',
-			'ConvertKit: Post: Restricted Content: Product: Filter Test',
-			'Visible content.',
-			'Member only content.',
-			'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+			[
+				'post_type' => 'post',
+				'post_title' => 'ConvertKit: Post: Restricted Content: Product: Filter Test',
+				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+			]
 		);
 
 		// Navigate to Posts.

--- a/tests/acceptance/restrict-content/RestrictContentFilterPostCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentFilterPostCest.php
@@ -77,8 +77,8 @@ class RestrictContentFilterPostCest
 		$I->createRestrictedContentPage(
 			$I,
 			[
-				'post_type' => 'post',
-				'post_title' => 'ConvertKit: Post: Restricted Content: Product: Filter Test',
+				'post_type'                => 'post',
+				'post_title'               => 'ConvertKit: Post: Restricted Content: Product: Filter Test',
 				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'],
 			]
 		);

--- a/tests/acceptance/restrict-content/RestrictContentProductPageCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentProductPageCest.php
@@ -130,7 +130,7 @@ class RestrictContentProductPageCest
 			$url,
 			[
 				'visible_content' => $visibleContent,
-				'member_content' => $memberOnlyContent,
+				'member_content'  => $memberOnlyContent,
 			]
 		);
 	}
@@ -194,8 +194,8 @@ class RestrictContentProductPageCest
 		$pageID = $I->createRestrictedContentPage(
 			$I,
 			[
-				'post_title' => 'ConvertKit: Page: Restrict Content: Invalid Product',
-				'restrict_content_setting' => 'product_12345' // A fake Product that does not exist in ConvertKit.
+				'post_title'               => 'ConvertKit: Page: Restrict Content: Invalid Product',
+				'restrict_content_setting' => 'product_12345', // A fake Product that does not exist in ConvertKit.
 			]
 		);
 

--- a/tests/acceptance/restrict-content/RestrictContentProductPageCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentProductPageCest.php
@@ -83,12 +83,7 @@ class RestrictContentProductPageCest
 		$url = $I->publishGutenbergPage($I);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentByProductOnFrontend(
-			$I,
-			$url,
-			'Visible content.',
-			'Member only content.'
-		);
+		$I->testRestrictedContentByProductOnFrontend($I, $url);
 	}
 
 	/**
@@ -133,8 +128,10 @@ class RestrictContentProductPageCest
 		$I->testRestrictedContentByProductOnFrontend(
 			$I,
 			$url,
-			$visibleContent,
-			$memberOnlyContent
+			[
+				'visible_content' => $visibleContent,
+				'member_content' => $memberOnlyContent,
+			]
 		);
 	}
 
@@ -174,12 +171,7 @@ class RestrictContentProductPageCest
 		$url = $I->publishGutenbergPage($I);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentModalByProductOnFrontend(
-			$I,
-			$url,
-			'Visible content.',
-			'Member only content.'
-		);
+		$I->testRestrictedContentModalByProductOnFrontend($I, $url);
 	}
 
 	/**

--- a/tests/acceptance/restrict-content/RestrictContentProductPageCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentProductPageCest.php
@@ -201,11 +201,10 @@ class RestrictContentProductPageCest
 		// Programmatically create a Page.
 		$pageID = $I->createRestrictedContentPage(
 			$I,
-			'page',
-			'ConvertKit: Page: Restrict Content: Invalid Product',
-			'Visible content.',
-			'Member only content.',
-			'product_12345' // A fake Product that does not exist in ConvertKit.
+			[
+				'post_title' => 'ConvertKit: Page: Restrict Content: Invalid Product',
+				'restrict_content_setting' => 'product_12345' // A fake Product that does not exist in ConvertKit.
+			]
 		);
 
 		// Navigate to the page.
@@ -229,7 +228,12 @@ class RestrictContentProductPageCest
 		$I->setupConvertKitPluginDisableJS($I);
 
 		// Programmatically create a Page.
-		$pageID = $I->createRestrictedContentPage($I, 'page', 'ConvertKit: Page: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Quick Edit');
+		$pageID = $I->createRestrictedContentPage(
+			$I,
+			[
+				'post_title' => 'ConvertKit: Page: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Quick Edit',
+			]
+		);
 
 		// Quick Edit the Page in the Pages WP_List_Table.
 		$I->quickEdit(
@@ -260,8 +264,18 @@ class RestrictContentProductPageCest
 
 		// Programmatically create two Pages.
 		$pageIDs = array(
-			$I->createRestrictedContentPage($I, 'page', 'ConvertKit: Page: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Bulk Edit #1'),
-			$I->createRestrictedContentPage($I, 'page', 'ConvertKit: Page: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Bulk Edit #2'),
+			$I->createRestrictedContentPage(
+				$I,
+				[
+					'post_title' => 'ConvertKit: Page: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Bulk Edit #1',
+				]
+			),
+			$I->createRestrictedContentPage(
+				$I,
+				[
+					'post_title' => 'ConvertKit: Page: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Bulk Edit #2',
+				]
+			),
 		);
 
 		// Bulk Edit the Pages in the Pages WP_List_Table.

--- a/tests/acceptance/restrict-content/RestrictContentProductPostCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentProductPostCest.php
@@ -255,14 +255,14 @@ class RestrictContentProductPostCest
 		// Setup ConvertKit Plugin, disabling JS.
 		$I->setupConvertKitPluginDisableJS($I);
 
-		// Programmatically create a Page.
+		// Programmatically create a Post.
 		$postID = $I->createRestrictedContentPage(
 			$I,
-			'post',
-			'ConvertKit: Post: Restrict Content: Invalid Product',
-			'Visible content.',
-			'Member only content.',
-			'product_12345' // A fake Product that does not exist in ConvertKit.
+			[
+				'post_type' => 'post',
+				'post_title' => 'ConvertKit: Post: Restrict Content: Invalid Product',
+				'restrict_content_setting' => 'product_12345' // A fake Product that does not exist in ConvertKit.
+			]
 		);
 
 		// Navigate to the post.
@@ -288,8 +288,10 @@ class RestrictContentProductPostCest
 		// Programmatically create a Post.
 		$postID = $I->createRestrictedContentPage(
 			$I,
-			'post',
-			'ConvertKit: Post: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Quick Edit'
+			[
+				'post_type' => 'post',
+				'post_title' => 'ConvertKit: Post: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Quick Edit'
+			]
 		);
 
 		// Quick Edit the Post in the Posts WP_List_Table.
@@ -321,8 +323,20 @@ class RestrictContentProductPostCest
 
 		// Programmatically create two Posts.
 		$postIDs = array(
-			$I->createRestrictedContentPage($I, 'post', 'ConvertKit: Post: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Bulk Edit #1'),
-			$I->createRestrictedContentPage($I, 'post', 'ConvertKit: Post: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Bulk Edit #2'),
+			$I->createRestrictedContentPage(
+				$I,
+				[
+					'post_type' => 'post',
+					'post_title' => 'ConvertKit: Post: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Bulk Edit #1'
+				]
+			),
+			$I->createRestrictedContentPage(
+				$I,
+				[
+					'post_type' => 'post',
+					'post_title' => 'ConvertKit: Post: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Bulk Edit #2'
+				]
+			),
 		);
 
 		// Bulk Edit the Posts in the Posts WP_List_Table.

--- a/tests/acceptance/restrict-content/RestrictContentProductPostCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentProductPostCest.php
@@ -130,7 +130,7 @@ class RestrictContentProductPostCest
 			$url,
 			[
 				'visible_content' => $visibleContent,
-				'member_content' => $memberOnlyContent,
+				'member_content'  => $memberOnlyContent,
 			]
 		);
 	}
@@ -185,7 +185,7 @@ class RestrictContentProductPostCest
 			$I,
 			[
 				'visible_content' => $excerpt,
-				'member_content' => $memberOnlyContent,
+				'member_content'  => $memberOnlyContent,
 			]
 		);
 
@@ -197,7 +197,7 @@ class RestrictContentProductPostCest
 			$url,
 			[
 				'visible_content' => '',
-				'member_content' => $memberOnlyContent,
+				'member_content'  => $memberOnlyContent,
 			]
 		);
 
@@ -264,9 +264,9 @@ class RestrictContentProductPostCest
 		$postID = $I->createRestrictedContentPage(
 			$I,
 			[
-				'post_type' => 'post',
-				'post_title' => 'ConvertKit: Post: Restrict Content: Invalid Product',
-				'restrict_content_setting' => 'product_12345' // A fake Product that does not exist in ConvertKit.
+				'post_type'                => 'post',
+				'post_title'               => 'ConvertKit: Post: Restrict Content: Invalid Product',
+				'restrict_content_setting' => 'product_12345', // A fake Product that does not exist in ConvertKit.
 			]
 		);
 
@@ -294,8 +294,8 @@ class RestrictContentProductPostCest
 		$postID = $I->createRestrictedContentPage(
 			$I,
 			[
-				'post_type' => 'post',
-				'post_title' => 'ConvertKit: Post: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Quick Edit'
+				'post_type'  => 'post',
+				'post_title' => 'ConvertKit: Post: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Quick Edit',
 			]
 		);
 
@@ -331,15 +331,15 @@ class RestrictContentProductPostCest
 			$I->createRestrictedContentPage(
 				$I,
 				[
-					'post_type' => 'post',
-					'post_title' => 'ConvertKit: Post: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Bulk Edit #1'
+					'post_type'  => 'post',
+					'post_title' => 'ConvertKit: Post: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Bulk Edit #1',
 				]
 			),
 			$I->createRestrictedContentPage(
 				$I,
 				[
-					'post_type' => 'post',
-					'post_title' => 'ConvertKit: Post: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Bulk Edit #2'
+					'post_type'  => 'post',
+					'post_title' => 'ConvertKit: Post: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Bulk Edit #2',
 				]
 			),
 		);

--- a/tests/acceptance/restrict-content/RestrictContentProductPostCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentProductPostCest.php
@@ -83,12 +83,7 @@ class RestrictContentProductPostCest
 		$url = $I->publishGutenbergPage($I);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentByProductOnFrontend(
-			$I,
-			$url,
-			'Visible content.',
-			'Member only content.'
-		);
+		$I->testRestrictedContentByProductOnFrontend($I, $url);
 	}
 
 	/**
@@ -133,8 +128,10 @@ class RestrictContentProductPostCest
 		$I->testRestrictedContentByProductOnFrontend(
 			$I,
 			$url,
-			$visibleContent,
-			$memberOnlyContent
+			[
+				'visible_content' => $visibleContent,
+				'member_content' => $memberOnlyContent,
+			]
 		);
 	}
 
@@ -184,12 +181,25 @@ class RestrictContentProductPostCest
 
 		// Test Restrict Content functionality.
 		// Check content is not displayed, and CTA displays with expected text.
-		$I->testRestrictContentByProductHidesContentWithCTA($I, $excerpt, $memberOnlyContent);
+		$I->testRestrictContentByProductHidesContentWithCTA(
+			$I,
+			[
+				'visible_content' => $excerpt,
+				'member_content' => $memberOnlyContent,
+			]
+		);
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
 		// as if we entered the code sent in the email.
 		// Excerpt should not be displayed, as its an excerpt, and we now show the member content instead.
-		$I->testRestrictedContentShowsContentWithValidSubscriberID($I, $url, '', $memberOnlyContent);
+		$I->testRestrictedContentShowsContentWithValidSubscriberID(
+			$I,
+			$url,
+			[
+				'visible_content' => '',
+				'member_content' => $memberOnlyContent,
+			]
+		);
 
 		// Assert that the excerpt is no longer displayed.
 		$I->dontSee($excerpt);
@@ -231,12 +241,7 @@ class RestrictContentProductPostCest
 		$url = $I->publishGutenbergPage($I);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentModalByProductOnFrontend(
-			$I,
-			$url,
-			'Visible content.',
-			'Member only content.'
-		);
+		$I->testRestrictedContentModalByProductOnFrontend($I, $url);
 	}
 
 	/**

--- a/tests/acceptance/restrict-content/RestrictContentSettingsCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentSettingsCest.php
@@ -50,10 +50,6 @@ class RestrictContentSettingsCest
 	 */
 	public function testSaveDefaultSettings(AcceptanceTester $I)
 	{
-		// Define visible and member only content.
-		$visibleContent = 'Visible content.';
-		$memberContent  = 'Member only content.';
-
 		// Save settings.
 		$this->_setupConvertKitPluginRestrictContent($I);
 
@@ -66,15 +62,14 @@ class RestrictContentSettingsCest
 		// Create Restricted Content Page.
 		$pageID = $I->createRestrictedContentPage(
 			$I,
-			'page',
-			'ConvertKit: Restrict Content: Settings',
-			$visibleContent,
-			$memberContent,
-			'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+			[
+				'post_title' => 'ConvertKit: Restrict Content: Settings',
+				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+			]
 		);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentByProductOnFrontend($I, $pageID, $visibleContent, $memberContent);
+		$I->testRestrictedContentByProductOnFrontend($I, $pageID);
 	}
 
 	/**
@@ -87,10 +82,6 @@ class RestrictContentSettingsCest
 	 */
 	public function testSaveBlankSettings(AcceptanceTester $I)
 	{
-		// Define visible and member only content.
-		$visibleContent = 'Visible content.';
-		$memberContent  = 'Member only content.';
-
 		// Define settings.
 		$settings = array(
 			// Restrict by Product.
@@ -124,15 +115,14 @@ class RestrictContentSettingsCest
 		// Create Restricted Content Page.
 		$pageID = $I->createRestrictedContentPage(
 			$I,
-			'page',
-			'ConvertKit: Restrict Content: Settings: Blank',
-			$visibleContent,
-			$memberContent,
-			'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+			[
+				'post_title' => 'ConvertKit: Restrict Content: Settings: Blank',
+				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+			]
 		);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentByProductOnFrontend($I, $pageID, $visibleContent, $memberContent);
+		$I->testRestrictedContentByProductOnFrontend($I, $pageID);
 	}
 
 	/**
@@ -145,10 +135,6 @@ class RestrictContentSettingsCest
 	 */
 	public function testSaveSettings(AcceptanceTester $I)
 	{
-		// Define visible and member only content.
-		$visibleContent = 'Visible content.';
-		$memberContent  = 'Member only content.';
-
 		// Define settings.
 		$settings = array(
 			// Restrict by Product.
@@ -181,15 +167,16 @@ class RestrictContentSettingsCest
 		// Create Restricted Content Page.
 		$pageID = $I->createRestrictedContentPage(
 			$I,
-			'page',
-			'ConvertKit: Restrict Content: Settings: Custom',
-			$visibleContent,
-			$memberContent,
-			'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+			[
+				'post_title' => 'ConvertKit: Restrict Content: Settings: Custom',
+				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+			]
 		);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentByProductOnFrontend($I, $pageID, $visibleContent, $memberContent, $settings);
+		$I->testRestrictedContentByProductOnFrontend($I, $pageID, [
+			'text_items' => $settings
+		]);
 	}
 
 	/**
@@ -209,11 +196,10 @@ class RestrictContentSettingsCest
 		// Create Restricted Content Page.
 		$pageID = $I->createRestrictedContentPage(
 			$I,
-			'page',
-			'ConvertKit: Restrict Content: Settings: Custom',
-			'Visible content.',
-			'Member only content.',
-			'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+			[
+				'post_title' => 'ConvertKit: Restrict Content: Settings: Custom',
+				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+			]
 		);
 
 		// Confirm no CSS is output by the Plugin.

--- a/tests/acceptance/restrict-content/RestrictContentSettingsCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentSettingsCest.php
@@ -63,8 +63,8 @@ class RestrictContentSettingsCest
 		$pageID = $I->createRestrictedContentPage(
 			$I,
 			[
-				'post_title' => 'ConvertKit: Restrict Content: Settings',
-				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+				'post_title'               => 'ConvertKit: Restrict Content: Settings',
+				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'],
 			]
 		);
 
@@ -116,8 +116,8 @@ class RestrictContentSettingsCest
 		$pageID = $I->createRestrictedContentPage(
 			$I,
 			[
-				'post_title' => 'ConvertKit: Restrict Content: Settings: Blank',
-				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+				'post_title'               => 'ConvertKit: Restrict Content: Settings: Blank',
+				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'],
 			]
 		);
 
@@ -168,15 +168,19 @@ class RestrictContentSettingsCest
 		$pageID = $I->createRestrictedContentPage(
 			$I,
 			[
-				'post_title' => 'ConvertKit: Restrict Content: Settings: Custom',
-				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+				'post_title'               => 'ConvertKit: Restrict Content: Settings: Custom',
+				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'],
 			]
 		);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentByProductOnFrontend($I, $pageID, [
-			'text_items' => $settings
-		]);
+		$I->testRestrictedContentByProductOnFrontend(
+			$I,
+			$pageID,
+			[
+				'text_items' => $settings,
+			]
+		);
 	}
 
 	/**
@@ -197,8 +201,8 @@ class RestrictContentSettingsCest
 		$pageID = $I->createRestrictedContentPage(
 			$I,
 			[
-				'post_title' => 'ConvertKit: Restrict Content: Settings: Custom',
-				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID']
+				'post_title'               => 'ConvertKit: Restrict Content: Settings: Custom',
+				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'],
 			]
 		);
 

--- a/tests/acceptance/restrict-content/RestrictContentSetupCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentSetupCest.php
@@ -275,7 +275,7 @@ class RestrictContentSetupCest
 			$url,
 			[
 				'visible_content' => 'Some introductory text about lesson 1',
-				'member_content' => 'Lesson 1 content (that is available when the visitor has paid for the ConvertKit product) goes here.',
+				'member_content'  => 'Lesson 1 content (that is available when the visitor has paid for the ConvertKit product) goes here.',
 			]
 		);
 
@@ -426,7 +426,7 @@ class RestrictContentSetupCest
 			$I->generateEmailAddress(),
 			[
 				'visible_content' => 'Some introductory text about lesson 1',
-				'member_content' => 'Lesson 1 content (that is available when the visitor has paid for the ConvertKit product) goes here.'
+				'member_content'  => 'Lesson 1 content (that is available when the visitor has paid for the ConvertKit product) goes here.',
 			]
 		);
 

--- a/tests/acceptance/restrict-content/RestrictContentSetupCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentSetupCest.php
@@ -205,8 +205,9 @@ class RestrictContentSetupCest
 		$I->testRestrictedContentByProductOnFrontend(
 			$I,
 			$url,
-			'Visible content.',
-			'The downloadable content (that is available when the visitor has paid for the ConvertKit product) goes here.'
+			[
+				'member_content' => 'The downloadable content (that is available when the visitor has paid for the ConvertKit product) goes here.',
+			]
 		);
 	}
 
@@ -272,8 +273,10 @@ class RestrictContentSetupCest
 		$I->testRestrictedContentByProductOnFrontend(
 			$I,
 			$url,
-			'Some introductory text about lesson 1',
-			'Lesson 1 content (that is available when the visitor has paid for the ConvertKit product) goes here.'
+			[
+				'visible_content' => 'Some introductory text about lesson 1',
+				'member_content' => 'Lesson 1 content (that is available when the visitor has paid for the ConvertKit product) goes here.',
+			]
 		);
 
 		// Test Next / Previous links.
@@ -352,8 +355,9 @@ class RestrictContentSetupCest
 			$I,
 			$url,
 			$I->generateEmailAddress(),
-			'Visible content.',
-			'The downloadable content (that is available when the visitor has paid for the ConvertKit product) goes here.'
+			[
+				'member_content' => 'The downloadable content (that is available when the visitor has paid for the ConvertKit product) goes here.',
+			]
 		);
 	}
 
@@ -420,8 +424,10 @@ class RestrictContentSetupCest
 			$I,
 			$url,
 			$I->generateEmailAddress(),
-			'Some introductory text about lesson 1',
-			'Lesson 1 content (that is available when the visitor has paid for the ConvertKit product) goes here.'
+			[
+				'visible_content' => 'Some introductory text about lesson 1',
+				'member_content' => 'Lesson 1 content (that is available when the visitor has paid for the ConvertKit product) goes here.'
+			]
 		);
 
 		// Test Next / Previous links.

--- a/tests/acceptance/restrict-content/RestrictContentTagCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentTagCest.php
@@ -77,11 +77,10 @@ class RestrictContentTagCest
 		// Programmatically create a Page.
 		$pageID = $I->createRestrictedContentPage(
 			$I,
-			'page',
-			'ConvertKit: Page: Restrict Content: Invalid Tag',
-			'Visible content.',
-			'Member only content.',
-			'tag_12345' // A fake Tag that does not exist in ConvertKit.
+			[
+				'post_title' => 'ConvertKit: Page: Restrict Content: Invalid Tag',
+				'restrict_content_setting' => 'tag_12345' // A fake Tag that does not exist in ConvertKit.
+			]
 		);
 
 		// Navigate to the page.
@@ -102,7 +101,12 @@ class RestrictContentTagCest
 	public function testRestrictContentByTagUsingQuickEdit(AcceptanceTester $I)
 	{
 		// Programmatically create a Page.
-		$pageID = $I->createRestrictedContentPage($I, 'page', 'ConvertKit: Page: Restrict Content: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Quick Edit');
+		$pageID = $I->createRestrictedContentPage(
+			$I,
+			[
+				'post_title' => 'ConvertKit: Page: Restrict Content: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Quick Edit',
+			]
+		);
 
 		// Quick Edit the Page in the Pages WP_List_Table.
 		$I->quickEdit(
@@ -130,8 +134,18 @@ class RestrictContentTagCest
 	{
 		// Programmatically create two Pages.
 		$pageIDs = array(
-			$I->createRestrictedContentPage($I, 'page', 'ConvertKit: Page: Restrict Content: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit #1'),
-			$I->createRestrictedContentPage($I, 'page', 'ConvertKit: Page: Restrict Content: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit #2'),
+			$I->createRestrictedContentPage(
+				$I,
+				[
+					'post_title' => 'ConvertKit: Page: Restrict Content: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit #1',
+				]
+			),
+			$I->createRestrictedContentPage(
+				$I,
+				[
+					'post_title' => 'ConvertKit: Page: Restrict Content: Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ': Bulk Edit #2',
+				]
+			),
 		);
 
 		// Bulk Edit the Pages in the Pages WP_List_Table.

--- a/tests/acceptance/restrict-content/RestrictContentTagCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentTagCest.php
@@ -72,8 +72,8 @@ class RestrictContentTagCest
 		$pageID = $I->createRestrictedContentPage(
 			$I,
 			[
-				'post_title' => 'ConvertKit: Page: Restrict Content: Invalid Tag',
-				'restrict_content_setting' => 'tag_12345' // A fake Tag that does not exist in ConvertKit.
+				'post_title'               => 'ConvertKit: Page: Restrict Content: Invalid Tag',
+				'restrict_content_setting' => 'tag_12345', // A fake Tag that does not exist in ConvertKit.
 			]
 		);
 

--- a/tests/acceptance/restrict-content/RestrictContentTagCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentTagCest.php
@@ -52,13 +52,7 @@ class RestrictContentTagCest
 		$url = $I->publishGutenbergPage($I);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentByTagOnFrontend(
-			$I,
-			$url,
-			$I->generateEmailAddress(),
-			'Visible content.',
-			'Member only content.'
-		);
+		$I->testRestrictedContentByTagOnFrontend($I, $url, $I->generateEmailAddress());
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Refactors Restrict Content helper methods by accepting an array of named key/value pairs for optional arguments.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)