### PR TITLE
Remove jQuery from Modals

### DIFF
--- a/admin/class-convertkit-admin-tinymce.php
+++ b/admin/class-convertkit-admin-tinymce.php
@@ -146,7 +146,7 @@ class ConvertKit_Admin_TinyMCE {
 		// Enqueue TinyMCE CSS and JS.
 		wp_enqueue_script( 'convertkit-admin-tabs', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/tabs.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
 		wp_enqueue_script( 'convertkit-admin-tinymce', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/tinymce.js', array(), CONVERTKIT_PLUGIN_VERSION, true );
-		wp_enqueue_script( 'convertkit-admin-modal', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/modal.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
+		wp_enqueue_script( 'convertkit-admin-modal', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/modal.js', array(), CONVERTKIT_PLUGIN_VERSION, true );
 		wp_enqueue_style( 'convertkit-admin-tinymce', CONVERTKIT_PLUGIN_URL . 'resources/backend/css/tinymce.css', array(), CONVERTKIT_PLUGIN_VERSION );
 
 		// Register JS variable convertkit_admin_tinymce.nonce for AJAX calls.

--- a/views/backend/tinymce/modal-tabbed.php
+++ b/views/backend/tinymce/modal-tabbed.php
@@ -12,14 +12,7 @@
 <form class="convertkit-tinymce-popup wp-core-ui">
 	<input type="hidden" name="shortcode" value="convertkit_<?php echo esc_attr( $shortcode['name'] ); ?>" />
 	<input type="hidden" name="editor_type" value="<?php echo esc_attr( $editor_type ); // quicktags|tinymce. ?>" />
-
-	<?php
-	if ( $shortcode['shortcode_include_closing_tag'] ) {
-		?>
-		<input type="hidden" name="close_shortcode" value="1" />
-		<?php
-	}
-	?>
+	<input type="hidden" name="close_shortcode" value="<?php echo esc_attr( $shortcode['shortcode_include_closing_tag'] ? '1' : '0' ); ?>" />
 
 	<!-- Vertical Tabbed UI -->
 	<div class="convertkit-vertical-tabbed-ui">

--- a/views/backend/tinymce/modal.php
+++ b/views/backend/tinymce/modal.php
@@ -12,14 +12,9 @@
 <form class="convertkit-tinymce-popup wp-core-ui">
 	<input type="hidden" name="shortcode" value="convertkit_<?php echo esc_attr( $shortcode['name'] ); ?>" />
 	<input type="hidden" name="editor_type" value="<?php echo esc_attr( $editor_type ); // quicktags|tinymce. ?>" />
+	<input type="hidden" name="close_shortcode" value="<?php echo esc_attr( $shortcode['shortcode_include_closing_tag'] ? '1' : '0' ); ?>" />
 
 	<?php
-	if ( $shortcode['shortcode_include_closing_tag'] ) {
-		?>
-		<input type="hidden" name="close_shortcode" value="1" />
-		<?php
-	}
-
 	// Output each Field.
 	foreach ( $shortcode['fields'] as $field_name => $field ) {
 		include 'modal-field-row.php';


### PR DESCRIPTION
## Summary

Removes jQuery from Modal JS.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)