### PR TITLE
Member Content: Display Content when using Frontend Page Builder

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       DB_USER: root
       DB_PASS: root
       DB_HOST: localhost
-      INSTALL_PLUGINS: "admin-menu-editor contact-form-7 classic-editor custom-post-type-ui disable-welcome-messages-and-tips elementor forminator jetpack-boost woocommerce wordpress-seo wpforms-lite litespeed-cache wp-crontrol wp-super-cache w3-total-cache wp-fastest-cache wp-optimize sg-cachepress" # Don't include this repository's Plugin here.
+      INSTALL_PLUGINS: "admin-menu-editor beaver-builder-lite-version contact-form-7 classic-editor custom-post-type-ui disable-welcome-messages-and-tips elementor forminator jetpack-boost woocommerce wordpress-seo wpforms-lite litespeed-cache wp-crontrol wp-super-cache w3-total-cache wp-fastest-cache wp-optimize sg-cachepress" # Don't include this repository's Plugin here.
       INSTALL_PLUGINS_URLS: "https://downloads.wordpress.org/plugin/convertkit-for-woocommerce.1.6.4.zip http://cktestplugins.wpengine.com/wp-content/uploads/2024/01/convertkit-action-filter-tests.zip" # URLs to specific third party Plugins
       CONVERTKIT_API_KEY: ${{ secrets.CONVERTKIT_API_KEY }} # ConvertKit API Key, stored in the repository's Settings > Secrets
       CONVERTKIT_API_SECRET: ${{ secrets.CONVERTKIT_API_SECRET }} # ConvertKit API Secret, stored in the repository's Settings > Secrets

--- a/includes/class-convertkit-output-restrict-content.php
+++ b/includes/class-convertkit-output-restrict-content.php
@@ -310,6 +310,14 @@ class ConvertKit_Output_Restrict_Content {
 			return $content;
 		}
 
+		// Bail if the Page is being edited in a frontend Page Builder / Editor by a logged
+		// in WordPress user who has the capability to edit the Page.
+		// This ensures the User can view all content to edit it, instead of seeing the Restrict Content
+		// view.
+		if ( current_user_can( 'edit_post', get_the_ID() ) && WP_ConvertKit()->is_admin_or_frontend_editor() ) {
+			return $content;
+		}
+
 		// Get resource type (Product or Tag) that the visitor must be subscribed against to access this content.
 		$this->resource_type = $this->get_resource_type();
 

--- a/tests/acceptance/restrict-content/post-types/RestrictContentProductPageCest.php
+++ b/tests/acceptance/restrict-content/post-types/RestrictContentProductPageCest.php
@@ -255,6 +255,9 @@ class RestrictContentProductPageCest
 		// Check content is not displayed, and CTA displays with expected text,
 		// as we are not logged in.
 		$I->seeElementInDOM('#convertkit-restrict-content');
+
+		// Deactivate Beaver Builder Lite.
+		$I->deactivateThirdPartyPlugin($I, 'beaver-builder-lite-version');
 	}
 
 	/**

--- a/tests/acceptance/restrict-content/post-types/RestrictContentProductPageCest.php
+++ b/tests/acceptance/restrict-content/post-types/RestrictContentProductPageCest.php
@@ -207,6 +207,57 @@ class RestrictContentProductPageCest
 	}
 
 	/**
+	 * Test that content is displayed when the Page is being edited in a frontend
+	 * Page Builder / Editor by a logged in WordPress user who has the capability
+	 * to edit the Page.
+	 *
+	 * @since   2.4.8
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testRestrictContentWhenEditingWithFrontendPageBuilder(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin, disabling JS.
+		$I->setupConvertKitPluginDisableJS($I);
+
+		// Activate Beaver Builder Lite, a frontend Page Builder.
+		$I->activateThirdPartyPlugin($I, 'beaver-builder-lite-version');
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Restrict Content: Beaver Builder');
+
+		// Configure metabox's Restrict Content setting = Product name.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form'             => [ 'select2', 'None' ],
+				'restrict_content' => [ 'select2', $_ENV['CONVERTKIT_API_PRODUCT_NAME'] ],
+			]
+		);
+
+		// Publish Page.
+		$url = $I->publishGutenbergPage($I);
+
+		// Edit Page in Beaver Builder.
+		$I->amOnUrl($url . '?fl_builder&fl_builder_ui');
+
+		// Confirm that the CTA is not displayed.
+		$I->dontSeeElementInDOM('#convertkit-restrict-content');
+
+		// Log out.
+		$I->logOut();
+
+		// Attempt to edit Page in Beaver Builder.
+		// Beaver Builder won't load as we're not logged in.
+		$I->amOnUrl($url . '?fl_builder&fl_builder_ui');
+
+		// Check content is not displayed, and CTA displays with expected text,
+		// as we are not logged in.
+		$I->seeElementInDOM('#convertkit-restrict-content');
+	}
+
+	/**
 	 * Test that search engines can access Restrict Content.
 	 *
 	 * @since   2.4.2


### PR DESCRIPTION
## Summary

Fixes [this issue](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/12263830936660?view=List), by ensuring that Member Content functionality does not run when:
- a WordPress Page has its Member Content setting defined, and
- a logged in WordPress User has the capability to edit a Page, and
- the WordPress User is editing the Page through a frontend page builder, such as Beaver Builder.

Before:
![Screenshot 2024-04-08 at 15 13 17](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/149fbdb4-30fb-48cb-97c2-81090726b5ef)

After:
![Screenshot 2024-04-08 at 15 13 22](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/5abaf17c-0efc-4227-802b-0fc56d12215b)

## Testing

`testRestrictContentWhenEditingWithFrontendPageBuilder`: Test that content is displayed when the Page is being edited in a frontend Page Builder / Editor by a logged in WordPress user who has the capability to edit the Page.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)