### PR TITLE
Fix 'Member Only' Grammar

### DIFF
--- a/admin/class-convertkit-admin-settings-restrict-content.php
+++ b/admin/class-convertkit-admin-settings-restrict-content.php
@@ -213,7 +213,7 @@ class ConvertKit_Admin_Settings_Restrict_Content extends ConvertKit_Settings_Bas
 				'name'        => 'email_button_label',
 				'label_for'   => 'email_button_label',
 				'description' => array(
-					__( 'The text to display for the button to submit the subscriber\'s email address and receive a login link to access the member only content.', 'convertkit' ),
+					__( 'The text to display for the button to submit the subscriber\'s email address and receive a login link to access the member-only content.', 'convertkit' ),
 				),
 			)
 		);

--- a/languages/convertkit.pot
+++ b/languages/convertkit.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2024-01-31T16:12:21+00:00\n"
+"POT-Creation-Date: 2024-01-31T16:18:12+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.9.0\n"
 "X-Domain: convertkit\n"
@@ -167,7 +167,7 @@ msgid "Email Button Label"
 msgstr ""
 
 #: admin/class-convertkit-admin-settings-restrict-content.php:216
-msgid "The text to display for the button to submit the subscriber's email address and receive a login link to access the member only content."
+msgid "The text to display for the button to submit the subscriber's email address and receive a login link to access the member-only content."
 msgstr ""
 
 #: admin/class-convertkit-admin-settings-restrict-content.php:223

--- a/tests/_support/Helper/Acceptance/ConvertKitRestrictContent.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitRestrictContent.php
@@ -130,7 +130,7 @@ class ConvertKitRestrictContent extends \Codeception\Module
 			'post_type'                => 'page',
 			'post_title'               => 'Restrict Content',
 			'visible_content'          => 'Visible content.',
-			'member_content'           => 'Member only content.',
+			'member_content'           => 'Member-only content.',
 			'restrict_content_setting' => '',
 		];
 
@@ -519,7 +519,7 @@ class ConvertKitRestrictContent extends \Codeception\Module
 		// Define default options for Restrict Content tests.
 		$defaults = [
 			'visible_content' => 'Visible content.',
-			'member_content'  => 'Member only content.',
+			'member_content'  => 'Member-only content.',
 			'text_items'      => $this->getRestrictedContentDefaultSettings(),
 		];
 

--- a/tests/acceptance/restrict-content/RestrictContentCacheCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentCacheCest.php
@@ -58,7 +58,7 @@ class RestrictContentCacheCest
 		$I->amOnPage('?p=' . $pageID);
 
 		// Test that the restricted content CTA displays when no valid signed subscriber ID is used,
-		// to confirm caching does not show member only content.
+		// to confirm caching does not show member-only content.
 		$I->testRestrictContentByProductHidesContentWithCTA($I);
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
@@ -107,7 +107,7 @@ class RestrictContentCacheCest
 		$I->amOnPage('?p=' . $pageID);
 
 		// Test that the restricted content CTA displays when no valid signed subscriber ID is used,
-		// to confirm caching does not show member only content.
+		// to confirm caching does not show member-only content.
 		$I->testRestrictContentByProductHidesContentWithCTA($I);
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
@@ -154,7 +154,7 @@ class RestrictContentCacheCest
 		$I->amOnPage('?p=' . $pageID);
 
 		// Test that the restricted content CTA displays when no valid signed subscriber ID is used,
-		// to confirm caching does not show member only content.
+		// to confirm caching does not show member-only content.
 		$I->testRestrictContentByProductHidesContentWithCTA($I);
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
@@ -201,7 +201,7 @@ class RestrictContentCacheCest
 		$I->amOnPage('?p=' . $pageID);
 
 		// Test that the restricted content CTA displays when no valid signed subscriber ID is used,
-		// to confirm caching does not show member only content.
+		// to confirm caching does not show member-only content.
 		$I->testRestrictContentByProductHidesContentWithCTA($I);
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,
@@ -248,7 +248,7 @@ class RestrictContentCacheCest
 		$I->amOnPage('?p=' . $pageID);
 
 		// Test that the restricted content CTA displays when no valid signed subscriber ID is used,
-		// to confirm caching does not show member only content.
+		// to confirm caching does not show member-only content.
 		$I->testRestrictContentByProductHidesContentWithCTA($I);
 
 		// Test that the restricted content displays when a valid signed subscriber ID is used,

--- a/tests/acceptance/restrict-content/RestrictContentProductCPTCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentProductCPTCest.php
@@ -43,7 +43,7 @@ class RestrictContentProductCPTCest
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
 		$I->addGutenbergBlock($I, 'More', 'more');
-		$I->addGutenbergParagraphBlock($I, 'Member only content.');
+		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Article.
 		$url = $I->publishGutenbergPage($I);
@@ -51,7 +51,7 @@ class RestrictContentProductCPTCest
 		// Confirm that all content is displayed.
 		$I->amOnUrl($url);
 		$I->see('Visible content.');
-		$I->see('Member only content.');
+		$I->see('Member-only content.');
 	}
 
 	/**
@@ -106,7 +106,7 @@ class RestrictContentProductCPTCest
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
 		$I->addGutenbergBlock($I, 'More', 'more');
-		$I->addGutenbergParagraphBlock($I, 'Member only content.');
+		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Article.
 		$url = $I->publishGutenbergPage($I);
@@ -129,9 +129,9 @@ class RestrictContentProductCPTCest
 		// Setup ConvertKit Plugin, disabling JS.
 		$I->setupConvertKitPluginDisableJS($I);
 
-		// Define visible content and member only content.
+		// Define visible content and member-only content.
 		$visibleContent    = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at velit purus. Nam gravida tempor tellus, sit amet euismod arcu. Mauris sed mattis leo. Mauris viverra eget tellus sit amet vehicula. Nulla eget sapien quis felis euismod pellentesque. Quisque elementum et diam nec eleifend. Sed ornare quam eget augue consequat, in maximus quam fringilla. Morbi';
-		$memberOnlyContent = 'Member only content';
+		$memberOnlyContent = 'Member-only content';
 
 		// Add the CPT using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'article', 'ConvertKit: Article: Restrict Content: Product: Generated Excerpt');
@@ -194,7 +194,7 @@ class RestrictContentProductCPTCest
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
 		$I->addGutenbergBlock($I, 'More', 'more');
-		$I->addGutenbergParagraphBlock($I, 'Member only content.');
+		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Article.
 		$url = $I->publishGutenbergPage($I);

--- a/tests/acceptance/restrict-content/RestrictContentProductPageCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentProductPageCest.php
@@ -37,7 +37,7 @@ class RestrictContentProductPageCest
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
 		$I->addGutenbergBlock($I, 'More', 'more');
-		$I->addGutenbergParagraphBlock($I, 'Member only content.');
+		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Page.
 		$url = $I->publishGutenbergPage($I);
@@ -45,7 +45,7 @@ class RestrictContentProductPageCest
 		// Confirm that all content is displayed.
 		$I->amOnUrl($url);
 		$I->see('Visible content.');
-		$I->see('Member only content.');
+		$I->see('Member-only content.');
 	}
 
 	/**
@@ -77,7 +77,7 @@ class RestrictContentProductPageCest
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
 		$I->addGutenbergBlock($I, 'More', 'more');
-		$I->addGutenbergParagraphBlock($I, 'Member only content.');
+		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Page.
 		$url = $I->publishGutenbergPage($I);
@@ -100,9 +100,9 @@ class RestrictContentProductPageCest
 		// Setup ConvertKit Plugin, disabling JS.
 		$I->setupConvertKitPluginDisableJS($I);
 
-		// Define visible content and member only content.
+		// Define visible content and member-only content.
 		$visibleContent    = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at velit purus. Nam gravida tempor tellus, sit amet euismod arcu. Mauris sed mattis leo. Mauris viverra eget tellus sit amet vehicula. Nulla eget sapien quis felis euismod pellentesque. Quisque elementum et diam nec eleifend. Sed ornare quam eget augue consequat, in maximus quam fringilla. Morbi';
-		$memberOnlyContent = 'Member only content';
+		$memberOnlyContent = 'Member-only content';
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Restrict Content: Product: Generated Excerpt');
@@ -165,7 +165,7 @@ class RestrictContentProductPageCest
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
 		$I->addGutenbergBlock($I, 'More', 'more');
-		$I->addGutenbergParagraphBlock($I, 'Member only content.');
+		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Page.
 		$url = $I->publishGutenbergPage($I);
@@ -247,7 +247,7 @@ class RestrictContentProductPageCest
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
 		$I->addGutenbergBlock($I, 'More', 'more');
-		$I->addGutenbergParagraphBlock($I, 'Member only content.');
+		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Page.
 		$url = $I->publishGutenbergPage($I);

--- a/tests/acceptance/restrict-content/RestrictContentProductPostCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentProductPostCest.php
@@ -37,7 +37,7 @@ class RestrictContentProductPostCest
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
 		$I->addGutenbergBlock($I, 'More', 'more');
-		$I->addGutenbergParagraphBlock($I, 'Member only content.');
+		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Post.
 		$url = $I->publishGutenbergPage($I);
@@ -45,7 +45,7 @@ class RestrictContentProductPostCest
 		// Confirm that all content is displayed.
 		$I->amOnUrl($url);
 		$I->see('Visible content.');
-		$I->see('Member only content.');
+		$I->see('Member-only content.');
 	}
 
 	/**
@@ -77,7 +77,7 @@ class RestrictContentProductPostCest
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
 		$I->addGutenbergBlock($I, 'More', 'more');
-		$I->addGutenbergParagraphBlock($I, 'Member only content.');
+		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Post.
 		$url = $I->publishGutenbergPage($I);
@@ -100,9 +100,9 @@ class RestrictContentProductPostCest
 		// Setup ConvertKit Plugin, disabling JS.
 		$I->setupConvertKitPluginDisableJS($I);
 
-		// Define visible content and member only content.
+		// Define visible content and member-only content.
 		$visibleContent    = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at velit purus. Nam gravida tempor tellus, sit amet euismod arcu. Mauris sed mattis leo. Mauris viverra eget tellus sit amet vehicula. Nulla eget sapien quis felis euismod pellentesque. Quisque elementum et diam nec eleifend. Sed ornare quam eget augue consequat, in maximus quam fringilla. Morbi';
-		$memberOnlyContent = 'Member only content';
+		$memberOnlyContent = 'Member-only content';
 
 		// Add a Post using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Restrict Content: Product: Generated Excerpt');
@@ -149,7 +149,7 @@ class RestrictContentProductPostCest
 		// Setup ConvertKit Plugin, disabling JS.
 		$I->setupConvertKitPluginDisableJS($I);
 
-		// Define visible content and member only content.
+		// Define visible content and member-only content.
 		$excerpt           = 'This is a defined excerpt';
 		$memberOnlyContent = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at velit purus. Nam gravida tempor tellus, sit amet euismod arcu. Mauris sed mattis leo. Mauris viverra eget tellus sit amet vehicula. Nulla eget sapien quis felis euismod pellentesque. Quisque elementum et diam nec eleifend. Sed ornare quam eget augue consequat, in maximus quam fringilla. Morbi';
 
@@ -235,7 +235,7 @@ class RestrictContentProductPostCest
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
 		$I->addGutenbergBlock($I, 'More', 'more');
-		$I->addGutenbergParagraphBlock($I, 'Member only content.');
+		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Post.
 		$url = $I->publishGutenbergPage($I);

--- a/tests/acceptance/restrict-content/RestrictContentTagCest.php
+++ b/tests/acceptance/restrict-content/RestrictContentTagCest.php
@@ -46,7 +46,7 @@ class RestrictContentTagCest
 		// Add blocks.
 		$I->addGutenbergParagraphBlock($I, 'Visible content.');
 		$I->addGutenbergBlock($I, 'More', 'more');
-		$I->addGutenbergParagraphBlock($I, 'Member only content.');
+		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
 
 		// Publish Page.
 		$url = $I->publishGutenbergPage($I);


### PR DESCRIPTION
## Summary

Correct grammar for member-only content strings in field description and tests

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)