### PR TITLE
v4 API: Refresh Tokens: Check Client ID

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
         id: check_files
         uses: andstor/file-existence-action@v1
         with:
-          files: "vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-api.php, vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-log.php, vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-resource.php, vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-review-request.php"
+          files: "vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-api-traits.php, vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-api-v4.php, vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-log.php, vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-resource.php, vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-review-request.php"
 
       # Deploy to wordpress.org, if expected files exist.
       - name: WordPress Plugin Deploy

--- a/admin/class-convertkit-admin-notices.php
+++ b/admin/class-convertkit-admin-notices.php
@@ -64,7 +64,7 @@ class ConvertKit_Admin_Notices {
 		foreach ( $notices as $notice ) {
 			switch ( $notice ) {
 				case 'authorization_failed':
-					$api    = new ConvertKit_API( CONVERTKIT_OAUTH_CLIENT_ID, CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI );
+					$api    = new ConvertKit_API_V4( CONVERTKIT_OAUTH_CLIENT_ID, CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI );
 					$output = sprintf(
 						'%s %s',
 						esc_html__( 'ConvertKit: Authorization failed. Please', 'convertkit' ),

--- a/admin/class-convertkit-admin-post.php
+++ b/admin/class-convertkit-admin-post.php
@@ -146,7 +146,7 @@ class ConvertKit_Admin_Post {
 		$settings = new ConvertKit_Settings();
 		if ( ! $settings->has_access_and_refresh_token() ) {
 			$post_type = get_post_type_object( $post->post_type );
-			$api       = new ConvertKit_API( CONVERTKIT_OAUTH_CLIENT_ID, CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI );
+			$api       = new ConvertKit_API_V4( CONVERTKIT_OAUTH_CLIENT_ID, CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI );
 			include CONVERTKIT_PLUGIN_PATH . '/views/backend/post/no-api-key.php';
 			return;
 		}

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -19,7 +19,7 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 	 *
 	 * @since   1.9.6
 	 *
-	 * @var     ConvertKit_API
+	 * @var     ConvertKit_API_V4
 	 */
 	private $api;
 
@@ -87,7 +87,7 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 		}
 
 		// Initialize the API.
-		$this->api = new ConvertKit_API(
+		$this->api = new ConvertKit_API_V4(
 			CONVERTKIT_OAUTH_CLIENT_ID,
 			CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
 			$this->settings->get_access_token(),

--- a/admin/section/class-convertkit-settings-oauth.php
+++ b/admin/section/class-convertkit-settings-oauth.php
@@ -61,7 +61,7 @@ class ConvertKit_Settings_OAuth extends ConvertKit_Settings_Base {
 		$authorization_code = sanitize_text_field( $_REQUEST['code'] ); // phpcs:ignore WordPress.Security.NonceVerification
 
 		// Exchange the authorization code and verifier for an access token.
-		$api    = new ConvertKit_API( CONVERTKIT_OAUTH_CLIENT_ID, CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI );
+		$api    = new ConvertKit_API_V4( CONVERTKIT_OAUTH_CLIENT_ID, CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI );
 		$result = $api->get_access_token( $authorization_code );
 
 		// Redirect with an error if we could not fetch the access token.
@@ -121,7 +121,7 @@ class ConvertKit_Settings_OAuth extends ConvertKit_Settings_Base {
 	public function render() {
 
 		// Determine the OAuth URL to begin the authorization process.
-		$api       = new ConvertKit_API( CONVERTKIT_OAUTH_CLIENT_ID, CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI );
+		$api       = new ConvertKit_API_V4( CONVERTKIT_OAUTH_CLIENT_ID, CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI );
 		$oauth_url = $api->get_oauth_url( admin_url( 'options-general.php?page=_wp_convertkit_settings' ) );
 
 		/**

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php
@@ -207,7 +207,7 @@ class ConvertKit_Admin_Setup_Wizard_Plugin extends ConvertKit_Admin_Setup_Wizard
 				$api_key    = sanitize_text_field( wp_unslash( $_POST['api_key'] ) );
 				$api_secret = sanitize_text_field( wp_unslash( $_POST['api_secret'] ) );
 
-				$api    = new ConvertKit_API( $api_key, $api_secret, false, 'setup_wizard' );
+				$api    = new ConvertKit_API_V4( $api_key, $api_secret, false, 'setup_wizard' );
 				$result = $api->get_account();
 
 				// Show an error message if Account Details could not be fetched e.g. API credentials supplied are invalid.

--- a/includes/blocks/class-convertkit-block-content.php
+++ b/includes/blocks/class-convertkit-block-content.php
@@ -231,7 +231,7 @@ class ConvertKit_Block_Content extends ConvertKit_Block {
 		}
 
 		// Initialize the API.
-		$api = new ConvertKit_API(
+		$api = new ConvertKit_API_V4(
 			CONVERTKIT_OAUTH_CLIENT_ID,
 			CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
 			$settings->get_access_token(),

--- a/includes/blocks/class-convertkit-block-form.php
+++ b/includes/blocks/class-convertkit-block-form.php
@@ -337,7 +337,7 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 		// In this instance, fetch the Form HTML without checking that the Form ID exists in the Form Resources.
 		if ( is_wp_error( $form ) ) {
 			// Initialize the API.
-			$api = new ConvertKit_API(
+			$api = new ConvertKit_API_V4(
 				CONVERTKIT_OAUTH_CLIENT_ID,
 				CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
 				$settings->get_access_token(),

--- a/includes/class-convertkit-ajax.php
+++ b/includes/class-convertkit-ajax.php
@@ -194,7 +194,7 @@ class ConvertKit_AJAX {
 		}
 
 		// Initialize the API.
-		$api = new ConvertKit_API(
+		$api = new ConvertKit_API_V4(
 			CONVERTKIT_OAUTH_CLIENT_ID,
 			CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
 			$settings->get_access_token(),

--- a/includes/class-convertkit-broadcasts-exporter.php
+++ b/includes/class-convertkit-broadcasts-exporter.php
@@ -216,7 +216,7 @@ class ConvertKit_Broadcasts_Exporter {
 		$content = WP_ConvertKit()->get_class( 'broadcasts_importer' )->get_permitted_html( $content, $this->broadcasts_settings->no_styles() );
 
 		// Initialize the API.
-		$api = new ConvertKit_API(
+		$api = new ConvertKit_API_V4(
 			CONVERTKIT_OAUTH_CLIENT_ID,
 			CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
 			$this->settings->get_access_token(),

--- a/includes/class-convertkit-broadcasts-importer.php
+++ b/includes/class-convertkit-broadcasts-importer.php
@@ -69,7 +69,7 @@ class ConvertKit_Broadcasts_Importer {
 		}
 
 		// Initialize the API.
-		$api = new ConvertKit_API(
+		$api = new ConvertKit_API_V4(
 			CONVERTKIT_OAUTH_CLIENT_ID,
 			CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
 			$settings->get_access_token(),

--- a/includes/class-convertkit-output-restrict-content.php
+++ b/includes/class-convertkit-output-restrict-content.php
@@ -85,7 +85,7 @@ class ConvertKit_Output_Restrict_Content {
 	 *
 	 * @since   2.1.0
 	 *
-	 * @var     bool|ConvertKit_API
+	 * @var     bool|ConvertKit_API_V4
 	 */
 	public $api = false;
 
@@ -168,7 +168,7 @@ class ConvertKit_Output_Restrict_Content {
 		}
 
 		// Initialize the API.
-		$this->api = new ConvertKit_API(
+		$this->api = new ConvertKit_API_V4(
 			CONVERTKIT_OAUTH_CLIENT_ID,
 			CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
 			$this->settings->get_access_token(),
@@ -276,7 +276,7 @@ class ConvertKit_Output_Restrict_Content {
 		$this->post_id = absint( sanitize_text_field( $_REQUEST['convertkit_post_id'] ) );
 
 		// Initialize the API.
-		$this->api = new ConvertKit_API(
+		$this->api = new ConvertKit_API_V4(
 			CONVERTKIT_OAUTH_CLIENT_ID,
 			CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
 			$this->settings->get_access_token(),
@@ -760,7 +760,7 @@ class ConvertKit_Output_Restrict_Content {
 	private function subscriber_has_access( $subscriber_id ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
 
 		// Initialize the API.
-		$this->api = new ConvertKit_API(
+		$this->api = new ConvertKit_API_V4(
 			CONVERTKIT_OAUTH_CLIENT_ID,
 			CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
 			$this->settings->get_access_token(),

--- a/includes/class-convertkit-resource-creator-network-recommendations.php
+++ b/includes/class-convertkit-resource-creator-network-recommendations.php
@@ -12,7 +12,7 @@
  *
  * @since   2.2.7
  */
-class ConvertKit_Resource_Creator_Network_Recommendations extends ConvertKit_Resource {
+class ConvertKit_Resource_Creator_Network_Recommendations extends ConvertKit_Resource_V4 {
 
 	/**
 	 * Holds the Settings Key that stores site wide ConvertKit settings
@@ -35,7 +35,7 @@ class ConvertKit_Resource_Creator_Network_Recommendations extends ConvertKit_Res
 		// Initialize the API if the Access Token has been defined in the Plugin Settings.
 		$settings = new ConvertKit_Settings();
 		if ( $settings->has_access_and_refresh_token() ) {
-			$this->api = new ConvertKit_API(
+			$this->api = new ConvertKit_API_V4(
 				CONVERTKIT_OAUTH_CLIENT_ID,
 				CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
 				$settings->get_access_token(),

--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -12,7 +12,7 @@
  *
  * @since   1.9.6
  */
-class ConvertKit_Resource_Forms extends ConvertKit_Resource {
+class ConvertKit_Resource_Forms extends ConvertKit_Resource_V4 {
 
 	/**
 	 * Holds the Settings Key that stores site wide ConvertKit settings
@@ -40,7 +40,7 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource {
 		// Initialize the API if the Access Token has been defined in the Plugin Settings.
 		$settings = new ConvertKit_Settings();
 		if ( $settings->has_access_and_refresh_token() ) {
-			$this->api = new ConvertKit_API(
+			$this->api = new ConvertKit_API_V4(
 				CONVERTKIT_OAUTH_CLIENT_ID,
 				CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
 				$settings->get_access_token(),
@@ -282,7 +282,7 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource {
 			}
 
 			// Initialize the API.
-			$api = new ConvertKit_API(
+			$api = new ConvertKit_API_V4(
 				CONVERTKIT_OAUTH_CLIENT_ID,
 				CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
 				$settings->get_access_token(),

--- a/includes/class-convertkit-resource-landing-pages.php
+++ b/includes/class-convertkit-resource-landing-pages.php
@@ -12,7 +12,7 @@
  *
  * @since   1.9.6
  */
-class ConvertKit_Resource_Landing_Pages extends ConvertKit_Resource {
+class ConvertKit_Resource_Landing_Pages extends ConvertKit_Resource_V4 {
 
 	/**
 	 * Holds the Settings Key that stores site wide ConvertKit settings
@@ -40,7 +40,7 @@ class ConvertKit_Resource_Landing_Pages extends ConvertKit_Resource {
 		// Initialize the API if the Access Token has been defined in the Plugin Settings.
 		$settings = new ConvertKit_Settings();
 		if ( $settings->has_access_and_refresh_token() ) {
-			$this->api = new ConvertKit_API(
+			$this->api = new ConvertKit_API_V4(
 				CONVERTKIT_OAUTH_CLIENT_ID,
 				CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
 				$settings->get_access_token(),
@@ -67,7 +67,7 @@ class ConvertKit_Resource_Landing_Pages extends ConvertKit_Resource {
 
 		// Setup API.
 		$settings  = new ConvertKit_Settings();
-		$this->api = new ConvertKit_API(
+		$this->api = new ConvertKit_API_V4(
 			CONVERTKIT_OAUTH_CLIENT_ID,
 			CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
 			$settings->get_access_token(),

--- a/includes/class-convertkit-resource-posts.php
+++ b/includes/class-convertkit-resource-posts.php
@@ -12,7 +12,7 @@
  *
  * @since   1.9.7.4
  */
-class ConvertKit_Resource_Posts extends ConvertKit_Resource {
+class ConvertKit_Resource_Posts extends ConvertKit_Resource_V4 {
 
 	/**
 	 * Holds the Settings Key that stores site wide ConvertKit settings
@@ -77,7 +77,7 @@ class ConvertKit_Resource_Posts extends ConvertKit_Resource {
 		// Initialize the API if the Access Token has been defined in the Plugin Settings.
 		$settings = new ConvertKit_Settings();
 		if ( $settings->has_access_and_refresh_token() ) {
-			$this->api = new ConvertKit_API(
+			$this->api = new ConvertKit_API_V4(
 				CONVERTKIT_OAUTH_CLIENT_ID,
 				CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
 				$settings->get_access_token(),

--- a/includes/class-convertkit-resource-products.php
+++ b/includes/class-convertkit-resource-products.php
@@ -12,7 +12,7 @@
  *
  * @since   2.0.0
  */
-class ConvertKit_Resource_Products extends ConvertKit_Resource {
+class ConvertKit_Resource_Products extends ConvertKit_Resource_V4 {
 
 	/**
 	 * Holds the Settings Key that stores site wide ConvertKit settings
@@ -40,7 +40,7 @@ class ConvertKit_Resource_Products extends ConvertKit_Resource {
 		// Initialize the API if the Access Token has been defined in the Plugin Settings.
 		$settings = new ConvertKit_Settings();
 		if ( $settings->has_access_and_refresh_token() ) {
-			$this->api = new ConvertKit_API(
+			$this->api = new ConvertKit_API_V4(
 				CONVERTKIT_OAUTH_CLIENT_ID,
 				CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
 				$settings->get_access_token(),

--- a/includes/class-convertkit-resource-tags.php
+++ b/includes/class-convertkit-resource-tags.php
@@ -12,7 +12,7 @@
  *
  * @since   1.9.6
  */
-class ConvertKit_Resource_Tags extends ConvertKit_Resource {
+class ConvertKit_Resource_Tags extends ConvertKit_Resource_V4 {
 
 	/**
 	 * Holds the Settings Key that stores site wide ConvertKit settings
@@ -40,7 +40,7 @@ class ConvertKit_Resource_Tags extends ConvertKit_Resource {
 		// Initialize the API if the Access Token has been defined in the Plugin Settings.
 		$settings = new ConvertKit_Settings();
 		if ( $settings->has_access_and_refresh_token() ) {
-			$this->api = new ConvertKit_API(
+			$this->api = new ConvertKit_API_V4(
 				CONVERTKIT_OAUTH_CLIENT_ID,
 				CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
 				$settings->get_access_token(),

--- a/includes/class-convertkit-settings.php
+++ b/includes/class-convertkit-settings.php
@@ -46,7 +46,7 @@ class ConvertKit_Settings {
 		}
 
 		// Update Access Token when refreshed by the API class.
-		add_action( 'convertkit_api_refresh_token', array( $this, 'update_credentials' ), 10, 1 );
+		add_action( 'convertkit_api_refresh_token', array( $this, 'update_credentials' ), 10, 2 );
 
 	}
 
@@ -412,7 +412,13 @@ class ConvertKit_Settings {
 	 *
 	 * @param   array $result     New Access Token, Refresh Token and Expiry.
 	 */
-	public function update_credentials( $result ) {
+	public function update_credentials( $result, $client_id ) {
+
+		// Don't save these credentials if they're not for this Client ID.
+		// They're for another ConvertKit Plugin that uses OAuth.
+		if ( $client_id !== CONVERTKIT_OAUTH_CLIENT_ID ) {
+			return;
+		}
 
 		$this->save(
 			array(

--- a/includes/class-convertkit-settings.php
+++ b/includes/class-convertkit-settings.php
@@ -410,7 +410,8 @@ class ConvertKit_Settings {
 	 *
 	 * @since   2.5.0
 	 *
-	 * @param   array $result     New Access Token, Refresh Token and Expiry.
+	 * @param   array  $result      New Access Token, Refresh Token and Expiry.
+	 * @param   string $client_id   OAuth Client ID used for the Access and Refresh Tokens.
 	 */
 	public function update_credentials( $result, $client_id ) {
 

--- a/includes/class-convertkit-setup.php
+++ b/includes/class-convertkit-setup.php
@@ -106,7 +106,7 @@ class ConvertKit_Setup {
 		}
 
 		// Get Access Token by API Key and Secret.
-		$api    = new ConvertKit_API( CONVERTKIT_OAUTH_CLIENT_ID, CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI );
+		$api    = new ConvertKit_API_V4( CONVERTKIT_OAUTH_CLIENT_ID, CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI );
 		$result = $api->get_access_token_by_api_key_and_secret(
 			$convertkit_settings->get_api_key(),
 			$convertkit_settings->get_api_secret()

--- a/includes/class-convertkit-subscriber.php
+++ b/includes/class-convertkit-subscriber.php
@@ -71,7 +71,7 @@ class ConvertKit_Subscriber {
 		}
 
 		// Initialize the API.
-		$api = new ConvertKit_API(
+		$api = new ConvertKit_API_V4(
 			CONVERTKIT_OAUTH_CLIENT_ID,
 			CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
 			$settings->get_access_token(),
@@ -121,7 +121,7 @@ class ConvertKit_Subscriber {
 		}
 
 		// Initialize the API.
-		$api = new ConvertKit_API(
+		$api = new ConvertKit_API_V4(
 			CONVERTKIT_OAUTH_CLIENT_ID,
 			CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
 			$settings->get_access_token(),

--- a/includes/integrations/contactform7/class-convertkit-contactform7.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7.php
@@ -120,7 +120,7 @@ class ConvertKit_ContactForm7 {
 
 		// If here, subscribe the user to the ConvertKit Form.
 		// Initialize the API.
-		$api = new ConvertKit_API(
+		$api = new ConvertKit_API_V4(
 			CONVERTKIT_OAUTH_CLIENT_ID,
 			CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
 			$settings->get_access_token(),

--- a/includes/integrations/forminator/class-convertkit-forminator.php
+++ b/includes/integrations/forminator/class-convertkit-forminator.php
@@ -123,7 +123,7 @@ class ConvertKit_Forminator {
 
 		// If here, subscribe the user to the ConvertKit Form.
 		// Initialize the API.
-		$api = new ConvertKit_API(
+		$api = new ConvertKit_API_V4(
 			CONVERTKIT_OAUTH_CLIENT_ID,
 			CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
 			$settings->get_access_token(),

--- a/includes/integrations/wishlist/class-convertkit-wishlist.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist.php
@@ -123,7 +123,7 @@ class ConvertKit_Wishlist {
 		}
 
 		// Initialize the API.
-		$api = new ConvertKit_API(
+		$api = new ConvertKit_API_V4(
 			CONVERTKIT_OAUTH_CLIENT_ID,
 			CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
 			$settings->get_access_token(),
@@ -169,7 +169,7 @@ class ConvertKit_Wishlist {
 		}
 
 		// Initialize the API.
-		$api = new ConvertKit_API(
+		$api = new ConvertKit_API_V4(
 			CONVERTKIT_OAUTH_CLIENT_ID,
 			CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
 			$settings->get_access_token(),
@@ -206,7 +206,7 @@ class ConvertKit_Wishlist {
 		}
 
 		// Initialize the API.
-		$api = new ConvertKit_API(
+		$api = new ConvertKit_API_V4(
 			CONVERTKIT_OAUTH_CLIENT_ID,
 			CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
 			$settings->get_access_token(),

--- a/tests/acceptance/general/ActivateDeactivatePluginCest.php
+++ b/tests/acceptance/general/ActivateDeactivatePluginCest.php
@@ -30,8 +30,6 @@ class ActivateDeactivatePluginCest
 	 */
 	public function testPluginActivationAndDeactivationWithOtherPlugins(AcceptanceTester $I)
 	{
-		$I->markTestIncomplete();
-
 		// Activate other ConvertKit Plugins from wordpress.org.
 		$I->activateThirdPartyPlugin($I, 'convertkit-for-woocommerce');
 

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -57,6 +57,117 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
+	 * Test that the Access Token is refreshed when a call is made to the API
+	 * using an expired Access Token, and that the new tokens are saved in
+	 * the Plugin settings.
+	 *
+	 * @since   2.5.0
+	 */
+	public function testAccessTokenRefreshedAndSavedWhenExpired()
+	{
+		// Confirm no Access or Refresh Token exists in the Plugin settings.
+		$settings = new ConvertKit_Settings();
+		$this->assertEquals( $settings->get_access_token(), '' );
+		$this->assertEquals( $settings->get_refresh_token(), '' );
+
+		// Filter requests to mock the token expiry and refreshing the token.
+		add_filter( 'pre_http_request', array( $this, 'mockAccessTokenExpiredResponse' ), 10, 3 );
+		add_filter( 'pre_http_request', array( $this, 'mockRefreshTokenResponse' ), 10, 3 );
+
+		// Run request, which will trigger the above filters as if the token expired and refreshes automatically.
+		$result = $this->api->get_account();
+
+		// Confirm "new" tokens now exist in the Plugin's settings, which confirms the `convertkit_api_refresh_token` hook was called when
+		// the tokens were refreshed.
+		$this->assertEquals( $settings->get_access_token(), $_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'] );
+		$this->assertEquals( $settings->get_refresh_token(), $_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN'] );
+	}
+
+	/**
+	 * Mocks an API response as if the Access Token expired.
+	 *
+	 * @since   2.5.0
+	 *
+	 * @param   mixed  $response       HTTP Response.
+	 * @param   array  $parsed_args    Request arguments.
+	 * @param   string $url            Request URL.
+	 * @return  mixed
+	 */
+	public function mockAccessTokenExpiredResponse( $response, $parsed_args, $url )
+	{
+		// Only mock requests made to the /account endpoint.
+		if ( strpos( $url, 'https://api.convertkit.com/v4/account' ) === false ) {
+			return $response;
+		}
+
+		// Remove this filter, so we don't end up in a loop when retrying the request.
+		remove_filter( 'pre_http_request', array( $this, 'mockAccessTokenExpiredResponse' ) );
+
+		// Return a 401 unauthorized response with the errors body as if the API
+		// returned "The access token expired".
+		return array(
+			'headers'       => array(),
+			'body'          => wp_json_encode(
+				array(
+					'errors' => array(
+						'The access token expired',
+					),
+				)
+			),
+			'response'      => array(
+				'code'    => 401,
+				'message' => 'The access token expired',
+			),
+			'cookies'       => array(),
+			'http_response' => null,
+		);
+	}
+
+	/**
+	 * Mocks an API response as if a refresh token was used to fetch new tokens.
+	 *
+	 * @since   2.5.0
+	 *
+	 * @param   mixed  $response       HTTP Response.
+	 * @param   array  $parsed_args    Request arguments.
+	 * @param   string $url            Request URL.
+	 * @return  mixed
+	 */
+	public function mockRefreshTokenResponse( $response, $parsed_args, $url )
+	{
+		// Only mock requests made to the /token endpoint.
+		if ( strpos( $url, 'https://api.convertkit.com/oauth/token' ) === false ) {
+			return $response;
+		}
+
+		// Remove this filter, so we don't end up in a loop when retrying the request.
+		remove_filter( 'pre_http_request', array( $this, 'mockRefreshTokenResponse' ) );
+
+		// Return a mock access and refresh token for this API request, as calling
+		// refresh_token results in a new access and refresh token being provided,
+		// which would result in other tests breaking due to changed tokens.
+		return array(
+			'headers'       => array(),
+			'body'          => wp_json_encode(
+				array(
+					'access_token'  => $_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
+					'refresh_token' => $_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN'],
+					'token_type'    => 'bearer',
+					'created_at'    => strtotime( 'now' ),
+					'expires_in'    => 10000,
+					'scope'         => 'public',
+				)
+			),
+			'response'      => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'cookies'       => array(),
+			'http_response' => null,
+		);
+	}
+
+	/**
 	 * Test that the User Agent string is in the expected format and
 	 * includes the Plugin's name and version number.
 	 *

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -35,7 +35,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		activate_plugins('convertkit/wp-convertkit.php');
 
 		// Initialize the classes we want to test.
-		$this->api = new ConvertKit_API(
+		$this->api = new ConvertKit_API_V4(
 			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
 			$_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
 			$_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -30,17 +30,17 @@ define( 'CONVERTKIT_OAUTH_CLIENT_ID', 'HXZlOCj-K5r0ufuWCtyoyo3f688VmMAYSsKg1eGvw
 define( 'CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI', 'https://cktestplugins.wpengine.com/' );
 
 // Load shared classes, if they have not been included by another ConvertKit Plugin.
-if ( ! class_exists( 'ConvertKit_API_Traits' ) ) {
+if ( ! trait_exists( 'ConvertKit_API_Traits' ) ) {
 	require_once CONVERTKIT_PLUGIN_PATH . '/vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-api-traits.php';
 }
-if ( ! class_exists( 'ConvertKit_API' ) ) {
-	require_once CONVERTKIT_PLUGIN_PATH . '/vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-api.php';
+if ( ! class_exists( 'ConvertKit_API_V4' ) ) {
+	require_once CONVERTKIT_PLUGIN_PATH . '/vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-api-v4.php';
 }
 if ( ! class_exists( 'ConvertKit_Log' ) ) {
 	require_once CONVERTKIT_PLUGIN_PATH . '/vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-log.php';
 }
-if ( ! class_exists( 'ConvertKit_Resource' ) ) {
-	require_once CONVERTKIT_PLUGIN_PATH . '/vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-resource.php';
+if ( ! class_exists( 'ConvertKit_Resource_V4' ) ) {
+	require_once CONVERTKIT_PLUGIN_PATH . '/vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-resource-v4.php';
 }
 if ( ! class_exists( 'ConvertKit_Review_Request' ) ) {
 	require_once CONVERTKIT_PLUGIN_PATH . '/vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-review-request.php';


### PR DESCRIPTION
## Summary

As each ConvertKit WordPress Plugin has its own OAuth Client ID, adds a check when tokens are refreshed by the WordPress Libraries, ensuring tokens are only saved if they belong to this Plugin's Client ID.

## Testing

- `testAccessTokenRefreshedAndSavedWhenExpired`: Tests that the new Access and Refresh Tokens are saved in the Plugin's settings when the WordPress Libraries make a call to an API endpoint with an expired Access Token.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)