### PR TITLE
Remove jQuery from Setup Wizard

### DIFF
--- a/admin/class-convertkit-admin-setup-wizard.php
+++ b/admin/class-convertkit-admin-setup-wizard.php
@@ -295,7 +295,7 @@ class ConvertKit_Admin_Setup_Wizard {
 
 		// Enqueue JS.
 		wp_enqueue_script( 'convertkit-admin-preview-output', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/preview-output.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
-		wp_enqueue_script( 'convertkit-admin-setup-wizard', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/setup-wizard.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
+		wp_enqueue_script( 'convertkit-admin-setup-wizard', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/setup-wizard.js', array(), CONVERTKIT_PLUGIN_VERSION, true );
 
 	}
 

--- a/resources/backend/js/setup-wizard.js
+++ b/resources/backend/js/setup-wizard.js
@@ -11,38 +11,49 @@
  *
  * @since 	1.9.8.4
  */
-jQuery( document ).ready(
-	function ( $ ) {
+document.addEventListener(
+	'DOMContentLoaded',
+	function () {
 
 		// Redirect parent screen to a given URL after clicking a link that opens
 		// the href URL in a new tab.
-		$( 'a.convertkit-redirect' ).on(
-			'click',
-			function ( e ) {
+		document.querySelectorAll( 'a.convertkit-redirect' ).forEach(
+			function ( element ) {
 
-				var link = this;
+				element.addEventListener(
+					'click',
+					function ( e ) {
 
-				// Delay the redirect, otherwise browsers will block opening the href attribute
-				// thinking it's a popup.
-				setTimeout(
-					function () {
-						// Redirect the parent screen to the link's data-convertkit-redirect-url property.
-						window.location.href = $( link ).data( 'convertkit-redirect-url' );
-					},
-					1000
+						// Delay the redirect, otherwise browsers will block opening the href attribute
+						// thinking it's a popup.
+						setTimeout(
+							function () {
+								// Redirect the parent screen to the link's data-convertkit-redirect-url property.
+								window.location.href = element.dataset.convertkitRedirectUrl;
+							},
+							1000
+						);
+
+					}
 				);
 
 			}
 		);
 
 		// Show a confirmation dialog for specific links.
-		$( 'a.convertkit-confirm' ).on(
-			'click',
-			function ( e ) {
+		document.querySelectorAll( 'a.convertkit-confirm' ).forEach(
+			function ( element ) {
 
-				if ( ! confirm( $( this ).data( 'message' ) ) ) {
-					e.preventDefault();
-				}
+				element.addEventListener(
+					'click',
+					function ( e ) {
+
+						if ( ! confirm( element.dataset.message ) ) {
+							e.preventDefault();
+						}
+
+					}
+				);
 
 			}
 		);


### PR DESCRIPTION
## Summary

Removes jQuery from Setup Wizard JS.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)