### PR TITLE
Exclude Forms from Perfmatters `Delay JS`

### DIFF
--- a/includes/class-convertkit-cache-plugins.php
+++ b/includes/class-convertkit-cache-plugins.php
@@ -57,7 +57,7 @@ class ConvertKit_Cache_Plugins {
 		// Perfmatters: Exclude Forms from Delay JavaScript.
 		add_filter( 'convertkit_output_script_footer', array( $this, 'perfmatters_exclude_delay_js' ) );
 		add_filter( 'convertkit_resource_forms_output_script', array( $this, 'perfmatters_exclude_delay_js' ) );
-		
+
 		// Siteground Speed Optimizer: Exclude Forms from JS combine.
 		add_filter( 'convertkit_output_script_footer', array( $this, 'siteground_speed_optimizer_exclude_js_combine' ) );
 		add_filter( 'convertkit_resource_forms_output_script', array( $this, 'siteground_speed_optimizer_exclude_js_combine' ) );

--- a/includes/class-convertkit-cache-plugins.php
+++ b/includes/class-convertkit-cache-plugins.php
@@ -54,6 +54,10 @@ class ConvertKit_Cache_Plugins {
 		add_filter( 'convertkit_output_script_footer', array( $this, 'litespeed_cache_exclude_js_defer' ) );
 		add_filter( 'convertkit_resource_forms_output_script', array( $this, 'litespeed_cache_exclude_js_defer' ) );
 
+		// Perfmatters: Exclude Forms from Delay JavaScript.
+		add_filter( 'convertkit_output_script_footer', array( $this, 'perfmatters_exclude_delay_js' ) );
+		add_filter( 'convertkit_resource_forms_output_script', array( $this, 'perfmatters_exclude_delay_js' ) );
+		
 		// Siteground Speed Optimizer: Exclude Forms from JS combine.
 		add_filter( 'convertkit_output_script_footer', array( $this, 'siteground_speed_optimizer_exclude_js_combine' ) );
 		add_filter( 'convertkit_resource_forms_output_script', array( $this, 'siteground_speed_optimizer_exclude_js_combine' ) );
@@ -104,6 +108,31 @@ class ConvertKit_Cache_Plugins {
 				'data-no-defer' => '1',
 			)
 		);
+
+	}
+
+	/**
+	 * Exclude ConvertKit scripts from Perfmatters' "Delay JS" setting.
+	 *
+	 * @since   2.4.7
+	 *
+	 * @param   array $script     Script key/value pairs to output as <script> tag.
+	 * @return  array
+	 */
+	public function perfmatters_exclude_delay_js( $script ) {
+
+		add_filter(
+			'perfmatters_delay_js_exclusions',
+			function ( $exclusions ) use ( $script ) {
+
+				$exclusions[] = $script['src'];
+				return $exclusions;
+
+			}
+		);
+
+		// Return original script.
+		return $script;
 
 	}
 

--- a/tests/acceptance/forms/blocks-shortcodes/PageBlockFormCest.php
+++ b/tests/acceptance/forms/blocks-shortcodes/PageBlockFormCest.php
@@ -785,6 +785,67 @@ class PageBlockFormCest
 	}
 
 	/**
+	 * Test that the Form <script> embed is output in the content when the Perfmatters Plugin is active and its "Delay JavaScript"
+	 * setting is enabled.
+	 *
+	 * @since   2.4.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFormBlockWithPerfmattersPlugin(AcceptanceTester $I)
+	{
+		// Setup Plugin and Resources.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Activate Perfmatters Plugin.
+		$I->activateThirdPartyPlugin($I, 'perfmatters');
+
+		// Enable Defer and Delay JavaScript.
+		$I->haveOptionInDatabase(
+			'perfmatters_options',
+			[
+				'assets' => [
+					'defer_js' => 1,
+					'delay_js' => 1,
+				],
+			]
+		);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Block: Perfmatters');
+
+		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
+
+		// Add block to Page, setting the Form setting to the value specified in the .env file.
+		$I->addGutenbergBlock(
+			$I,
+			'ConvertKit Form',
+			'convertkit-form',
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+			]
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that one ConvertKit Form is output in the DOM within the <main> element.
+		// This confirms that there is only one script on the page for this form, which renders the form.
+		$I->seeNumberOfElementsInDOM('main form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+
+		// Deactivate Perfmatters Plugin.
+		$I->deactivateThirdPartyPlugin($I, 'perfmatters');
+	}
+
+	/**
 	 * Test that the Form <script> embed is output in the content when the WP Rocket Plugin is active and its "Delay JavaScript execution"
 	 * setting is enabled.
 	 *

--- a/tests/acceptance/forms/blocks-shortcodes/PageShortcodeFormCest.php
+++ b/tests/acceptance/forms/blocks-shortcodes/PageShortcodeFormCest.php
@@ -572,6 +572,67 @@ class PageShortcodeFormCest
 	}
 
 	/**
+	 * Test that the Form <script> embed is output in the content when the Perfmatters Plugin is active and its "Delay JavaScript"
+	 * setting is enabled.
+	 *
+	 * @since   2.4.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFormShortcodeWithPerfmattersPlugin(AcceptanceTester $I)
+	{
+		// Setup Plugin and Resources.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Activate Perfmatters Plugin.
+		$I->activateThirdPartyPlugin($I, 'perfmatters');
+
+		// Enable Defer and Delay JavaScript.
+		$I->haveOptionInDatabase(
+			'perfmatters_options',
+			[
+				'assets' => [
+					'defer_js' => 1,
+					'delay_js' => 1,
+				],
+			]
+		);
+
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Form: Shortcode: Perfmatters');
+
+		// Configure metabox's Form setting = None, ensuring we only test the shortcode in the Classic Editor.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
+
+		// Add shortcode to Page, setting the Form setting to the value specified in the .env file.
+		$I->addVisualEditorShortcode(
+			$I,
+			'ConvertKit Form',
+			[
+				'form' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+			],
+			'[convertkit_form form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]'
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewClassicEditorPage($I);
+
+		// Confirm that one ConvertKit Form is output in the DOM within the <main> element.
+		// This confirms that there is only one script on the page for this form, which renders the form.
+		$I->seeNumberOfElementsInDOM('main form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+
+		// Deactivate Perfmatters Plugin.
+		$I->deactivateThirdPartyPlugin($I, 'perfmatters');
+	}
+
+	/**
 	 * Test that the Form <script> embed is output in the content when the Siteground Speed Optimizer Plugin is active
 	 * and its "Combine JavaScript Files" setting is enabled.
 	 *

--- a/tests/acceptance/forms/post-types/PageFormCest.php
+++ b/tests/acceptance/forms/post-types/PageFormCest.php
@@ -364,6 +364,57 @@ class PageFormCest
 	}
 
 	/**
+	 * Test that the Modal Form is output once when the Perfmatters Plugin is active and its "Delay JavaScript"
+	 * setting is enabled.
+	 *
+	 * @since   2.4.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewPageUsingModalFormWithPerfmattersPlugin(AcceptanceTester $I)
+	{
+		// Setup Plugin and Resources.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Activate Perfmatters Plugin.
+		$I->activateThirdPartyPlugin($I, 'perfmatters');
+
+		// Enable Defer and Delay JavaScript.
+		$I->haveOptionInDatabase(
+			'perfmatters_options',
+			[
+				'assets' => [
+					'defer_js' => 1,
+					'delay_js' => 1,
+				],
+			]
+		);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] . ': WP Rocket');
+
+		// Configure metabox's Form setting = None.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_NAME'] ],
+			]
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that one ConvertKit Form is output in the DOM within the <main> element.
+		// This confirms that there is only one script on the page for this form, which renders the form.
+		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '"]', 1);
+
+		// Deactivate Perfmatters Plugin.
+		$I->deactivateThirdPartyPlugin($I, 'perfmatters');
+	}
+
+	/**
 	 * Test that the Modal Form is output once when the WP Rocket Plugin is active and its "Delay JavaScript execution"
 	 * setting is enabled.
 	 *


### PR DESCRIPTION
## Summary

Fixes [this issue](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/conversation/12263830602836?view=List) by excluding ConvertKit Forms from Perfmatters' Plugin's `Delay JS` and `Defer JS` settings, ensuring forms and modals display.

## Testing

- `PageBlockFormCest:testFormBlockWithPerfMattersPlugin`: Test that the Form <script> embed is output in the content when the Perfmatters Plugin is active and its "Delay JavaScript" setting is enabled.
- `PageShortcodeFormCest:testFormShortcodeWithPerfmattersPlugin`: Test that the Form <script> embed is output in the content when the Perfmatters Plugin is active and its "Delay JavaScript" setting is enabled.
- `PageFormCest:testAddNewPageUsingModalFormWithPerfmattersPlugin`: Test that the Modal Form is output once when the Perfmatters Plugin is active and its "Delay JavaScript execution" setting is enabled.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)