### PR TITLE
Products: Add checkout step option

### DIFF
--- a/includes/blocks/class-convertkit-block-product.php
+++ b/includes/blocks/class-convertkit-block-product.php
@@ -121,7 +121,7 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 			// Shortcode: TinyMCE / QuickTags Modal Width and Height.
 			'modal'                             => array(
 				'width'  => 600,
-				'height' => 425,
+				'height' => 518,
 			),
 
 			// Shortcode: Include a closing [/shortcode] tag when using TinyMCE or QuickTag Modals.

--- a/includes/blocks/class-convertkit-block-product.php
+++ b/includes/blocks/class-convertkit-block-product.php
@@ -181,6 +181,10 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 				'type'    => 'string',
 				'default' => $this->get_default_value( 'discount_code' ),
 			),
+			'checkout'                => array(
+				'type'    => 'boolean',
+				'default' => $this->get_default_value( 'checkout' ),
+			),
 			'disable_modal_on_mobile' => array(
 				'type'    => 'boolean',
 				'default' => $this->get_default_value( 'disable_modal_on_mobile' ),
@@ -307,6 +311,11 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 				'type'        => 'text',
 				'description' => __( 'Optional: A discount code to include. Must be defined in the ConvertKit Product.', 'convertkit' ),
 			),
+			'checkout'                => array(
+				'label'       => __( 'Load checkout step', 'convertkit' ),
+				'type'        => 'toggle',
+				'description' => __( 'If enabled, immediately loads the checkout screen, instead of the ConvertKit Product description.', 'convertkit' ),
+			),
 			'disable_modal_on_mobile' => array(
 				'label'       => __( 'Disable modal on mobile', 'convertkit' ),
 				'type'        => 'toggle',
@@ -350,6 +359,7 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 					'product',
 					'text',
 					'discount_code',
+					'checkout',
 					'disable_modal_on_mobile',
 					'background_color',
 					'text_color',
@@ -372,6 +382,7 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 			'product'                 => '',
 			'text'                    => __( 'Buy my product', 'convertkit' ),
 			'discount_code'           => '',
+			'checkout'                => false,
 			'disable_modal_on_mobile' => false,
 			'background_color'        => '',
 			'text_color'              => '',
@@ -420,6 +431,7 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 			$atts['text'],
 			array(
 				'discount_code'  => $atts['discount_code'],
+				'checkout'       => $atts['checkout'],
 				'disable_modal'  => ( $atts['disable_modal_on_mobile'] && wp_is_mobile() ),
 				'css_classes'    => $atts['_css_classes'],
 				'css_styles'     => $atts['_css_styles'],

--- a/includes/class-convertkit-resource-products.php
+++ b/includes/class-convertkit-resource-products.php
@@ -113,6 +113,7 @@ class ConvertKit_Resource_Products extends ConvertKit_Resource {
 		$defaults = array(
 			'disable_modal'  => false,
 			'discount_code'  => false,
+			'checkout'       => false,
 			'css_classes'    => array(),
 			'css_styles'     => array(),
 			'return_as_span' => false,
@@ -143,10 +144,22 @@ class ConvertKit_Resource_Products extends ConvertKit_Resource {
 
 		// Build product URL.
 		$product_url = $this->resources[ $id ]['url'];
+
+		// If a discount code is specified, add it to the URL now.
 		if ( $options['discount_code'] ) {
 			$product_url = add_query_arg(
 				array(
 					'promo' => $options['discount_code'],
+				),
+				$product_url
+			);
+		}
+
+		// If the URL should directly load the checkout step, add it to the URL now.
+		if ( $options['checkout'] ) {
+			$product_url = add_query_arg(
+				array(
+					'step' => 'checkout',
 				),
 				$product_url
 			);

--- a/tests/acceptance/products/PageBlockProductCest.php
+++ b/tests/acceptance/products/PageBlockProductCest.php
@@ -268,6 +268,55 @@ class PageBlockProductCest
 	}
 
 	/**
+	 * Test the Product shortcode opens the ConvertKit Product's checkuot step
+	 * when the Checkout option is enabled.
+	 *
+	 * @since   2.4.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testProductBlockWithCheckoutParameterEnabled(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPluginNoDefaultForms($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Product: Checkout Step');
+
+		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
+
+		// Add block to Page, setting the Product setting to the value specified in the .env file.
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Product',
+			'convertkit-product',
+			[
+				'product'                     => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+				'#inspector-toggle-control-0' => [ 'toggle', true ],
+			]
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that the ConvertKit Product is displayed.
+		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
+
+		// Confirm the checkout step is displayed.
+		$I->switchToIFrame('iframe[data-active]');
+		$I->waitForElementVisible('.formkit-main');
+		$I->see('Order Summary');
+	}
+
+	/**
 	 * Test the Product block opens the ConvertKit Product in the same window instead
 	 * of a modal when the Disable modal on mobile option is enabled.
 	 *
@@ -300,7 +349,7 @@ class PageBlockProductCest
 			'convertkit-product',
 			[
 				'product'                     => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
-				'#inspector-toggle-control-0' => [ 'toggle', true ],
+				'#inspector-toggle-control-1' => [ 'toggle', true ],
 			]
 		);
 

--- a/tests/acceptance/products/PageShortcodeProductCest.php
+++ b/tests/acceptance/products/PageShortcodeProductCest.php
@@ -264,6 +264,46 @@ class PageShortcodeProductCest
 	}
 
 	/**
+	 * Test the Product shortcode opens the ConvertKit Product's checkuot step
+	 * when the Checkout option is enabled.
+	 *
+	 * @since   2.4.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testProductShortcodeWithCheckoutParameterEnabled(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin with no default form specified.
+		$I->setupConvertKitPluginNoDefaultForms($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Product: Shortcode: Checkout Step');
+
+		// Add shortcode to Page, setting the Product setting to the value specified in the .env file.
+		$I->addVisualEditorShortcode(
+			$I,
+			'ConvertKit Product',
+			[
+				'product'  => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+				'checkout' => [ 'toggle', 'Yes' ],
+			],
+			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" checkout="1"]'
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage($I);
+
+		// Confirm that the ConvertKit Product is displayed.
+		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
+
+		// Confirm the checkout step is displayed.
+		$I->switchToIFrame('iframe[data-active]');
+		$I->waitForElementVisible('.formkit-main');
+		$I->see('Order Summary');
+	}
+
+	/**
 	 * Test the Product shortcode opens the ConvertKit Product in the same window instead
 	 * of a modal when the Disable modal on mobile option is enabled.
 	 *

--- a/tests/acceptance/products/PageShortcodeProductCest.php
+++ b/tests/acceptance/products/PageShortcodeProductCest.php
@@ -288,7 +288,7 @@ class PageShortcodeProductCest
 				'product'  => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 				'checkout' => [ 'toggle', 'Yes' ],
 			],
-			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" checkout="1"]'
+			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" checkout="1" disable_modal_on_mobile="0"]'
 		);
 
 		// Publish and view the Page on the frontend site.

--- a/tests/acceptance/products/PageShortcodeProductCest.php
+++ b/tests/acceptance/products/PageShortcodeProductCest.php
@@ -42,7 +42,7 @@ class PageShortcodeProductCest
 			[
 				'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			],
-			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" disable_modal_on_mobile="0"]'
+			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" checkout="0" disable_modal_on_mobile="0"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -76,7 +76,7 @@ class PageShortcodeProductCest
 			[
 				'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 			],
-			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" disable_modal_on_mobile="0"]'
+			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" checkout="0" disable_modal_on_mobile="0"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -141,7 +141,7 @@ class PageShortcodeProductCest
 				'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 				'text'    => [ 'input', 'Buy now' ],
 			],
-			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy now"  disable_modal_on_mobile="0"]'
+			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy now" checkout="0" disable_modal_on_mobile="0"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -175,7 +175,7 @@ class PageShortcodeProductCest
 				'product' => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 				'text'    => [ 'input', '' ],
 			],
-			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '"  disable_modal_on_mobile="0"]'
+			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" checkout="0" disable_modal_on_mobile="0"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -209,7 +209,7 @@ class PageShortcodeProductCest
 				'product'       => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 				'discount_code' => [ 'input', $_ENV['CONVERTKIT_API_PRODUCT_DISCOUNT_CODE'] ],
 			],
-			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" discount_code="' . $_ENV['CONVERTKIT_API_PRODUCT_DISCOUNT_CODE'] . '"  disable_modal_on_mobile="0"]'
+			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" discount_code="' . $_ENV['CONVERTKIT_API_PRODUCT_DISCOUNT_CODE'] . '" checkout="0" disable_modal_on_mobile="0"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -248,7 +248,7 @@ class PageShortcodeProductCest
 				'product'       => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 				'discount_code' => [ 'input', 'fake' ],
 			],
-			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" discount_code="fake"  disable_modal_on_mobile="0"]'
+			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" discount_code="fake" checkout="0" disable_modal_on_mobile="0"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -328,7 +328,7 @@ class PageShortcodeProductCest
 				'product'                 => [ 'select', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
 				'disable_modal_on_mobile' => [ 'toggle', 'Yes' ],
 			],
-			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" disable_modal_on_mobile="1"]'
+			'[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" checkout="0" disable_modal_on_mobile="1"]'
 		);
 
 		// Publish and view the Page on the frontend site.
@@ -379,7 +379,7 @@ class PageShortcodeProductCest
 		$I->havePageInDatabase(
 			[
 				'post_name'    => 'convertkit-page-product-shortcode-hex-color-params',
-				'post_content' => '[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product"  disable_modal_on_mobile="0" background_color="' . $backgroundColor . '" text_color="' . $textColor . '"]',
+				'post_content' => '[convertkit_product product="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '" text="Buy my product" checkout="0" disable_modal_on_mobile="0" background_color="' . $backgroundColor . '" text_color="' . $textColor . '"]',
 			]
 		);
 


### PR DESCRIPTION
## Summary

Adds an option to immediately load the checkout step in the ConvertKit Product Modal when the button is clicked.

Block:
![Screenshot 2024-02-22 at 17 13 47](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/bdc21787-32ea-4336-b2a0-2d0642721f82)

Shortcode:
![Screenshot 2024-02-22 at 17 16 44](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/8cf4c68e-d9e3-47dc-a4db-6b70bee2b0d3)

Result when button is clicked with checkout option enabled:
![Screenshot 2024-02-23 at 14 41 37](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/d960e0cd-be51-4aa4-887f-c37daf48b5a2)

## Testing

- `PageBlockProductCest:testProductBlockWithCheckoutParameterEnabled`: Test the Product block opens checkout step of the ConvertKit Product when the checkout option is enabled.
- `PageShortcodeProductCest:testProductShortcodeWithCheckoutParameterEnabled`: Test the Product shortcode opens checkout step of the ConvertKit Product when the checkout option is enabled.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)