### PR TITLE
Divi: Fix missing scrollbars

### DIFF
--- a/includes/class-convertkit-gutenberg.php
+++ b/includes/class-convertkit-gutenberg.php
@@ -187,8 +187,8 @@ class ConvertKit_Gutenberg {
 	 */
 	public function enqueue_styles() {
 
-		// Bail if request isn't for the Admin or a Frontend Editor.
-		if ( ! WP_ConvertKit()->is_admin_or_frontend_editor() ) {
+		// Bail if request isn't for the Admin.
+		if ( ! is_admin() ) {
 			return;
 		}
 


### PR DESCRIPTION
## Summary

When using the Divi Builder, and switching from desktop to tablet or mobile views, the ability to vertically scroll disappears. Reported [here](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/conversation/12263829446216?view=List) and [here](https://drive.google.com/file/d/1fdNo5GkoxpaMrdFwHt_mRxAxm98lrkXm/view?usp=sharing).

Not loading our Plugin's `gutenberg.css` stylesheet resolves, by ensuring it only loads when in the WordPress Administration (previously, this would be loaded if in the WordPress Administration or using a third party Page Builder on the frontend site).

Given the stylesheet is only used when in the Gutenberg / block editor, it doesn't need to be loaded.

Before (no scrollbar on the right, no ability to scroll using scrollbar or mouse wheel):
![Screenshot 2024-01-31 at 14 01 32](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/000fecc2-6b7b-4bfb-9404-62ede41c4dda)

After (scrollbar on the right, can scroll using scrollbar or mouse wheel):
![Screenshot 2024-01-31 at 14 01 43](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/8628890a-6211-4983-a72a-8e5eac0237e7)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)