### PR TITLE
Remove unused `wp-color-picker` dependencies

### DIFF
--- a/admin/class-convertkit-admin-tinymce.php
+++ b/admin/class-convertkit-admin-tinymce.php
@@ -119,10 +119,6 @@ class ConvertKit_Admin_TinyMCE {
 		// Enqueue Quicktag CSS.
 		wp_enqueue_style( 'convertkit-admin-quicktags', CONVERTKIT_PLUGIN_URL . 'resources/backend/css/quicktags.css', array(), CONVERTKIT_PLUGIN_VERSION );
 
-		// Enqueue WordPress JS and CSS.
-		wp_enqueue_script( 'wp-color-picker' );
-		wp_enqueue_style( 'wp-color-picker' );
-
 		// Output Backbone View Template.
 		add_action( 'wp_print_footer_scripts', array( $this, 'output_quicktags_modal' ) );
 		add_action( 'admin_print_footer_scripts', array( $this, 'output_quicktags_modal' ) );


### PR DESCRIPTION
## Summary

Removes the unused `wp-color-picker` script and style dependencies, as [this PR](https://github.com/ConvertKit/convertkit-wordpress/pull/613) uses the browser's native color picker.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)