### PR TITLE
TinyMCE and QuickTags: Backend: Remove jQuery

### DIFF
--- a/admin/class-convertkit-admin-tinymce.php
+++ b/admin/class-convertkit-admin-tinymce.php
@@ -102,7 +102,7 @@ class ConvertKit_Admin_TinyMCE {
 		}
 
 		// Enqueue Quicktag JS.
-		wp_enqueue_script( 'convertkit-admin-quicktags', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/quicktags.js', array( 'jquery', 'quicktags' ), CONVERTKIT_PLUGIN_VERSION, true );
+		wp_enqueue_script( 'convertkit-admin-quicktags', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/quicktags.js', array( 'quicktags' ), CONVERTKIT_PLUGIN_VERSION, true );
 
 		// Make shortcodes available as convertkit_quicktags JS variable.
 		wp_localize_script( 'convertkit-admin-quicktags', 'convertkit_quicktags', $shortcodes );
@@ -149,7 +149,7 @@ class ConvertKit_Admin_TinyMCE {
 
 		// Enqueue TinyMCE CSS and JS.
 		wp_enqueue_script( 'convertkit-admin-tabs', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/tabs.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
-		wp_enqueue_script( 'convertkit-admin-tinymce', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/tinymce.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
+		wp_enqueue_script( 'convertkit-admin-tinymce', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/tinymce.js', array(), CONVERTKIT_PLUGIN_VERSION, true );
 		wp_enqueue_script( 'convertkit-admin-modal', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/modal.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
 		wp_enqueue_style( 'convertkit-admin-tinymce', CONVERTKIT_PLUGIN_URL . 'resources/backend/css/tinymce.css', array(), CONVERTKIT_PLUGIN_VERSION );
 

--- a/resources/backend/css/tinymce.css
+++ b/resources/backend/css/tinymce.css
@@ -61,6 +61,13 @@
 .convertkit-option select {
 	border: 1px solid #8c8f94;
 }
+.convertkit-option input[type=color] {
+	width: 80px;
+	height: 27px;
+	border: none;
+	margin: 0;
+	padding: 0;
+}
 .convertkit-option p {
 	white-space: normal;
 }
@@ -70,22 +77,6 @@
  */
 #convertkit-modal-body div.mce-foot div.mce-cancel {
 	left: 10px !important;
-}
-
-/**
- * Ensures consistent styling applied to 'Select color' button
- * provided by WordPress' color picker across TinyMCE and QuickTag modals
- */
-.convertkit-option .wp-color-result-text {
-	background: #f6f7f7;
-	border-radius: 0 2px 2px 0;
-	border-left: 1px solid #c3c4c7;
-	color: #50575e;
-	display: block;
-	line-height: 2.54545455;
-	padding: 0 6px;
-	font-size: 11px;
-	text-align: center;
 }
 
 /**

--- a/resources/backend/js/modal.js
+++ b/resources/backend/js/modal.js
@@ -52,18 +52,34 @@ jQuery( document ).ready(
 							return true;
 						}
 
-						// Skip if the value is empty.
-						if ( ! $( this ).val() ) {
-							return true;
-						}
-						if ( $( this ).val().length === 0 ) {
-							return true;
-						}
-
 						// Get shortcode attribute.
 						let key = $( this ).data( 'shortcode' ),
-						trim    = ( $( this ).data( 'trim' ) === '0' ? false : true ),
-						val     = $( this ).val();
+						trim    = ( $( this ).data( 'trim' ) === '0' ? false : true );
+
+						let val = '';
+
+						// If this is a color picker, #000000 will be submitted by the browser as the value
+						// even if no value / color was selected.
+						// Check the data-value attribute instead.
+						switch ( $( this ).attr( 'type' ) ) {
+							case 'color':
+								val = $( this ).data( 'value' );
+								break;
+							default:
+								val = $( this ).val();
+								break;
+						}
+
+						console.log( key );
+						console.log( val );
+
+						// Skip if the value is empty.
+						if ( ! val ) {
+							return true;
+						}
+						if ( val.length === 0 ) {
+							return true;
+						}
 
 						// Skip if the shortcode is empty.
 						if ( ! key.length ) {

--- a/resources/backend/js/modal.js
+++ b/resources/backend/js/modal.js
@@ -52,10 +52,6 @@ jQuery( document ).ready(
 							return true;
 						}
 
-						// Get shortcode attribute.
-						let key = $( this ).data( 'shortcode' ),
-						trim    = ( $( this ).data( 'trim' ) === '0' ? false : true );
-
 						let val = '';
 
 						// If this is a color picker, #000000 will be submitted by the browser as the value
@@ -70,9 +66,6 @@ jQuery( document ).ready(
 								break;
 						}
 
-						console.log( key );
-						console.log( val );
-
 						// Skip if the value is empty.
 						if ( ! val ) {
 							return true;
@@ -80,6 +73,10 @@ jQuery( document ).ready(
 						if ( val.length === 0 ) {
 							return true;
 						}
+
+						// Get shortcode attribute.
+						let key = $( this ).data( 'shortcode' ),
+						trim    = ( $( this ).data( 'trim' ) === '0' ? false : true );
 
 						// Skip if the shortcode is empty.
 						if ( ! key.length ) {

--- a/resources/backend/js/quicktags.js
+++ b/resources/backend/js/quicktags.js
@@ -71,6 +71,9 @@ function convertKitQuickTagRegister( block ) {
 
 					// Initialize tabbed interface.
 					convertKitTabsInit();
+
+					// Listen for color input changes.
+					convertKitColorInputInit();
 				}
 			)
 			.catch(

--- a/resources/backend/js/quicktags.js
+++ b/resources/backend/js/quicktags.js
@@ -23,54 +23,63 @@ for ( const block in convertkit_quicktags ) {
  */
 function convertKitQuickTagRegister( block ) {
 
-	( function ( $ ) {
+	QTags.addButton(
+		'convertkit-' + block.name,
+		block.title,
+		function () {
 
-		QTags.addButton(
-			'convertkit-' + block.name,
-			block.title,
-			function () {
-
-				// Perform an AJAX call to load the modal's view.
-				$.post(
-					ajaxurl,
-					{
-						'action': 		'convertkit_admin_tinymce_output_modal',
-						'nonce':  		convertkit_admin_tinymce.nonce,
-						'editor_type':  'quicktags',
-						'shortcode': 	block.name
-
+			// Perform an AJAX call to load the modal's view.
+			fetch(
+				ajaxurl,
+				{
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/x-www-form-urlencoded',
 					},
-					function ( response ) {
+					body: new URLSearchParams(
+						{
+							'action': 		'convertkit_admin_tinymce_output_modal',
+							'nonce':  		convertkit_admin_tinymce.nonce,
+							'editor_type':  'quicktags',
+							'shortcode': 	block.name
+						}
+					),
+				}
+			)
+			.then(
+				function ( response ) {
+					return response.text();
+				}
+			)
+			.then(
+				function ( result ) {
+					// Show Modal.
+					convertKitQuickTagsModal.open();
 
-						// Show Modal.
-						convertKitQuickTagsModal.open();
+					// Get Modal.
+					const quicktagsModal = document.querySelector( 'div.convertkit-quicktags-modal div.media-modal.wp-core-ui' );
 
-						// Resize Modal so it's not full screen.
-						$( 'div.convertkit-quicktags-modal div.media-modal.wp-core-ui' ).css(
-							{
-								width: ( block.modal.width ) + 'px',
-								height: ( block.modal.height + 106 ) + 'px' // Prevents a vertical scroll bar.
-							}
-						);
+					// Resize Modal so it's not full screen.
+					quicktagsModal.style.width  = block.modal.width + 'px';
+					quicktagsModal.style.height = block.modal.height + 106 + 'px'; // Prevents a vertical scroll bar.
 
-						// Set Title.
-						$( '#convertkit-quicktags-modal .media-frame-title h1' ).text( block.title );
+					// Set Title.
+					document.querySelector( '#convertkit-quicktags-modal .media-frame-title h1' ).textContent = block.title;
 
-						// Inject HTML into modal.
-						$( '#convertkit-quicktags-modal .media-frame-content' ).html( response );
+					// Inject HTML into modal.
+					document.querySelector( '#convertkit-quicktags-modal .media-frame-content' ).innerHTML = result;
 
-						// Initialize tabbed interface.
-						convertKitTabsInit();
+					// Initialize tabbed interface.
+					convertKitTabsInit();
+				}
+			)
+			.catch(
+				function ( error ) {
+					console.error( error );
+				}
+			);
 
-						// Initialize color pickers.
-						$( '.convertkit-color-picker' ).wpColorPicker();
-
-					}
-				);
-
-			}
-		);
-
-	} )( jQuery );
+		}
+	);
 
 }

--- a/resources/backend/js/tinymce.js
+++ b/resources/backend/js/tinymce.js
@@ -17,84 +17,95 @@
  */
 function convertKitTinyMCERegisterPlugin( block ) {
 
-	( function ( $ ) {
+	tinymce.PluginManager.add(
+		'convertkit_' + block.name,
+		function ( editor, url ) {
 
-		tinymce.PluginManager.add(
-			'convertkit_' + block.name,
-			function ( editor, url ) {
+			// Add Button to Visual Editor Toolbar.
+			editor.addButton(
+				'convertkit_' + block.name,
+				{
+					title: 	block.title,
+					image: 	url + '../../../../' + block.icon,
+					cmd: 	'convertkit_' + block.name,
+				}
+			);
 
-				// Add Button to Visual Editor Toolbar.
-				editor.addButton(
-					'convertkit_' + block.name,
-					{
-						title: 	block.title,
-						image: 	url + '../../../../' + block.icon,
-						cmd: 	'convertkit_' + block.name,
-					}
-				);
+			// Load View when button clicked.
+			editor.addCommand(
+				'convertkit_' + block.name,
+				function () {
 
-				// Load View when button clicked.
-				editor.addCommand(
-					'convertkit_' + block.name,
-					function () {
+					// Close any existing QuickTags modal.
+					convertKitQuickTagsModal.close();
 
-						// Close any existing QuickTags modal.
-						convertKitQuickTagsModal.close();
+					// Open the TinyMCE Modal.
+					editor.windowManager.open(
+						{
+							id: 	'convertkit-modal-body',
+							title: 	block.title,
+							width: 	block.modal.width,
 
-						// Open the TinyMCE Modal.
-						editor.windowManager.open(
-							{
-								id: 	'convertkit-modal-body',
-								title: 	block.title,
-								width: 	block.modal.width,
-
-								// Set modal height up to a maximum of 580px.
-								// Content will overflow-y to show a scrollbar where necessary.
-								height: ( block.modal.height < 580 ? block.modal.height : 580 ),
-								inline: 1,
-								buttons: [
+							// Set modal height up to a maximum of 580px.
+							// Content will overflow-y to show a scrollbar where necessary.
+							height: ( block.modal.height < 580 ? block.modal.height : 580 ),
+							inline: 1,
+							buttons: [
 								{
 									text: 'Cancel',
 									classes: 'cancel'
-								},
+							},
 								{
 									text: 'Insert',
 									subtype: 'primary',
 									classes: 'insert'
-								}
-								]
 							}
-						);
+							]
+						}
+					);
 
-						// Perform an AJAX call to load the modal's view.
-						$.post(
-							ajaxurl,
-							{
-								'action': 		'convertkit_admin_tinymce_output_modal',
-								'nonce':  		convertkit_admin_tinymce.nonce,
-								'editor_type':  'tinymce',
-								'shortcode': 	block.name
+					// Perform an AJAX call to load the modal's view.
+					fetch(
+						ajaxurl,
+						{
+							method: 'POST',
+							headers: {
+								'Content-Type': 'application/x-www-form-urlencoded',
 							},
-							function ( response ) {
+							body: new URLSearchParams(
+								{
+									'action': 		'convertkit_admin_tinymce_output_modal',
+									'nonce':  		convertkit_admin_tinymce.nonce,
+									'editor_type':  'tinymce',
+									'shortcode': 	block.name
+								}
+							),
+						}
+					)
+					.then(
+						function ( response ) {
+							return response.text();
+						}
+					)
+					.then(
+						function ( result ) {
+							// Inject HTML into modal.
+							document.querySelector( '#convertkit-modal-body-body' ).innerHTML = result;
 
-								// Inject HTML into modal.
-								$( '#convertkit-modal-body-body' ).html( response );
+							// Initialize tabbed interface.
+							convertKitTabsInit();
+						}
+					)
+					.catch(
+						function ( error ) {
+							console.error( error );
+						}
+					);
 
-								// Initialize tabbed interface.
-								convertKitTabsInit();
+				}
+			);
 
-								// Initialize color pickers.
-								$( '.convertkit-color-picker' ).wpColorPicker();
-
-							}
-						);
-
-					}
-				);
-
-			}
-		);
-
-	} )( jQuery );
+		}
+	);
 
 }

--- a/resources/backend/js/tinymce.js
+++ b/resources/backend/js/tinymce.js
@@ -94,6 +94,9 @@ function convertKitTinyMCERegisterPlugin( block ) {
 
 							// Initialize tabbed interface.
 							convertKitTabsInit();
+
+							// Listen for color input changes.
+							convertKitColorInputInit();
 						}
 					)
 					.catch(
@@ -105,6 +108,30 @@ function convertKitTinyMCERegisterPlugin( block ) {
 				}
 			);
 
+		}
+	);
+
+}
+
+/**
+ * Listens for changes to input[type=color] inputs within a TinyMCE or QuickTags modal,
+ * assigning the value to the input's data-value attribute.
+ *
+ * The modal.js will check the data-value for the 'true' value, as any color input will always
+ * send #000000 as the value, even when none is supplied.
+ *
+ * @since 	2.4.3
+ */
+function convertKitColorInputInit() {
+
+	document.querySelectorAll( '.convertkit-option input[type=color]' ).forEach(
+		function ( colorPicker ) {
+			colorPicker.addEventListener(
+				'change',
+				function ( event ) {
+					event.target.dataset.value = event.target.value;
+				}
+			);
 		}
 	);
 

--- a/views/backend/tinymce/modal-field.php
+++ b/views/backend/tinymce/modal-field.php
@@ -92,6 +92,7 @@ switch ( $field['type'] ) {
 				id="tinymce_modal_<?php echo esc_attr( $field_name ); ?>"
 				name="<?php echo esc_attr( $field_name ); ?>"
 				value="<?php echo esc_attr( isset( $shortcode['attributes'][ $field_name ]['default'] ) ? $shortcode['attributes'][ $field_name ]['default'] : '' ); ?>" 
+				data-value="<?php echo esc_attr( isset( $shortcode['attributes'][ $field_name ]['default'] ) ? $shortcode['attributes'][ $field_name ]['default'] : '' ); ?>" 
 				data-shortcode="<?php echo esc_attr( $field_name ); ?>"
 				placeholder="<?php echo esc_attr( isset( $field['placeholder'] ) ? $field['placeholder'] : '' ); ?>" />
 		<?php

--- a/views/backend/tinymce/modal-field.php
+++ b/views/backend/tinymce/modal-field.php
@@ -88,13 +88,12 @@ switch ( $field['type'] ) {
 	 */
 	case 'color':
 		?>
-		<input type="text" 
+		<input type="color" 
 				id="tinymce_modal_<?php echo esc_attr( $field_name ); ?>"
 				name="<?php echo esc_attr( $field_name ); ?>"
 				value="<?php echo esc_attr( isset( $shortcode['attributes'][ $field_name ]['default'] ) ? $shortcode['attributes'][ $field_name ]['default'] : '' ); ?>" 
 				data-shortcode="<?php echo esc_attr( $field_name ); ?>"
-				placeholder="<?php echo esc_attr( isset( $field['placeholder'] ) ? $field['placeholder'] : '' ); ?>"
-				class="widefat convertkit-color-picker" />
+				placeholder="<?php echo esc_attr( isset( $field['placeholder'] ) ? $field['placeholder'] : '' ); ?>" />
 		<?php
 		break;
 }


### PR DESCRIPTION
## Summary

Replaces jQuery with vanilla JS for the backend TinyMCE and QuickTags (Text Editor) functionality.

Replaces `wpColorPicker()` with browser native `input[type=color]` elements.

Further PR's to follow for other backend JS, with the goal to not rely on jQuery as a dependency. jQuery is commonly used within the WordPress Administration interface, but as more screens move away from this, it's a good idea to not rely on needing jQuery.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)