### PR TITLE
Restrict Content: Support Public Custom Post Types

### DIFF
--- a/admin/class-convertkit-admin-restrict-content.php
+++ b/admin/class-convertkit-admin-restrict-content.php
@@ -113,7 +113,7 @@ class ConvertKit_Admin_Restrict_Content {
 		}
 
 		// Don't filter if we're not querying a Post Type that supports Restricted Content.
-		if ( ! in_array( $query->get( 'post_type' ), convertkit_get_supported_restrict_content_post_types(), true ) ) {
+		if ( ! in_array( $query->get( 'post_type' ), convertkit_get_supported_post_types(), true ) ) {
 			return;
 		}
 
@@ -206,7 +206,7 @@ class ConvertKit_Admin_Restrict_Content {
 	public function output_wp_list_table_filters( $post_type ) {
 
 		// Don't output filters if we're not viewing a Post Type that supports Restricted Content.
-		if ( ! in_array( $post_type, convertkit_get_supported_restrict_content_post_types(), true ) ) {
+		if ( ! in_array( $post_type, convertkit_get_supported_post_types(), true ) ) {
 			return;
 		}
 
@@ -280,7 +280,7 @@ class ConvertKit_Admin_Restrict_Content {
 		}
 
 		// Return whether Post Type is supported for Restrict Content functionality.
-		return in_array( $screen->post_type, convertkit_get_supported_restrict_content_post_types(), true );
+		return in_array( $screen->post_type, convertkit_get_supported_post_types(), true );
 
 	}
 

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php
@@ -229,7 +229,7 @@ class ConvertKit_Admin_Setup_Wizard_Restrict_Content extends ConvertKit_Admin_Se
 
 		// Bail if the Post Type isn't supported.
 		$this->post_type = isset( $_REQUEST['ck_post_type'] ) ? sanitize_text_field( $_REQUEST['ck_post_type'] ) : 'page'; // phpcs:ignore WordPress.Security.NonceVerification
-		if ( ! in_array( $this->post_type, convertkit_get_supported_restrict_content_post_types(), true ) ) {
+		if ( ! in_array( $this->post_type, convertkit_get_supported_post_types(), true ) ) {
 			wp_die(
 				sprintf(
 					/* translators: Post Type */

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -152,25 +152,13 @@ function convertkit_get_supported_post_types() {
  *
  * @since   2.1.0
  *
+ * @deprecated 2.4.3 No longer used by internal code and not recommended. Use `convertkit_get_supported_post_types` instead.
+ *
  * @return  array   Post Types
  */
 function convertkit_get_supported_restrict_content_post_types() {
 
-	$post_types = array(
-		'page',
-		'post',
-	);
-
-	/**
-	 * Defines the Post Types that support Restricted Content / Members Content functionality.
-	 *
-	 * @since   2.0.0
-	 *
-	 * @param   array   $post_types     Post Types
-	 */
-	$post_types = apply_filters( 'convertkit_get_supported_restrict_content_post_types', $post_types );
-
-	return $post_types;
+	return convertkit_get_supported_post_types();
 
 }
 

--- a/tests/acceptance/restrict-content/RestrictContentFilterCPTCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentFilterCPTCest.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Tests the filter dropdown for Restrict Content in the CPT WP_List_Table.
+ *
+ * @since   2.4.3
+ */
+class RestrictContentFilterCPTCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   2.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		// Activate ConvertKit plugin.
+		$I->activateConvertKitPlugin($I);
+
+		// Create a public Custom Post Type called Articles, using the Custom Post Type UI Plugin.
+		$I->registerCustomPostType($I, 'article', 'Articles', 'Article');
+
+		// Create a non-public Custom Post Type called Private, using the Custom Post Type UI Plugin.
+		$I->registerCustomPostType($I, 'private', 'Private', 'Private', false);
+	}
+
+	/**
+	 * Test that no dropdown filter on the CPT screen is displayed when no API keys are configured.
+	 *
+	 * @since   2.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testNoFilterDisplayedWhenNoAPIKeys(AcceptanceTester $I)
+	{
+		// Navigate to Articles.
+		$I->amOnAdminPage('edit.php?post_type=article');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check no filter is displayed, as the Plugin isn't configured.
+		$I->dontSeeElementInDOM('#wp-convertkit-restrict-content-filter');
+	}
+
+	/**
+	 * Test that no dropdown filter on the CPT screen is displayed when the ConvertKit
+	 * account has no Forms, Tag and Products.
+	 *
+	 * @since   2.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testNoFilterDisplayedWhenNoResources(AcceptanceTester $I)
+	{
+		// Setup Plugin using API keys that have no resources.
+		$I->setupConvertKitPluginAPIKeyNoData($I);
+
+		// Navigate to Articles.
+		$I->amOnAdminPage('edit.php?post_type=article');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check no filter is displayed, as the ConvertKit account has no resources.
+		$I->dontSeeElementInDOM('#wp-convertkit-restrict-content-filter');
+	}
+
+	/**
+	 * Test that no dropdown filter on the CPT screen is displayed when the Post Type
+	 * is not public.
+	 *
+	 * @since   2.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testNoFilterOnPrivateCPT(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Navigate to Private CPT.
+		$I->amOnAdminPage('edit.php?post_type=private');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check no filter is displayed.
+		$I->dontSeeElementInDOM('#wp-convertkit-restrict-content-filter');
+	}
+
+	/**
+	 * Test that filtering by Product works on the Articles screen.
+	 *
+	 * @since   2.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFilterByProduct(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Create Article, set to restrict content to a Product.
+		$I->createRestrictedContentPage(
+			$I,
+			[
+				'post_type'                => 'article',
+				'post_title'               => 'ConvertKit: Article: Restricted Content: Product: Filter Test',
+				'restrict_content_setting' => 'product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+			]
+		);
+
+		// Navigate to Articles.
+		$I->amOnAdminPage('edit.php?post_type=article');
+
+		// Wait for the WP_List_Table of Articles to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Article is listed, and has the 'ConvertKit Member Content' label.
+		$I->see('ConvertKit: Article: Restricted Content: Product: Filter Test');
+		$I->see('ConvertKit Member Content');
+
+		// Filter by Product.
+		$I->selectOption('#wp-convertkit-restrict-content-filter', $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
+		$I->click('Filter');
+
+		// Wait for the WP_List_Table of Articles to load.
+		$I->waitForElementVisible('tbody#the-list');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Article is still listed, and has the 'ConvertKit Member Content' label.
+		$I->see('ConvertKit: Article: Restricted Content: Product: Filter Test');
+		$I->see('ConvertKit Member Content');
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   2.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->unregisterCustomPostType($I, 'article');
+		$I->unregisterCustomPostType($I, 'private');
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
+	}
+}

--- a/tests/acceptance/restrict-content/RestrictContentProductCPTCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentProductCPTCest.php
@@ -1,0 +1,362 @@
+<?php
+/**
+ * Tests Restrict Content by Product functionality on WordPress Pages.
+ *
+ * @since   2.1.0
+ */
+class RestrictContentProductPageCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		// Activate ConvertKit plugin.
+		$I->activateConvertKitPlugin($I);
+	}
+
+	/**
+	 * Test that content is not restricted when not configured on a WordPress Page.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentWhenDisabled(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin, disabling JS.
+		$I->setupConvertKitPluginDisableJS($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Restrict Content: Product');
+
+		// Add blocks.
+		$I->addGutenbergParagraphBlock($I, 'Visible content.');
+		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergParagraphBlock($I, 'Member only content.');
+
+		// Publish Page.
+		$url = $I->publishGutenbergPage($I);
+
+		// Confirm that all content is displayed.
+		$I->amOnUrl($url);
+		$I->see('Visible content.');
+		$I->see('Member only content.');
+	}
+
+	/**
+	 * Test that restricting content by a Product specified in the Page Settings works when
+	 * creating and viewing a new WordPress Page.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentByProduct(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin, disabling JS.
+		$I->setupConvertKitPluginDisableJS($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Restrict Content: Product');
+
+		// Configure metabox's Restrict Content setting = Product name.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form'             => [ 'select2', 'None' ],
+				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+			]
+		);
+
+		// Add blocks.
+		$I->addGutenbergParagraphBlock($I, 'Visible content.');
+		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergParagraphBlock($I, 'Member only content.');
+
+		// Publish Page.
+		$url = $I->publishGutenbergPage($I);
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentByProductOnFrontend($I, $url);
+	}
+
+	/**
+	 * Test that restricting content by a Product specified in the Page Settings works when
+	 * creating and viewing a new WordPress Page, and that the WordPress generated Page Excerpt
+	 * is displayed when no more tag exists.
+	 *
+	 * @since   2.3.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentByProductWithGeneratedExcerpt(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin, disabling JS.
+		$I->setupConvertKitPluginDisableJS($I);
+
+		// Define visible content and member only content.
+		$visibleContent    = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at velit purus. Nam gravida tempor tellus, sit amet euismod arcu. Mauris sed mattis leo. Mauris viverra eget tellus sit amet vehicula. Nulla eget sapien quis felis euismod pellentesque. Quisque elementum et diam nec eleifend. Sed ornare quam eget augue consequat, in maximus quam fringilla. Morbi';
+		$memberOnlyContent = 'Member only content';
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Restrict Content: Product: Generated Excerpt');
+
+		// Configure metabox's Restrict Content setting = Product name.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form'             => [ 'select2', 'None' ],
+				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+			]
+		);
+
+		// Add blocks.
+		$I->addGutenbergParagraphBlock($I, $visibleContent);
+		$I->addGutenbergParagraphBlock($I, $memberOnlyContent);
+
+		// Publish Page.
+		$url = $I->publishGutenbergPage($I);
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentByProductOnFrontend(
+			$I,
+			$url,
+			[
+				'visible_content' => $visibleContent,
+				'member_content'  => $memberOnlyContent,
+			]
+		);
+	}
+
+	/**
+	 * Test that restricting content by a Product specified in the Page Settings works when
+	 * creating and viewing a new WordPress Page, and JS is enabled to allow the modal
+	 * version for the authentication flow to be used.
+	 *
+	 * @since   2.3.8
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentModalByProduct(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Restrict Content: Product: Modal');
+
+		// Configure metabox's Restrict Content setting = Product name.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form'             => [ 'select2', 'None' ],
+				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+			]
+		);
+
+		// Add blocks.
+		$I->addGutenbergParagraphBlock($I, 'Visible content.');
+		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergParagraphBlock($I, 'Member only content.');
+
+		// Publish Page.
+		$url = $I->publishGutenbergPage($I);
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentModalByProductOnFrontend($I, $url);
+	}
+
+	/**
+	 * Test that restricting content by a Product that does not exist does not output
+	 * a fatal error and instead displays all of the Page's content.
+	 *
+	 * This checks for when a Product is deleted in ConvertKit, but is still specified
+	 * as the Restrict Content setting for a Page.
+	 *
+	 * @since   2.3.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentByInvalidProduct(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin, disabling JS.
+		$I->setupConvertKitPluginDisableJS($I);
+
+		// Programmatically create a Page.
+		$pageID = $I->createRestrictedContentPage(
+			$I,
+			[
+				'post_title'               => 'ConvertKit: Page: Restrict Content: Invalid Product',
+				'restrict_content_setting' => 'product_12345', // A fake Product that does not exist in ConvertKit.
+			]
+		);
+
+		// Navigate to the page.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Confirm all content displays, with no errors, as the Product is invalid.
+		$I->testRestrictContentDisplaysContent($I);
+	}
+
+	/**
+	 * Test that search engines can access Restrict Content.
+	 *
+	 * @since   2.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentUsingCrawler(AcceptanceTester $I)
+	{
+		// Enable ConvertKit Action and Filter Tests Plugin.
+		// This will register Chrome and 127.0.0.1 as a user agent and client IP address combination
+		// that is permitted to bypass Restrict Content functionality, as if we were a crawler.
+		$I->activateThirdPartyPlugin($I, 'convertkit-actions-and-filters-tests');
+
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+
+		// Setup Restrict Content functionality with permit crawlers setting enabled.
+		$I->setupConvertKitPluginRestrictContent(
+			$I,
+			[
+				'permit_crawlers' => 'on',
+			]
+		);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Restrict Content: Product: Search Engines');
+
+		// Configure metabox's Restrict Content setting = Product name.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form'             => [ 'select2', 'None' ],
+				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+			]
+		);
+
+		// Add blocks.
+		$I->addGutenbergParagraphBlock($I, 'Visible content.');
+		$I->addGutenbergBlock($I, 'More', 'more');
+		$I->addGutenbergParagraphBlock($I, 'Member only content.');
+
+		// Publish Page.
+		$url = $I->publishGutenbergPage($I);
+
+		// Load page.
+		$I->amOnUrl($url);
+
+		// Confirm page displays all content, as we're a crawler.
+		$I->testRestrictContentDisplaysContent($I);
+	}
+
+	/**
+	 * Test that restricting content by a Product specified in the Page Settings works when
+	 * using the Quick Edit functionality.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentByProductUsingQuickEdit(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin, disabling JS.
+		$I->setupConvertKitPluginDisableJS($I);
+
+		// Programmatically create a Page.
+		$pageID = $I->createRestrictedContentPage(
+			$I,
+			[
+				'post_title' => 'ConvertKit: Page: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Quick Edit',
+			]
+		);
+
+		// Quick Edit the Page in the Pages WP_List_Table.
+		$I->quickEdit(
+			$I,
+			'page',
+			$pageID,
+			[
+				'restrict_content' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+			]
+		);
+
+		// Test Restrict Content functionality.
+		$I->testRestrictedContentByProductOnFrontend($I, $pageID);
+	}
+
+	/**
+	 * Test that restricting content by a Product specified in the Page Settings works when
+	 * using the Bulk Edit functionality.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentByProductUsingBulkEdit(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin, disabling JS.
+		$I->setupConvertKitPluginDisableJS($I);
+
+		// Programmatically create two Pages.
+		$pageIDs = array(
+			$I->createRestrictedContentPage(
+				$I,
+				[
+					'post_title' => 'ConvertKit: Page: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Bulk Edit #1',
+				]
+			),
+			$I->createRestrictedContentPage(
+				$I,
+				[
+					'post_title' => 'ConvertKit: Page: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Bulk Edit #2',
+				]
+			),
+		);
+
+		// Bulk Edit the Pages in the Pages WP_List_Table.
+		$I->bulkEdit(
+			$I,
+			'page',
+			$pageIDs,
+			[
+				'restrict_content' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+			]
+		);
+
+		// Iterate through Pages to run frontend tests.
+		foreach ($pageIDs as $pageID) {
+			// Test Restrict Content functionality.
+			$I->testRestrictedContentByProductOnFrontend($I, $pageID);
+			$I->resetCookie('ck_subscriber_id');
+		}
+	}
+
+
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   2.1.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->resetCookie('ck_subscriber_id');
+		$I->deactivateThirdPartyPlugin($I, 'convertkit-actions-and-filters-tests');
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
+	}
+}

--- a/tests/acceptance/restrict-content/RestrictContentProductCPTCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentProductCPTCest.php
@@ -97,7 +97,7 @@ class RestrictContentProductCPTCest
 	 * creating and viewing a new WordPress CPT, and that the WordPress generated CPT Excerpt
 	 * is displayed when no more tag exists.
 	 *
-	 * @since   2.3.7
+	 * @since   2.4.3
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
@@ -146,7 +146,7 @@ class RestrictContentProductCPTCest
 	 * creating and viewing a new WordPress CPT, and JS is enabled to allow the modal
 	 * version for the authentication flow to be used.
 	 *
-	 * @since   2.3.8
+	 * @since   2.4.3
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */

--- a/tests/acceptance/restrict-content/RestrictContentProductCPTCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentProductCPTCest.php
@@ -55,6 +55,29 @@ class RestrictContentProductCPTCest
 	}
 
 	/**
+	 * Test that no Restrict Content options are displayed when the Post Type
+	 * is not public.
+	 *
+	 * @since   2.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testNoRestrictContentOnPrivateCPT(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin, disabling JS.
+		$I->setupConvertKitPluginDisableJS($I);
+
+		// Add the CPT using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'private', 'ConvertKit: Private: Restrict Content');
+
+		// Check that the metabox is not displayed.
+		$I->dontSeeElementInDOM('#wp-convertkit-meta-box');
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+	}
+
+	/**
 	 * Test that restricting content by a Product specified in the CPT Settings works when
 	 * creating and viewing a new WordPress CPT.
 	 *
@@ -309,6 +332,8 @@ class RestrictContentProductCPTCest
 	 */
 	public function _passed(AcceptanceTester $I)
 	{
+		$I->unregisterCustomPostType($I, 'article');
+		$I->unregisterCustomPostType($I, 'private');
 		$I->resetCookie('ck_subscriber_id');
 		$I->deactivateConvertKitPlugin($I);
 		$I->resetConvertKitPlugin($I);

--- a/tests/acceptance/restrict-content/RestrictContentProductCPTCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentProductCPTCest.php
@@ -1,15 +1,15 @@
 <?php
 /**
- * Tests Restrict Content by Product functionality on WordPress Pages.
+ * Tests Restrict Content by Product functionality on WordPress Custom Post Types.
  *
- * @since   2.1.0
+ * @since   2.4.3
  */
-class RestrictContentProductPageCest
+class RestrictContentProductCPTCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
 	 *
-	 * @since   2.1.0
+	 * @since   2.4.3
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
@@ -17,12 +17,18 @@ class RestrictContentProductPageCest
 	{
 		// Activate ConvertKit plugin.
 		$I->activateConvertKitPlugin($I);
+
+		// Create a public Custom Post Type called Articles, using the Custom Post Type UI Plugin.
+		$I->registerCustomPostType($I, 'article', 'Articles', 'Article');
+
+		// Create a non-public Custom Post Type called Private, using the Custom Post Type UI Plugin.
+		$I->registerCustomPostType($I, 'private', 'Private', 'Private', false);
 	}
 
 	/**
-	 * Test that content is not restricted when not configured on a WordPress Page.
+	 * Test that content is not restricted when not configured on a WordPress CPT.
 	 *
-	 * @since   2.1.0
+	 * @since   2.4.3
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
@@ -31,15 +37,15 @@ class RestrictContentProductPageCest
 		// Setup ConvertKit Plugin, disabling JS.
 		$I->setupConvertKitPluginDisableJS($I);
 
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Restrict Content: Product');
+		// Add the CPT using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'article', 'ConvertKit: Article: Restrict Content: Product');
 
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
 		$I->addGutenbergBlock($I, 'More', 'more');
 		$I->addGutenbergParagraphBlock($I, 'Member only content.');
 
-		// Publish Page.
+		// Publish Article.
 		$url = $I->publishGutenbergPage($I);
 
 		// Confirm that all content is displayed.
@@ -49,10 +55,10 @@ class RestrictContentProductPageCest
 	}
 
 	/**
-	 * Test that restricting content by a Product specified in the Page Settings works when
-	 * creating and viewing a new WordPress Page.
+	 * Test that restricting content by a Product specified in the CPT Settings works when
+	 * creating and viewing a new WordPress CPT.
 	 *
-	 * @since   2.1.0
+	 * @since   2.4.3
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
@@ -61,8 +67,8 @@ class RestrictContentProductPageCest
 		// Setup ConvertKit Plugin, disabling JS.
 		$I->setupConvertKitPluginDisableJS($I);
 
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Restrict Content: Product');
+		// Add the CPT using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'article', 'ConvertKit: Article: Restrict Content: Product');
 
 		// Configure metabox's Restrict Content setting = Product name.
 		$I->configureMetaboxSettings(
@@ -79,7 +85,7 @@ class RestrictContentProductPageCest
 		$I->addGutenbergBlock($I, 'More', 'more');
 		$I->addGutenbergParagraphBlock($I, 'Member only content.');
 
-		// Publish Page.
+		// Publish Article.
 		$url = $I->publishGutenbergPage($I);
 
 		// Test Restrict Content functionality.
@@ -87,8 +93,8 @@ class RestrictContentProductPageCest
 	}
 
 	/**
-	 * Test that restricting content by a Product specified in the Page Settings works when
-	 * creating and viewing a new WordPress Page, and that the WordPress generated Page Excerpt
+	 * Test that restricting content by a Product specified in the CPT Settings works when
+	 * creating and viewing a new WordPress CPT, and that the WordPress generated CPT Excerpt
 	 * is displayed when no more tag exists.
 	 *
 	 * @since   2.3.7
@@ -104,8 +110,8 @@ class RestrictContentProductPageCest
 		$visibleContent    = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at velit purus. Nam gravida tempor tellus, sit amet euismod arcu. Mauris sed mattis leo. Mauris viverra eget tellus sit amet vehicula. Nulla eget sapien quis felis euismod pellentesque. Quisque elementum et diam nec eleifend. Sed ornare quam eget augue consequat, in maximus quam fringilla. Morbi';
 		$memberOnlyContent = 'Member only content';
 
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Restrict Content: Product: Generated Excerpt');
+		// Add the CPT using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'article', 'ConvertKit: Article: Restrict Content: Product: Generated Excerpt');
 
 		// Configure metabox's Restrict Content setting = Product name.
 		$I->configureMetaboxSettings(
@@ -136,8 +142,8 @@ class RestrictContentProductPageCest
 	}
 
 	/**
-	 * Test that restricting content by a Product specified in the Page Settings works when
-	 * creating and viewing a new WordPress Page, and JS is enabled to allow the modal
+	 * Test that restricting content by a Product specified in the CPT Settings works when
+	 * creating and viewing a new WordPress CPT, and JS is enabled to allow the modal
 	 * version for the authentication flow to be used.
 	 *
 	 * @since   2.3.8
@@ -149,8 +155,8 @@ class RestrictContentProductPageCest
 		// Setup ConvertKit Plugin.
 		$I->setupConvertKitPlugin($I);
 
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Restrict Content: Product: Modal');
+		// Add the CPT using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'article', 'ConvertKit: Article: Restrict Content: Product: Modal');
 
 		// Configure metabox's Restrict Content setting = Product name.
 		$I->configureMetaboxSettings(
@@ -167,7 +173,7 @@ class RestrictContentProductPageCest
 		$I->addGutenbergBlock($I, 'More', 'more');
 		$I->addGutenbergParagraphBlock($I, 'Member only content.');
 
-		// Publish Page.
+		// Publish Article.
 		$url = $I->publishGutenbergPage($I);
 
 		// Test Restrict Content functionality.
@@ -176,12 +182,12 @@ class RestrictContentProductPageCest
 
 	/**
 	 * Test that restricting content by a Product that does not exist does not output
-	 * a fatal error and instead displays all of the Page's content.
+	 * a fatal error and instead displays all of the CPT's content.
 	 *
 	 * This checks for when a Product is deleted in ConvertKit, but is still specified
-	 * as the Restrict Content setting for a Page.
+	 * as the Restrict Content setting for the CPT.
 	 *
-	 * @since   2.3.3
+	 * @since   2.4.3
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
@@ -190,80 +196,28 @@ class RestrictContentProductPageCest
 		// Setup ConvertKit Plugin, disabling JS.
 		$I->setupConvertKitPluginDisableJS($I);
 
-		// Programmatically create a Page.
-		$pageID = $I->createRestrictedContentPage(
+		// Programmatically create the CPT.
+		$postID = $I->createRestrictedContentPage(
 			$I,
 			[
-				'post_title'               => 'ConvertKit: Page: Restrict Content: Invalid Product',
+				'post_type'                => 'article',
+				'post_title'               => 'ConvertKit: Article: Restrict Content: Invalid Product',
 				'restrict_content_setting' => 'product_12345', // A fake Product that does not exist in ConvertKit.
 			]
 		);
 
-		// Navigate to the page.
-		$I->amOnPage('?p=' . $pageID);
+		// Navigate to the article.
+		$I->amOnPage('?p=' . $postID);
 
 		// Confirm all content displays, with no errors, as the Product is invalid.
 		$I->testRestrictContentDisplaysContent($I);
 	}
 
 	/**
-	 * Test that search engines can access Restrict Content.
-	 *
-	 * @since   2.4.2
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 */
-	public function testRestrictContentUsingCrawler(AcceptanceTester $I)
-	{
-		// Enable ConvertKit Action and Filter Tests Plugin.
-		// This will register Chrome and 127.0.0.1 as a user agent and client IP address combination
-		// that is permitted to bypass Restrict Content functionality, as if we were a crawler.
-		$I->activateThirdPartyPlugin($I, 'convertkit-actions-and-filters-tests');
-
-		// Setup ConvertKit Plugin.
-		$I->setupConvertKitPlugin($I);
-
-		// Setup Restrict Content functionality with permit crawlers setting enabled.
-		$I->setupConvertKitPluginRestrictContent(
-			$I,
-			[
-				'permit_crawlers' => 'on',
-			]
-		);
-
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Restrict Content: Product: Search Engines');
-
-		// Configure metabox's Restrict Content setting = Product name.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			[
-				'form'             => [ 'select2', 'None' ],
-				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
-			]
-		);
-
-		// Add blocks.
-		$I->addGutenbergParagraphBlock($I, 'Visible content.');
-		$I->addGutenbergBlock($I, 'More', 'more');
-		$I->addGutenbergParagraphBlock($I, 'Member only content.');
-
-		// Publish Page.
-		$url = $I->publishGutenbergPage($I);
-
-		// Load page.
-		$I->amOnUrl($url);
-
-		// Confirm page displays all content, as we're a crawler.
-		$I->testRestrictContentDisplaysContent($I);
-	}
-
-	/**
-	 * Test that restricting content by a Product specified in the Page Settings works when
+	 * Test that restricting content by a Product specified in the CPT Settings works when
 	 * using the Quick Edit functionality.
 	 *
-	 * @since   2.1.0
+	 * @since   2.4.3
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
@@ -272,33 +226,34 @@ class RestrictContentProductPageCest
 		// Setup ConvertKit Plugin, disabling JS.
 		$I->setupConvertKitPluginDisableJS($I);
 
-		// Programmatically create a Page.
-		$pageID = $I->createRestrictedContentPage(
+		// Programmatically create the CPT.
+		$postID = $I->createRestrictedContentPage(
 			$I,
 			[
-				'post_title' => 'ConvertKit: Page: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Quick Edit',
+				'post_type'  => 'article',
+				'post_title' => 'ConvertKit: Article: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Quick Edit',
 			]
 		);
 
-		// Quick Edit the Page in the Pages WP_List_Table.
+		// Quick Edit the CPT in the CPTs WP_List_Table.
 		$I->quickEdit(
 			$I,
-			'page',
-			$pageID,
+			'article',
+			$postID,
 			[
 				'restrict_content' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			]
 		);
 
 		// Test Restrict Content functionality.
-		$I->testRestrictedContentByProductOnFrontend($I, $pageID);
+		$I->testRestrictedContentByProductOnFrontend($I, $postID);
 	}
 
 	/**
-	 * Test that restricting content by a Product specified in the Page Settings works when
+	 * Test that restricting content by a Product specified in the CPT Settings works when
 	 * using the Bulk Edit functionality.
 	 *
-	 * @since   2.1.0
+	 * @since   2.4.3
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
@@ -307,55 +262,54 @@ class RestrictContentProductPageCest
 		// Setup ConvertKit Plugin, disabling JS.
 		$I->setupConvertKitPluginDisableJS($I);
 
-		// Programmatically create two Pages.
-		$pageIDs = array(
+		// Programmatically create two CPTs.
+		$postIDs = array(
 			$I->createRestrictedContentPage(
 				$I,
 				[
-					'post_title' => 'ConvertKit: Page: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Bulk Edit #1',
+					'post_type'  => 'article',
+					'post_title' => 'ConvertKit: Article: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Bulk Edit #1',
 				]
 			),
 			$I->createRestrictedContentPage(
 				$I,
 				[
-					'post_title' => 'ConvertKit: Page: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Bulk Edit #2',
+					'post_type'  => 'article',
+					'post_title' => 'ConvertKit: Article: Restrict Content: Product: ' . $_ENV['CONVERTKIT_API_PRODUCT_NAME'] . ': Bulk Edit #2',
 				]
 			),
 		);
 
-		// Bulk Edit the Pages in the Pages WP_List_Table.
+		// Bulk Edit the CPTs in the CPTs WP_List_Table.
 		$I->bulkEdit(
 			$I,
-			'page',
-			$pageIDs,
+			'article',
+			$postIDs,
 			[
 				'restrict_content' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			]
 		);
 
-		// Iterate through Pages to run frontend tests.
-		foreach ($pageIDs as $pageID) {
+		// Iterate through Articles to run frontend tests.
+		foreach ($postIDs as $postID) {
 			// Test Restrict Content functionality.
-			$I->testRestrictedContentByProductOnFrontend($I, $pageID);
+			$I->testRestrictedContentByProductOnFrontend($I, $postID);
 			$I->resetCookie('ck_subscriber_id');
 		}
 	}
-
-
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
 	 *
-	 * @since   2.1.0
+	 * @since   2.4.3
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{
 		$I->resetCookie('ck_subscriber_id');
-		$I->deactivateThirdPartyPlugin($I, 'convertkit-actions-and-filters-tests');
 		$I->deactivateConvertKitPlugin($I);
 		$I->resetConvertKitPlugin($I);
 	}

--- a/tests/acceptance/restrict-content/RestrictContentProductPageCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentProductPageCest.php
@@ -341,8 +341,6 @@ class RestrictContentProductPageCest
 		}
 	}
 
-
-
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin


### PR DESCRIPTION
## Summary

Adds support for Member Content functionality on public [Custom Post Types](https://developer.wordpress.org/plugins/post-types/registering-custom-post-types/), as requested [here](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/12263829418792?view=List) (in this example, the Recipe Custom Post Type registered through the Advanced Custom Fields Plugin has the option to restrict by Product or Tag).

![Screenshot 2024-01-31 at 13 53 15](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/35848242-39be-4513-8396-0328a1139e1c)

Previously, the option to restrict content to a ConvertKit Tag or Product was only available on Pages and Posts

## Testing

- `RestrictContentFilterCPTCest`: Test that filter options on a public Custom Post Type are displayed and work.
- `RestrictContentProductCPTCest`: Test that Restrict Content functionality works on a public Custom Post Type.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)