### PR TITLE
Editor: Use `enqueue_block_assets` hook instead of `enqueue_block_editor_assets`

### DIFF
--- a/includes/class-convertkit-gutenberg.php
+++ b/includes/class-convertkit-gutenberg.php
@@ -119,7 +119,7 @@ class ConvertKit_Gutenberg {
 
 		// Enqueue block scripts and styles in the editor view.
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_styles' ) );
+		add_action( 'enqueue_block_assets', array( $this, 'enqueue_styles' ) );
 
 		// Enqueue block scripts and styles in the editor and frontend views.
 		add_action( 'enqueue_block_assets', array( $this, 'enqueue_scripts_editor_and_frontend' ) );


### PR DESCRIPTION
## Summary

Fixes a console warning when using the WordPress Site Editor

![Screenshot 2024-01-11 at 16 13 16](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/9404ecde-b06b-4d03-86ab-6ebd72b2c4f7)

Follows guidance at https://developer.wordpress.org/block-editor/how-to-guides/enqueueing-assets-in-the-editor/#editor-content-scripts-and-styles which recommends to use the `enqueue_block_assets` hook with an admin check when load styles only for the editor.

We [already have an admin check](https://github.com/ConvertKit/convertkit-wordpress/blob/fix-site-editor-enqueue-console-warning/includes/class-convertkit-gutenberg.php#L188-L202) in the called `enqueue_styles` method, so this PR changes the hook from `enqueue_block_editor_assets` to `enqueue_block_assets`, as recommended in the docs above.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)