### PR TITLE
Tests: Update `php-webdriver`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "codeception/module-filesystem": "^1.0",                                   
         "codeception/module-cli": "^1.0",                                          
         "codeception/util-universalframework": "^1.0",
-        "php-webdriver/webdriver": "<=1.14.0",
+        "php-webdriver/webdriver": "^1.0",
         "wp-coding-standards/wpcs": "^3.0.0",
         "phpstan/phpstan": "^1.7",
         "szepeviktor/phpstan-wordpress": "^1.0",

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -75,7 +75,7 @@ modules:
             port: 9515
             window_size: 1920x1080
             capabilities:
-                chromeOptions:
+                goog:chromeOptions:
                     args: [
                         "--headless=new",
                         "--disable-gpu",


### PR DESCRIPTION
## Summary

Updates `php-webdriver` to the latest version `1.15.1`, now that the `goog:chromeOptions` key is supported upstream (originally fixed `php-webdriver` to `1.14.x` in [this PR](https://github.com/ConvertKit/convertkit-wordpress/pull/533)).

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)