### PR TITLE
Output Form on Category Archives

### DIFF
--- a/admin/class-convertkit-admin-category.php
+++ b/admin/class-convertkit-admin-category.php
@@ -200,8 +200,8 @@ class ConvertKit_Admin_Category {
 
 		// Build metadata.
 		$meta = array(
-			'form' 		=> ( isset( $_POST['wp-convertkit']['form'] ) ? intval( $_POST['wp-convertkit']['form'] ) : '' ),
-			'form_position' 	=> ( isset( $_POST['wp-convertkit']['form_position'] ) ? $_POST['wp-convertkit']['form_position'] : '' ),
+			'form'          => ( isset( $_POST['wp-convertkit']['form'] ) ? intval( $_POST['wp-convertkit']['form'] ) : '' ),
+			'form_position' => ( isset( $_POST['wp-convertkit']['form_position'] ) ? $_POST['wp-convertkit']['form_position'] : '' ),
 		);
 
 		// Save metadata.

--- a/admin/class-convertkit-admin-category.php
+++ b/admin/class-convertkit-admin-category.php
@@ -199,6 +199,7 @@ class ConvertKit_Admin_Category {
 		}
 
 		// Build metadata.
+		// @TODO update to support position.
 		$meta = ( isset( $_POST['wp-convertkit']['form'] ) ? intval( $_POST['wp-convertkit']['form'] ) : '' );
 
 		// Save metadata.

--- a/admin/class-convertkit-admin-category.php
+++ b/admin/class-convertkit-admin-category.php
@@ -201,7 +201,7 @@ class ConvertKit_Admin_Category {
 		// Build metadata.
 		$meta = array(
 			'form' 		=> ( isset( $_POST['wp-convertkit']['form'] ) ? intval( $_POST['wp-convertkit']['form'] ) : '' ),
-			'position' 	=> ( isset( $_POST['wp-convertkit']['position'] ) ? $_POST['wp-convertkit']['position'] : '' ),
+			'form_position' 	=> ( isset( $_POST['wp-convertkit']['form_position'] ) ? $_POST['wp-convertkit']['form_position'] : '' ),
 		);
 
 		// Save metadata.

--- a/admin/class-convertkit-admin-category.php
+++ b/admin/class-convertkit-admin-category.php
@@ -199,8 +199,10 @@ class ConvertKit_Admin_Category {
 		}
 
 		// Build metadata.
-		// @TODO update to support position.
-		$meta = ( isset( $_POST['wp-convertkit']['form'] ) ? intval( $_POST['wp-convertkit']['form'] ) : '' );
+		$meta = array(
+			'form' 		=> ( isset( $_POST['wp-convertkit']['form'] ) ? intval( $_POST['wp-convertkit']['form'] ) : '' ),
+			'position' 	=> ( isset( $_POST['wp-convertkit']['position'] ) ? $_POST['wp-convertkit']['position'] : '' ),
+		);
 
 		// Save metadata.
 		$convertkit_term = new ConvertKit_Term( $term_id );

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -303,11 +303,7 @@ class ConvertKit_Output {
 			return $hooked_blocks;
 		}
 
-		// Don't append if we cannot get the context.
-		if ( ! is_array( $context ) ) {
-			return $hooked_blocks;
-		}
-		if ( ! isset( $context['slug'] ) ) {
+		if ( $context instanceof WP_Block_Template && $context->slug !== 'archive' ) {
 			return $hooked_blocks;
 		}
 

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -311,6 +311,7 @@ class ConvertKit_Output {
 			return $hooked_blocks;
 		}
 
+		// @TODO Read settings to fetch position.
 		if ( $position !== 'after' ) {
 			return $hooked_blocks;
 		}

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -284,7 +284,7 @@ class ConvertKit_Output {
 	}
 
 	/**
-	 * Registers the ConvertKit Form block to display immediately after the Taxonomy Query Loop block, when viewing a taxonomy archive.
+	 * Registers the ConvertKit Form block to before or after the Query Loop block, when viewing a Category archive.
 	 *
 	 * See append_form_block_on_category_archive() configures the block to display the applicable category's Form.
 	 *
@@ -321,7 +321,7 @@ class ConvertKit_Output {
 		if ( ! $form_position ) {
 			// Unhook this function as we don't need to check again in this request, as we'll
 			// never output a form on the Category archive.
-			remove_filter( 'hooked_block_types', array( $this, 'maybe_register_form_block_on_category_archive' ), 10, 4 );
+			remove_filter( 'hooked_block_types', array( $this, 'maybe_register_form_block_on_category_archive' ), 10 );
 
 			return $hooked_blocks;
 		}
@@ -336,7 +336,7 @@ class ConvertKit_Output {
 
 		// Unhook this function as we don't need to check again in this request, as
 		// we have now appended the form.
-		remove_filter( 'hooked_block_types', array( $this, 'maybe_register_form_block_on_category_archive' ), 10, 4 );
+		remove_filter( 'hooked_block_types', array( $this, 'maybe_register_form_block_on_category_archive' ), 10 );
 
 		return $hooked_blocks;
 

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -73,7 +73,7 @@ class ConvertKit_Output {
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 		add_filter( 'the_content', array( $this, 'append_form_to_content' ) );
 		add_filter( 'hooked_block_types', array( $this, 'maybe_register_form_block_on_category_archive' ), 10, 4 );
-		add_filter( 'hooked_block_convertkit/form', array( $this, 'append_form_block_to_category_archive' ), 10, 5 );
+		add_filter( 'hooked_block_convertkit/form', array( $this, 'append_form_block_to_category_archive' ), 10, 1 );
 		add_action( 'wp_footer', array( $this, 'output_global_non_inline_form' ), 1 );
 		add_action( 'wp_footer', array( $this, 'output_scripts_footer' ) );
 
@@ -285,12 +285,16 @@ class ConvertKit_Output {
 
 	/**
 	 * Registers the ConvertKit Form block to display immediately after the Taxonomy Query Loop block, when viewing a taxonomy archive.
-	 * 
-	 * append_form_block_on_category_archive() configures the block to display the applicable category's Form.
-	 * 
-	 * @since 	2.5.0
-	 * 
-	 * @TODO
+	 *
+	 * See append_form_block_on_category_archive() configures the block to display the applicable category's Form.
+	 *
+	 * @since   2.5.0
+	 *
+	 * @param   array                           $hooked_blocks              The list of hooked block types.
+	 * @param   string                          $position                   The relative position of the hooked blocks.
+	 * @param   string                          $anchor_block               The anchor block type.
+	 * @param   WP_Block_Template|WP_Post|array $context                    The block template, template part, wp_navigation post type, or pattern that the anchor block belongs to.
+	 * @return  array
 	 */
 	public function maybe_register_form_block_on_category_archive( $hooked_blocks, $position, $anchor_block, $context ) {
 
@@ -317,7 +321,7 @@ class ConvertKit_Output {
 		if ( ! $form_position ) {
 			// Unhook this function as we don't need to check again in this request, as we'll
 			// never output a form on the Category archive.
-			// @TODO.
+			remove_filter( 'hooked_block_types', array( $this, 'maybe_register_form_block_on_category_archive' ), 10, 4 );
 
 			return $hooked_blocks;
 		}
@@ -332,7 +336,7 @@ class ConvertKit_Output {
 
 		// Unhook this function as we don't need to check again in this request, as
 		// we have now appended the form.
-		// @TODO.
+		remove_filter( 'hooked_block_types', array( $this, 'maybe_register_form_block_on_category_archive' ), 10, 4 );
 
 		return $hooked_blocks;
 
@@ -341,12 +345,13 @@ class ConvertKit_Output {
 	/**
 	 * Configures the ConvertKit Form block that was hooked below the Query Loop block by maybe_register_form_block_on_category_archive,
 	 * defining the Form ID based on the current Category's Form ID.
-	 * 
-	 * @since 	2.5.0
-	 * 
-	 * @TODO
+	 *
+	 * @since   2.5.0
+	 *
+	 * @param   array $parsed_hooked_block    The parsed block array for the given hooked block type, or null to suppress the block.
+	 * @return  null|array
 	 */
-	public function append_form_block_to_category_archive( $parsed_hooked_block, $hooked_block_type, $relative_position, $parsed_anchor_block, $context ) {
+	public function append_form_block_to_category_archive( $parsed_hooked_block ) {
 
 		// Sanity check that we're still viewing a Category archive.
 		if ( ! is_category() ) {
@@ -457,6 +462,13 @@ class ConvertKit_Output {
 
 	}
 
+	/**
+	 * Returns the Form Position setting for the currently viewed Category.
+	 *
+	 * @since   2.5.0
+	 *
+	 * @return  bool|string
+	 */
 	private function get_term_form_position() {
 
 		// Get Category archive being viewed.

--- a/includes/class-convertkit-setup.php
+++ b/includes/class-convertkit-setup.php
@@ -114,7 +114,7 @@ class ConvertKit_Setup {
 			$term_settings = new ConvertKit_Term( $term_id );
 			$term_settings->save( array(
 				'form' 	   => get_term_meta( $term_id, 'ck_default_form', true ), // Fetch form setting from old meta key.
-				'position' => '', // Default to no position.
+				'form_position' => '', // Default to no position.
 			) );
 
 			// Delete old Term meta.

--- a/includes/class-convertkit-setup.php
+++ b/includes/class-convertkit-setup.php
@@ -86,23 +86,25 @@ class ConvertKit_Setup {
 	/**
 	 * Migrate ck_default_form to _wp_convertkit_term_meta[form], as Term settings
 	 * support multiple options (form, position etc).
-	 * 
-	 * @since 	2.5.0
+	 *
+	 * @since   2.5.0
 	 */
 	private function migrate_term_form_settings() {
 
 		// Get all Terms that have ConvertKit settings defined.
-		$query = new WP_Term_Query( array(
-			'taxonomy' => 'category',
-			'hide_empty' => false,
-			'fields' => 'ids',
-			'meta_query' => array(
-				array(
-					'key' => 'ck_default_form',
-					'comparison' => 'EXISTS',
+		$query = new WP_Term_Query(
+			array(
+				'taxonomy'   => 'category',
+				'hide_empty' => false,
+				'fields'     => 'ids',
+				'meta_query' => array(
+					array(
+						'key'        => 'ck_default_form',
+						'comparison' => 'EXISTS',
+					),
 				),
-			),
-		) );
+			)
+		);
 
 		// Bail if no Terms exist.
 		if ( is_null( $query->terms ) ) {
@@ -112,10 +114,12 @@ class ConvertKit_Setup {
 		// Iterate through Terms, mapping settings.
 		foreach ( $query->terms as $term_id ) {
 			$term_settings = new ConvertKit_Term( $term_id );
-			$term_settings->save( array(
-				'form' 	   => get_term_meta( $term_id, 'ck_default_form', true ), // Fetch form setting from old meta key.
-				'form_position' => '', // Default to no position.
-			) );
+			$term_settings->save(
+				array(
+					'form'          => get_term_meta( $term_id, 'ck_default_form', true ), // Fetch form setting from old meta key.
+					'form_position' => '', // Default to no position.
+				)
+			);
 
 			// Delete old Term meta.
 			delete_term_meta( $term_id, 'ck_default_form' );

--- a/includes/class-convertkit-setup.php
+++ b/includes/class-convertkit-setup.php
@@ -99,7 +99,7 @@ class ConvertKit_Setup {
 				'fields'     => 'ids',
 				'meta_query' => array(
 					array(
-						'key'        => 'ck_default_formXXX',
+						'key'        => 'ck_default_form',
 						'comparison' => 'EXISTS',
 					),
 				),

--- a/includes/class-convertkit-setup.php
+++ b/includes/class-convertkit-setup.php
@@ -99,7 +99,7 @@ class ConvertKit_Setup {
 				'fields'     => 'ids',
 				'meta_query' => array(
 					array(
-						'key'        => 'ck_default_form',
+						'key'        => 'ck_default_formXXX',
 						'comparison' => 'EXISTS',
 					),
 				),
@@ -107,7 +107,7 @@ class ConvertKit_Setup {
 		);
 
 		// Bail if no Terms exist.
-		if ( is_null( $query->terms ) ) {
+		if ( ! $query->terms ) {
 			return;
 		}
 

--- a/includes/class-convertkit-term.php
+++ b/includes/class-convertkit-term.php
@@ -153,7 +153,7 @@ class ConvertKit_Term {
 	public function get_default_settings() {
 
 		$defaults = array(
-			'form' 			=> '',
+			'form'          => '',
 			'form_position' => '',
 		);
 

--- a/includes/class-convertkit-term.php
+++ b/includes/class-convertkit-term.php
@@ -18,7 +18,7 @@ class ConvertKit_Term {
 	 *
 	 * @var     string
 	 */
-	const TERM_META_KEY = 'ck_default_form';
+	const TERM_META_KEY = '_wp_convertkit_term_meta';
 
 	/**
 	 * Holds the Term ID
@@ -55,16 +55,6 @@ class ConvertKit_Term {
 			// Fallback to default settings.
 			$meta = $this->get_default_settings();
 		}
-
-		// If a string, convert to array.
-		if ( is_string( $meta ) ) {
-			$meta = array(
-				'form' => $meta,
-				'position' => '',
-			);
-		}
-
-		var_dump( $meta );
 
 		// Assign Term's Settings to the object.
 		$this->settings = $meta;

--- a/includes/class-convertkit-term.php
+++ b/includes/class-convertkit-term.php
@@ -32,7 +32,7 @@ class ConvertKit_Term {
 	/**
 	 * Holds the Term's Settings
 	 *
-	 * @var     bool|string
+	 * @var     bool|array
 	 */
 	private $settings = false;
 
@@ -66,7 +66,7 @@ class ConvertKit_Term {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  string
+	 * @return  array
 	 */
 	public function get() {
 

--- a/includes/class-convertkit-term.php
+++ b/includes/class-convertkit-term.php
@@ -56,6 +56,16 @@ class ConvertKit_Term {
 			$meta = $this->get_default_settings();
 		}
 
+		// If a string, convert to array.
+		if ( is_string( $meta ) ) {
+			$meta = array(
+				'form' => $meta,
+				'position' => '',
+			);
+		}
+
+		var_dump( $meta );
+
 		// Assign Term's Settings to the object.
 		$this->settings = $meta;
 
@@ -83,7 +93,7 @@ class ConvertKit_Term {
 	 */
 	public function get_form() {
 
-		return $this->settings;
+		return $this->settings['form'];
 
 	}
 
@@ -96,20 +106,35 @@ class ConvertKit_Term {
 	 */
 	public function has_form() {
 
-		// Backward compat. for Terms created/edited prior to 1.9.6, where
-		// 'default' was used instead of zero to denote the Post / Post Type
-		// setting should be used for determining the Form to display.
-		// Using a comparison operator on 'default' will return different results in:
-		// PHP < 8.0: 'default' > 0 is false
-		// PHP 8.0+: 'default' > 0 is true
-		// See https://www.php.net/manual/en/language.operators.comparison.php.
-		if ( $this->settings === 'default' ) {
-			return false;
-		}
+		return ( $this->settings['form'] > 0 );
 
-		// If the setting is greater than zero, it's a specific Form ID that
-		// should be used for Posts assigned to this Category.
-		return ( $this->settings > 0 );
+	}
+
+	/**
+	 * Returns the form position setting for the Term
+	 * on the Term archive.
+	 *
+	 * @since   2.5.0
+	 *
+	 * @return  string
+	 */
+	public function get_position() {
+
+		return $this->settings['position'];
+
+	}
+
+	/**
+	 * Whether the Term has a ConvertKit Form Position defined
+	 * for the Term archive.
+	 *
+	 * @since   2.5.0
+	 *
+	 * @return  bool
+	 */
+	public function has_position() {
+
+		return ( $this->settings['position'] !== '' );
 
 	}
 
@@ -118,7 +143,8 @@ class ConvertKit_Term {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @param   string $meta   Settings.
+	 * @param   array $meta   Settings.
+	 * @return  bool          Term Meta was updated
 	 */
 	public function save( $meta ) {
 
@@ -132,11 +158,14 @@ class ConvertKit_Term {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @return  string
+	 * @return  array
 	 */
 	public function get_default_settings() {
 
-		$defaults = '';
+		$defaults = array(
+			'form' => '',
+			'position' => '',
+		);
 
 		/**
 		 * The default settings, used to populate the Term's Settings when a Term
@@ -144,7 +173,7 @@ class ConvertKit_Term {
 		 *
 		 * @since   1.9.6
 		 *
-		 * @param   string  $defaults   Default Form
+		 * @param   array  $defaults   Default Form
 		 */
 		$defaults = apply_filters( 'convertkit_term_get_default_settings', $defaults );
 

--- a/includes/class-convertkit-term.php
+++ b/includes/class-convertkit-term.php
@@ -108,9 +108,9 @@ class ConvertKit_Term {
 	 *
 	 * @return  string
 	 */
-	public function get_position() {
+	public function get_form_position() {
 
-		return $this->settings['position'];
+		return $this->settings['form_position'];
 
 	}
 
@@ -122,9 +122,9 @@ class ConvertKit_Term {
 	 *
 	 * @return  bool
 	 */
-	public function has_position() {
+	public function has_form_position() {
 
-		return ( $this->settings['position'] !== '' );
+		return ( $this->settings['form_position'] !== '' );
 
 	}
 
@@ -153,8 +153,8 @@ class ConvertKit_Term {
 	public function get_default_settings() {
 
 		$defaults = array(
-			'form' => '',
-			'position' => '',
+			'form' 			=> '',
+			'form_position' => '',
 		);
 
 		/**

--- a/tests/acceptance/forms/general/CategoryFormCest.php
+++ b/tests/acceptance/forms/general/CategoryFormCest.php
@@ -32,11 +32,6 @@ class CategoryFormCest
 	 */
 	public function testAddCategoryWithValidFormSetting(AcceptanceTester $I)
 	{
-		// Activate and Setup ConvertKit plugin.
-		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
-		$I->setupConvertKitPluginResources($I);
-
 		// Navigate to Posts > Categories.
 		$I->amOnAdminPage('edit-tags.php?taxonomy=category');
 
@@ -98,11 +93,6 @@ class CategoryFormCest
 	 */
 	public function testEditCategoryWithValidFormSetting(AcceptanceTester $I)
 	{
-		// Activate and Setup ConvertKit plugin.
-		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
-		$I->setupConvertKitPluginResources($I);
-
 		// Create Category.
 		$termID = $I->haveTermInDatabase( 'ConvertKit: Edit Category', 'category' );
 		$termID = $termID[0];
@@ -174,11 +164,6 @@ class CategoryFormCest
 	 */
 	public function testAddCategoryWithFormPositionBefore(AcceptanceTester $I)
 	{
-		// Activate and Setup ConvertKit plugin.
-		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
-		$I->setupConvertKitPluginResources($I);
-
 		// Navigate to Posts > Categories.
 		$I->amOnAdminPage('edit-tags.php?taxonomy=category');
 
@@ -237,11 +222,6 @@ class CategoryFormCest
 	 */
 	public function testAddCategoryWithFormPositionAfter(AcceptanceTester $I)
 	{
-		// Activate and Setup ConvertKit plugin.
-		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
-		$I->setupConvertKitPluginResources($I);
-
 		// Navigate to Posts > Categories.
 		$I->amOnAdminPage('edit-tags.php?taxonomy=category');
 
@@ -299,11 +279,6 @@ class CategoryFormCest
 	 */
 	public function testEditCategoryWithFormPositionBefore(AcceptanceTester $I)
 	{
-		// Activate and Setup ConvertKit plugin.
-		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
-		$I->setupConvertKitPluginResources($I);
-
 		// Create Category.
 		$termID = $I->haveTermInDatabase( 'ConvertKit: Edit: Position: Before', 'category' );
 		$termID = $termID[0];
@@ -383,11 +358,6 @@ class CategoryFormCest
 	 */
 	public function testEditCategoryWithFormPositionAfter(AcceptanceTester $I)
 	{
-		// Activate and Setup ConvertKit plugin.
-		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
-		$I->setupConvertKitPluginResources($I);
-
 		// Create Category.
 		$termID = $I->haveTermInDatabase( 'ConvertKit: Edit: Position: After', 'category' );
 		$termID = $termID[0];
@@ -472,11 +442,6 @@ class CategoryFormCest
 	 */
 	public function testAddNewPostUsingDefaultFormWithCategoryCreatedBefore1960(AcceptanceTester $I)
 	{
-		// Activate and Setup ConvertKit plugin.
-		$I->activateConvertKitPlugin($I);
-		$I->setupConvertKitPlugin($I);
-		$I->setupConvertKitPluginResources($I);
-
 		// Create Category as if it were created / edited when the ConvertKit Plugin < 1.9.6.0
 		// was active.
 		$termID = $I->haveTermInDatabase(
@@ -500,6 +465,12 @@ class CategoryFormCest
 				],
 			]
 		);
+
+		// Downgrade the Plugin version to simulate an upgrade.
+		$I->haveOptionInDatabase('convertkit_version', '2.4.9');
+
+		// Load admin screen.
+		$I->amOnAdminPage('index.php');
 
 		// Load the Post on the frontend site.
 		$I->amOnPage('/?p=' . $postID);

--- a/tests/acceptance/forms/general/CategoryFormCest.php
+++ b/tests/acceptance/forms/general/CategoryFormCest.php
@@ -214,9 +214,11 @@ class CategoryFormCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm form is after closing h1 element.
-		$I->seeInSource('</h1>
+		$I->seeInSource(
+			'</h1>
 
-	<form action="https://app.convertkit.com/forms/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/subscriptions"');
+	<form action="https://app.convertkit.com/forms/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/subscriptions"'
+		);
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
@@ -275,8 +277,10 @@ class CategoryFormCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm form is after closing div element.
-		$I->seeInSource('</div>
-	<form action="https://app.convertkit.com/forms/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/subscriptions"');
+		$I->seeInSource(
+			'</div>
+	<form action="https://app.convertkit.com/forms/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/subscriptions"'
+		);
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
@@ -356,9 +360,11 @@ class CategoryFormCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm form is after closing h1 element.
-		$I->seeInSource('</h1>
+		$I->seeInSource(
+			'</h1>
 
-	<form action="https://app.convertkit.com/forms/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/subscriptions"');
+	<form action="https://app.convertkit.com/forms/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/subscriptions"'
+		);
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
@@ -438,8 +444,10 @@ class CategoryFormCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm form is after closing div element.
-		$I->seeInSource('</div>
-	<form action="https://app.convertkit.com/forms/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/subscriptions"');
+		$I->seeInSource(
+			'</div>
+	<form action="https://app.convertkit.com/forms/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/subscriptions"'
+		);
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
@@ -507,9 +515,9 @@ class CategoryFormCest
 	/**
 	 * Tests that existing Category settings stored in the Term Meta key [] are
 	 * automatically migrated when updating the Plugin to 2.5.0 or higher.
-	 * 
-	 * @since 	2.5.0
-	 * 
+	 *
+	 * @since   2.5.0
+	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testCategorySettingsMigratedOnUpgrade(AcceptanceTester $I)
@@ -545,18 +553,22 @@ class CategoryFormCest
 		$I->amOnAdminPage('index.php');
 
 		// Check Category settings structure has been updated to the new meta key.
-		$I->dontSeeTermMetaInDatabase([
-			'term_id' => $termID,
-			'meta_key' => 'ck_default_form',
-		]);
-		$I->seeTermMetaInDatabase([
-			'term_id' => $termID,
-			'meta_key' => '_wp_convertkit_term_meta',
-			'meta_value' => [
-				'form' => $_ENV['CONVERTKIT_API_FORM_ID'],
-				'form_position' => '',
-			],
-		]);
+		$I->dontSeeTermMetaInDatabase(
+			[
+				'term_id'  => $termID,
+				'meta_key' => 'ck_default_form',
+			]
+		);
+		$I->seeTermMetaInDatabase(
+			[
+				'term_id'    => $termID,
+				'meta_key'   => '_wp_convertkit_term_meta',
+				'meta_value' => [
+					'form'          => $_ENV['CONVERTKIT_API_FORM_ID'],
+					'form_position' => '',
+				],
+			]
+		);
 
 		// Load the Post on the frontend site.
 		$I->amOnPage('/?p=' . $postID);

--- a/tests/acceptance/forms/general/CategoryFormCest.php
+++ b/tests/acceptance/forms/general/CategoryFormCest.php
@@ -32,6 +32,11 @@ class CategoryFormCest
 	 */
 	public function testAddCategoryWithValidFormSetting(AcceptanceTester $I)
 	{
+		// Activate and Setup ConvertKit plugin.
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Navigate to Posts > Categories.
 		$I->amOnAdminPage('edit-tags.php?taxonomy=category');
 
@@ -93,6 +98,11 @@ class CategoryFormCest
 	 */
 	public function testEditCategoryWithValidFormSetting(AcceptanceTester $I)
 	{
+		// Activate and Setup ConvertKit plugin.
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Create Category.
 		$termID = $I->haveTermInDatabase( 'ConvertKit: Edit Category', 'category' );
 		$termID = $termID[0];
@@ -153,6 +163,290 @@ class CategoryFormCest
 	}
 
 	/**
+	 * Test that the expected Form is displayed on the Category archive above the Posts
+	 * when the user:
+	 * - Creates a Category in WordPress, selecting the ConvertKit Form to display before the Posts
+	 * - Creates a WordPress Post assigned to the created Category.
+	 *
+	 * @since   2.5.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddCategoryWithFormPositionBefore(AcceptanceTester $I)
+	{
+		// Activate and Setup ConvertKit plugin.
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Navigate to Posts > Categories.
+		$I->amOnAdminPage('edit-tags.php?taxonomy=category');
+
+		// Create Category.
+		$I->fillField('tag-name', 'ConvertKit: Position: Before');
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->selectOption('wp-convertkit[form_position]', 'before');
+
+		// Save.
+		$I->click('Add New Category');
+
+		// Confirm Category saved.
+		$I->waitForElementVisible('.notice-success');
+
+		// Get the Category ID from the table.
+		$termID = (int) str_replace( 'tag-', '', $I->grabAttributeFrom('#the-list tr:first-child', 'id') );
+
+		// Create Post, assigned to ConvertKit Category.
+		$postID = $I->havePostInDatabase(
+			[
+				'post_type'  => 'post',
+				'post_title' => 'ConvertKit: Post for Position: Before',
+				'tax_input'  => [
+					[ 'category' => (int) $termID ],
+				],
+			]
+		);
+
+		// Load the Category archive on the frontend site.
+		$I->amOnPage('/category/convertkit-position-before');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm form is after closing h1 element.
+		$I->seeInSource('</h1>
+
+	<form action="https://app.convertkit.com/forms/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/subscriptions"');
+
+		// Confirm that one ConvertKit Form is output in the DOM.
+		// This confirms that there is only one script on the page for this form, which renders the form.
+		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+	}
+
+	/**
+	 * Test that the expected Form is displayed on the Category archive above the Posts
+	 * when the user:
+	 * - Creates a Category in WordPress, selecting the ConvertKit Form to display after the Posts
+	 * - Creates a WordPress Post assigned to the created Category.
+	 *
+	 * @since   2.5.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddCategoryWithFormPositionAfter(AcceptanceTester $I)
+	{
+		// Activate and Setup ConvertKit plugin.
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Navigate to Posts > Categories.
+		$I->amOnAdminPage('edit-tags.php?taxonomy=category');
+
+		// Create Category.
+		$I->fillField('tag-name', 'ConvertKit: Position: After');
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->selectOption('wp-convertkit[form_position]', 'after');
+
+		// Save.
+		$I->click('Add New Category');
+
+		// Confirm Category saved.
+		$I->waitForElementVisible('.notice-success');
+
+		// Get the Category ID from the table.
+		$termID = (int) str_replace( 'tag-', '', $I->grabAttributeFrom('#the-list tr:first-child', 'id') );
+
+		// Create Post, assigned to ConvertKit Category.
+		$postID = $I->havePostInDatabase(
+			[
+				'post_type'  => 'post',
+				'post_title' => 'ConvertKit: Post for Position: After',
+				'tax_input'  => [
+					[ 'category' => (int) $termID ],
+				],
+			]
+		);
+
+		// Load the Category archive on the frontend site.
+		$I->amOnPage('/category/convertkit-position-after');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm form is after closing div element.
+		$I->seeInSource('</div>
+	<form action="https://app.convertkit.com/forms/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/subscriptions"');
+
+		// Confirm that one ConvertKit Form is output in the DOM.
+		// This confirms that there is only one script on the page for this form, which renders the form.
+		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+	}
+
+	/**
+	 * Test that the expected Form is displayed on the Category archive above the Posts
+	 * when the user:
+	 * - Edits an existing Category in WordPress, selecting the ConvertKit Form to display before the Posts
+	 * - Creates a WordPress Post assigned to the created Category.
+	 *
+	 * @since   2.5.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testEditCategoryWithFormPositionBefore(AcceptanceTester $I)
+	{
+		// Activate and Setup ConvertKit plugin.
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Create Category.
+		$termID = $I->haveTermInDatabase( 'ConvertKit: Edit: Position: Before', 'category' );
+		$termID = $termID[0];
+
+		// Create Post, assigned to ConvertKit Category.
+		$postID = $I->havePostInDatabase(
+			[
+				'post_type'  => 'post',
+				'post_title' => 'ConvertKit: Post: Edit: Position: Before',
+				'tax_input'  => [
+					[ 'category' => (int) $termID ],
+				],
+			]
+		);
+
+		// Edit the Term, defining a Form.
+		$I->amOnAdminPage('term.php?taxonomy=category&tag_ID=' . $termID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that settings have label[for] attributes.
+		$I->seeInSource('<label for="wp-convertkit-form">');
+
+		// Check the order of the Form resources are alphabetical, with the Default option prepending the Forms.
+		$I->checkSelectFormOptionOrder(
+			$I,
+			'#wp-convertkit-form',
+			[
+				'Default',
+			]
+		);
+
+		// Change Form to value specified in the .env file.
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->selectOption('wp-convertkit[form_position]', 'before');
+
+		// Click Update.
+		$I->click('Update');
+
+		// Wait for the page to load.
+		$I->waitForElementVisible('#wpfooter');
+
+		// Check that the update succeeded.
+		$I->seeElementInDOM('div.notice-success');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Load the Category archive on the frontend site.
+		$I->amOnPage('/category/convert-kit-edit-position-before');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm form is after closing h1 element.
+		$I->seeInSource('</h1>
+
+	<form action="https://app.convertkit.com/forms/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/subscriptions"');
+
+		// Confirm that one ConvertKit Form is output in the DOM.
+		// This confirms that there is only one script on the page for this form, which renders the form.
+		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+	}
+
+	/**
+	 * Test that the expected Form is displayed on the Category archive above the Posts
+	 * when the user:
+	 * - Edits an existing Category in WordPress, selecting the ConvertKit Form to display after the Posts
+	 * - Creates a WordPress Post assigned to the created Category.
+	 *
+	 * @since   2.5.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testEditCategoryWithFormPositionAfter(AcceptanceTester $I)
+	{
+		// Activate and Setup ConvertKit plugin.
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Create Category.
+		$termID = $I->haveTermInDatabase( 'ConvertKit: Edit: Position: After', 'category' );
+		$termID = $termID[0];
+
+		// Create Post, assigned to ConvertKit Category.
+		$postID = $I->havePostInDatabase(
+			[
+				'post_type'  => 'post',
+				'post_title' => 'ConvertKit: Post: Edit: Position: After',
+				'tax_input'  => [
+					[ 'category' => (int) $termID ],
+				],
+			]
+		);
+
+		// Edit the Term, defining a Form.
+		$I->amOnAdminPage('term.php?taxonomy=category&tag_ID=' . $termID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that settings have label[for] attributes.
+		$I->seeInSource('<label for="wp-convertkit-form">');
+
+		// Check the order of the Form resources are alphabetical, with the Default option prepending the Forms.
+		$I->checkSelectFormOptionOrder(
+			$I,
+			'#wp-convertkit-form',
+			[
+				'Default',
+			]
+		);
+
+		// Change Form to value specified in the .env file.
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->selectOption('wp-convertkit[form_position]', 'after');
+
+		// Click Update.
+		$I->click('Update');
+
+		// Wait for the page to load.
+		$I->waitForElementVisible('#wpfooter');
+
+		// Check that the update succeeded.
+		$I->seeElementInDOM('div.notice-success');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Load the Category archive on the frontend site.
+		$I->amOnPage('/category/convert-kit-edit-position-after');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm form is after closing div element.
+		$I->seeInSource('</div>
+	<form action="https://app.convertkit.com/forms/' . $_ENV['CONVERTKIT_API_FORM_ID'] . '/subscriptions"');
+
+		// Confirm that one ConvertKit Form is output in the DOM.
+		// This confirms that there is only one script on the page for this form, which renders the form.
+		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+	}
+
+	/**
 	 * Test that the Default Form specified at Plugin level for Posts displays when:
 	 * - A Category was created with ConvertKit Form = 'None' when 1.9.5.2 or earlier of the Plugin was activated,
 	 * - The WordPress Post is set to use the Default Form,
@@ -170,6 +464,11 @@ class CategoryFormCest
 	 */
 	public function testAddNewPostUsingDefaultFormWithCategoryCreatedBefore1960(AcceptanceTester $I)
 	{
+		// Activate and Setup ConvertKit plugin.
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Create Category as if it were created / edited when the ConvertKit Plugin < 1.9.6.0
 		// was active.
 		$termID = $I->haveTermInDatabase(
@@ -202,6 +501,72 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
+		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+	}
+
+	/**
+	 * Tests that existing Category settings stored in the Term Meta key [] are
+	 * automatically migrated when updating the Plugin to 2.5.0 or higher.
+	 * 
+	 * @since 	2.5.0
+	 * 
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testCategorySettingsMigratedOnUpgrade(AcceptanceTester $I)
+	{
+		// Create Category as if it were created / edited when the ConvertKit Plugin < 2.5.0
+		// was active.
+		$termID = $I->haveTermInDatabase(
+			'ConvertKit 2.5.0 and earlier',
+			'category',
+			[
+				'meta' => [
+					'ck_default_form' => $_ENV['CONVERTKIT_API_FORM_ID'],
+				],
+			]
+		);
+		$termID = $termID[0];
+
+		// Create Post, assigned to Category.
+		$postID = $I->havePostInDatabase(
+			[
+				'post_type'  => 'post',
+				'post_title' => 'ConvertKit: Default Form: Category Created before 1.9.6.0',
+				'tax_input'  => [
+					[ 'category' => $termID ],
+				],
+			]
+		);
+
+		// Downgrade the Plugin version to simulate an upgrade.
+		$I->haveOptionInDatabase('convertkit_version', '2.4.9');
+
+		// Load admin screen.
+		$I->amOnAdminPage('index.php');
+
+		// Check Category settings structure has been updated to the new meta key.
+		$I->dontSeeTermMetaInDatabase([
+			'term_id' => $termID,
+			'meta_key' => 'ck_default_form',
+		]);
+		$I->seeTermMetaInDatabase([
+			'term_id' => $termID,
+			'meta_key' => '_wp_convertkit_term_meta',
+			'meta_value' => [
+				'form' => $_ENV['CONVERTKIT_API_FORM_ID'],
+				'form_position' => '',
+			],
+		]);
+
+		// Load the Post on the frontend site.
+		$I->amOnPage('/?p=' . $postID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that one ConvertKit Form is output in the DOM.
+		// This confirms that there is only one script on the page for this form, which renders the form,
+		// and that the Category settings were correctly mapped.
 		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
 	}
 

--- a/tests/acceptance/forms/general/NonInlineFormCest.php
+++ b/tests/acceptance/forms/general/NonInlineFormCest.php
@@ -371,7 +371,9 @@ class NonInlineFormCest
 			'category',
 			[
 				'meta' => [
-					'ck_default_form' => $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'],
+					'_wp_convertkit_term_meta' => [
+						'form' => $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'],
+					],
 				],
 			]
 		);

--- a/views/backend/term/fields-add.php
+++ b/views/backend/term/fields-add.php
@@ -53,7 +53,7 @@
 	</select>
 	<p class="description">
 		<?php
-		esc_html_e( 'Whether to display the Form on this Category\'s archive page, above or below the main Query Loop block.', 'convertkit' );
+		esc_html_e( 'Whether to display the Form on this Category\'s archive page, above or below the main posts list.', 'convertkit' );
 		?>
 	</p>
 

--- a/views/backend/term/fields-add.php
+++ b/views/backend/term/fields-add.php
@@ -47,7 +47,7 @@
 	<label for="wp-convertkit-form-position"><?php esc_html_e( 'Display CovertKit Form on Archive?', 'convertkit' ); ?></label>
 
 	<select name="wp-convertkit[form_position]" id="wp-convertkit-form-position" size="1">
-		<option value="" selected><?php _e( 'No', 'convertkit' ); ?></option>
+		<option value="" selected><?php esc_attr_e( 'No', 'convertkit' ); ?></option>
 		<option value="before"><?php esc_attr_e( 'Before Posts', 'convertkit' ); ?></option>
 		<option value="after"><?php esc_attr_e( 'After Posts', 'convertkit' ); ?></option>
 	</select>

--- a/views/backend/term/fields-add.php
+++ b/views/backend/term/fields-add.php
@@ -44,15 +44,18 @@
 </div>
 
 <div class="form-field term-description-wrap">
-	<label for="wp-convertkit-position"><?php esc_html_e( 'Display on Archive?', 'convertkit' ); ?></label>
+	<label for="wp-convertkit-form-position"><?php esc_html_e( 'Display CovertKit Form on Archive?', 'convertkit' ); ?></label>
 
-	<div class="convertkit-select2-container convertkit-select2-container-grid">
-		<select name="wp-convertkit[position]" size="1">
-			<option value="">No</option>
-			<option value="above">Before Posts</option>
-			<option value="below">After Posts</option>
-		</select>
-	</div>
+	<select name="wp-convertkit[form_position]" id="wp-convertkit-form-position" size="1">
+		<option value="" selected><?php _e( 'No', 'convertkit' ); ?></option>
+		<option value="before"><?php esc_attr_e( 'Before Posts', 'convertkit' ); ?></option>
+		<option value="after"><?php esc_attr_e( 'After Posts', 'convertkit' ); ?></option>
+	</select>
+	<p class="description">
+		<?php
+		esc_html_e( 'Whether to display the Form on this Category\'s archive page, above or below the main Query Loop block.', 'convertkit' );
+		?>
+	</p>
 
 	<?php
 	wp_nonce_field( 'wp-convertkit-save-meta', 'wp-convertkit-save-meta-nonce' );

--- a/views/backend/term/fields-add.php
+++ b/views/backend/term/fields-add.php
@@ -41,6 +41,18 @@
 			?>
 		</p>
 	</div>
+</div>
+
+<div class="form-field term-description-wrap">
+	<label for="wp-convertkit-position"><?php esc_html_e( 'Display on Archive?', 'convertkit' ); ?></label>
+
+	<div class="convertkit-select2-container convertkit-select2-container-grid">
+		<select name="wp-convertkit[position]" size="1">
+			<option value="">No</option>
+			<option value="above">Before Posts</option>
+			<option value="below">After Posts</option>
+		</select>
+	</div>
 
 	<?php
 	wp_nonce_field( 'wp-convertkit-save-meta', 'wp-convertkit-save-meta-nonce' );

--- a/views/backend/term/fields-edit.php
+++ b/views/backend/term/fields-edit.php
@@ -43,6 +43,22 @@
 				?>
 			</p>
 		</div>
+	</td>
+</tr>
+<tr class="form-field">
+	<th scope="row">
+		<label for="wp-convertkit-position"><?php esc_html_e( 'Display on Archive?', 'convertkit' ); ?></label>
+	</th>
+	<td>
+	
+		<div class="convertkit-select2-container convertkit-select2-container-grid">
+			<select name="wp-convertkit[position]" size="1">
+				<option value="">No</option>
+				<option value="above">Before Posts</option>
+				<option value="below">After Posts</option>
+			</select>
+		</div>
+
 		<?php
 		wp_nonce_field( 'wp-convertkit-save-meta', 'wp-convertkit-save-meta-nonce' );
 		?>

--- a/views/backend/term/fields-edit.php
+++ b/views/backend/term/fields-edit.php
@@ -47,13 +47,13 @@
 </tr>
 <tr class="form-field">
 	<th scope="row">
-		<label for="wp-convertkit-position"><?php esc_html_e( 'Display on Archive?', 'convertkit' ); ?></label>
+		<label for="wp-convertkit-form-position"><?php esc_html_e( 'Display ConvertKit Form on Archive?', 'convertkit' ); ?></label>
 	</th>
 	<td>
-		<select name="wp-convertkit[position]" size="1">
+		<select name="wp-convertkit[form_position]" id="wp-convertkit-form-position" size="1">
 			<option value=""><?php _e( 'No', 'convertkit' ); ?></option>
-			<option value="above"<?php selected( 'above', $convertkit_term->get_position() ); ?>><?php esc_attr_e( 'Before Posts', 'convertkit' ); ?></option>
-			<option value="below"<?php selected( 'below', $convertkit_term->get_position() ); ?>><?php esc_attr_e( 'After Posts', 'convertkit' ); ?></option>
+			<option value="before"<?php selected( 'before', $convertkit_term->get_form_position() ); ?>><?php esc_attr_e( 'Before Posts', 'convertkit' ); ?></option>
+			<option value="after"<?php selected( 'after', $convertkit_term->get_form_position() ); ?>><?php esc_attr_e( 'After Posts', 'convertkit' ); ?></option>
 		</select>
 		<p class="description">
 			<?php

--- a/views/backend/term/fields-edit.php
+++ b/views/backend/term/fields-edit.php
@@ -57,7 +57,7 @@
 		</select>
 		<p class="description">
 			<?php
-			esc_html_e( 'Whether to display the Form on this Category\'s archive page, above or below the main Query Loop block.', 'convertkit' );
+			esc_html_e( 'Whether to display the Form on this Category\'s archive page, above or below the main posts list.', 'convertkit' );
 			?>
 		</p>
 	

--- a/views/backend/term/fields-edit.php
+++ b/views/backend/term/fields-edit.php
@@ -50,15 +50,17 @@
 		<label for="wp-convertkit-position"><?php esc_html_e( 'Display on Archive?', 'convertkit' ); ?></label>
 	</th>
 	<td>
+		<select name="wp-convertkit[position]" size="1">
+			<option value=""><?php _e( 'No', 'convertkit' ); ?></option>
+			<option value="above"<?php selected( 'above', $convertkit_term->get_position() ); ?>><?php esc_attr_e( 'Before Posts', 'convertkit' ); ?></option>
+			<option value="below"<?php selected( 'below', $convertkit_term->get_position() ); ?>><?php esc_attr_e( 'After Posts', 'convertkit' ); ?></option>
+		</select>
+		<p class="description">
+			<?php
+			esc_html_e( 'Whether to display the Form on this Category\'s archive page, above or below the main Query Loop block.', 'convertkit' );
+			?>
+		</p>
 	
-		<div class="convertkit-select2-container convertkit-select2-container-grid">
-			<select name="wp-convertkit[position]" size="1">
-				<option value="">No</option>
-				<option value="above">Before Posts</option>
-				<option value="below">After Posts</option>
-			</select>
-		</div>
-
 		<?php
 		wp_nonce_field( 'wp-convertkit-save-meta', 'wp-convertkit-save-meta-nonce' );
 		?>

--- a/views/backend/term/fields-edit.php
+++ b/views/backend/term/fields-edit.php
@@ -51,7 +51,7 @@
 	</th>
 	<td>
 		<select name="wp-convertkit[form_position]" id="wp-convertkit-form-position" size="1">
-			<option value=""><?php _e( 'No', 'convertkit' ); ?></option>
+			<option value=""><?php esc_attr_e( 'No', 'convertkit' ); ?></option>
 			<option value="before"<?php selected( 'before', $convertkit_term->get_form_position() ); ?>><?php esc_attr_e( 'Before Posts', 'convertkit' ); ?></option>
 			<option value="after"<?php selected( 'after', $convertkit_term->get_form_position() ); ?>><?php esc_attr_e( 'After Posts', 'convertkit' ); ?></option>
 		</select>

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -25,7 +25,7 @@ define( 'CONVERTKIT_PLUGIN_NAME', 'ConvertKit' ); // Used for user-agent in API 
 define( 'CONVERTKIT_PLUGIN_FILE', plugin_basename( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_PATH', __DIR__ );
-define( 'CONVERTKIT_PLUGIN_VERSION', '2.4.9' );
+define( 'CONVERTKIT_PLUGIN_VERSION', '2.5.0' );
 
 // Load shared classes, if they have not been included by another ConvertKit Plugin.
 if ( ! class_exists( 'ConvertKit_API' ) ) {


### PR DESCRIPTION
## Summary

Presently, the Form setting at Category level is designed to output the Form on individual Posts that are assigned to a Category.

There have been a few requests for an option to also use this setting when viewing that Category's archive (a list of Posts assigned to that Category).

This PR adds an option to output the Form on the Category archives (`Display ConvertKit Form on Archive?`), with the option to choose to place the form above or below the list / grid of Posts for that Category:

![Screenshot 2024-05-30 at 17 38 39](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/cbb16ef5-fd96-4a58-b0f4-58d42b8a0308)
![Screenshot 2024-05-30 at 17 38 54](https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/bd1ba255-9d61-42a9-a5c7-d424d1a8e219)

## Testing

- `testAddCategoryWithFormPositionBefore`: Test that a form is output before the Posts in the category archive when creating a new Category
- `testAddCategoryWithFormPositionAfter`: Test that a form is output after the Posts in the category archive when creating a new Category
- `testEditCategoryWithFormPositionBefore`: Test that a form is output before the Posts in the category archive when editing an existing Category
- `testEditCategoryWithFormPositionAfter`: Test that a form is output after the Posts in the category archive when editing an existing Category
- `testCategorySettingsMigratedOnUpgrade`: Test that the settings structure on Categories are correctly migrated to the new structure on upgrading the Plugin.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)