### PR TITLE
Fix Failing Tests on PHP 7.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,24 +48,11 @@ jobs:
       fail-fast: false
       matrix:
         wp-versions: [ 'latest' ] #[ '6.1.1', 'latest' ]
-        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3' ] #[ '7.4', '8.0', '8.1' ]
+        php-versions: [ '7.4' ] #[ '7.4', '8.0', '8.1' ]
 
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
-          'acceptance/broadcasts/blocks',
-          'acceptance/broadcasts/shortcodes',
-          'acceptance/broadcasts/import',
-          'acceptance/forms/blocks',
-          'acceptance/forms/general',
-          'acceptance/forms/shortcodes',
-          'acceptance/general',
-          'acceptance/integrations/elementor',
-          'acceptance/integrations/other',
-          'acceptance/integrations/wlm',
-          'acceptance/integrations/woocommerce',
-          'acceptance/products',
-          'acceptance/restrict-content',
-          'acceptance/tags',
+          'acceptance/broadcasts/blocks'
         ]
 
     # Steps to install, configure and run tests
@@ -184,7 +171,7 @@ jobs:
       # Make sure your committed .env.dist.testing file ends with a newline.
       # The formatting of the contents to include a blank newline is deliberate.
       - name: Define GitHub Secrets in .env.dist.testing
-        uses: DamianReeves/write-file-action@v1.2
+        uses: DamianReeves/write-file-action@v1.3
         with:
           path: ${{ env.PLUGIN_DIR }}/.env.dist.testing
           contents: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,11 +48,24 @@ jobs:
       fail-fast: false
       matrix:
         wp-versions: [ 'latest' ] #[ '6.1.1', 'latest' ]
-        php-versions: [ '7.4' ] #[ '7.4', '8.0', '8.1' ]
+        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3' ] #[ '7.4', '8.0', '8.1' ]
 
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
-          'acceptance/broadcasts/blocks'
+          'acceptance/broadcasts/blocks',
+          'acceptance/broadcasts/shortcodes',
+          'acceptance/broadcasts/import',
+          'acceptance/forms/blocks',
+          'acceptance/forms/general',
+          'acceptance/forms/shortcodes',
+          'acceptance/general',
+          'acceptance/integrations/elementor',
+          'acceptance/integrations/other',
+          'acceptance/integrations/wlm',
+          'acceptance/integrations/woocommerce',
+          'acceptance/products',
+          'acceptance/restrict-content',
+          'acceptance/tags',
         ]
 
     # Steps to install, configure and run tests
@@ -171,7 +184,7 @@ jobs:
       # Make sure your committed .env.dist.testing file ends with a newline.
       # The formatting of the contents to include a blank newline is deliberate.
       - name: Define GitHub Secrets in .env.dist.testing
-        uses: DamianReeves/write-file-action@v1.3
+        uses: DamianReeves/write-file-action@v1.2
         with:
           path: ${{ env.PLUGIN_DIR }}/.env.dist.testing
           contents: |

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "convertkit/convertkit-wordpress-libraries": "1.4.1"
     },
     "require-dev": {
-        "lucatume/wp-browser": "^3.0",
+        "lucatume/wp-browser": "<3.5",
         "codeception/module-asserts": "^1.3",                                      
         "codeception/module-phpbrowser": "^1.0",                                   
         "codeception/module-webdriver": "^1.0",                                    


### PR DESCRIPTION
## Summary

[wp-browser 3.5](https://wpbrowser.wptestkit.dev/migration/#migrate-from-version-3-to-35) (released today) breaks tests in PHP 7.4, despite stating it's supported - specifically failing to load .env file values resulting in errors:

![Screenshot 2024-02-20 at 15 28 11](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/c691325d-b3b5-4404-822a-c13dc953c97a)

This PR follows docs to revert wp-browser to < `3.5`, to ensure tests pass in PHP 7.4.

Will need to review tests and a separate PR to add support for wp-browser 3.5.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)