### PR TITLE
Use WordPress Libraries 1.4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "1.4.0"
+        "convertkit/convertkit-wordpress-libraries": "1.4.1"
     },
     "require-dev": {
         "lucatume/wp-browser": "^3.0",

--- a/includes/class-convertkit-resource-landing-pages.php
+++ b/includes/class-convertkit-resource-landing-pages.php
@@ -64,14 +64,15 @@ class ConvertKit_Resource_Landing_Pages extends ConvertKit_Resource {
 	public function get_html( $id ) {
 
 		// Setup API.
-		$api = new ConvertKit_API( false, false, true, 'output_landing_page' );
+		$api      = new ConvertKit_API( false, false, true, 'output_landing_page' );
+		$settings = new ConvertKit_Settings();
 
 		// If the ID is a URL, this is a Legacy Landing Page defined for use on this Page
 		// in a Plugin version < 1.9.6.
 		// 1.9.6+ always uses a Landing Page ID.
 		if ( strstr( $id, 'http' ) ) {
 			// Return Legacy Landing Page HTML for url property.
-			return $api->get_landing_page_html( $id );
+			return $api->get_landing_page_html( $id, $settings->debug_enabled() );
 		}
 
 		// Cast ID to integer.
@@ -97,11 +98,11 @@ class ConvertKit_Resource_Landing_Pages extends ConvertKit_Resource {
 		// If the resource has a 'url' property, this is a Legacy Landing Page, and the 'url' should be used.
 		if ( isset( $this->resources[ $id ]['url'] ) ) {
 			// Return Legacy Landing Page HTML for url property.
-			return $api->get_landing_page_html( $this->resources[ $id ]['url'] );
+			return $api->get_landing_page_html( $this->resources[ $id ]['url'], $settings->debug_enabled() );
 		}
 
 		// Return Landing Page HTML for embed_url property.
-		return $api->get_landing_page_html( $this->resources[ $id ]['embed_url'] );
+		return $api->get_landing_page_html( $this->resources[ $id ]['embed_url'], $settings->debug_enabled() );
 
 	}
 


### PR DESCRIPTION
## Summary

Use the latest ConvertKit WordPress Libraries, [1.4.1](https://github.com/ConvertKit/convertkit-wordpress-libraries/releases/tag/1.4.1).

Passes the debug parameter to `get_landing_page_html`, which is now supported.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)