### PR TITLE
Broadcasts to Posts: Improve descriptions

### DIFF
--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -161,14 +161,17 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 		$enabled_description = '';
 		if ( $this->settings->enabled() && $posts->get_cron_event_next_scheduled() && $posts->get_cron_event_next_scheduled() > 1 ) {
 			$enabled_description = sprintf(
-				'%s %s',
+				'%s %s<br />%s <strong>%s</strong> %s',
 				esc_html__( 'Broadcasts will next import at approximately ', 'convertkit' ),
 				// The cron event's next scheduled timestamp is always in UTC.
 				// Display it converted to the WordPress site's timezone.
 				get_date_from_gmt(
 					gmdate( 'Y-m-d H:i:s', $posts->get_cron_event_next_scheduled() ),
 					get_option( 'date_format' ) . ' ' . get_option( 'time_format' )
-				)
+				),
+				esc_html__( 'Broadcasts', 'convertkit' ),
+				esc_html__( 'must', 'convertkit' ),
+				esc_html__( 'have their "Enabled on public feeds" setting enabled in ConvertKit, to be eligible for import.', 'convertkit' )
 			);
 		}
 
@@ -206,7 +209,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 			array(
 				'name'        => 'post_status',
 				'label_for'   => 'post_status',
-				'description' => __( 'The WordPress Post status to assign imported broadcasts to.', 'convertkit' ),
+				'description' => __( 'The WordPress Post status to assign imported public broadcasts to.', 'convertkit' ),
 			)
 		);
 
@@ -219,7 +222,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 			array(
 				'name'        => 'author_id',
 				'label_for'   => 'author_id',
-				'description' => __( 'The WordPress User to set as the author for WordPress Posts created from imported broadcasts.', 'convertkit' ),
+				'description' => __( 'The WordPress User to set as the author for WordPress Posts created from imported public broadcasts.', 'convertkit' ),
 			)
 		);
 
@@ -232,7 +235,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 			array(
 				'name'        => 'category_id',
 				'label_for'   => 'category_id',
-				'description' => __( 'The category to assign imported broadcasts to.', 'convertkit' ),
+				'description' => __( 'The category to assign imported public broadcasts to.', 'convertkit' ),
 			)
 		);
 
@@ -259,7 +262,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 			array(
 				'name'        => 'published_at_min_date',
 				'label_for'   => 'published_at_min_date',
-				'description' => __( 'The earliest date to import broadcasts from, based on the broadcast\'s published date and time.', 'convertkit' ),
+				'description' => __( 'The earliest date to import public broadcasts from, based on the broadcast\'s published date and time.', 'convertkit' ),
 			)
 		);
 
@@ -300,7 +303,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 
 		?>
 		<span class="convertkit-beta-label"><?php esc_html_e( 'Beta', 'convertkit' ); ?></span>
-		<p class="description"><?php esc_html_e( 'Defines whether public broadcasts created in ConvertKit should automatically be published on this site as WordPress Posts, and whether to enable options to create draft ConvertKit Broadcasts from WordPress Posts.', 'convertkit' ); ?></p>
+		<p class="description"><?php esc_html_e( 'Defines whether public broadcasts ("Enabled on public feeds") in ConvertKit should automatically be published on this site as WordPress Posts, and whether to enable options to create draft ConvertKit Broadcasts from WordPress Posts.', 'convertkit' ); ?></p>
 		<?php
 
 	}


### PR DESCRIPTION
## Summary

Based on [this ticket](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/12263829341914?view=List), attempts to make it clear that Broadcasts must have `enabled on public feeds` enabled for them to be imported to WordPress.

![Screenshot 2024-01-26 at 15 56 03](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/baed15c2-b43d-48ce-9f2e-5288ece70ebe)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)