### PR TITLE
LiteSpeed Cache: Fix Duplicate Forms

### DIFF
--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -487,7 +487,7 @@ class ConvertKit_Output {
 		// which may result in non-inline forms displaying twice.
 		$data_attributes = array(
 			'data-jetpack-boost' => 'ignore', // Jetpack Boost.
-			'data-no-defer' => '1', // LiteSpeed Cache.
+			'data-no-defer'      => '1', // LiteSpeed Cache.
 		);
 
 		/**

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -482,6 +482,14 @@ class ConvertKit_Output {
 		// Define array of scripts.
 		$scripts = array();
 
+		// Define data attributes to apply to all scripts.
+		// These are typically to prevent third party performance / caching Plugins interfering with ConvertKit scripts,
+		// which may result in non-inline forms displaying twice.
+		$data_attributes = array(
+			'data-jetpack-boost' => 'ignore', // Jetpack Boost.
+			'data-no-defer' => '1', // LiteSpeed Cache.
+		);
+
 		/**
 		 * Define an array of scripts to output in the footer of the WordPress site.
 		 *
@@ -513,6 +521,12 @@ class ConvertKit_Output {
 				// Output the attribute and value.
 				$output .= ' ' . esc_attr( $attribute ) . '="' . esc_attr( $value ) . '"';
 			}
+
+			// Append data attributes.
+			foreach ( $data_attributes as $attribute => $value ) {
+				$output .= ' ' . esc_attr( $attribute ) . '="' . esc_attr( $value ) . '"';
+			}
+
 			$output .= '></script>';
 
 			// Add to array.

--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -324,9 +324,10 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource {
 		}
 
 		// If here, return Form <script> embed now, as we want the inline form to display at this specific point of the content.
-		// data-jetpack-boost="ignore" is required to prevent Jetpack Boost from moving this to the footer when its
-		// "Defer Non-Essential JavaScript" setting is enabled: https://jetpack.com/support/jetpack-boost/.
-		return '<script async data-uid="' . esc_attr( $this->resources[ $id ]['uid'] ) . '" src="' . esc_url( $this->resources[ $id ]['embed_js'] ) . '" data-jetpack-boost="ignore"></script>';
+		// To prevent third party caching / performance Plugins moving this to the footer of the site, data- attributes are added:
+		// data-jetpack-boost="ignore": Ignore Jetpack Boost "Defer Non-Essential JavaScript" setting: https://jetpack.com/support/jetpack-boost/.
+		// data-no-defer="1": Ignore LiteSpeed Cache "Load JS Deferred" setting .
+		return '<script async data-uid="' . esc_attr( $this->resources[ $id ]['uid'] ) . '" src="' . esc_url( $this->resources[ $id ]['embed_js'] ) . '" data-jetpack-boost="ignore" data-no-defer="1"></script>';
 
 	}
 

--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -326,7 +326,7 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource {
 		// If here, return Form <script> embed now, as we want the inline form to display at this specific point of the content.
 		// To prevent third party caching / performance Plugins moving this to the footer of the site, data- attributes are added:
 		// data-jetpack-boost="ignore": Ignore Jetpack Boost "Defer Non-Essential JavaScript" setting: https://jetpack.com/support/jetpack-boost/.
-		// data-no-defer="1": Ignore LiteSpeed Cache "Load JS Deferred" setting .
+		// data-no-defer="1": Ignore LiteSpeed Cache "Load JS Deferred" setting.
 		return '<script async data-uid="' . esc_attr( $this->resources[ $id ]['uid'] ) . '" src="' . esc_url( $this->resources[ $id ]['embed_js'] ) . '" data-jetpack-boost="ignore" data-no-defer="1"></script>';
 
 	}

--- a/tests/acceptance/forms/blocks/PageBlockFormCest.php
+++ b/tests/acceptance/forms/blocks/PageBlockFormCest.php
@@ -675,6 +675,63 @@ class PageBlockFormCest
 	}
 
 	/**
+	 * Test that the Form <script> embed is output in the content, and not the footer of the site
+	 * when the LiteSpeed Cache Plugin is active and its "Load JS Deferred" setting is enabled.
+	 *
+	 * @since   2.4.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFormBlockWithLiteSpeedCachePlugin(AcceptanceTester $I)
+	{
+		// Setup Plugin and Resources.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Activate and enable LiteSpeed Cache Plugin.
+		$I->activateThirdPartyPlugin($I, 'litespeed-cache');
+		$I->enableCachingLiteSpeedCachePlugin($I);
+
+		// Enable LiteSpeed Cache's "Load JS Deferred" setting.
+		$I->amOnAdminPage('admin.php?page=litespeed-page_optm#settings_js');
+		$I->click('label[for=input_radio_optmjs_defer_1]');
+		$I->click('Save Changes');
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: LiteSpeed Cache');
+
+		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
+
+		// Add block to Page, setting the Form setting to the value specified in the .env file.
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+			]
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that one ConvertKit Form is output in the DOM within the <main> element.
+		// This confirms that there is only one script on the page for this form, which renders the form,
+		// and that LiteSpeed Cache hasn't moved the script embed to the footer of the site.
+		$I->seeNumberOfElementsInDOM('main form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+
+		// Deactivate LiteSpeed Cache Plugin.
+		$I->deactivateThirdPartyPlugin($I, 'litespeed-cache');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/acceptance/forms/general/PageFormCest.php
+++ b/tests/acceptance/forms/general/PageFormCest.php
@@ -230,6 +230,98 @@ class PageFormCest
 	}
 
 	/**
+	 * Test that the Modal Form is output once when the Jetpack Boost Plugin is active and
+	 * its "Defer Non-Essential JavaScript" setting is enabled.
+	 *
+	 * @since   2.4.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewPageUsingModalFormWithJetpackBoostPlugin(AcceptanceTester $I)
+	{
+		// Setup Plugin and Resources.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Activate Jetpack Boost Plugin.
+		$I->activateThirdPartyPlugin($I, 'jetpack-boost');
+
+		// Enable Jetpack Boost's "Defer Non-Essential JavaScript" setting.
+		$I->amOnAdminPage('admin.php?page=jetpack-boost');
+		$I->click('#inspector-toggle-control-1');
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . ': Jetpack Boost');
+
+		// Configure metabox's Form setting = None.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
+			]
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that one ConvertKit Form is output in the DOM.
+		// This confirms that there is only one script on the page for this form, which renders the form,
+		// and that Jetpack Boost hasn't moved the script embed to the footer of the site.
+		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '"]', 1);
+
+		// Deactivate Jetpack Boost Plugin.
+		$I->deactivateThirdPartyPlugin($I, 'jetpack-boost');
+	}
+
+	/**
+	 * Test that the Modal Form is output once when the LiteSpeed Cache Plugin is active and
+	 * its "Load JS Deferred" setting is enabled.
+	 *
+	 * @since   2.4.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewPageUsingModalFormWithLiteSpeedCachePlugin(AcceptanceTester $I)
+	{
+		// Setup ConvertKit plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Activate and enable LiteSpeed Cache Plugin.
+		$I->activateThirdPartyPlugin($I, 'litespeed-cache');
+		$I->enableCachingLiteSpeedCachePlugin($I);
+
+		// Enable LiteSpeed Cache's "Load JS Deferred" setting.
+		$I->amOnAdminPage('admin.php?page=litespeed-page_optm#settings_js');
+		$I->click('label[for=input_radio_optmjs_defer_1]');
+		$I->click('Save Changes');
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . ': LiteSpeed Cache');
+
+		// Configure metabox's Form setting = None.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
+			]
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that one ConvertKit Form is output in the DOM.
+		// This confirms that there is only one script on the page for this form, which renders the form,
+		// and that LiteSpeed Cache hasn't moved the script embed to the footer of the site.
+		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '"]', 1);
+
+		// Deactivate LiteSpeed Cache Plugin.
+		$I->deactivateThirdPartyPlugin($I, 'litespeed-cache');
+	}
+
+	/**
 	 * Test that the Legacy Form specified in the Page Settings works when
 	 * creating and viewing a new WordPress Page.
 	 *


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/12263829995739?view=List), where a modal form is output twice, due to LiteSpeed Cache's `Load JS Deferred` setting duplicating the embed script.

Adding the `data-no-defer` attribute to ConvertKit Form `script` embeds resolves, similar to adding the `data-jetpack-boost` for [Jetpack Boost](https://github.com/ConvertKit/convertkit-wordpress/pull/621).

## Testing

Tests in PHP 7.4 are failing due to wp-browser updating to 3.5 today, which is resolved in [this PR](https://github.com/ConvertKit/convertkit-wordpress/pull/635).

- `PageShortcodeFormCest:testFormShortcodeWithLiteSpeedCachePlugin`: Test that a single form is output when added via a shortcode with the LiteSpeed Cache Plugin enabled and its `Load JS Deferred` setting enabled.
- `PageBlockFormCest:testFormBlockWithLiteSpeedCachePlugin`: Test that a single form is output when added via a block with the LiteSpeed Cache Plugin enabled and its `Load JS Deferred` setting enabled.
- `PageFormCest:testAddNewPageUsingModalFormWithLiteSpeedCachePlugin`: Test that a single modal form is output when added via the Page's settings, with the LiteSpeed Cache Plugin enabled and its `Load JS Deferred` setting enabled.
- `PageFormCest:testAddNewPageUsingModalFormWithJetpackBoostPlugin`: Test that a single modal form is output when added via the Page's settings, with the Jetpack Boost Plugin enabled and its `Defer Non-Essential JavaScript` setting enabled.  Added for completeness, given we test modals in this PR against LiteSpeed Cache.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)