### PR TITLE
Broadcasts: Frontend: Remove jQuery

### DIFF
--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -61,7 +61,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 		// Get ConvertKit Settings.
 		$settings = new ConvertKit_Settings();
 
-		wp_enqueue_script( 'convertkit-' . $this->get_name(), CONVERTKIT_PLUGIN_URL . 'resources/frontend/js/broadcasts.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
+		wp_enqueue_script( 'convertkit-' . $this->get_name(), CONVERTKIT_PLUGIN_URL . 'resources/frontend/js/broadcasts.js', array(), CONVERTKIT_PLUGIN_VERSION, true );
 		wp_localize_script(
 			'convertkit-' . $this->get_name(),
 			'convertkit_broadcasts',

--- a/resources/frontend/js/broadcasts.js
+++ b/resources/frontend/js/broadcasts.js
@@ -1,7 +1,7 @@
 /**
- * Frontend functionality for subscribers and tags.
+ * Frontend functionality for the Broadcasts block and shortcode.
  *
- * @since   1.9.6
+ * @since   1.9.7.4
  *
  * @package ConvertKit
  * @author ConvertKit

--- a/resources/frontend/js/broadcasts.js
+++ b/resources/frontend/js/broadcasts.js
@@ -10,41 +10,40 @@
 /**
  * Register events
  */
-jQuery( document ).ready(
-	function ( $ ) {
+document.addEventListener( 'DOMContentLoaded', () => {
 
-		$( document ).on(
-			'click',
-			'ul.convertkit-broadcasts-pagination a',
-			function ( e ) {
+	// Listen for click events.
+	document.addEventListener( 'click', (e) => {
 
-				e.preventDefault();
+		// If the click isn't on a broadcast pagination element, ignore it. 
+    	if ( e.target.matches( 'ul.convertkit-broadcasts-pagination a' ) ) {
+      		
+      		e.preventDefault();
 
-				// Get block container and build object of data-* attributes.
-				let blockContainer = $( this ).closest( 'div.convertkit-broadcasts' );
-				let atts           = {
-					display_date: $( blockContainer ).data( 'display-date' ),
-					date_format: $( blockContainer ).data( 'date-format' ),
-					display_image: $( blockContainer ).data( 'display-image' ),
-					display_description: $( blockContainer ).data( 'display-description' ),
-					display_read_more: $( blockContainer ).data( 'display-read-more' ),
-					read_more_label: $( blockContainer ).data( 'read-more-label' ),
-					limit: $( blockContainer ).data( 'limit' ),
-					paginate: $( blockContainer ).data( 'paginate' ),
-					paginate_label_prev: $( blockContainer ).data( 'paginate-label-prev' ),
-					paginate_label_next: $( blockContainer ).data( 'paginate-label-next' ),
-					link_color: $( blockContainer ).data( 'link-color' ),
-					page: $( this ).data( 'page' ), // Page is supplied as a data- attribute on the link clicked, not the container.
-					nonce: $( this ).data( 'nonce' ) // Nonce is supplied as a data- attribute on the link clicked, not the container.
-				};
+			// Get block container and build object of data-* attributes.
+			let blockContainer = e.target.closest( 'div.convertkit-broadcasts' );
+			let atts = {
+				display_date: blockContainer.dataset.displayDate,
+				date_format: blockContainer.dataset.dateFormat,
+				display_image: blockContainer.dataset.displayImage,
+				display_description: blockContainer.dataset.displayDescription,
+				display_read_more: blockContainer.dataset.displayReadMore,
+				read_more_label: blockContainer.dataset.readMoreLabel,
+				limit: blockContainer.dataset.limit,
+				paginate: blockContainer.dataset.paginate,
+				paginate_label_prev: blockContainer.dataset.paginateLabelPrev,
+				paginate_label_next: blockContainer.dataset.paginateLabelNext,
+				link_color: blockContainer.dataset.linkColor,
+				page: e.target.dataset.page,
+				nonce: e.target.dataset.nonce,
+			};
 
-				convertKitBroadcastsRender( blockContainer, atts );
+			convertKitBroadcastsRender( blockContainer, atts );
+		}
 
-			}
-		);
+	} );
 
-	}
-);
+} );
 
 /**
  * Sends an AJAX request to request HTML based on the supplied block attributes,
@@ -57,48 +56,50 @@ jQuery( document ).ready(
  */
 function convertKitBroadcastsRender( blockContainer, atts ) {
 
-	( function ( $ ) {
+	// Append action.
+	atts.action = convertkit_broadcasts.action;
 
-		// Append action.
-		atts.action = convertkit_broadcasts.action;
+	if ( convertkit_broadcasts.debug ) {
+		console.log( 'convertKitBroadcastsRender()' );
+		console.log( atts );
+	}
 
+	// Show loading indicator.
+	blockContainer.classList.add( 'convertkit-broadcasts-loading' );
+
+	// Fetch HTML.
+	fetch( convertkit_broadcasts.ajax_url, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/x-www-form-urlencoded',
+		},
+		body: new URLSearchParams( atts ),
+	} )
+	.then( ( response ) => {
 		if ( convertkit_broadcasts.debug ) {
-			console.log( 'convertKitBroadcastsRender()' );
-			console.log( atts );
+			console.log( response );
+		}
+		
+		return response.json();
+	} )
+	.then( ( result ) => {
+		if ( convertkit_broadcasts.debug ) {
+			console.log( result );
 		}
 
-		// Show loading indicator.
-		$( blockContainer ).addClass( 'convertkit-broadcasts-loading' );
+		// Remove loading indicator.
+		blockContainer.classList.remove( 'convertkit-broadcasts-loading' );
 
-		$.ajax(
-			{
-				url:        convertkit_broadcasts.ajax_url,
-				type:       'POST',
-				async:      true,
-				data:      	atts,
-				success: function ( result ) {
-					if ( convertkit_broadcasts.debug ) {
-						console.log( result );
-					}
+		// Replace block container's HTML with response data.
+		blockContainer.innerHTML = result.data;
+	} )
+	.catch( ( error ) => {
+		// Remove loading indicator.
+		blockContainer.classList.remove('convertkit-broadcasts-loading');
 
-					// Remove loading indicator.
-					$( blockContainer ).removeClass( 'convertkit-broadcasts-loading' );
-
-					// Replace block container's HTML with response data.
-					$( blockContainer ).html( result.data );
-				}
-			}
-		).fail(
-			function (response) {
-				// Remove loading indicator.
-				$( blockContainer ).removeClass( 'convertkit-broadcasts-loading' );
-
-				if ( convertkit.debug ) {
-					console.log( response );
-				}
-			}
-		);
-
-	} )( jQuery );
+		if ( convertkit.debug ) {
+			console.error( error );
+		}
+	} );
 
 }

--- a/resources/frontend/js/broadcasts.js
+++ b/resources/frontend/js/broadcasts.js
@@ -10,40 +10,43 @@
 /**
  * Register events
  */
-document.addEventListener( 'DOMContentLoaded', () => {
+document.addEventListener(
+	'DOMContentLoaded',
+	function () {
+		// Listen for click events.
+		document.addEventListener(
+			'click',
+			function (e) {
+				// Check the broadcasts pagination was clicked.
+				if ( e.target.matches( 'ul.convertkit-broadcasts-pagination a' ) ) {
 
-	// Listen for click events.
-	document.addEventListener( 'click', (e) => {
+					e.preventDefault();
 
-		// If the click isn't on a broadcast pagination element, ignore it. 
-    	if ( e.target.matches( 'ul.convertkit-broadcasts-pagination a' ) ) {
-      		
-      		e.preventDefault();
+					// Get block container and build object of data-* attributes.
+					let blockContainer = e.target.closest( 'div.convertkit-broadcasts' );
+					let atts           = {
+						display_date: blockContainer.dataset.displayDate,
+						date_format: blockContainer.dataset.dateFormat,
+						display_image: blockContainer.dataset.displayImage,
+						display_description: blockContainer.dataset.displayDescription,
+						display_read_more: blockContainer.dataset.displayReadMore,
+						read_more_label: blockContainer.dataset.readMoreLabel,
+						limit: blockContainer.dataset.limit,
+						paginate: blockContainer.dataset.paginate,
+						paginate_label_prev: blockContainer.dataset.paginateLabelPrev,
+						paginate_label_next: blockContainer.dataset.paginateLabelNext,
+						link_color: blockContainer.dataset.linkColor,
+						page: e.target.dataset.page,
+						nonce: e.target.dataset.nonce,
+					};
 
-			// Get block container and build object of data-* attributes.
-			let blockContainer = e.target.closest( 'div.convertkit-broadcasts' );
-			let atts = {
-				display_date: blockContainer.dataset.displayDate,
-				date_format: blockContainer.dataset.dateFormat,
-				display_image: blockContainer.dataset.displayImage,
-				display_description: blockContainer.dataset.displayDescription,
-				display_read_more: blockContainer.dataset.displayReadMore,
-				read_more_label: blockContainer.dataset.readMoreLabel,
-				limit: blockContainer.dataset.limit,
-				paginate: blockContainer.dataset.paginate,
-				paginate_label_prev: blockContainer.dataset.paginateLabelPrev,
-				paginate_label_next: blockContainer.dataset.paginateLabelNext,
-				link_color: blockContainer.dataset.linkColor,
-				page: e.target.dataset.page,
-				nonce: e.target.dataset.nonce,
-			};
+					convertKitBroadcastsRender( blockContainer, atts );
+				}
 
-			convertKitBroadcastsRender( blockContainer, atts );
-		}
-
-	} );
-
-} );
+			}
+		);
+	}
+);
 
 /**
  * Sends an AJAX request to request HTML based on the supplied block attributes,
@@ -68,38 +71,47 @@ function convertKitBroadcastsRender( blockContainer, atts ) {
 	blockContainer.classList.add( 'convertkit-broadcasts-loading' );
 
 	// Fetch HTML.
-	fetch( convertkit_broadcasts.ajax_url, {
-		method: 'POST',
-		headers: {
-			'Content-Type': 'application/x-www-form-urlencoded',
-		},
-		body: new URLSearchParams( atts ),
-	} )
-	.then( ( response ) => {
-		if ( convertkit_broadcasts.debug ) {
-			console.log( response );
+	fetch(
+		convertkit_broadcasts.ajax_url,
+		{
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams( atts ),
 		}
-		
-		return response.json();
-	} )
-	.then( ( result ) => {
-		if ( convertkit_broadcasts.debug ) {
-			console.log( result );
+	)
+	.then(
+		function ( response ) {
+			if ( convertkit_broadcasts.debug ) {
+				console.log( response );
+			}
+
+			return response.json();
 		}
+	)
+	.then(
+		function ( result ) {
+			if ( convertkit_broadcasts.debug ) {
+				console.log( result );
+			}
 
-		// Remove loading indicator.
-		blockContainer.classList.remove( 'convertkit-broadcasts-loading' );
+			// Remove loading indicator.
+			blockContainer.classList.remove( 'convertkit-broadcasts-loading' );
 
-		// Replace block container's HTML with response data.
-		blockContainer.innerHTML = result.data;
-	} )
-	.catch( ( error ) => {
-		// Remove loading indicator.
-		blockContainer.classList.remove('convertkit-broadcasts-loading');
-
-		if ( convertkit.debug ) {
-			console.error( error );
+			// Replace block container's HTML with response data.
+			blockContainer.innerHTML = result.data;
 		}
-	} );
+	)
+	.catch(
+		function ( error ) {
+			if ( convertkit.debug ) {
+				console.error( error );
+			}
+
+			// Remove loading indicator.
+			blockContainer.classList.remove( 'convertkit-broadcasts-loading' );
+		}
+	);
 
 }


### PR DESCRIPTION
## Summary

Replaces jQuery with vanilla JS for the frontend Broadcasts block and shortcode functionality.

Further PR's to follow for other frontend JS, with the goal to remove jQuery as a dependency. For sites that don't load jQuery via other Plugins / Theme, this will save loading ~ 100kb of dependencies.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)