### PR TITLE
Set `z-index` CSS on Sticky Bar Forms

### DIFF
--- a/resources/frontend/css/form.css
+++ b/resources/frontend/css/form.css
@@ -12,3 +12,12 @@ form.formkit-form[data-format="inline"] {
 		margin-bottom: 30px;
 	}
 }
+
+/**
+ * Set a high z-index on sticky bar forms, to ensure sites
+ * that use a z-index on a header / menu don't cover the
+ * sticky bar form.
+ */
+.formkit-sticky-bar {
+	z-index: 999999 !important;
+}


### PR DESCRIPTION
## Summary

Fixes [this issue](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/12263831100062?view=List), where a sticky bar form remains hidden on WordPress sites that use a high z-index property on a sticky / fixed header or menu.  This saves users having to add custom CSS to the form in ConvertKit.

Before:
![Screenshot 2024-04-08 at 14 32 19](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/c547405b-a6fa-43ff-bdf2-7af3ad21f5a2)

After:
![Screenshot 2024-04-08 at 14 31 50](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/93400723-a54f-4d67-a05b-240462cceb5f)

## Testing

Existing tests passed. Visual tests performed to confirm CSS fixes.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)