### PR TITLE
Remove spaces from API Key and Secret

### DIFF
--- a/admin/section/class-convertkit-settings-base.php
+++ b/admin/section/class-convertkit-settings-base.php
@@ -494,15 +494,6 @@ abstract class ConvertKit_Settings_Base {
 	 */
 	public function sanitize_settings( $settings ) {
 
-		// If a Form or Landing Page was specified, request a review.
-		// This can safely be called multiple times, as the review request
-		// class will ensure once a review request is dismissed by the user,
-		// it is never displayed again.
-		if ( ( isset( $settings['page_form'] ) && $settings['page_form'] ) ||
-			( isset( $settings['post_form'] ) && $settings['post_form'] ) ) {
-			WP_ConvertKit()->get_class( 'review_request' )->request_review();
-		}
-
 		// Merge settings with defaults.
 		$settings = wp_parse_args( $settings, $this->settings->get_defaults() );
 

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -595,4 +595,23 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 
 	}
 
+	/**
+	 * Sanitizes the settings prior to being saved.
+	 *
+	 * @since   2.4.3
+	 *
+	 * @param   array $settings   Submitted Settings Fields.
+	 * @return  array               Sanitized Settings with Defaults
+	 */
+	public function sanitize_settings( $settings ) {
+
+		// Remove whitespace, tabs and line ends from the API Key and Secret.
+		$settings['api_key']    = preg_replace( '/\s+/', '', $settings['api_key'] );
+		$settings['api_secret'] = preg_replace( '/\s+/', '', $settings['api_secret'] );
+
+		// Return settings to be saved.
+		return $settings;
+
+	}
+
 }

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -605,9 +605,21 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 	 */
 	public function sanitize_settings( $settings ) {
 
+		// Call parent class to merge settings with defaults.
+		$settings = parent::sanitize_settings( $settings );
+
 		// Remove whitespace, tabs and line ends from the API Key and Secret.
 		$settings['api_key']    = preg_replace( '/\s+/', '', $settings['api_key'] );
 		$settings['api_secret'] = preg_replace( '/\s+/', '', $settings['api_secret'] );
+
+		// If a Form or Landing Page was specified, request a review.
+		// This can safely be called multiple times, as the review request
+		// class will ensure once a review request is dismissed by the user,
+		// it is never displayed again.
+		if ( ( isset( $settings['page_form'] ) && $settings['page_form'] ) ||
+			( isset( $settings['post_form'] ) && $settings['post_form'] ) ) {
+			WP_ConvertKit()->get_class( 'review_request' )->request_review();
+		}
 
 		// Return settings to be saved.
 		return $settings;

--- a/tests/acceptance/general/PluginSettingsGeneralCest.php
+++ b/tests/acceptance/general/PluginSettingsGeneralCest.php
@@ -194,6 +194,42 @@ class PluginSettingsGeneralCest
 	}
 
 	/**
+	 * Test that API credentials have spaces removed when entered.
+	 *
+	 * @since   2.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSaveValidAPICredentialsContainingSpaces(AcceptanceTester $I)
+	{
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsGeneralScreen($I);
+
+		// Complete API Fields.
+		$I->fillField('_wp_convertkit_settings[api_key]', '   ' . $_ENV['CONVERTKIT_API_KEY'] . '   ' );
+		$I->fillField('_wp_convertkit_settings[api_secret]', '   ' . $_ENV['CONVERTKIT_API_SECRET'] . '   ' );
+
+		// Click the Save Changes button.
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check the value of the fields match the inputs provided.
+		$I->seeInField('_wp_convertkit_settings[api_key]', $_ENV['CONVERTKIT_API_KEY']);
+		$I->seeInField('_wp_convertkit_settings[api_secret]', $_ENV['CONVERTKIT_API_SECRET']);
+
+		// Check that no notice is displayed that the API credentials are invalid.
+		$I->dontSeeErrorNotice($I, 'Authorization Failed: API Key not valid');
+
+		// Navigate to the WordPress Admin.
+		$I->amOnAdminPage('index.php');
+
+		// Check that no notice is displayed that the API credentials are invalid.
+		$I->dontSeeErrorNotice($I, 'Convertkit: Authorization failed. Please enter valid API credentials on the settings screen.');
+	}
+
+	/**
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
 	 * when the Default Form for Pages and Posts are changed, and that the preview links
 	 * work when the Default Form is changed.


### PR DESCRIPTION
## Summary

Remove whitespace, tabs and line ends from the API Key and Secret when entered and saved in the Plugin's settings, as reported [here](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/12263829243826?view=List).

Moves logic for the review request notification from the abstract `ConvertKit_Settings_Base` class to the specific `ConvertKit_Settings_General` class, which handles default forms.

## Testing

- `PluginSettingsGeneralCest:testSaveValidAPICredentialsContainingSpaces`: Test that spaces contained in an API Key and Secret are removed prior to saving and testing credentials.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)