### PR TITLE
Setup Wizard: Fix `Preview Form` link for Pages

### DIFF
--- a/tests/acceptance/general/PluginSettingsGeneralCest.php
+++ b/tests/acceptance/general/PluginSettingsGeneralCest.php
@@ -272,6 +272,9 @@ class PluginSettingsGeneralCest
 		// Switch to newly opened tab.
 		$I->switchToNextTab();
 
+		// Confirm that the preview is a WordPress Page.
+		$I->seeElementInDOM('body.page');
+
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
 		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
@@ -288,6 +291,9 @@ class PluginSettingsGeneralCest
 
 		// Switch to newly opened tab.
 		$I->switchToNextTab();
+
+		// Confirm that the preview is a WordPress Post.
+		$I->seeElementInDOM('body.single-post');
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.

--- a/tests/acceptance/general/PluginSetupWizardCest.php
+++ b/tests/acceptance/general/PluginSetupWizardCest.php
@@ -287,6 +287,9 @@ class PluginSetupWizardCest
 		// Switch to newly opened tab.
 		$I->switchToNextTab();
 
+		// Confirm that the preview is a WordPress Post.
+		$I->seeElementInDOM('body.single-post');
+
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
 		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
@@ -303,6 +306,9 @@ class PluginSetupWizardCest
 
 		// Switch to newly opened tab.
 		$I->switchToNextTab();
+
+		// Confirm that the preview is a WordPress Page.
+		$I->seeElementInDOM('body.page');
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.

--- a/views/backend/setup-wizard/convertkit-setup/content-3.php
+++ b/views/backend/setup-wizard/convertkit-setup/content-3.php
@@ -106,7 +106,7 @@ if ( ! $this->forms->exist() ) {
 			),
 			array(
 				'data-target' => '#convertkit-preview-form-page',
-				'data-link'   => esc_attr( $this->preview_post_url ) . '&convertkit_form_id=',
+				'data-link'   => esc_attr( $this->preview_page_url ) . '&convertkit_form_id=',
 			)
 		);
 		?>


### PR DESCRIPTION
## Summary

Fixes an issue where the preview form link for Pages would show the previewed form on a WordPress Post, not a Page.

## Testing

- `PluginSettingsGeneralCest:testChangeDefaultFormSettingAndPreviewFormLinks`: Confirm that the Post Type being viewed for the form preview is correct.
- `PluginSetupWIzardCest: testSetupWizardFormConfigurationScreen `: Confirm that the Post Type being viewed for the form preview is correct.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)