### PR TITLE
Tests: Perfmatters: Fix 502 Bad Gateway error in PHP 7.4

### DIFF
--- a/tests/acceptance/forms/blocks-shortcodes/PageBlockFormCest.php
+++ b/tests/acceptance/forms/blocks-shortcodes/PageBlockFormCest.php
@@ -806,8 +806,9 @@ class PageBlockFormCest
 			'perfmatters_options',
 			[
 				'assets' => [
-					'defer_js' => 1,
-					'delay_js' => 1,
+					'defer_js'            => 1,
+					'delay_js'            => 1,
+					'delay_js_inclusions' => '',
 				],
 			]
 		);


### PR DESCRIPTION
## Summary

Perfmatters tests in PHP 7.4 [began failing](https://github.com/ConvertKit/convertkit-wordpress/actions/runs/8542220431), despite the [original PR passing](https://github.com/ConvertKit/convertkit-wordpress/actions/runs/8523711315).

Identified the cause to be a missing setting key which appears to trip up the test in PHP 7.4.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)