### PR TITLE
TinyMCE / QuickTag Modals: Remove scrollbar on Safari

### DIFF
--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -133,7 +133,7 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 			// Shortcode: TinyMCE / QuickTags Modal Width and Height.
 			'modal'                             => array(
 				'width'  => 650,
-				'height' => 405,
+				'height' => 385,
 			),
 
 			// Shortcode: Include a closing [/shortcode] tag when using TinyMCE or QuickTag Modals.

--- a/includes/blocks/class-convertkit-block-form-trigger.php
+++ b/includes/blocks/class-convertkit-block-form-trigger.php
@@ -99,7 +99,7 @@ class ConvertKit_Block_Form_Trigger extends ConvertKit_Block {
 			// Shortcode: TinyMCE / QuickTags Modal Width and Height.
 			'modal'                             => array(
 				'width'  => 500,
-				'height' => 352,
+				'height' => 282,
 			),
 
 			// Shortcode: Include a closing [/shortcode] tag when using TinyMCE or QuickTag Modals.

--- a/includes/blocks/class-convertkit-block-form.php
+++ b/includes/blocks/class-convertkit-block-form.php
@@ -118,7 +118,7 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 			// Shortcode: TinyMCE / QuickTags Modal Width and Height.
 			'modal'                             => array(
 				'width'  => 500,
-				'height' => 106,
+				'height' => 55,
 			),
 
 			// Shortcode: Include a closing [/shortcode] tag when using TinyMCE or QuickTag Modals.

--- a/includes/blocks/class-convertkit-block-product.php
+++ b/includes/blocks/class-convertkit-block-product.php
@@ -121,7 +121,7 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 			// Shortcode: TinyMCE / QuickTags Modal Width and Height.
 			'modal'                             => array(
 				'width'  => 600,
-				'height' => 440,
+				'height' => 425,
 			),
 
 			// Shortcode: Include a closing [/shortcode] tag when using TinyMCE or QuickTag Modals.

--- a/resources/backend/css/quicktags.css
+++ b/resources/backend/css/quicktags.css
@@ -6,12 +6,15 @@
 }
 .convertkit-quicktags-modal .media-modal .media-frame-title {
 	left: 0;
-	height: 30px;
+	height: 60px;
 }
 .convertkit-quicktags-modal .media-modal .media-frame-content {
 	left: 0;
 	top: 54px;
 	bottom: 54px; /* 34px + .media-toolbar top and bottom padding */
+}
+.convertkit-quicktags-modal .media-modal .media-frame-content p {
+	line-height: normal;
 }
 .convertkit-quicktags-modal .media-modal .media-frame-toolbar {
 	left: 0;

--- a/resources/backend/css/tinymce.css
+++ b/resources/backend/css/tinymce.css
@@ -1,10 +1,6 @@
 /**
  * TinyMCE and QuickTag Modals
  */
-#convertkit-modal-body {
-	/* Scroll inner contents so that modal height doesn't need to exceed screen resolution. */
-	overflow-y: auto;
-}
 #convertkit-modal-body #convertkit-modal-body-body {
 	background-color: #f7f7f7;
 }

--- a/resources/backend/css/tinymce.css
+++ b/resources/backend/css/tinymce.css
@@ -43,7 +43,7 @@
 }
 .convertkit-option div.left *:not(input) {
 	line-height: 27px;
-	text-wrap: wrap;
+	white-space: normal;
 }
 .convertkit-option div.right {
 	width: 100%;

--- a/resources/backend/js/quicktags.js
+++ b/resources/backend/js/quicktags.js
@@ -57,9 +57,9 @@ function convertKitQuickTagRegister( block ) {
 					convertKitQuickTagsModal.open();
 
 					// Get Modal.
-					const quicktagsModal = document.querySelector( 'div.convertkit-quicktags-modal div.media-modal.wp-core-ui' ),
-						  quicktagsModalHeader = quicktagsModal.querySelector( 'div.media-frame-title' ),
-						  quicktagsModalFooter = quicktagsModal.querySelector( 'div.media-frame-toolbar div.media-toolbar' );
+					const quicktagsModal         = document.querySelector( 'div.convertkit-quicktags-modal div.media-modal.wp-core-ui' ),
+							quicktagsModalHeader = quicktagsModal.querySelector( 'div.media-frame-title' ),
+							quicktagsModalFooter = quicktagsModal.querySelector( 'div.media-frame-toolbar div.media-toolbar' );
 
 					// Resize Modal so it's not full screen.
 					quicktagsModal.style.width  = block.modal.width + 'px';

--- a/resources/backend/js/quicktags.js
+++ b/resources/backend/js/quicktags.js
@@ -57,11 +57,13 @@ function convertKitQuickTagRegister( block ) {
 					convertKitQuickTagsModal.open();
 
 					// Get Modal.
-					const quicktagsModal = document.querySelector( 'div.convertkit-quicktags-modal div.media-modal.wp-core-ui' );
+					const quicktagsModal = document.querySelector( 'div.convertkit-quicktags-modal div.media-modal.wp-core-ui' ),
+						  quicktagsModalHeader = quicktagsModal.querySelector( 'div.media-frame-title' ),
+						  quicktagsModalFooter = quicktagsModal.querySelector( 'div.media-frame-toolbar div.media-toolbar' );
 
 					// Resize Modal so it's not full screen.
 					quicktagsModal.style.width  = block.modal.width + 'px';
-					quicktagsModal.style.height = block.modal.height + 106 + 'px'; // Prevents a vertical scroll bar.
+					quicktagsModal.style.height = block.modal.height + quicktagsModalHeader.offsetHeight + quicktagsModalFooter.offsetHeight + 'px'; // Prevents a vertical scroll bar.
 
 					// Set Title.
 					document.querySelector( '#convertkit-quicktags-modal .media-frame-title h1' ).textContent = block.title;


### PR DESCRIPTION
## Summary

Removes an unnecessary scrollbar on Safari.
Improves calculation of QuickTags modal height by reading header and footer element heights.
Uses `white-space` instead of `text-wrap` for Safari compatibility.

Before:
![before](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/7607b1d4-6e1e-4266-aa9d-fad6f78372d8)

After:
![after](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/abba0f25-bc20-44bf-974b-4d941a67dc1d)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)