### PR TITLE
Remove jQuery from Refresh Resources

### DIFF
--- a/admin/class-convertkit-admin-refresh-resources.php
+++ b/admin/class-convertkit-admin-refresh-resources.php
@@ -111,7 +111,7 @@ class ConvertKit_Admin_Refresh_Resources {
 		}
 
 		// Enqueue JS to perform AJAX request to refresh resources.
-		wp_enqueue_script( 'convertkit-admin-refresh-resources', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/refresh-resources.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
+		wp_enqueue_script( 'convertkit-admin-refresh-resources', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/refresh-resources.js', array(), CONVERTKIT_PLUGIN_VERSION, true );
 		wp_localize_script(
 			'convertkit-admin-refresh-resources',
 			'convertkit_admin_refresh_resources',

--- a/resources/backend/js/quick-edit.js
+++ b/resources/backend/js/quick-edit.js
@@ -61,6 +61,9 @@ document.addEventListener(
 					}
 				);
 
+				// Bind refresh resource event listeners.
+				convertKitRefreshResourcesInitEventListeners();
+
 			};
 		}
 

--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -5,25 +5,32 @@
  * @author ConvertKit
  */
 
-document.addEventListener(
-	'DOMContentLoaded',
-	function () {
+document.addEventListener( 'DOMContentLoaded', convertKitRefreshResourcesInitEventListeners );
 
-		// Refreshes resources when the Refresh button is clicked.
-		document.querySelectorAll( 'button.wp-convertkit-refresh-resources' ).forEach(
-			function ( button ) {
-				button.addEventListener(
-					'click',
-					function ( e ) {
-						e.preventDefault();
-						convertKitRefreshResources( button );
-					}
-				);
-			}
-		);
+/**
+ * Binds click event listeners to refresh resource buttons.
+ *
+ * @since 	2.4.4
+ */
+function convertKitRefreshResourcesInitEventListeners() {
 
-	}
-);
+	// Refreshes resources when the Refresh button is clicked.
+	document.querySelectorAll( 'button.wp-convertkit-refresh-resources' ).forEach(
+		function ( element ) {
+
+			element.addEventListener(
+				'click',
+				function ( e ) {
+					e.preventDefault();
+					convertKitRefreshResources( element );
+				},
+				false
+			);
+
+		},
+	);
+
+}
 
 /**
  * Refresh resources when a button is clicked.
@@ -38,7 +45,7 @@ function convertKitRefreshResources( button ) {
 	convertKitRefreshResourcesRemoveNotices();
 
 	const resource = button.dataset.resource,
-			 field = button.dataset.field;
+			field  = button.dataset.field;
 
 	// Disable button.
 	button.disabled = true;

--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -5,126 +5,150 @@
  * @author ConvertKit
  */
 
-/**
- * Refreshes resources when the Refresh button is clicked.
- *
- * @since 	1.9.8.0
- */
-jQuery( document ).ready(
-	function ( $ ) {
+document.addEventListener(
+	'DOMContentLoaded',
+	function () {
 
-		$( 'button.wp-convertkit-refresh-resources' ).on(
-			'click',
-			function ( e ) {
-
-				// Prevent default button behaviour.
-				e.preventDefault();
-
-				// Remove any existing error notices that might be displayed.
-				convertKitRefreshResourcesRemoveNotices();
-
-				// Fetch some DOM elements.
-				var button = this,
-				resource   = $( button ).data( 'resource' ),
-				field      = $( button ).data( 'field' );
-
-				// Disable button.
-				$( button ).prop( 'disabled', true );
-
-				// Perform AJAX request to refresh resource.
-				$.ajax(
-					{
-						type: 'POST',
-						data: {
-							action: 'convertkit_admin_refresh_resources',
-							nonce: convertkit_admin_refresh_resources.nonce,
-							resource: resource // e.g. forms, landing_pages, tags.
-						},
-						url: convertkit_admin_refresh_resources.ajaxurl,
-						success: function ( response ) {
-
-							if ( convertkit_admin_refresh_resources.debug ) {
-								console.log( response );
-							}
-
-							// Show an error if the request wasn't successful.
-							if ( ! response.success ) {
-								// Show error notice.
-								convertKitRefreshResourcesOutputErrorNotice( response.data );
-
-								// Enable button.
-								$( button ).prop( 'disabled', false );
-
-								return;
-							}
-
-							// Get currently selected option.
-							var selectedOption = $( field ).val();
-
-							// Remove existing select options.
-							$( 'option', $( field ) ).each(
-								function () {
-									// Skip if data-preserve-on-refresh is specified, as this means we want to keep this specific option.
-									// This will be present on the 'None' and 'Default' options.
-									if ( typeof $( this ).data( 'preserve-on-refresh' ) !== 'undefined' ) {
-										return;
-									}
-
-									// Remove this option.
-									$( this ).remove();
-								}
-							);
-
-							// Populate select options from response data.
-							response.data.forEach(
-								function ( item ) {
-									// Define label.
-									let label = '';
-									switch ( resource ) {
-										case 'forms':
-											label = item.name + ' [' + ( item.format !== '' ? item.format : 'inline' ) + ']';
-											break;
-
-										default:
-											label = item.name;
-											break;
-									}
-
-									// Add option.
-									$( field ).append( new Option( label, item.id, false, ( selectedOption == item.id ? true : false ) ) );
-
-								}
-							);
-
-							// Trigger a change event on the select field, to allow Select2 instances to repopulate their options.
-							$( field ).trigger( 'change' );
-
-							// Enable button.
-							$( button ).prop( 'disabled', false );
-						}
-					}
-				).fail(
-					function ( response ) {
-						if ( convertkit_admin_refresh_resources.debug ) {
-							console.log( response );
-						}
-
-						// Remove any existing error notices that might be displayed.
-						convertKitRefreshResourcesRemoveNotices();
-
-						// Show error notice.
-						convertKitRefreshResourcesOutputErrorNotice( 'ConvertKit: ' + response.status + ' ' + response.statusText );
-
-						// Enable button.
-						$( button ).prop( 'disabled', false );
+		// Refreshes resources when the Refresh button is clicked.
+		document.querySelectorAll( 'button.wp-convertkit-refresh-resources' ).forEach(
+			function ( button ) {
+				button.addEventListener(
+					'click',
+					function ( e ) {
+						e.preventDefault();
+						convertKitRefreshResources( button );
 					}
 				);
-
 			}
 		);
 
 	}
 );
+
+/**
+ * Refresh resources when a button is clicked.
+ *
+ * @since 	2.4.4
+ *
+ * @param 	DOMObject 	button
+ */
+function convertKitRefreshResources( button ) {
+
+	// Remove any existing error notices that might be displayed.
+	convertKitRefreshResourcesRemoveNotices();
+
+	const resource = button.dataset.resource,
+			 field = button.dataset.field;
+
+	// Disable button.
+	button.disabled = true;
+
+	// Perform AJAX request to refresh resource.
+	fetch(
+		convertkit_admin_refresh_resources.ajaxurl,
+		{
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded'
+			},
+			body: new URLSearchParams(
+				{
+					action: 'convertkit_admin_refresh_resources',
+					nonce: convertkit_admin_refresh_resources.nonce,
+					resource: resource // e.g. forms, landing_pages, tags.
+				}
+			)
+		}
+	)
+	.then(
+		function ( response ) {
+
+			// Convert response JSON string to object.
+			return response.json();
+
+		}
+	)
+	.then(
+		function ( response ) {
+
+			if ( convertkit_admin_refresh_resources.debug ) {
+				console.log( response );
+			}
+
+			// Show an error if the request wasn't successful.
+			if ( ! response.success ) {
+				// Show error notice.
+				convertKitRefreshResourcesOutputErrorNotice( response.data );
+
+				// Enable button.
+				button.disabled = false;
+
+				return;
+			}
+
+			const selectedOption = document.querySelector( field ).value;
+
+			// Remove existing select options.
+			document.querySelectorAll( field + ' option' ).forEach(
+				function ( option ) {
+					// Skip if data-preserve-on-refresh is specified, as this means we want to keep this specific option.
+					// This will be present on the 'None' and 'Default' options.
+					if ( option.dataset.preserveOnRefresh !== undefined ) {
+							return;
+					}
+
+					// Remove this option.
+					option.remove();
+				}
+			);
+
+			// Populate select options from response data.
+			response.data.forEach(
+				function ( item ) {
+					let label = '';
+					switch ( resource ) {
+						case 'forms':
+							label = item.name + ' [' + ( item.format !== '' ? item.format : 'inline' ) + ']';
+								break;
+						default:
+							label = item.name;
+						break;
+					}
+
+					// Add option.
+					const option = new Option( label, item.id, false, selectedOption == item.id );
+					document.querySelector( field ).add( option );
+				}
+			);
+
+			// Trigger a change event on the select field, to allow Select2 instances to repopulate their options.
+			document.querySelector( field ).dispatchEvent( new Event( 'change' ) );
+
+			// Enable button.
+			button.disabled = false;
+
+		}
+	)
+	.catch(
+		function ( error ) {
+
+			if ( convertkit_admin_refresh_resources.debug ) {
+				console.log( error );
+			}
+
+			// Remove any existing error notices that might be displayed.
+			convertKitRefreshResourcesRemoveNotices();
+
+			// Show error notice.
+			convertKitRefreshResourcesOutputErrorNotice( 'ConvertKit: ' + error.status + ' ' + error.statusText );
+
+			// Enable button.
+			button.disabled = false;
+
+		}
+	);
+
+}
 
 /**
  * Removes any existing ConvertKit WordPress style error notices.
@@ -134,18 +158,18 @@ jQuery( document ).ready(
 function convertKitRefreshResourcesRemoveNotices() {
 
 	// If we're editing a Page, Post or Custom Post Type in Gutenberg, use wp.data.dispatch to remove the error.
-	if ( typeof wp !== 'undefined' && typeof wp.blocks !== 'undefined' ) {
+	if (typeof wp !== 'undefined' && typeof wp.blocks !== 'undefined') {
 		// Gutenberg Editor.
 		wp.data.dispatch( 'core/notices' ).removeNotice( 'convertkit-error' );
 		return;
 	}
 
 	// Classic Editor, WP_List_Table (Bulk/Quick edit) or Edit Term.
-	( function ( $ ) {
-
-		$( 'div.convertkit-error' ).remove();
-
-	} )( jQuery );
+	document.querySelectorAll( 'div.convertkit-error' ).forEach(
+		function ( div ) {
+			div.remove();
+		}
+	);
 
 }
 
@@ -165,33 +189,22 @@ function convertKitRefreshResourcesOutputErrorNotice( message ) {
 	// If we're editing a Page, Post or Custom Post Type in Gutenberg, use wp.data.dispatch to show the error.
 	if ( typeof wp !== 'undefined' && typeof wp.blocks !== 'undefined' ) {
 		// Gutenberg Editor.
-		wp.data.dispatch( 'core/notices' ).createErrorNotice(
-			message,
-			{
-				id: 'convertkit-error'
-			}
-		);
-
+		wp.data.dispatch( 'core/notices' ).createErrorNotice( message, { id: 'convertkit-error' } );
 		return;
 	}
 
 	// Classic Editor, WP_List_Table (Bulk/Quick edit) or Edit Term.
-	( function ( $ ) {
+	const notice = '<div id="message" class="error convertkit-error notice is-dismissible"><p>' + message + '</p></div>';
 
-		var notice = '<div id="message" class="error convertkit-error notice is-dismissible"><p>' + message + '</p></div>';
-
-		// Append the WordPress style error notice, depending on the screen.
-		if ( $( 'hr.wp-header-end' ).length > 0 ) {
-			$( 'hr.wp-header-end' ).after( notice );
-		} else if ( $( '#ajax-response' ).length > 0 ) {
-			$( '#ajax-response' ).after( notice );
-		}
+	// Append the WordPress style error notice, depending on the screen.
+	const insertLocation = document.querySelector( 'hr.wp-header-end' ) || document.querySelector( '#ajax-response' );
+	if ( insertLocation ) {
+		insertLocation.insertAdjacentHTML( 'afterend', notice );
 
 		// Notify WordPress that a new dismissible notification exists, triggering WordPress' makeNoticesDismissible() function,
 		// which adds a dismiss button and binds necessary events to hide the notification.
 		// We can't directly call makeNoticesDismissible(), as its minified function name will be different.
-		$( document ).trigger( 'wp-updates-notice-added' );
-
-	} )( jQuery );
+		document.dispatchEvent( new Event( 'wp-updates-notice-added' ) );
+	}
 
 }


### PR DESCRIPTION
## Summary

Removes jQuery from refresh resources JS.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)