### PR TITLE
Center Inline Forms

### DIFF
--- a/resources/frontend/css/form.css
+++ b/resources/frontend/css/form.css
@@ -2,11 +2,13 @@
  * Replicates CSS styles provided by block themes for older non-block themes
  * that may not include these definitions, resulting in incorrect spacing.
  */
-form.formkit-form {
+form.formkit-form[data-format="inline"] {
+	margin-left: auto;
+	margin-right: auto;
 	margin-bottom: 20px;
 }
 @media only screen and (min-width: 482px) {
-	form.formkit-form {
+	form.formkit-form[data-format="inline"] {
 		margin-bottom: 30px;
 	}
 }


### PR DESCRIPTION
## Summary

Fixes [this issue](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/12263830003582?view=List) by adding `margin-left` and `margin-right` `auto` properties to inline forms, for WordPress Themes that don't automatically center inner forms / elements.

Before:
![Screenshot 2024-02-16 at 17 16 41](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/7787ef17-1d5d-4780-b248-4121442a944d)

After:
![Screenshot 2024-02-16 at 17 17 03](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/8ef36359-a99e-4fc9-9406-35c71325d77c)

Also removes the `margin-bottom` from non-inline forms, which would incorrectly shift e.g. a modal form slightly.  This property was added to ensure inline forms have similar spacing in both block and non-block themes ([original PR](https://github.com/ConvertKit/convertkit-wordpress/pull/565))

Before:
![Screenshot 2024-02-16 at 17 16 54](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/7ac826ec-9b4d-480e-a2c2-d6c2e9ae6094)

After:
![Screenshot 2024-02-16 at 17 17 10](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/c1762383-acf6-458f-b9c8-a7e870b8e243)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)