### PR TITLE
Bulk and Quick Edit: Backend: Remove jQuery

### DIFF
--- a/admin/class-convertkit-admin-bulk-edit.php
+++ b/admin/class-convertkit-admin-bulk-edit.php
@@ -51,7 +51,7 @@ class ConvertKit_Admin_Bulk_Edit {
 		}
 
 		// Enqueue JS.
-		wp_enqueue_script( 'convertkit-bulk-edit', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/bulk-edit.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
+		wp_enqueue_script( 'convertkit-bulk-edit', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/bulk-edit.js', array(), CONVERTKIT_PLUGIN_VERSION, true );
 
 		// Output Bulk Edit fields in the footer of the Administration screen.
 		add_action( 'in_admin_footer', array( $this, 'bulk_edit_fields' ), 10 );

--- a/admin/class-convertkit-admin-quick-edit.php
+++ b/admin/class-convertkit-admin-quick-edit.php
@@ -51,7 +51,7 @@ class ConvertKit_Admin_Quick_Edit {
 		}
 
 		// Enqueue JS.
-		wp_enqueue_script( 'convertkit-admin-quick-edit', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/quick-edit.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
+		wp_enqueue_script( 'convertkit-admin-quick-edit', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/quick-edit.js', array(), CONVERTKIT_PLUGIN_VERSION, true );
 
 		// Enqueue CSS.
 		wp_enqueue_style( 'convertkit-admin-bulk-quick-edit', CONVERTKIT_PLUGIN_URL . 'resources/backend/css/bulk-quick-edit.css', array(), CONVERTKIT_PLUGIN_VERSION );

--- a/resources/backend/js/bulk-edit.js
+++ b/resources/backend/js/bulk-edit.js
@@ -13,16 +13,20 @@
  *
  * @since 	1.9.8.0
  */
-jQuery( document ).ready(
-	function ( $ ) {
+document.addEventListener(
+	'DOMContentLoaded',
+	function () {
 
-		// Move Bulk Edit fields from footer into the hidden bulk-edit table row,
-		// if a bulk-edit table row exists (it won't exist if searching returns no pages).
-		if ( $( 'tr#bulk-edit .inline-edit-wrapper fieldset.inline-edit-col-right' ).length > 0 ) {
-			$( 'tr#bulk-edit .inline-edit-wrapper fieldset.inline-edit-col-right' ).first().append( $( '#convertkit-bulk-edit' ) );
+		const convertKitBulkEditWrapper = document.querySelector( 'tr#bulk-edit .inline-edit-wrapper fieldset.inline-edit-col-right' ),
+			convertKitBulkEdit          = document.querySelector( '#convertkit-bulk-edit' );
+
+		if ( convertKitBulkEditWrapper ) {
+			// Move Bulk Edit fields from footer into the hidden bulk-edit table row,
+			// if a bulk-edit table row exists (it won't exist if searching returns no pages).
+			convertKitBulkEditWrapper.appendChild( convertKitBulkEdit );
 
 			// Show the Bulk Edit fields, as they are now contained in the inline-edit row which WordPress will show/hide as necessary.
-			$( '#convertkit-bulk-edit' ).show();
+			convertKitBulkEdit.style.display = 'block';
 		}
 
 	}

--- a/resources/backend/js/quick-edit.js
+++ b/resources/backend/js/quick-edit.js
@@ -45,10 +45,19 @@ document.addEventListener(
 				}
 
 				// Iterate through any ConvertKit inline data, assigning values to Quick Edit fields.
-				document.querySelectorAll( '.convertkit', document.querySelector( '#inline_' + id ) ).forEach(
+				document.querySelectorAll( '#inline_' + id + ' .convertkit' ).forEach(
 					function ( element ) {
+						// Get Quick Edit field.
+						let convertKitQuickEditField = document.querySelector( '#convertkit-quick-edit select[name="wp-convertkit[' + element.dataset.setting + ']"]' );
+
+						// If the Quick Edit field doesn't exist for this setting, skip it.
+						// (e.g. we're editing a Post and this is a Landing Page setting, that isn't supported in Posts).
+						if ( convertKitQuickEditField === null ) {
+							return;
+						}
+
 						// Assign the setting's value to the setting's Quick Edit field.
-						document.querySelector( '#convertkit-quick-edit select[name="wp-convertkit[' + element.dataset.setting + ']"]' ).value = element.dataset.value;
+						convertKitQuickEditField.value = element.dataset.value;
 					}
 				);
 

--- a/resources/backend/js/quick-edit.js
+++ b/resources/backend/js/quick-edit.js
@@ -17,38 +17,42 @@
  *
  * @since 	1.9.8.0
  */
-jQuery( document ).ready(
-	function ( $ ) {
 
-		// Move Quick Edit fields from footer into the hidden inline-edit table row.
-		$( 'tr#inline-edit .inline-edit-wrapper fieldset.inline-edit-col-left' ).first().append( $( '#convertkit-quick-edit' ) );
+document.addEventListener(
+	'DOMContentLoaded',
+	function () {
 
-		// Show the Quick Edit fields, as they are now contained in the inline-edit row which WordPress will show/hide as necessary.
-		$( '#convertkit-quick-edit' ).show();
+		const convertKitQuickEditWrapper = document.querySelector( 'tr#inline-edit .inline-edit-wrapper fieldset.inline-edit-col-left' ),
+			convertKitQuickEdit          = document.querySelector( '#convertkit-quick-edit' ),
+			convertKitInlineEditPost     = inlineEditPost.edit;
 
-		var convertKitInlineEditPost = inlineEditPost.edit;
+		if ( convertKitQuickEditWrapper ) {
+			// Move Quick Edit fields from footer into the hidden inline-edit table row.
+			convertKitQuickEditWrapper.appendChild( convertKitQuickEdit );
 
-		// Extend WordPress' inline edit function to load the Plugin's Quick Edit fields.
-		inlineEditPost.edit = function ( id ) {
+			// Show the Quick Edit fields, as they are now contained in the inline-edit row which WordPress will show/hide as necessary.
+			convertKitQuickEdit.style.display = 'block';
 
-			// Merge arguments from original function.
-			convertKitInlineEditPost.apply( this, arguments );
+			// Extend WordPress' inline edit function to load the Plugin's Quick Edit fields.
+			inlineEditPost.edit = function ( id ) {
 
-			// Get Post ID.
-			if ( typeof( id ) === 'object' ) {
-				id = parseInt( this.getId( id ) );
-			}
+				// Merge arguments from the original function.
+				convertKitInlineEditPost.apply( this, arguments );
 
-			// Iterate through any ConvertKit inline data, assigning values to Quick Edit fields.
-			$( '.convertkit', $( '#inline_' + id ) ).each(
-				function () {
-
-					// Assign the setting's value to the setting's Quick Edit field.
-					$( '#convertkit-quick-edit select[name="wp-convertkit[' + $( this ).data( 'setting' ) + ']"]' ).val( $( this ).data( 'value' ) );
-
+				// Get Post ID.
+				if (typeof id === 'object') {
+					id = parseInt( this.getId( id ) );
 				}
-			);
 
+				// Iterate through any ConvertKit inline data, assigning values to Quick Edit fields.
+				document.querySelectorAll( '.convertkit', document.querySelector( '#inline_' + id ) ).forEach(
+					function ( element ) {
+						// Assign the setting's value to the setting's Quick Edit field.
+						document.querySelector( '#convertkit-quick-edit select[name="wp-convertkit[' + element.dataset.setting + ']"]' ).value = element.dataset.value;
+					}
+				);
+
+			};
 		}
 
 	}


### PR DESCRIPTION
## Summary

Replaces jQuery with vanilla JS for the backend Bulk and Quick Edit functionality.

Further PR's to follow for other backend JS, with the goal to not rely on jQuery as a dependency. jQuery is commonly used within the WordPress Administration interface, but as more screens move away from this, it's a good idea to not rely on needing jQuery.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)