### PR TITLE
Member Content: Fix Refresh Resources

### DIFF
--- a/admin/class-convertkit-admin-refresh-resources.php
+++ b/admin/class-convertkit-admin-refresh-resources.php
@@ -69,7 +69,7 @@ class ConvertKit_Admin_Refresh_Resources {
 
 			case 'restrict_content':
 				// Fetch Tags.
-				$tags    = new ConvertKit_Resource_Tags( 'user_refresh_resource' );
+				$tags         = new ConvertKit_Resource_Tags( 'user_refresh_resource' );
 				$results_tags = $tags->refresh();
 
 				// Bail if an error occured.
@@ -78,8 +78,8 @@ class ConvertKit_Admin_Refresh_Resources {
 				}
 
 				// Fetch Products.
-				$products = new ConvertKit_Resource_Products( 'user_refresh_resource' );
-				$results_products  = $products->refresh();
+				$products         = new ConvertKit_Resource_Products( 'user_refresh_resource' );
+				$results_products = $products->refresh();
 
 				// Bail if an error occured.
 				if ( is_wp_error( $results_products ) ) {
@@ -87,10 +87,12 @@ class ConvertKit_Admin_Refresh_Resources {
 				}
 
 				// Return resources.
-				wp_send_json_success( array(
-					'tags' => array_values( $results_tags ),
-					'products' => array_values( $results_products ),
-				) );
+				wp_send_json_success(
+					array(
+						'tags'     => array_values( $results_tags ),
+						'products' => array_values( $results_products ),
+					)
+				);
 				break;
 
 			default:

--- a/admin/class-convertkit-admin-refresh-resources.php
+++ b/admin/class-convertkit-admin-refresh-resources.php
@@ -63,8 +63,34 @@ class ConvertKit_Admin_Refresh_Resources {
 				break;
 
 			case 'products':
-				$products = new ConvertKit_Resource_Products();
+				$products = new ConvertKit_Resource_Products( 'user_refresh_resource' );
 				$results  = $products->refresh();
+				break;
+
+			case 'restrict_content':
+				// Fetch Tags.
+				$tags    = new ConvertKit_Resource_Tags( 'user_refresh_resource' );
+				$results_tags = $tags->refresh();
+
+				// Bail if an error occured.
+				if ( is_wp_error( $results_tags ) ) {
+					wp_send_json_error( $results_tags->get_error_message() );
+				}
+
+				// Fetch Products.
+				$products = new ConvertKit_Resource_Products( 'user_refresh_resource' );
+				$results_products  = $products->refresh();
+
+				// Bail if an error occured.
+				if ( is_wp_error( $results_products ) ) {
+					wp_send_json_error( $results_products->get_error_message() );
+				}
+
+				// Return resources.
+				wp_send_json_success( array(
+					'tags' => array_values( $results_tags ),
+					'products' => array_values( $results_products ),
+				) );
 				break;
 
 			default:

--- a/admin/class-convertkit-admin-refresh-resources.php
+++ b/admin/class-convertkit-admin-refresh-resources.php
@@ -93,6 +93,7 @@ class ConvertKit_Admin_Refresh_Resources {
 						'products' => array_values( $results_products ),
 					)
 				);
+				// no break as wp_send_json_success terminates.
 
 			default:
 				$results = new WP_Error(

--- a/admin/class-convertkit-admin-refresh-resources.php
+++ b/admin/class-convertkit-admin-refresh-resources.php
@@ -93,7 +93,6 @@ class ConvertKit_Admin_Refresh_Resources {
 						'products' => array_values( $results_products ),
 					)
 				);
-				break;
 
 			default:
 				$results = new WP_Error(

--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -75,26 +75,48 @@ jQuery( document ).ready(
 								}
 							);
 
-							// Populate select options from response data.
-							response.data.forEach(
-								function ( item ) {
-									// Define label.
-									let label = '';
-									switch ( resource ) {
-										case 'forms':
-											label = item.name + ' [' + ( item.format !== '' ? item.format : 'inline' ) + ']';
-											break;
+							// Depending on the resource we're refreshing, populate the <select> options.
+							switch ( resource ) {
+								case 'restrict_content':
+									console.log( response.data );
+									// Populate select opgroups from response data, which comprises of Tags and Products.
+									response.data.tags.forEach(
+										function ( item ) {
+											$( 'optgroup[data-resource="tags"]', field ).append( new Option( item.name, item.id, false, ( selectedOption == item.id ? true : false ) ) );
+										}
+									);
 
-										default:
-											label = item.name;
-											break;
-									}
+									response.data.products.forEach(
+										function ( item ) {
+											$( 'optgroup[data-resource="products"]', field ).append( new Option( item.name, item.id, false, ( selectedOption == item.id ? true : false ) ) );
+										}
+									);
+									break;
 
-									// Add option.
-									$( field ).append( new Option( label, item.id, false, ( selectedOption == item.id ? true : false ) ) );
+								default:
+									// Populate select options from response data.
+									response.data.forEach(
+										function ( item ) {
 
+											// Define label.
+											let label = '';
+											switch ( resource ) {
+												case 'forms':
+													label = item.name + ' [' + ( item.format !== '' ? item.format : 'inline' ) + ']';
+													break;
+
+												default:
+													label = item.name;
+													break;
+											}
+
+											// Add option.
+											$( field ).append( new Option( label, item.id, false, ( selectedOption == item.id ? true : false ) ) );
+
+										}
+									);
+									break;
 								}
-							);
 
 							// Trigger a change event on the select field, to allow Select2 instances to repopulate their options.
 							$( field ).trigger( 'change' );

--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -61,8 +61,6 @@ jQuery( document ).ready(
 							// Get currently selected option.
 							var selectedOption = $( field ).val();
 
-							console.log( selectedOption );
-
 							// Remove existing select options.
 							$( 'option', $( field ) ).each(
 								function () {
@@ -80,17 +78,32 @@ jQuery( document ).ready(
 							// Depending on the resource we're refreshing, populate the <select> options.
 							switch ( resource ) {
 								case 'restrict_content':
-									console.log( response.data );
-									// Populate select opgroups from response data, which comprises of Tags and Products.
+									// Populate select `optgroup`` from response data, which comprises of Tags and Products.
+									// Tags.
 									response.data.tags.forEach(
 										function ( item ) {
-											$( 'optgroup[data-resource="tags"]', field ).append( new Option( item.name, 'tag_' + item.id, false, ( selectedOption == 'tag_' + item.id ? true : false ) ) );
+											$( 'optgroup[data-resource="tags"]', field ).append(
+												new Option(
+													item.name,
+													'tag_' + item.id,
+													false,
+													( selectedOption == 'tag_' + item.id ? true : false )
+												)
+											);
 										}
 									);
 
+									// Products.
 									response.data.products.forEach(
 										function ( item ) {
-											$( 'optgroup[data-resource="products"]', field ).append( new Option( item.name, 'product_' + item.id, false, ( selectedOption == 'product_' + item.id ? true : false ) ) );
+											$( 'optgroup[data-resource="products"]', field ).append(
+												new Option(
+													item.name,
+													'product_' + item.id,
+													false,
+													( selectedOption == 'product_' + item.id ? true : false )
+												)
+											);
 										}
 									);
 									break;
@@ -118,7 +131,7 @@ jQuery( document ).ready(
 										}
 									);
 									break;
-								}
+							}
 
 							// Trigger a change event on the select field, to allow Select2 instances to repopulate their options.
 							$( field ).trigger( 'change' );

--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -61,6 +61,8 @@ jQuery( document ).ready(
 							// Get currently selected option.
 							var selectedOption = $( field ).val();
 
+							console.log( selectedOption );
+
 							// Remove existing select options.
 							$( 'option', $( field ) ).each(
 								function () {
@@ -82,13 +84,13 @@ jQuery( document ).ready(
 									// Populate select opgroups from response data, which comprises of Tags and Products.
 									response.data.tags.forEach(
 										function ( item ) {
-											$( 'optgroup[data-resource="tags"]', field ).append( new Option( item.name, item.id, false, ( selectedOption == item.id ? true : false ) ) );
+											$( 'optgroup[data-resource="tags"]', field ).append( new Option( item.name, 'tag_' + item.id, false, ( selectedOption == 'tag_' + item.id ? true : false ) ) );
 										}
 									);
 
 									response.data.products.forEach(
 										function ( item ) {
-											$( 'optgroup[data-resource="products"]', field ).append( new Option( item.name, item.id, false, ( selectedOption == item.id ? true : false ) ) );
+											$( 'optgroup[data-resource="products"]', field ).append( new Option( item.name, 'product_' + item.id, false, ( selectedOption == 'product_' + item.id ? true : false ) ) );
 										}
 									);
 									break;

--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -121,7 +121,7 @@ function convertKitRefreshResources( button ) {
 									item.name,
 									'tag_' + item.id,
 									false,
-									( selectedOption == 'tag_' + item.id ? true : false )
+									( selectedOption === 'tag_' + item.id )
 								)
 							);
 						}
@@ -135,7 +135,7 @@ function convertKitRefreshResources( button ) {
 									item.name,
 									'product_' + item.id,
 									false,
-									( selectedOption == 'product_' + item.id ? true : false )
+									( selectedOption === 'product_' + item.id )
 								)
 							);
 						}

--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -166,15 +166,13 @@ function convertKitRefreshResources( button ) {
 									item.id,
 									false,
 									( selectedOption == item.id ? true : false )
-								) 
+								)
 							);
 
 						}
 					);
 					break;
 			}
-
-
 
 			// Trigger a change event on the select field, to allow Select2 instances to repopulate their options.
 			document.querySelector( field ).dispatchEvent( new Event( 'change' ) );

--- a/tests/acceptance/general/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/general/RefreshResourcesButtonCest.php
@@ -98,13 +98,17 @@ class RefreshResourcesButtonCest
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-tag-container', $_ENV['CONVERTKIT_API_TAG_NAME']);
 
 		// Click the Restrict Content refresh button.
-		$I->click('button.wp-convertkit-refresh-resources[data-resource="products"]');
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="restrict_content"]');
 
 		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="products"]:not(:disabled)');
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="restrict_content"]:not(:disabled)');
 
-		// Change resource to value specified in the .env file, which should now be available.
-		// If the expected dropdown value does not exist in the Select2 field, this will fail the test.
+		// Confirm that the expected Tag is within the Tags option group and selectable.
+		$I->seeElementInDOM('select#wp-convertkit-restrict_content optgroup[data-resource="tags"] option[value="tag_' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]');
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-restrict_content-container', $_ENV['CONVERTKIT_API_TAG_NAME']);
+
+		// Confirm that the expected Product is within the Products option group and selectable.
+		$I->seeElementInDOM('select#wp-convertkit-restrict_content optgroup[data-resource="products"] option[value="product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '"]');
 		$I->fillSelect2Field($I, '#select2-wp-convertkit-restrict_content-container', $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
 	}
 
@@ -170,14 +174,18 @@ class RefreshResourcesButtonCest
 		// If the expected dropdown value does not exist, this will fail the test.
 		$I->selectOption('#wp-convertkit-quick-edit-tag', $_ENV['CONVERTKIT_API_TAG_NAME']);
 
-		// Click the Products refresh button.
-		$I->click('button.wp-convertkit-refresh-resources[data-resource="products"]');
+		// Click the Restrict Content refresh button.
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="restrict_content"]');
 
 		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="products"]:not(:disabled)');
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="restrict_content"]:not(:disabled)');
 
-		// Change resource to value specified in the .env file, which should now be available.
-		// If the expected dropdown value does not exist, this will fail the test.
+		// Confirm that the expected Tag is within the Tags option group and selectable.
+		$I->seeElementInDOM('#wp-convertkit-quick-edit-restrict_content optgroup[data-resource="tags"] option[value="tag_' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]');
+		$I->selectOption('#wp-convertkit-quick-edit-restrict_content', $_ENV['CONVERTKIT_API_TAG_NAME']);
+
+		// Confirm that the expected Product is within the Products option group and selectable.
+		$I->seeElementInDOM('#wp-convertkit-quick-edit-restrict_content optgroup[data-resource="products"] option[value="product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '"]');
 		$I->selectOption('#wp-convertkit-quick-edit-restrict_content', $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
 	}
 
@@ -253,14 +261,18 @@ class RefreshResourcesButtonCest
 		// If the expected dropdown value does not exist, this will fail the test.
 		$I->selectOption('#wp-convertkit-bulk-edit-tag', $_ENV['CONVERTKIT_API_TAG_NAME']);
 
-		// Click the Products refresh button.
-		$I->click('button.wp-convertkit-refresh-resources[data-resource="products"]');
+		// Click the Restrict Content refresh button.
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="restrict_content"]');
 
 		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="products"]:not(:disabled)');
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="restrict_content"]:not(:disabled)');
 
-		// Change resource to value specified in the .env file, which should now be available.
-		// If the expected dropdown value does not exist, this will fail the test.
+		// Confirm that the expected Tag is within the Tags option group and selectable.
+		$I->seeElementInDOM('#wp-convertkit-bulk-edit-restrict_content optgroup[data-resource="tags"] option[value="tag_' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]');
+		$I->selectOption('#wp-convertkit-bulk-edit-restrict_content', $_ENV['CONVERTKIT_API_TAG_NAME']);
+
+		// Confirm that the expected Product is within the Products option group and selectable.
+		$I->seeElementInDOM('#wp-convertkit-bulk-edit-restrict_content optgroup[data-resource="products"] option[value="product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '"]');
 		$I->selectOption('#wp-convertkit-bulk-edit-restrict_content', $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
 	}
 

--- a/views/backend/post/bulk-edit.php
+++ b/views/backend/post/bulk-edit.php
@@ -82,40 +82,34 @@
 				<option value="-2" data-preserve-on-refresh="1"><?php esc_html_e( '— No Change —', 'convertkit' ); ?></option>
 				<option value="0" data-preserve-on-refresh="1"><?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?></option>
 
-				<?php
-				// Tags.
-				if ( $convertkit_tags->exist() ) {
-					?>
-					<optgroup label="<?php esc_attr_e( 'Tags', 'convertkit' ); ?>">
-						<?php
+				<optgroup label="<?php esc_attr_e( 'Tags', 'convertkit' ); ?>" data-resource="tags">
+					<?php
+					// Tags.
+					if ( $convertkit_tags->exist() ) {
 						foreach ( $convertkit_tags->get() as $convertkit_tag ) {
 							?>
 							<option value="tag_<?php echo esc_attr( $convertkit_tag['id'] ); ?>"><?php echo esc_attr( $convertkit_tag['name'] ); ?></option>
 							<?php
 						}
-						?>
-					</optgroup>
-					<?php
-				}
-
-				// Products.
-				if ( $convertkit_products->exist() ) {
+					}
 					?>
-					<optgroup label="<?php esc_attr_e( 'Products', 'convertkit' ); ?>">
-						<?php
+				</optgroup>
+
+				<optgroup label="<?php esc_attr_e( 'Products', 'convertkit' ); ?>" data-resource="products">
+					<?php
+					// Products.
+					if ( $convertkit_products->exist() ) {
 						foreach ( $convertkit_products->get() as $product ) {
 							?>
 							<option value="product_<?php echo esc_attr( $product['id'] ); ?>"><?php echo esc_attr( $product['name'] ); ?></option>
 							<?php
 						}
-						?>
-					</optgroup>
-					<?php
-				}
-				?>
+					}
+					?>
+				</optgroup>
 			</select>
 		</label>
-		<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Products from ConvertKit account', 'convertkit' ); ?>" data-resource="products" data-field="#wp-convertkit-bulk-edit-restrict_content">
+		<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Products and Tags from ConvertKit account', 'convertkit' ); ?>" data-resource="restrict_content" data-field="#wp-convertkit-bulk-edit-restrict_content">
 			<span class="dashicons dashicons-update"></span>
 		</button>
 	</div>

--- a/views/backend/post/meta-box.php
+++ b/views/backend/post/meta-box.php
@@ -145,37 +145,33 @@
 					<select name="wp-convertkit[restrict_content]" id="wp-convertkit-restrict_content" class="convertkit-select2">
 						<option value="0"<?php selected( '', $convertkit_post->get_restrict_content() ); ?> data-preserve-on-refresh="1"><?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?></option>
 
-						<?php
-						if ( $convertkit_tags->exist() ) {
-							?>
-							<optgroup label="<?php esc_attr_e( 'Tags', 'convertkit' ); ?>">
-								<?php
+						<optgroup label="<?php esc_attr_e( 'Tags', 'convertkit' ); ?>" data-resource="tags">
+							<?php
+							// Tags.
+							if ( $convertkit_tags->exist() ) {
 								foreach ( $convertkit_tags->get() as $convertkit_tag ) {
 									?>
 									<option value="tag_<?php echo esc_attr( $convertkit_tag['id'] ); ?>"<?php selected( 'tag_' . $convertkit_tag['id'], $convertkit_post->get_restrict_content() ); ?>><?php echo esc_attr( $convertkit_tag['name'] ); ?></option>
 									<?php
 								}
-								?>
-							</optgroup>
-							<?php
-						}
-
-						if ( $convertkit_products->exist() ) {
+							}
 							?>
-							<optgroup label="<?php esc_attr_e( 'Products', 'convertkit' ); ?>">
-								<?php
+						</optgroup>
+
+						<optgroup label="<?php esc_attr_e( 'Products', 'convertkit' ); ?>" data-resource="products">
+							<?php
+							// Products.
+							if ( $convertkit_products->exist() ) {
 								foreach ( $convertkit_products->get() as $product ) {
 									?>
 									<option value="product_<?php echo esc_attr( $product['id'] ); ?>"<?php selected( 'product_' . $product['id'], $convertkit_post->get_restrict_content() ); ?>><?php echo esc_attr( $product['name'] ); ?></option>
 									<?php
 								}
-								?>
-							</optgroup>
-							<?php
-						}
-						?>
+							}
+							?>
+						</optgroup>
 					</select>
-					<button class="wp-convertkit-refresh-resources" class="button button-secondary hide-if-no-js" title="<?php esc_attr_e( 'Refresh Products Pages from ConvertKit account', 'convertkit' ); ?>" data-resource="products" data-field="#wp-convertkit-restrict_content">
+					<button class="wp-convertkit-refresh-resources" class="button button-secondary hide-if-no-js" title="<?php esc_attr_e( 'Refresh Products and Tags from ConvertKit account', 'convertkit' ); ?>" data-resource="restrict_content" data-field="#wp-convertkit-restrict_content">
 						<span class="dashicons dashicons-update"></span>
 					</button>
 					<p class="description">

--- a/views/backend/post/quick-edit.php
+++ b/views/backend/post/quick-edit.php
@@ -60,40 +60,34 @@
 			<select name="wp-convertkit[restrict_content]" id="wp-convertkit-quick-edit-restrict_content" size="1">
 				<option value="0" data-preserve-on-refresh="1"><?php esc_html_e( 'Don\'t restrict content to members only.', 'convertkit' ); ?></option>
 
-				<?php
-				// Tags.
-				if ( $convertkit_tags->exist() ) {
-					?>
-					<optgroup label="<?php esc_attr_e( 'Tags', 'convertkit' ); ?>">
-						<?php
+				<optgroup label="<?php esc_attr_e( 'Tags', 'convertkit' ); ?>" data-resource="tags">
+					<?php
+					// Tags.
+					if ( $convertkit_tags->exist() ) {
 						foreach ( $convertkit_tags->get() as $convertkit_tag ) {
 							?>
 							<option value="tag_<?php echo esc_attr( $convertkit_tag['id'] ); ?>"><?php echo esc_attr( $convertkit_tag['name'] ); ?></option>
 							<?php
 						}
-						?>
-					</optgroup>
-					<?php
-				}
-
-				// Products.
-				if ( $convertkit_products->exist() ) {
+					}
 					?>
-					<optgroup label="<?php esc_attr_e( 'Products', 'convertkit' ); ?>">
-						<?php
+				</optgroup>
+
+				<optgroup label="<?php esc_attr_e( 'Products', 'convertkit' ); ?>" data-resource="products">
+					<?php
+					// Products.
+					if ( $convertkit_products->exist() ) {
 						foreach ( $convertkit_products->get() as $product ) {
 							?>
 							<option value="product_<?php echo esc_attr( $product['id'] ); ?>"><?php echo esc_attr( $product['name'] ); ?></option>
 							<?php
 						}
-						?>
-					</optgroup>
-					<?php
-				}
-				?>
+					}
+					?>
+				</optgroup>
 			</select>
 		</label>
-		<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Products from ConvertKit account', 'convertkit' ); ?>" data-resource="products" data-field="#wp-convertkit-quick-edit-restrict_content">
+		<button class="wp-convertkit-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh Products and Tags from ConvertKit account', 'convertkit' ); ?>" data-resource="restrict_content" data-field="#wp-convertkit-quick-edit-restrict_content">
 			<span class="dashicons dashicons-update"></span>
 		</button>
 	</div>

--- a/views/backend/setup-wizard/convertkit-restrict-content-setup/content-2.php
+++ b/views/backend/setup-wizard/convertkit-restrict-content-setup/content-2.php
@@ -62,7 +62,7 @@ if ( $this->type === 'course' ) {
 			// Tags.
 			if ( $this->tags->exist() ) {
 				?>
-				<optgroup label="<?php esc_attr_e( 'Tags', 'convertkit' ); ?>">
+				<optgroup label="<?php esc_attr_e( 'Tags', 'convertkit' ); ?>" data-resource="tags">
 					<?php
 					foreach ( $this->tags->get() as $convertkit_tag ) {
 						?>
@@ -77,7 +77,7 @@ if ( $this->type === 'course' ) {
 			// Products.
 			if ( $this->products->exist() ) {
 				?>
-				<optgroup label="<?php esc_attr_e( 'Products', 'convertkit' ); ?>">
+				<optgroup label="<?php esc_attr_e( 'Products', 'convertkit' ); ?>" data-resource="products">
 					<?php
 					foreach ( $this->products->get() as $product ) {
 						?>


### PR DESCRIPTION
## Summary

Fixes issues where clicking the refresh button on the Member Content setting would result in:
- Tags and Products not being assigned to their applicable `optgroup` sections,
- `option` values not being prefixed with `tag_` or `product_`, resulting in an invalid value if the setting was changed and then saved.

## Testing

- `RefreshResourcesButtonCest`: Confirm that Tags and Products are assigned to `optgroup` sections, and the value of a Tag and Product `option` is the correct format.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)