### PR TITLE
Jetpack Boost: Fix inline Forms output

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       DB_USER: root
       DB_PASS: root
       DB_HOST: localhost
-      INSTALL_PLUGINS: "admin-menu-editor contact-form-7 classic-editor custom-post-type-ui disable-welcome-messages-and-tips elementor forminator woocommerce wordpress-seo wpforms-lite litespeed-cache wp-crontrol wp-super-cache w3-total-cache wp-fastest-cache wp-optimize" # Don't include this repository's Plugin here.
+      INSTALL_PLUGINS: "admin-menu-editor contact-form-7 classic-editor custom-post-type-ui disable-welcome-messages-and-tips elementor forminator jetpack-boost woocommerce wordpress-seo wpforms-lite litespeed-cache wp-crontrol wp-super-cache w3-total-cache wp-fastest-cache wp-optimize" # Don't include this repository's Plugin here.
       INSTALL_PLUGINS_URLS: "https://downloads.wordpress.org/plugin/convertkit-for-woocommerce.1.6.4.zip http://cktestplugins.wpengine.com/wp-content/uploads/2024/01/convertkit-action-filter-tests.zip" # URLs to specific third party Plugins
       CONVERTKIT_API_KEY: ${{ secrets.CONVERTKIT_API_KEY }} # ConvertKit API Key, stored in the repository's Settings > Secrets
       CONVERTKIT_API_SECRET: ${{ secrets.CONVERTKIT_API_SECRET }} # ConvertKit API Secret, stored in the repository's Settings > Secrets

--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -324,7 +324,9 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource {
 		}
 
 		// If here, return Form <script> embed now, as we want the inline form to display at this specific point of the content.
-		return '<script async data-uid="' . esc_attr( $this->resources[ $id ]['uid'] ) . '" src="' . esc_url( $this->resources[ $id ]['embed_js'] ) . '"></script>';
+		// data-jetpack-boost="ignore" is required to prevent Jetpack Boost from moving this to the footer when its
+		// "Defer Non-Essential JavaScript" setting is enabled: https://jetpack.com/support/jetpack-boost/.
+		return '<script async data-uid="' . esc_attr( $this->resources[ $id ]['uid'] ) . '" src="' . esc_url( $this->resources[ $id ]['embed_js'] ) . '" data-jetpack-boost="ignore"></script>';
 
 	}
 

--- a/tests/acceptance/forms/blocks/PageBlockFormCest.php
+++ b/tests/acceptance/forms/blocks/PageBlockFormCest.php
@@ -620,6 +620,61 @@ class PageBlockFormCest
 	}
 
 	/**
+	 * Test that the Form <script> embed is output in the content, and not the footer of the site
+	 * when the Jetpack Boost Plugin is active and its "Defer Non-Essential JavaScript" setting is enabled.
+	 *
+	 * @since   2.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFormBlockWithJetpackBoostPlugin(AcceptanceTester $I)
+	{
+		// Setup Plugin and Resources.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Activate Jetpack Boost Plugin.
+		$I->activateThirdPartyPlugin($I, 'jetpack-boost');
+
+		// Enable Jetpack Boost's "Defer Non-Essential JavaScript" setting.
+		$I->amOnAdminPage('admin.php?page=jetpack-boost');
+		$I->click('#inspector-toggle-control-1');
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Jetpack Boost');
+
+		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
+
+		// Add block to Page, setting the Form setting to the value specified in the .env file.
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+			]
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that one ConvertKit Form is output in the DOM within the <main> element.
+		// This confirms that there is only one script on the page for this form, which renders the form,
+		// and that Jetpack Boost hasn't moved the script embed to the footer of the site.
+		$I->seeNumberOfElementsInDOM('main form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+
+		// Deactivate Jetpack Boost Plugin.
+		$I->deactivateThirdPartyPlugin($I, 'jetpack-boost');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/acceptance/forms/shortcodes/PageShortcodeFormCest.php
+++ b/tests/acceptance/forms/shortcodes/PageShortcodeFormCest.php
@@ -460,6 +460,61 @@ class PageShortcodeFormCest
 	}
 
 	/**
+	 * Test that the Form <script> embed is output in the content, and not the footer of the site
+	 * when the Jetpack Boost Plugin is active and its "Defer Non-Essential JavaScript" setting is enabled.
+	 *
+	 * @since   2.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFormShortcodeWithJetpackBoostPlugin(AcceptanceTester $I)
+	{
+		// Setup Plugin and Resources.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Activate Jetpack Boost Plugin.
+		$I->activateThirdPartyPlugin($I, 'jetpack-boost');
+
+		// Enable Jetpack Boost's "Defer Non-Essential JavaScript" setting.
+		$I->amOnAdminPage('admin.php?page=jetpack-boost');
+		$I->click('#inspector-toggle-control-1');
+
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Form: Shortcode: Jetpack Boost');
+
+		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
+
+		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+		$I->addVisualEditorShortcode(
+			$I,
+			'ConvertKit Form',
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+			],
+			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage($I);
+
+		// Confirm that one ConvertKit Form is output in the DOM within the <main> element.
+		// This confirms that there is only one script on the page for this form, which renders the form,
+		// and that Jetpack Boost hasn't moved the script embed to the footer of the site.
+		$I->seeNumberOfElementsInDOM('main form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+
+		// Deactivate Jetpack Boost Plugin.
+		$I->deactivateThirdPartyPlugin($I, 'jetpack-boost');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/12263829151905?view=List), where an inline Form's `script` embed is moved to the footer of the WordPress site when the Jetpack Boost Plugin is active and its "Defer Non-Essential JavaScript" setting is enabled, by adding a `data-jetpack-boost="ignore"` attribute to the script embed, as documented [here](https://jetpack.com/support/jetpack-boost/).

Before:

![Screenshot 2024-01-31 at 14 23 03](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/9f96152d-6e8f-47f4-935f-2f186620e6c9)

After:

![Screenshot 2024-01-31 at 14 23 09](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/c9b7bc71-e7dc-4a7e-ba49-d5f0ac85fce7)

## Testing

- `PageBlockFormCest:testFormBlockWithJetpackBoostPlugin`: Tests that the ConvertKit Form Block is output in the correct section of the WordPress Page when the Jetpack Boost Plugin is activated and configured.
- `PageShortcodeFormCest:testFormShortcodeWithJetpackBoostPlugin`: Tests that the ConvertKit Form Shortcode is output in the correct section of the WordPress Page when the Jetpack Boost Plugin is activated and configured.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)