### PR TITLE
Tests: Fix WooCommerce Plugin Activation

### DIFF
--- a/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
+++ b/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
@@ -26,8 +26,20 @@ class ThirdPartyPlugin extends \Codeception\Module
 		// Go to the Plugins screen in the WordPress Administration interface.
 		$I->amOnPluginsPage();
 
-		// Activate the Plugin.
-		$I->activatePlugin($name);
+		// Depending on the Plugin name, perform activation.
+		switch ($name) {
+			case 'woocommerce':
+				// The bulk action to activate won't be available in WordPress 6.5 due to dependent
+				// plugins being installed.
+				// See https://core.trac.wordpress.org/ticket/60863.
+				$I->click('a#activate-' . $name);
+				break;
+
+			default:
+				// Activate the Plugin.
+				$I->activatePlugin($name);
+				break;
+		}
 
 		// Go to the Plugins screen again; this prevents any Plugin that loads a wizard-style screen from
 		// causing seePluginActivated() to fail.
@@ -45,9 +57,6 @@ class ThirdPartyPlugin extends \Codeception\Module
 
 		// Some Plugins throw warnings / errors on activation, so we can't reliably check for errors.
 		if ($name === 'wishlist-member' && version_compare( phpversion(), '8.1', '>' )) {
-			return;
-		}
-		if ($name === 'woocommerce') {
 			return;
 		}
 
@@ -72,7 +81,25 @@ class ThirdPartyPlugin extends \Codeception\Module
 		// Go to the Plugins screen in the WordPress Administration interface.
 		$I->amOnPluginsPage();
 
-		// Deactivate the Plugin.
-		$I->deactivatePlugin($name);
+		// Depending on the Plugin name, perform activation.
+		switch ($name) {
+			case 'woocommerce':
+				// The bulk action to deactivate won't be available in WordPress 6.5 due to dependent
+				// plugins being installed.
+				// See https://core.trac.wordpress.org/ticket/60863.
+				$I->click('a#deactivate-' . $name);
+				break;
+
+			default:
+				// Dectivate the Plugin.
+				$I->deactivatePlugin($name);
+				break;
+		}
+
+		// Check that the Plugin deactivated successfully.
+		$I->seePluginDeactivated($name);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 	}
 }


### PR DESCRIPTION
## Summary

WordPress 6.5 introduces the concept of dependent Plugins. As a result, the bulk actions in the Plugins screen aren't available to our testing suite when attempting to activate a Plugin that utilises this feature (in this case, WooCommerce for our WooCommerce tests):

![Screenshot 2024-04-30 at 14 51 00](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/2a1111aa-8428-4709-abb0-ff084a50567f)

To resolve, this PR checks for the Plugin that is being activated, and uses the `Activate` link instead if necessary.

This is the same logic added to tests for the [WooCommerce integration](https://github.com/ConvertKit/convertkit-woocommerce/pull/175).

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)