### PR TITLE
Forminator: Support Quizzes

### DIFF
--- a/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
+++ b/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
@@ -112,10 +112,10 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 
 		// Get Forminator Forms.
 		$forminator_forms = $this->get_forminator_forms();
-
+		
 		// Bail with an error if no Forminator Forms exist.
 		if ( ! $forminator_forms ) {
-			$this->output_error( __( 'No Forminator Forms exist in the Forminator Plugin.', 'convertkit' ) );
+			$this->output_error( __( 'No Forminator Forms, Quizzes or Polls exist in the Forminator Plugin.', 'convertkit' ) );
 			$this->render_container_end();
 			return;
 		}
@@ -191,18 +191,42 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 		$forms = array();
 
 		// Get all forms using Forminator API class.
-		$results = Forminator_API::get_forms( null, 1, -1 );
-
-		// Bail if no results.
-		if ( ! count( $results ) ) {
-			return false;
-		}
-
-		foreach ( $results as $forminator_form ) {
+		foreach ( Forminator_API::get_forms( null, 1, -1 ) as $forminator_form ) {
 			$forms[] = array(
 				'id'   => $forminator_form->id,
-				'name' => $forminator_form->name,
+				'name' => sprintf(
+					'%s: %s',
+					esc_html__( 'Form', 'convertkit' ),
+					$forminator_form->name
+				),
 			);
+		}
+
+		foreach ( Forminator_API::get_quizzes( null, 1, -1 ) as $forminator_form ) {
+			$forms[] = array(
+				'id'   => $forminator_form->id,
+				'name' => sprintf(
+					'%s: %s',
+					esc_html__( 'Quiz', 'convertkit' ),
+					$forminator_form->name
+				),
+			);
+		}
+
+		foreach ( Forminator_API::get_polls( null, 1, -1 ) as $forminator_form ) {
+			$forms[] = array(
+				'id'   => $forminator_form->id,
+				'name' => sprintf(
+					'%s: %s',
+					esc_html__( 'Poll', 'convertkit' ),
+					$forminator_form->name
+				),
+			);
+		}
+
+		// If no Forms, Quizzes or Polls were found in Forminator, return false.
+		if ( ! count( $forms ) ) {
+			return false;
 		}
 
 		return $forms;

--- a/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
+++ b/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
@@ -112,7 +112,7 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 
 		// Get Forminator Forms.
 		$forminator_forms = $this->get_forminator_forms();
-		
+
 		// Bail with an error if no Forminator Forms exist.
 		if ( ! $forminator_forms ) {
 			$this->output_error( __( 'No Forminator Forms or Quizzes exist in the Forminator Plugin.', 'convertkit' ) );

--- a/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
+++ b/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
@@ -115,7 +115,7 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 		
 		// Bail with an error if no Forminator Forms exist.
 		if ( ! $forminator_forms ) {
-			$this->output_error( __( 'No Forminator Forms, Quizzes or Polls exist in the Forminator Plugin.', 'convertkit' ) );
+			$this->output_error( __( 'No Forminator Forms or Quizzes exist in the Forminator Plugin.', 'convertkit' ) );
 			$this->render_container_end();
 			return;
 		}
@@ -213,18 +213,7 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 			);
 		}
 
-		foreach ( Forminator_API::get_polls( null, 1, -1 ) as $forminator_form ) {
-			$forms[] = array(
-				'id'   => $forminator_form->id,
-				'name' => sprintf(
-					'%s: %s',
-					esc_html__( 'Poll', 'convertkit' ),
-					$forminator_form->name
-				),
-			);
-		}
-
-		// If no Forms, Quizzes or Polls were found in Forminator, return false.
+		// If no Forms or Quizzes were found in Forminator, return false.
 		if ( ! count( $forms ) ) {
 			return false;
 		}

--- a/includes/integrations/forminator/class-convertkit-forminator.php
+++ b/includes/integrations/forminator/class-convertkit-forminator.php
@@ -71,9 +71,9 @@ class ConvertKit_Forminator {
 	 *
 	 * @since   2.3.0
 	 *
-	 * @param   array $entry              Entry.
-	 * @param   int   $form_id            Forminator Form ID.
-	 * @param   array $form_data_array    Forminator submitted data.
+	 * @param   Forminator_Form_Entry_Model $entry              Entry.
+	 * @param   int                         $form_id            Forminator Form ID.
+	 * @param   array                       $form_data_array    Forminator submitted data.
 	 */
 	public function maybe_subscribe( $entry, $form_id, $form_data_array ) {
 

--- a/includes/integrations/forminator/class-convertkit-forminator.php
+++ b/includes/integrations/forminator/class-convertkit-forminator.php
@@ -78,8 +78,10 @@ class ConvertKit_Forminator {
 	public function maybe_subscribe( $entry, $form_id, $form_data_array ) {
 
 		// Get ConvertKit Form ID mapped to this Forminator Form.
+		// We deliberately use the entry's form ID, as $form_id for a Quiz will point to a lead generation form, which
+		// has a different Form ID.
 		$forminator_settings = new ConvertKit_Forminator_Settings();
-		$convertkit_form_id  = $forminator_settings->get_convertkit_form_id_by_forminator_form_id( $form_id );
+		$convertkit_form_id  = $forminator_settings->get_convertkit_form_id_by_forminator_form_id( $entry->form_id );
 
 		// If no ConvertKit Form is mapped to this Forminator Form, bail.
 		if ( ! $convertkit_form_id ) {

--- a/tests/acceptance/integrations/other/ForminatorCest.php
+++ b/tests/acceptance/integrations/other/ForminatorCest.php
@@ -64,16 +64,16 @@ class ForminatorCest
 	}
 
 	/**
-	 * Test that saving a Forminator to ConvertKit Form Mapping works.
+	 * Test that saving a Forminator Form to ConvertKit Form Mapping works.
 	 *
 	 * @since   2.3.0
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testSettingsForminatorToConvertKitFormMapping(AcceptanceTester $I)
+	public function testSettingsForminatorFormToConvertKitFormMapping(AcceptanceTester $I)
 	{
 		// Setup ConvertKit Plugin.
-		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginNoDefaultForms($I);
 		$I->setupConvertKitPluginResources($I);
 
 		// Create Forminator Form.
@@ -141,6 +141,80 @@ class ForminatorCest
 	}
 
 	/**
+	 * Test that saving a Forminator Quiz to ConvertKit Form Mapping works.
+	 *
+	 * @since   2.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSettingsForminatorQuizToConvertKitFormMapping(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPluginNoDefaultForms($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Create Forminator Quiz.
+		$forminatorFormID = $this->_createForminatorQuiz($I);
+
+		// Load Forminator Plugin Settings.
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=forminator');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check that a Form Mapping option is displayed.
+		$I->seeElementInDOM('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID);
+
+		// Change Form to value specified in the .env file.
+		$I->selectOption('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID, $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME']);
+
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check the value of the Form field matches the input provided.
+		$I->seeOptionIsSelected('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID, $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME']);
+
+		// Create Page with Forminator Shortcode.
+		$I->havePageInDatabase(
+			[
+				'post_title'   => 'ConvertKit: Forminator Quiz Shortcode',
+				'post_name'    => 'convertkit-forminator-quiz-shortcode',
+				'post_content' => 'Form:
+[forminator_quiz id="' . $forminatorFormID . '"]',
+			]
+		);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/convertkit-forminator-quiz-shortcode');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Complete quiz.
+		$I->checkOption('answers[question-1-0]', '0');
+		$I->click('View Results');
+
+		// Complete Name and Email.
+		$I->waitForElementVisible('input[name=name-1]');
+		$I->fillField('input[name=name-1]', 'ConvertKit Name');
+		$I->fillField('input[name=email-1]', $emailAddress);
+
+		// Submit Form.
+		$I->click('Submit');
+
+		// Wait for submission to complete.
+		$I->waitForElementVisible('.forminator-icon-check');
+
+		// Confirm that the email address was added to ConvertKit.
+		$I->apiCheckSubscriberExists($I, $emailAddress);
+	}
+
+	/**
 	 * Tests that the 'Enable Creator Network Recommendations' is not displayed when API Keys are specified
 	 * for a ConvertKit account that does not have Creator Network Recommendations enabled.
 	 *
@@ -189,7 +263,7 @@ class ForminatorCest
 	public function testSettingsForminatorCreatorNetworkRecommendationsWhenEnabledOnConvertKitAccount(AcceptanceTester $I)
 	{
 		// Setup ConvertKit Plugin.
-		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginNoDefaultForms($I);
 		$I->setupConvertKitPluginResources($I);
 
 		// Create Forminator Form.
@@ -287,6 +361,136 @@ class ForminatorCest
 						'settings' => [
 							'enable-ajax' => 'true',
 						],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Creates a Forminator Quiz
+	 *
+	 * @since   2.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 * @return  int                     Form ID
+	 */
+	private function _createForminatorQuiz(AcceptanceTester $I)
+	{
+		// Create Form for Leads.
+		$formLeadsID = $I->havePostInDatabase(
+			[
+				'post_name'   => 'forminator-form-leads',
+				'post_title'  => 'Forminator Form Leads',
+				'post_type'   => 'forminator_forms',
+				'post_status' => 'publish',
+				'meta_input'  => [
+					'forminator_form_meta' => [
+						'fields'   => [
+							[
+								'id'          => 'name-1',
+								'element_id'  => 'name-1',
+								'type'        => 'name',
+								'required'    => 'true',
+								'field_label' => 'First Name',
+							],
+							[
+								'id'          => 'email-1',
+								'element_id'  => 'email-1',
+								'type'        => 'email',
+								'required'    => 'true',
+								'field_label' => 'Email Address',
+							],
+						],
+						'settings' => [
+							'form-type'            => 'leads',
+							'submission-behaviour' => 'behaviour-thankyou',
+							'thankyou-message'     => 'Thank you for contacting us, we will be in touch shortly.',
+							'submitData'           => [
+								'custom-submit-text' => 'Submit',
+								'custom-invalid-form-message' => 'Error: Your form is not valid, please fix the errors!',
+							],
+							'enable-ajax'          => 'true',
+							'validation-inline'    => true,
+							'formName'             => 'Forminator Quiz - Leads Form',
+						],
+					],
+				],
+			]
+		);
+
+		// Create and return Quiz Form.
+		return $I->havePostInDatabase(
+			[
+				'post_name'   => 'forminator-quiz',
+				'post_title'  => 'Forminator Quiz',
+				'post_type'   => 'forminator_quizzes',
+				'post_status' => 'publish',
+				'meta_input'  => [
+					'forminator_form_meta' => [
+						'fields'    => [],
+						'settings'  => [
+							'hasLeads'          => '1',
+							'formName'          => 'Forminator Quiz',
+							'results_behav'     => 'end',
+							'leadsId'           => $formLeadsID,
+							'store_submissions' => '1',
+							'quiz_title'        => 'Forminator Quiz',
+							'wrappers'          => [
+								[
+									'wrapper_id' => '1',
+									'fields'     => [
+										[
+											'id'          => 'name-1',
+											'element_id'  => 'name-1',
+											'type'        => 'name',
+											'required'    => 'true',
+											'field_label' => 'First Name',
+										],
+										[
+											'id'          => 'email-1',
+											'element_id'  => 'email-1',
+											'type'        => 'email',
+											'required'    => 'true',
+											'field_label' => 'Email Address',
+										],
+									],
+								],
+							],
+							'lead_settings'     => [
+								'form-type'            => 'leads',
+								'submission-behaviour' => 'behaviour-thankyou',
+								'thankyou-message'     => 'Thank you for contacting us, we will be in touch shortly.',
+								'submitData'           => [
+									'custom-submit-text' => 'Submit',
+									'custom-invalid-form-message' => 'Error: Your form is not valid, please fix the errors!',
+								],
+								'enable-ajax'          => 'true',
+								'validation-inline'    => '1',
+								'formName'             => 'Forminator Quiz - Leads form',
+								'form_id'              => $formLeadsID,
+								'store_submissions'    => '1',
+							],
+							'quiz_name'         => 'Forminator Quiz',
+							'form-placement'    => 'end',
+						],
+						'questions' => [
+							[
+								'slug'    => 'question-1',
+								'answers' => [
+									[
+										'title'  => 'Correct Answer',
+										'toggle' => '1',
+									],
+									[
+										'title' => 'Incorrect Answer',
+									],
+								],
+								'type'    => 'knowledge',
+								'title'   => 'Question',
+							],
+						],
+						'quiz_type' => 'knowledge',
 					],
 				],
 			]


### PR DESCRIPTION
## Summary

Adds options to subscribe entries to a specified ConvertKit Form when a Forminator Quiz form is submitted, as requested [here](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/12263829259133?view=List).

![Screenshot 2024-01-30 at 17 00 08](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/48f780ab-e201-4280-bebd-840e84576a1a)

## Testing

- `ForminatorCest:testSettingsForminatorQuizToConvertKitFormMapping`: Test that a Forminator Quiz is displayed in the Plugin's settings screen, and that subscribers are sent to ConvertKit when enabled.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)