### PR TITLE
Frontend: Remove jQuery

### DIFF
--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -364,7 +364,7 @@ class ConvertKit_Output {
 		wp_register_script(
 			'convertkit-js',
 			CONVERTKIT_PLUGIN_URL . 'resources/frontend/js/convertkit.js',
-			array( 'jquery' ),
+			array(),
 			CONVERTKIT_PLUGIN_VERSION,
 			true
 		);

--- a/resources/frontend/js/convertkit.js
+++ b/resources/frontend/js/convertkit.js
@@ -259,8 +259,6 @@ document.addEventListener(
 		document.addEventListener(
 			'click',
 			function (e) {
-				console.log( e );
-
 				// Check if the form submit button was clicked, or the span element was clicked and its parent is the form submit button.
 				if ( ! e.target.matches( '.formkit-submit' ) && ! e.target.parentElement.matches( '.formkit-submit' ) ) {
 					if ( convertkit.debug ) {

--- a/resources/frontend/js/convertkit.js
+++ b/resources/frontend/js/convertkit.js
@@ -259,8 +259,14 @@ document.addEventListener(
 		document.addEventListener(
 			'click',
 			function (e) {
-				// Check the broadcasts pagination was clicked.
-				if ( ! e.target.matches( '.formkit-submit' ) ) {
+				console.log( e );
+
+				// Check if the form submit button was clicked, or the span element was clicked and its parent is the form submit button.
+				if ( ! e.target.matches( '.formkit-submit' ) && ! e.target.parentElement.matches( '.formkit-submit' ) ) {
+					if ( convertkit.debug ) {
+						console.log( 'not a ck form' );
+					}
+
 					return;
 				}
 

--- a/resources/frontend/js/convertkit.js
+++ b/resources/frontend/js/convertkit.js
@@ -26,36 +26,51 @@ function convertKitTagSubscriber( subscriber_id, tag, post_id ) {
 		console.log( post_id );
 	}
 
-	( function ( $ ) {
-
-		$.ajax(
-			{
-				type: 'POST',
-				data: {
+	fetch(
+		convertkit.ajaxurl,
+		{
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams(
+				{
 					action: 'convertkit_tag_subscriber',
 					convertkit_nonce: convertkit.nonce,
 					subscriber_id: subscriber_id,
 					tag: tag,
-					post_id: post_id
-				},
-				url: convertkit.ajaxurl,
-				success: function ( response ) {
-					if ( convertkit.debug ) {
-						console.log( response );
-					}
-					convertKitRemoveSubscriberIDFromURL( window.location.href );
+					post_id: post_id,
 				}
+			)
+		}
+	)
+	.then(
+		function ( response ) {
+			if ( convertkit.debug ) {
+				console.log( response );
 			}
-		).fail(
-			function (response) {
-				if ( convertkit.debug ) {
-					console.log( response );
-				}
-				convertKitRemoveSubscriberIDFromURL( window.location.href );
-			}
-		);
 
-	} )( jQuery );
+			return response.json();
+		}
+	)
+	.then(
+		function ( result ) {
+			if ( convertkit.debug ) {
+				console.log( result );
+			}
+
+			convertKitRemoveSubscriberIDFromURL( window.location.href );
+		}
+	)
+	.catch(
+		function ( error ) {
+			if ( convertkit.debug ) {
+				console.error( error );
+			}
+
+			convertKitRemoveSubscriberIDFromURL( window.location.href );
+		}
+	);
 
 }
 
@@ -79,36 +94,49 @@ function convertStoreSubscriberIDInCookie( subscriber_id ) {
 		console.log( subscriber_id );
 	}
 
-	( function ( $ ) {
-
-		$.ajax(
-			{
-				type: 'POST',
-				data: {
+	fetch(
+		convertkit.ajaxurl,
+		{
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams(
+				{
 					action: 'convertkit_store_subscriber_id_in_cookie',
 					convertkit_nonce: convertkit.nonce,
 					subscriber_id: subscriber_id
-				},
-				url: convertkit.ajaxurl,
-				success: function ( response ) {
-					if ( convertkit.debug ) {
-						console.log( response );
-					}
-
-					convertKitRemoveSubscriberIDFromURL( window.location.href );
 				}
+			)
+		}
+	)
+	.then(
+		function ( response ) {
+			if ( convertkit.debug ) {
+				console.log( response );
 			}
-		).fail(
-			function (response) {
-				if ( convertkit.debug ) {
-					console.log( response );
-				}
 
-				convertKitRemoveSubscriberIDFromURL( window.location.href );
+			return response.json();
+		}
+	)
+	.then(
+		function ( result ) {
+			if ( convertkit.debug ) {
+				console.log( result );
 			}
-		);
 
-	} )( jQuery );
+			convertKitRemoveSubscriberIDFromURL( window.location.href );
+		}
+	)
+	.catch(
+		function ( error ) {
+			if ( convertkit.debug ) {
+				console.error( error );
+			}
+
+			convertKitRemoveSubscriberIDFromURL( window.location.href );
+		}
+	);
 
 }
 
@@ -132,32 +160,43 @@ function convertStoreSubscriberEmailAsIDInCookie( emailAddress ) {
 		console.log( emailAddress );
 	}
 
-	( function ( $ ) {
-
-		$.ajax(
-			{
-				type: 'POST',
-				data: {
+	fetch(
+		convertkit.ajaxurl,
+		{
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams(
+				{
 					action: 'convertkit_store_subscriber_email_as_id_in_cookie',
 					convertkit_nonce: convertkit.nonce,
-					email:  emailAddress
-				},
-				url: convertkit.ajaxurl,
-				success: function ( response ) {
-					if ( convertkit.debug ) {
-						console.log( response );
-					}
+					email: emailAddress
 				}
+			)
+		}
+	)
+	.then(
+		function ( response ) {
+			if ( convertkit.debug ) {
+				console.log( response );
 			}
-		).fail(
-			function (response) {
-				if ( convertkit.debug ) {
-					console.log( response );
-				}
+		}
+	)
+	.then(
+		function ( result ) {
+			if ( convertkit.debug ) {
+				console.log( result );
 			}
-		);
-
-	} )( jQuery );
+		}
+	)
+	.catch(
+		function ( error ) {
+			if ( convertkit.debug ) {
+				console.error( error );
+			}
+		}
+	);
 
 }
 
@@ -202,8 +241,9 @@ function convertKitSleep( milliseconds ) {
 /**
  * Register events
  */
-jQuery( document ).ready(
-	function ( $ ) {
+document.addEventListener(
+	'DOMContentLoaded',
+	function () {
 
 		if ( convertkit.subscriber_id > 0 && convertkit.tag && convertkit.post_id ) {
 			// If the user can be detected as a ConvertKit Subscriber (i.e. their Subscriber ID is in a cookie or the URL),
@@ -216,11 +256,16 @@ jQuery( document ).ready(
 		}
 
 		// Store subscriber ID as a cookie from the email address used when a ConvertKit Form is submitted.
-		$( document ).on(
+		document.addEventListener(
 			'click',
-			'.formkit-submit',
-			function () {
-				var emailAddress = $( 'input[name="email_address"]' ).val();
+			function (e) {
+				// Check the broadcasts pagination was clicked.
+				if ( ! e.target.matches( '.formkit-submit' ) ) {
+					return;
+				}
+
+				// Get email address.
+				let emailAddress = document.querySelector( 'input[name="email_address"]' ).value;
 
 				// If the email address is empty, don't attempt to get the subscriber ID by email.
 				if ( ! emailAddress.length ) {


### PR DESCRIPTION
## Summary

Replaces jQuery with vanilla JS for the remaining frontend functionality (tagging and storing valid subscriber ID as a cookie).

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)