### PR TITLE
Prevent WP Rocket caching/minifying Landing Pages

### DIFF
--- a/includes/class-convertkit-cache-minification-plugins.php
+++ b/includes/class-convertkit-cache-minification-plugins.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * ConvertKit Cache and Minification Plugins class.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Configures third party caching Plugins to ensure ConvertKit functionality
+ * (such as Landing Pages) works correctly by disabling minification and/or
+ * caching as applicable.
+ *
+ * @since   2.4.3
+ */
+class ConvertKit_Cache_Minification_Plugins {
+
+	/**
+	 * Holds sensible external hosts to exclude from CSS and JS minification.
+	 * 
+	 * @since 	2.4.3
+	 * 
+	 * @var 	array
+	 */
+	public $exclude_hosts = array(
+		'cdnjs.cloudflare.com',
+		'pages.convertkit.com',
+		'convertkit.com',
+	);
+
+	/**
+	 * Constructor
+	 * 
+	 * @since 	2.4.3
+	 */
+	public function __construct() {
+
+		add_action( 'convertkit_output_landing_page_before', array( $this, 'disable_caching_and_minification_on_landing_pages' ) );
+
+	}
+
+	/**
+	 * Disable caching and minification when a WordPress Page configured to display a
+	 * ConvertKit Landing Page is viewed.
+	 * 
+	 * @since 	2.4.3
+	 */
+	public function disable_caching_and_minification_on_landing_pages() {
+
+		// WP-Rocket.
+		add_filter( 'rocket_minify_excluded_external_js', array( $this, 'exclude_hosts_from_minification' ) );
+		add_filter( 'rocket_exclude_css', array( $this, 'exclude_hosts_from_minification' ) );
+		add_filter( 'do_rocket_lazyload', '__return_false' );
+
+	}
+
+	/**
+	 * Appends the $exclude_hosts property to an array of existing hosts excluded from
+	 * minification for third party Plugins.
+	 * 
+	 * @since 	2.4.3
+	 * 
+	 * @param 	array 	$hosts 	External hosts to ignore.
+	 * @return 	array
+	 */
+	public function exclude_hosts_from_minification( $hosts ) {
+
+		return array_merge( $hosts, $this->exclude_hosts );
+
+	}
+
+}

--- a/includes/class-convertkit-cache-minification-plugins.php
+++ b/includes/class-convertkit-cache-minification-plugins.php
@@ -17,10 +17,10 @@ class ConvertKit_Cache_Minification_Plugins {
 
 	/**
 	 * Holds sensible external hosts to exclude from CSS and JS minification.
-	 * 
-	 * @since 	2.4.3
-	 * 
-	 * @var 	array
+	 *
+	 * @since   2.4.3
+	 *
+	 * @var     array
 	 */
 	public $exclude_hosts = array(
 		'cdnjs.cloudflare.com',
@@ -30,8 +30,8 @@ class ConvertKit_Cache_Minification_Plugins {
 
 	/**
 	 * Constructor
-	 * 
-	 * @since 	2.4.3
+	 *
+	 * @since   2.4.3
 	 */
 	public function __construct() {
 
@@ -42,8 +42,8 @@ class ConvertKit_Cache_Minification_Plugins {
 	/**
 	 * Disable caching and minification when a WordPress Page configured to display a
 	 * ConvertKit Landing Page is viewed.
-	 * 
-	 * @since 	2.4.3
+	 *
+	 * @since   2.4.3
 	 */
 	public function disable_caching_and_minification_on_landing_pages() {
 
@@ -57,11 +57,11 @@ class ConvertKit_Cache_Minification_Plugins {
 	/**
 	 * Appends the $exclude_hosts property to an array of existing hosts excluded from
 	 * minification for third party Plugins.
-	 * 
-	 * @since 	2.4.3
-	 * 
-	 * @param 	array 	$hosts 	External hosts to ignore.
-	 * @return 	array
+	 *
+	 * @since   2.4.3
+	 *
+	 * @param   array $hosts  External hosts to ignore.
+	 * @return  array
 	 */
 	public function exclude_hosts_from_minification( $hosts ) {
 

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -168,7 +168,7 @@ class ConvertKit_Output {
 		 * CSS / JS minification and lazy loading images, which can interfere
 		 * with Landing Pages.
 		 *
-		 * @since   2.4.3
+		 * @since   2.4.4
 		 *
 		 * @param   string  $landing_page       ConvertKit Landing Page HTML.
 		 * @param   int     $landing_page_id    ConvertKit Landing Page ID.

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -67,8 +67,6 @@ class ConvertKit_Output {
 	 */
 	public function __construct() {
 
-
-
 		add_action( 'init', array( $this, 'get_subscriber_id_from_request' ), 1 );
 		add_action( 'template_redirect', array( $this, 'output_form' ) );
 		add_action( 'template_redirect', array( $this, 'page_takeover' ) );
@@ -165,16 +163,16 @@ class ConvertKit_Output {
 
 		/**
 		 * Perform any actions immediately prior to outputting the Landing Page.
-		 * 
+		 *
 		 * Caching and minification Plugins may need to hook here to prevent
 		 * CSS / JS minification and lazy loading images, which can interfere
 		 * with Landing Pages.
-		 * 
-		 * @since 	2.4.3
-		 * 
-		 * @param 	string 	$landing_page 		ConvertKit Landing Page HTML.
-		 * @param 	int 	$landing_page_id 	ConvertKit Landing Page ID.
-		 * @param 	int 	$post_id 			WordPress Page ID.
+		 *
+		 * @since   2.4.3
+		 *
+		 * @param   string  $landing_page       ConvertKit Landing Page HTML.
+		 * @param   int     $landing_page_id    ConvertKit Landing Page ID.
+		 * @param   int     $post_id            WordPress Page ID.
 		 */
 		do_action( 'convertkit_output_landing_page_before', $landing_page, $landing_page_id, $post_id );
 

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -67,6 +67,8 @@ class ConvertKit_Output {
 	 */
 	public function __construct() {
 
+
+
 		add_action( 'init', array( $this, 'get_subscriber_id_from_request' ), 1 );
 		add_action( 'template_redirect', array( $this, 'output_form' ) );
 		add_action( 'template_redirect', array( $this, 'page_takeover' ) );
@@ -160,6 +162,21 @@ class ConvertKit_Output {
 
 		// Replace the favicon with the WordPress site's favicon, if specified.
 		$landing_page = $this->landing_pages->replace_favicon( $landing_page );
+
+		/**
+		 * Perform any actions immediately prior to outputting the Landing Page.
+		 * 
+		 * Caching and minification Plugins may need to hook here to prevent
+		 * CSS / JS minification and lazy loading images, which can interfere
+		 * with Landing Pages.
+		 * 
+		 * @since 	2.4.3
+		 * 
+		 * @param 	string 	$landing_page 		ConvertKit Landing Page HTML.
+		 * @param 	int 	$landing_page_id 	ConvertKit Landing Page ID.
+		 * @param 	int 	$post_id 			WordPress Page ID.
+		 */
+		do_action( 'convertkit_output_landing_page_before', $landing_page, $landing_page_id, $post_id );
 
 		// Output Landing Page.
 		// Output is supplied from ConvertKit's API, which is already sanitized.

--- a/includes/class-convertkit-wp-rocket.php
+++ b/includes/class-convertkit-wp-rocket.php
@@ -1,19 +1,19 @@
 <?php
 /**
- * ConvertKit Cache and Minification Plugins class.
+ * ConvertKit WP-Rocket Class.
  *
  * @package ConvertKit
  * @author ConvertKit
  */
 
 /**
- * Configures third party caching Plugins to ensure ConvertKit functionality
- * (such as Landing Pages) works correctly by disabling minification and/or
- * caching as applicable.
+ * Disables WP-Rocket from:
+ * - minifying JS / CSS and lazy loading images on Landing Pages,
+ * - []
  *
  * @since   2.4.3
  */
-class ConvertKit_Cache_Minification_Plugins {
+class ConvertKit_WP_Rocket {
 
 	/**
 	 * Holds sensible external hosts to exclude from CSS and JS minification.
@@ -35,6 +35,7 @@ class ConvertKit_Cache_Minification_Plugins {
 	 */
 	public function __construct() {
 
+		
 		add_action( 'convertkit_output_landing_page_before', array( $this, 'disable_caching_and_minification_on_landing_pages' ) );
 
 	}

--- a/includes/class-convertkit-wp-rocket.php
+++ b/includes/class-convertkit-wp-rocket.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * ConvertKit WP-Rocket Class.
+ * ConvertKit WP Rocket Class.
  *
  * @package ConvertKit
  * @author ConvertKit
  */
 
 /**
- * Disables WP-Rocket from minifying JS / CSS and lazy loading images on Landing Pages.
+ * Disables WP Rocket from minifying JS / CSS and lazy loading images on Landing Pages.
  *
  * @since   2.4.4
  */
@@ -57,7 +57,6 @@ class ConvertKit_WP_Rocket {
 	 */
 	public function disable_caching_and_minification_on_landing_pages() {
 
-		// WP-Rocket.
 		add_filter( 'rocket_minify_excluded_external_js', array( $this, 'exclude_hosts_from_minification' ) );
 		add_filter( 'rocket_exclude_css', array( $this, 'exclude_hosts_from_minification' ) );
 		add_filter( 'rocket_exclude_js', array( $this, 'exclude_local_js_from_minification' ) );

--- a/includes/class-convertkit-wp-rocket.php
+++ b/includes/class-convertkit-wp-rocket.php
@@ -7,18 +7,16 @@
  */
 
 /**
- * Disables WP-Rocket from:
- * - minifying JS / CSS and lazy loading images on Landing Pages,
- * - []
+ * Disables WP-Rocket from minifying JS / CSS and lazy loading images on Landing Pages.
  *
- * @since   2.4.3
+ * @since   2.4.4
  */
 class ConvertKit_WP_Rocket {
 
 	/**
-	 * Holds sensible external hosts to exclude from CSS and JS minification.
+	 * Holds external hosts to exclude from CSS and JS minification.
 	 *
-	 * @since   2.4.3
+	 * @since   2.4.4
 	 *
 	 * @var     array
 	 */
@@ -29,13 +27,24 @@ class ConvertKit_WP_Rocket {
 	);
 
 	/**
+	 * Holds internal JS paths to exclude from JS minification.
+	 * Supports regular expressions.
+	 *
+	 * @since   2.4.4
+	 *
+	 * @var     array
+	 */
+	public $exclude_plugin_js = array(
+		'convertkit/resources/frontend/js/(.*).js',
+	);
+
+	/**
 	 * Constructor
 	 *
-	 * @since   2.4.3
+	 * @since   2.4.4
 	 */
 	public function __construct() {
 
-		
 		add_action( 'convertkit_output_landing_page_before', array( $this, 'disable_caching_and_minification_on_landing_pages' ) );
 
 	}
@@ -44,22 +53,23 @@ class ConvertKit_WP_Rocket {
 	 * Disable caching and minification when a WordPress Page configured to display a
 	 * ConvertKit Landing Page is viewed.
 	 *
-	 * @since   2.4.3
+	 * @since   2.4.4
 	 */
 	public function disable_caching_and_minification_on_landing_pages() {
 
 		// WP-Rocket.
 		add_filter( 'rocket_minify_excluded_external_js', array( $this, 'exclude_hosts_from_minification' ) );
 		add_filter( 'rocket_exclude_css', array( $this, 'exclude_hosts_from_minification' ) );
+		add_filter( 'rocket_exclude_js', array( $this, 'exclude_local_js_from_minification' ) );
 		add_filter( 'do_rocket_lazyload', '__return_false' );
 
 	}
 
 	/**
 	 * Appends the $exclude_hosts property to an array of existing hosts excluded from
-	 * minification for third party Plugins.
+	 * minification.
 	 *
-	 * @since   2.4.3
+	 * @since   2.4.4
 	 *
 	 * @param   array $hosts  External hosts to ignore.
 	 * @return  array
@@ -67,6 +77,21 @@ class ConvertKit_WP_Rocket {
 	public function exclude_hosts_from_minification( $hosts ) {
 
 		return array_merge( $hosts, $this->exclude_hosts );
+
+	}
+
+	/**
+	 * Appends the $exclude_plugin_js property to an array of existing JS files excluded from
+	 * minification.
+	 *
+	 * @since   2.4.4
+	 *
+	 * @param   array $scripts  Internal JS scripts to ignore.
+	 * @return  array
+	 */
+	public function exclude_local_js_from_minification( $scripts ) {
+
+		return array_merge( $scripts, $this->exclude_plugin_js );
 
 	}
 

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -141,6 +141,7 @@ class WP_ConvertKit {
 			return;
 		}
 
+		$this->classes['cache_minification_plugins'] = new ConvertKit_Cache_Minification_Plugins();
 		$this->classes['output'] = new ConvertKit_Output();
 
 		/**

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -142,7 +142,7 @@ class WP_ConvertKit {
 		}
 
 		$this->classes['cache_minification_plugins'] = new ConvertKit_Cache_Minification_Plugins();
-		$this->classes['output'] = new ConvertKit_Output();
+		$this->classes['output']                     = new ConvertKit_Output();
 
 		/**
 		 * Initialize integration classes for the frontend web site.

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -141,8 +141,8 @@ class WP_ConvertKit {
 			return;
 		}
 
-		$this->classes['cache_minification_plugins'] = new ConvertKit_Cache_Minification_Plugins();
-		$this->classes['output']                     = new ConvertKit_Output();
+		$this->classes['output']    = new ConvertKit_Output();
+		$this->classes['wp_rocket'] = new ConvertKit_WP_Rocket();
 
 		/**
 		 * Initialize integration classes for the frontend web site.

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -48,6 +48,7 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-wp-convertkit.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-ajax.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-broadcasts-exporter.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-broadcasts-importer.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-cache-minification-plugins.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-cron.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-gutenberg.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-media-library.php';

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -48,7 +48,6 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-wp-convertkit.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-ajax.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-broadcasts-exporter.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-broadcasts-importer.php';
-require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-cache-minification-plugins.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-cron.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-gutenberg.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-media-library.php';
@@ -71,6 +70,7 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-subscriber.php
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-term.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-user.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-widgets.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/class-convertkit-wp-rocket.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/blocks/class-convertkit-block.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/blocks/class-convertkit-block-broadcasts.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/blocks/class-convertkit-block-content.php';


### PR DESCRIPTION
## Summary

Prevents the WP-Rocket caching and minification Plugin from attempting to cache local and external CSS / JS, and attempting to lazy load images, when a Landing Page is selected for display on a WordPress Page, as reported [here](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/12263829294911?view=List).

It's possible to disable minification when editing an individual WordPress Page that uses a Landing Page, but these options are not always immediately visible or obvious.  This PR saves the user having to do this every time.

![Screenshot 2024-02-01 at 17 00 45](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/579f89c8-5498-4966-91d0-8bdcc980ab55)

Before:

![PageLandingPageCest testAddNewPageUsingDefinedLandingPageWithWPRocket fail](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/c23883ec-c4f9-42f9-bc53-b1d1642229ac)

After:

![PageLandingPageCest testAddNewPageUsingDefinedLandingPageWithWPRocket fail](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/732e9813-54f2-446f-9799-233cc9c19609)

## Testing

- `PageLandingPageCest:testAddNewPageUsingDefinedLandingPageWithWPRocket`: Test that a landing page outputs as expected, with no minification or lazy loading performed by WP Rocket.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)