### PR TITLE
Add `convertkit_post_settings` hook

### DIFF
--- a/includes/class-convertkit-post.php
+++ b/includes/class-convertkit-post.php
@@ -73,6 +73,18 @@ class ConvertKit_Post {
 			}
 		}
 
+		/**
+		 * Programmatically define ConvertKit settings for an individual Post, overriding those defined in the
+		 * meta box.
+		 *
+		 * @since   2.4.4
+		 *
+		 * @param   array   $meta       Post Settings.
+		 * @param   int     $post_id    Post ID.
+		 * @return  array               Post Settings.
+		 */
+		$meta = apply_filters( 'convertkit_post_settings', $meta, $this->post_id );
+
 		// Assign Post's Settings to the object.
 		$this->settings = $meta;
 
@@ -313,8 +325,9 @@ class ConvertKit_Post {
 		 * @since   1.9.6
 		 *
 		 * @param   array   $defaults   Default Settings.
+		 * @param   int     $post_id    Post ID.
 		 */
-		$defaults = apply_filters( 'convertkit_post_get_default_settings', $defaults );
+		$defaults = apply_filters( 'convertkit_post_get_default_settings', $defaults, $this->post_id );
 
 		return $defaults;
 


### PR DESCRIPTION
## Summary

Adds a `convertkit_post_settings` WordPress filter hook, to allow developers to programmatically define Post-level Plugin settings - for example, setting all Posts to a specific Member Content Tag or Product.

Adds the `post_id` value to the existing `convertkit_post_get_default_settings` WordPress filter hook.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)