### PR TITLE
v4 API: Improve Disconnect

### DIFF
--- a/tests/acceptance/general/PluginSettingsGeneralCest.php
+++ b/tests/acceptance/general/PluginSettingsGeneralCest.php
@@ -157,6 +157,25 @@ class PluginSettingsGeneralCest
 
 		// Check that no notice is displayed that the API credentials are invalid.
 		$I->dontSeeErrorNotice($I, 'ConvertKit: Authorization failed. Please connect your ConvertKit account.');
+
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsGeneralScreen($I);
+
+		// Disconnect the Plugin connection to ConvertKit.
+		$I->click('Disconnect');
+
+		// Confirm the Connect button displays.
+		$I->see('Connect');
+		$I->dontSee('Disconnect');
+		$I->dontSeeElementInDOM('input#submit');
+
+		// Check that the option table no longer contains cached resources.
+		$I->dontSeeOptionInDatabase('convertkit_creator_network_recommendations');
+		$I->dontSeeOptionInDatabase('convertkit_forms');
+		$I->dontSeeOptionInDatabase('convertkit_landing_pages');
+		$I->dontSeeOptionInDatabase('convertkit_posts');
+		$I->dontSeeOptionInDatabase('convertkit_products');
+		$I->dontSeeOptionInDatabase('convertkit_tags');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Improves the disconnect logic when clicking `Disconnect` on the `Settings > ConvertKit` screen, by:
- requiring a nonce be specified for security,
- removing cached resources (forms, landing pages, tags, products etc) when disconnected.

## Testing

- `testValidCredentials`: Test that clicking `Disconnect` removes the OAuth credentials from the Plugin settings, and that cached resources are deleted.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)