### PR TITLE
Restrict Content: Frontend: Remove jQuery

### DIFF
--- a/includes/class-convertkit-output-restrict-content.php
+++ b/includes/class-convertkit-output-restrict-content.php
@@ -962,7 +962,7 @@ class ConvertKit_Output_Restrict_Content {
 		// Only load scripts if the Disable Scripts option is off.
 		if ( ! $this->settings->scripts_disabled() ) {
 			// Enqueue scripts.
-			wp_enqueue_script( 'convertkit-restrict-content', CONVERTKIT_PLUGIN_URL . 'resources/frontend/js/restrict-content.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
+			wp_enqueue_script( 'convertkit-restrict-content', CONVERTKIT_PLUGIN_URL . 'resources/frontend/js/restrict-content.js', array(), CONVERTKIT_PLUGIN_VERSION, true );
 			wp_localize_script(
 				'convertkit-restrict-content',
 				'convertkit_restrict_content',

--- a/resources/frontend/js/restrict-content.js
+++ b/resources/frontend/js/restrict-content.js
@@ -19,7 +19,7 @@ document.addEventListener(
 			function ( element ) {
 				element.addEventListener(
 					'click',
-					function( e ) {
+					function ( e ) {
 						e.preventDefault();
 						convertKitRestrictContentOpenModal();
 					}
@@ -30,36 +30,40 @@ document.addEventListener(
 		// Handle modal form submissions.
 		document.addEventListener(
 			'submit',
-			function( e ) {
+			function ( e ) {
 				// Bail if the submission was not for the Restrict Content form.
 				if ( ! e.target.matches( '#convertkit-restrict-content-modal form#convertkit-restrict-content-form' ) ) {
 					return;
 				}
 
 				e.preventDefault();
-				convertKitRestrictContentFormSubmit();
+				convertKitRestrictContentFormSubmit( e );
 			}
-			
 		);
 
 		// Close modal.
-		document.querySelector( '#convertkit-restrict-content-modal-close' ).addEventListener(
-			'click',
-			function( e ) {
-				e.preventDefault();
-				convertKitRestrictContentCloseModal();
-			}
-		);
+		// Check if the element exists on screen; if another JS error occurs, OTP submission might not be async,
+		// resulting in the non-JS OTP code screen loading without a modal (i.e. ?convertkit_login=1).
+		let convertKitRestrictContentCloseElement = document.querySelector( '#convertkit-restrict-content-modal-close' );
+		if ( convertKitRestrictContentCloseElement !== null ) {
+			convertKitRestrictContentCloseElement.addEventListener(
+				'click',
+				function ( e ) {
+					e.preventDefault();
+					convertKitRestrictContentCloseModal();
+				}
+			);
+		}
 
 	}
 );
 
 /**
  * Handles Restrict Content form submission.
- * 
+ *
  * @since 	2.4.2
- * 
- * @param 	object 	e 	Event
+ *
+ * @param 	Event 	e 	Form submission event.
  */
 function convertKitRestrictContentFormSubmit( e ) {
 
@@ -96,7 +100,7 @@ function convertKitRestrictContentFormSubmit( e ) {
 		e.target.querySelector( 'input[name="convertkit_resource_id"]' ).value,
 		e.target.querySelector( 'input[name="convertkit_post_id"]' ).value
 	);
-		
+
 }
 
 /**
@@ -240,7 +244,7 @@ function convertKitRestrictContentSubscriberVerification( nonce, subscriber_code
 	.then(
 		function ( result ) {
 			if ( convertkit_restrict_content.debug ) {
-					console.log( result );
+				console.log( result );
 			}
 
 			// If the entered code is invalid, show the response in the modal.
@@ -285,7 +289,7 @@ function convertKitRestrictContentOTPField() {
 	}
 
 	otpInput.addEventListener(
-		'change',
+		'input',
 		function () {
 			// Update the --_otp-digit property when the input value changes.
 			otpInput.style.setProperty( '--_otp-digit', otpInput.value.length );
@@ -297,7 +301,7 @@ function convertKitRestrictContentOTPField() {
 			if ( otpInput.value.length === 6 ) {
 				otpInput.setSelectionRange( 0, 0 );
 				otpInput.blur();
-				document.querySelector( '#convertkit-restrict-content-form' ).dispatchEvent( new Event( 'submit' ) );
+				document.querySelector( '#convertkit-restrict-content-form' ).requestSubmit();
 			}
 		}
 	);

--- a/resources/frontend/js/restrict-content.js
+++ b/resources/frontend/js/restrict-content.js
@@ -10,61 +10,42 @@
 /**
  * Register events
  */
-jQuery( document ).ready(
-	function ( $ ) {
+document.addEventListener(
+	'DOMContentLoaded',
+	function () {
 
 		// Open modal.
-		$( '.convertkit-restrict-content-modal-open' ).on(
-			'click',
-			function ( e ) {
-				e.preventDefault();
-				convertKitRestrictContentOpenModal();
+		document.querySelectorAll( '.convertkit-restrict-content-modal-open' ).forEach(
+			function ( element ) {
+				element.addEventListener(
+					'click',
+					function( e ) {
+						e.preventDefault();
+						convertKitRestrictContentOpenModal();
+					}
+				);
 			}
 		);
 
 		// Handle modal form submissions.
-		$( document ).on(
+		document.addEventListener(
 			'submit',
-			'#convertkit-restrict-content-modal form#convertkit-restrict-content-form',
-			function ( e ) {
-
-				e.preventDefault();
-
-				// Disable inputs.
-				$( 'input[type="text"], input[type="email"], input[type="submit"]' ).attr( 'disabled', 'disabled' );
-
-				// Show loading overlay.
-				$( '#convertkit-restrict-content-modal-loading' ).show();
-
-				// Determine if this is the email or code submission.
-				if ( $( 'input#convertkit_subscriber_code' ).length > 0 ) {
-					// Code submission.
-					convertKitRestrictContentSubscriberVerification(
-						$( 'input[name="_wpnonce"]' ).val(),
-						$( 'input[name="subscriber_code"]' ).val(),
-						$( 'input[name="token"]' ).val(),
-						$( 'input[name="convertkit_post_id"]' ).val()
-					);
-
-					return false;
+			function( e ) {
+				// Bail if the submission was not for the Restrict Content form.
+				if ( ! e.target.matches( '#convertkit-restrict-content-modal form#convertkit-restrict-content-form' ) ) {
+					return;
 				}
 
-				// Email submission.
-				convertKitRestrictContentSubscriberAuthenticationSendCode(
-					$( 'input[name="_wpnonce"]' ).val(),
-					$( 'input[name="convertkit_email"]' ).val(),
-					$( 'input[name="convertkit_resource_type"]' ).val(),
-					$( 'input[name="convertkit_resource_id"]' ).val(),
-					$( 'input[name="convertkit_post_id"]' ).val()
-				);
-
+				e.preventDefault();
+				convertKitRestrictContentFormSubmit();
 			}
+			
 		);
 
 		// Close modal.
-		$( '#convertkit-restrict-content-modal-close' ).on(
+		document.querySelector( '#convertkit-restrict-content-modal-close' ).addEventListener(
 			'click',
-			function ( e ) {
+			function( e ) {
 				e.preventDefault();
 				convertKitRestrictContentCloseModal();
 			}
@@ -74,6 +55,51 @@ jQuery( document ).ready(
 );
 
 /**
+ * Handles Restrict Content form submission.
+ * 
+ * @since 	2.4.2
+ * 
+ * @param 	object 	e 	Event
+ */
+function convertKitRestrictContentFormSubmit( e ) {
+
+	// Disable inputs.
+	document.querySelectorAll( 'input[type="text"], input[type="email"], input[type="submit"]' ).forEach(
+		function ( input ) {
+			input.setAttribute( 'disabled', 'disabled' );
+		}
+	);
+
+	// Show loading overlay.
+	document.querySelector( '#convertkit-restrict-content-modal-loading' ).style.display = 'block';
+
+	// Determine if this is the email or code submission.
+	let isCodeSubmission = document.querySelector( 'input#convertkit_subscriber_code' ) !== null;
+
+	if ( isCodeSubmission ) {
+		// Code submission.
+		convertKitRestrictContentSubscriberVerification(
+			e.target.querySelector( 'input[name="_wpnonce"]' ).value,
+			e.target.querySelector( 'input[name="subscriber_code"]' ).value,
+			e.target.querySelector( 'input[name="token"]' ).value,
+			e.target.querySelector( 'input[name="convertkit_post_id"]' ).value
+		);
+
+		return false;
+	}
+
+	// Email submission.
+	convertKitRestrictContentSubscriberAuthenticationSendCode(
+		e.target.querySelector( 'input[name="_wpnonce"]' ).value,
+		e.target.querySelector( 'input[name="convertkit_email"]' ).value,
+		e.target.querySelector( 'input[name="convertkit_resource_type"]' ).value,
+		e.target.querySelector( 'input[name="convertkit_resource_id"]' ).value,
+		e.target.querySelector( 'input[name="convertkit_post_id"]' ).value
+	);
+		
+}
+
+/**
  * Opens the modal, displaying the content stored within the
  * #convertkit-restrict-content-modal-content element.
  *
@@ -81,12 +107,8 @@ jQuery( document ).ready(
  */
 function convertKitRestrictContentOpenModal() {
 
-	( function ( $ ) {
-
-		$( '#convertkit-restrict-content-modal-background' ).show();
-		$( '#convertkit-restrict-content-modal' ).show();
-
-	} )( jQuery );
+	document.querySelector( '#convertkit-restrict-content-modal-background' ).style.display = 'block';
+	document.querySelector( '#convertkit-restrict-content-modal' ).style.display            = 'block';
 
 }
 
@@ -97,13 +119,9 @@ function convertKitRestrictContentOpenModal() {
  */
 function convertKitRestrictContentCloseModal() {
 
-	( function ( $ ) {
-
-		$( '#convertkit-restrict-content-modal-background' ).hide();
-		$( '#convertkit-restrict-content-modal-loading' ).hide();
-		$( '#convertkit-restrict-content-modal' ).hide();
-
-	} )( jQuery );
+	document.querySelector( '#convertkit-restrict-content-modal-background' ).style.display = 'none';
+	document.querySelector( '#convertkit-restrict-content-modal-loading' ).style.display    = 'none';
+	document.querySelector( '#convertkit-restrict-content-modal' ).style.display            = 'none';
 
 }
 
@@ -123,47 +141,57 @@ function convertKitRestrictContentCloseModal() {
  */
 function convertKitRestrictContentSubscriberAuthenticationSendCode( nonce, email, resource_type, resource_id, post_id ) {
 
-	( function ( $ ) {
-
-		$.ajax(
-			{
-				type: 'POST',
-				data: {
+	fetch(
+		convertkit_restrict_content.ajaxurl,
+		{
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams(
+				{
 					action: 'convertkit_subscriber_authentication_send_code',
 					'_wpnonce': nonce,
 					convertkit_email: email,
 					convertkit_resource_type: resource_type,
 					convertkit_resource_id: resource_id,
-					convertkit_post_id: post_id
-				},
-				url: convertkit_restrict_content.ajaxurl,
-				success: function ( response ) {
-
-					if ( convertkit_restrict_content.debug ) {
-						console.log( response );
-					}
-
-					// Output response, which will be a form with/without an error message.
-					$( '#convertkit-restrict-content-modal-content' ).html( response.data );
-
-					// Hide loading overlay.
-					$( '#convertkit-restrict-content-modal-loading' ).hide();
-
-					// Re-bind OTP listener.
-					convertKitRestrictContentOTPField();
-
+					convertkit_post_id: post_id,
 				}
+			),
+		}
+	)
+	.then(
+		function ( response ) {
+			if ( convertkit_restrict_content.debug ) {
+				console.log( response );
 			}
-		).fail(
-			function ( response ) {
-				if ( convertkit_restrict_content.debug ) {
-					console.log( response );
-				}
 
+			return response.json();
+		}
+	)
+	.then(
+		function ( result ) {
+			if ( convertkit_restrict_content.debug ) {
+				console.log( result );
 			}
-		);
 
-	} )( jQuery );
+			// Output response, which will be a form with/without an error message.
+			document.querySelector( '#convertkit-restrict-content-modal-content' ).innerHTML = result.data;
+
+			// Hide loading overlay.
+			document.querySelector( '#convertkit-restrict-content-modal-loading' ).style.display = 'none';
+
+			// Re-bind OTP listener.
+			convertKitRestrictContentOTPField();
+		}
+	)
+	.catch(
+		function ( error ) {
+			if ( convertkit_restrict_content.debug ) {
+				console.error( error );
+			}
+		}
+	);
 
 }
 
@@ -182,54 +210,62 @@ function convertKitRestrictContentSubscriberAuthenticationSendCode( nonce, email
  */
 function convertKitRestrictContentSubscriberVerification( nonce, subscriber_code, token, post_id ) {
 
-	( function ( $ ) {
-
-		$.ajax(
-			{
-				type: 'POST',
-				data: {
+	fetch(
+		convertkit_restrict_content.ajaxurl,
+		{
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams(
+				{
 					action: 'convertkit_subscriber_verification',
 					'_wpnonce': nonce,
 					subscriber_code: subscriber_code,
 					token: token,
-					convertkit_post_id: post_id
-				},
-				url: convertkit_restrict_content.ajaxurl,
-				success: function ( response ) {
-
-					if ( convertkit_restrict_content.debug ) {
-						console.log( response );
-					}
-
-					// If the entered code is invalid, show the response in the modal.
-					if ( ! response.success ) {
-						$( '#convertkit-restrict-content-modal-content' ).html( response.data );
-
-						// Hide loading overlay.
-						$( '#convertkit-restrict-content-modal-loading' ).hide();
-
-						// Re-bind OTP listener.
-						convertKitRestrictContentOTPField();
-						return;
-					}
-
-					// Code entered is valid; load the URL in the response data, which will be the
-					// current URL with the `ck-cache-bust` parameter appended to it.
-					// As cookies are set, the user will now see the restricted content.
-					window.location = response.data;
-
+					convertkit_post_id: post_id,
 				}
+			),
+		}
+	)
+	.then(
+		function ( response ) {
+			if ( convertkit_restrict_content.debug ) {
+				console.log( response );
 			}
-		).fail(
-			function ( response ) {
-				if ( convertkit_restrict_content.debug ) {
-					console.log( response );
-				}
 
+			return response.json();
+		}
+	)
+	.then(
+		function ( result ) {
+			if ( convertkit_restrict_content.debug ) {
+					console.log( result );
 			}
-		);
 
-	} )( jQuery );
+			// If the entered code is invalid, show the response in the modal.
+			if ( ! result.success ) {
+				document.querySelector( '#convertkit-restrict-content-modal-content' ).innerHTML = result.data;
+
+				// Hide loading overlay.
+				document.querySelector( '#convertkit-restrict-content-modal-loading' ).style.display = 'none';
+
+				// Re-bind OTP listener.
+				convertKitRestrictContentOTPField();
+				return;
+			}
+
+			// Code entered is valid; load the URL in the response data.
+			window.location = result.data;
+		}
+	)
+	.catch(
+		function ( error ) {
+			if ( convertkit_restrict_content.debug ) {
+				console.error( error );
+			}
+		}
+	);
 
 }
 
@@ -241,33 +277,29 @@ function convertKitRestrictContentSubscriberVerification( nonce, subscriber_code
  */
 function convertKitRestrictContentOTPField() {
 
-	( function ( $ ) {
+	let otpInput = document.querySelector( '#convertkit_subscriber_code' );
 
-		// Bail if the OTP input isn't displayed on screen.
-		if ( $( '#convertkit_subscriber_code' ) === null ) {
-			return;
-		}
+	// Bail if the OTP input isn't displayed on screen.
+	if ( otpInput === null ) {
+		return;
+	}
 
-		$( '#convertkit_subscriber_code' ).on(
-			'change keyup input paste',
-			function () {
+	otpInput.addEventListener(
+		'change',
+		function () {
+			// Update the --_otp-digit property when the input value changes.
+			otpInput.style.setProperty( '--_otp-digit', otpInput.value.length );
 
-				// Update the --_otp-digit property when the input value changes.
-				$( '#convertkit_subscriber_code' ).css( '--_otp-digit', $( '#convertkit_subscriber_code' ).val().length );
-
-				// If all 6 digits have been entered:
-				// - move the caret input to the start, to avoid numbers shifting in input,
-				// - blur the input now that all numbers are entered,
-				// - submit the form.
-				if ( $( '#convertkit_subscriber_code' ).val().length === 6 ) {
-					$( '#convertkit_subscriber_code' )[0].setSelectionRange( 0, 0 );
-					$( '#convertkit_subscriber_code' ).blur();
-					$( '#convertkit-restrict-content-form' ).trigger( 'submit' );
-				}
-
+			// If all 6 digits have been entered:
+			// - move the caret input to the start,
+			// - blur the input now that all numbers are entered,
+			// - submit the form.
+			if ( otpInput.value.length === 6 ) {
+				otpInput.setSelectionRange( 0, 0 );
+				otpInput.blur();
+				document.querySelector( '#convertkit-restrict-content-form' ).dispatchEvent( new Event( 'submit' ) );
 			}
-		);
-
-	} )( jQuery );
+		}
+	);
 
 }


### PR DESCRIPTION
## Summary

Replaces jQuery with vanilla JS for the frontend Member Content functionality.

Further PR's to follow for other frontend JS, with the goal to remove jQuery as a dependency. For sites that don't load jQuery via other Plugins / Theme, this will save loading ~ 100kb of dependencies.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)