### PR TITLE
Tests: Fix Block Formatter Flaky Tests

### DIFF
--- a/tests/_support/Helper/Acceptance/WPGutenberg.php
+++ b/tests/_support/Helper/Acceptance/WPGutenberg.php
@@ -257,11 +257,16 @@ class WPGutenberg extends \Codeception\Module
 
 		// Apply formatter configuration.
 		if ( $formatterConfiguration ) {
+			// Confirm the popover displays.
 			$I->waitForElementVisible('.components-popover');
 
 			foreach ($formatterConfiguration as $field => $attributes) {
 				// Field ID will be formatter's programmatic name, followed by the attribute name.
 				$fieldID = '#' . $formatterProgrammaticName . '-' . $field;
+
+				// Wait for the field to be visible within the popover.
+				// This prevents tests from trying to fill out the field before it is positioned.
+				$I->waitForElementVisible('.components-popover ' . $fieldID);
 
 				// Depending on the field's type, define its value.
 				switch ($attributes[0]) {


### PR DESCRIPTION
## Summary

Waits for the field to be visible within the popover before interacting with it.

This prevents tests incorrectly failing due to Codeception trying to interact with the popover element before Gutenberg has positioned it:

![PageBlockFormatterProductLinkCest testProductLinkFormatterToggleProductSelection fail](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/576973f9-27b1-41d5-98d3-b3f301a3e72b)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)