### PR TITLE
Use Secure Log in WordPress Libraries

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -2,6 +2,7 @@
 /.github
 /.scripts
 /.wordpress-org
+/log
 /tests
 /vendor/autoload.php
 /vendor/composer

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -269,4 +269,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: log-${{ steps.test-group.outputs.value }}-${{ matrix.php-versions }}.txt
-          path: ${{ env.PLUGIN_DIR }}/log.txt
+          path: ${{ env.PLUGIN_DIR }}/log/log.txt

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .env.testing
 codeception.yml
 composer.lock
+log
 log.txt
 phpstan.neon
 tests/_output

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "1.4.1"
+        "convertkit/convertkit-wordpress-libraries": "dev-secure-log-file"
     },
     "require-dev": {
         "lucatume/wp-browser": "<3.5",
@@ -42,6 +42,7 @@
             "composer.json",
             "composer.lock",
             "Gruntfile.js",
+            "log",
             "log.txt",
             "package.json",
             "package-lock.json",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "dev-secure-log-file"
+        "convertkit/convertkit-wordpress-libraries": "1.4.2"
     },
     "require-dev": {
         "lucatume/wp-browser": "<3.5",

--- a/tests/acceptance/general/SubscriberEmailToIDOnFormSubmitCest.php
+++ b/tests/acceptance/general/SubscriberEmailToIDOnFormSubmitCest.php
@@ -132,9 +132,9 @@ class SubscriberEmailToIDOnFormSubmitCest
 		// Wait for JS and AJAX request to complete.
 		$I->wait(5);
 
-		// Check log does not contain get_subscriber_by_email() call with no email value.
+		// Check log contains get_subscriber_by_email() call with masked email value.
 		$I->loadConvertKitSettingsToolsScreen($I);
-		$I->seeInSource('API: get_subscriber_by_email(): [ email: ' . $emailAddress . ']');
+		$I->seeInSource('API: get_subscriber_by_email(): [ email: w********-2***');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Uses a more secure log file method, as added in our [WordPress Libraries](https://github.com/ConvertKit/convertkit-wordpress-libraries/pull/34).

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)