### PR TITLE
v4 API: Support Adding Subscribers to Legacy Forms

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "dev-v4-api"
+        "convertkit/convertkit-wordpress-libraries": "dev-v4-api-legacy-form-subscribe"
     },
     "require-dev": {
         "lucatume/wp-browser": "<3.5",

--- a/includes/class-convertkit-resource-forms.php
+++ b/includes/class-convertkit-resource-forms.php
@@ -95,6 +95,32 @@ class ConvertKit_Resource_Forms extends ConvertKit_Resource_V4 {
 	}
 
 	/**
+	 * Determines if the given Form ID is a legacy Form or Landing Page.
+	 *
+	 * @since   2.5.0
+	 *
+	 * @param   int $id     Form or Landing Page ID.
+	 */
+	public function is_legacy( $id ) {
+
+		// Get Form.
+		$form = $this->get_by_id( (int) $id );
+
+		// Return false if no Form exists.
+		if ( ! $form ) {
+			return false;
+		}
+
+		// If the `format` key exists, this is not a legacy Form.
+		if ( array_key_exists( 'format', $form ) ) {
+			return false;
+		}
+
+		return true;
+
+	}
+
+	/**
 	 * Returns a <select> field populated with all forms, based on the given parameters.
 	 *
 	 * @since   2.3.9

--- a/includes/integrations/contactform7/class-convertkit-contactform7.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7.php
@@ -129,8 +129,21 @@ class ConvertKit_ContactForm7 {
 			'contact_form_7'
 		);
 
-		// Send request.
-		$api->form_subscribe( $convertkit_form_id, $email, $first_name );
+		// For Legacy Forms, a different endpoint is used.
+		$forms = new ConvertKit_Resource_Forms();
+		if ( $forms->is_legacy( $convertkit_form_id ) ) {
+			return $api->legacy_form_subscribe(
+				$convertkit_form_id,
+				$email,
+				$first_name
+			);
+		}
+
+		return $api->form_subscribe(
+			$convertkit_form_id,
+			$email,
+			$first_name
+		);
 
 	}
 

--- a/includes/integrations/forminator/class-convertkit-forminator.php
+++ b/includes/integrations/forminator/class-convertkit-forminator.php
@@ -132,8 +132,21 @@ class ConvertKit_Forminator {
 			'forminator'
 		);
 
-		// Send request.
-		$api->form_subscribe( $convertkit_form_id, $email, $first_name );
+		// For Legacy Forms, a different endpoint is used.
+		$forms = new ConvertKit_Resource_Forms();
+		if ( $forms->is_legacy( $convertkit_form_id ) ) {
+			return $api->legacy_form_subscribe(
+				$convertkit_form_id,
+				$email,
+				$first_name
+			);
+		}
+
+		return $api->form_subscribe(
+			$convertkit_form_id,
+			$email,
+			$first_name
+		);
 
 	}
 

--- a/includes/integrations/wishlist/class-convertkit-wishlist.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist.php
@@ -147,6 +147,16 @@ class ConvertKit_Wishlist {
 		}
 
 		// Note Wishlist Member combines first and last name into 'display_name'.
+		// For Legacy Forms, a different endpoint is used.
+		$forms = new ConvertKit_Resource_Forms();
+		if ( $forms->is_legacy( $form_id ) ) {
+			return $api->legacy_form_subscribe(
+				$form_id,
+				$email,
+				$first_name
+			);
+		}
+
 		return $api->form_subscribe(
 			$form_id,
 			$email,

--- a/tests/acceptance/integrations/other/ContactForm7FormCest.php
+++ b/tests/acceptance/integrations/other/ContactForm7FormCest.php
@@ -136,6 +136,81 @@ class ContactForm7FormCest
 	}
 
 	/**
+	 * Test that saving a Contact Form 7 to ConvertKit Legacy Form Mapping works.
+	 *
+	 * @since   2.5.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSettingsContactForm7ToConvertKitLegacyFormMapping(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Create Contact Form 7 Form.
+		$contactForm7ID = $this->_createContactForm7Form($I);
+
+		// Load Contact Form 7 Plugin Settings.
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=contactform7');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check that a Form Mapping option is displayed.
+		$I->seeElementInDOM('#_wp_convertkit_integration_contactform7_settings_' . $contactForm7ID);
+
+		// Change Form to value specified in the .env file.
+		$I->selectOption('#_wp_convertkit_integration_contactform7_settings_' . $contactForm7ID, $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
+
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check the value of the Form field matches the input provided.
+		$I->seeOptionIsSelected('#_wp_convertkit_integration_contactform7_settings_' . $contactForm7ID, $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
+
+		// Create Page with Contact Form 7 Shortcode.
+		$I->havePageInDatabase(
+			[
+				'post_title'   => 'ConvertKit: Contact Form 7 Shortcode: Legacy Form',
+				'post_name'    => 'convertkit-contact-form-7-shortcode-legacy-form',
+				'post_content' => 'Form:
+[contact-form-7 id="' . $contactForm7ID . '"]',
+			]
+		);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/convertkit-contact-form-7-shortcode-legacy-form');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Complete Name and Email.
+		$I->fillField('input[name=your-name]', 'ConvertKit Name');
+		$I->fillField('input[name=your-email]', $emailAddress);
+		$I->fillField('input[name=your-subject]', 'ConvertKit Subject');
+
+		// Submit Form.
+		$I->click('Submit');
+
+		// Confirm the form submitted without errors.
+		$I->performOn(
+			'form.sent',
+			function($I) {
+				$I->see('Thank you for your message. It has been sent.');
+			}
+		);
+
+		// Confirm that the email address was added to ConvertKit.
+		$I->apiCheckSubscriberExists($I, $emailAddress);
+	}
+
+	/**
 	 * Tests that the 'Enable Creator Network Recommendations' option on a Form's settings
 	 * is not displayed when invalid credentials are specified at WPForms > Settings > Integrations > ConvertKit.
 	 *

--- a/tests/acceptance/integrations/wlm/WishListMemberCest.php
+++ b/tests/acceptance/integrations/wlm/WishListMemberCest.php
@@ -81,6 +81,65 @@ class WishListMemberCest
 	}
 
 	/**
+	 * Test that saving a WishList Member Level to ConvertKit Legacy Form Mapping works.
+	 *
+	 * @since   2.5.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSettingsWishListMemberLevelToConvertKitLegacyFormMapping(AcceptanceTester $I)
+	{
+		// Get WishList Member Level ID defined.
+		$wlmLevelID = $this->_getWishListMemberLevelID($I);
+
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Create a test WordPress User.
+		$userID = $this->_createUser($I, $emailAddress);
+
+		// Load WishList Member Plugin Settings.
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=wishlist-member');
+
+		// Check that no PHP warnings or notices were output, if we're on PHP < 8.1 (WLM will throw errors in 8.1+, outside of our control).
+		if (version_compare( phpversion(), '8.1', '<' )) {
+			$I->checkNoWarningsAndNoticesOnScreen($I);
+		}
+
+		// Check that a Form Mapping option is displayed.
+		$I->seeElementInDOM('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form');
+
+		// Change Form to value specified in the .env file.
+		$I->selectOption('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
+
+		// Save Changes.
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output, if we're on PHP < 8.1 (WLM will throw errors in 8.1+, outside of our control).
+		if (version_compare( phpversion(), '8.1', '<' )) {
+			$I->checkNoWarningsAndNoticesOnScreen($I);
+		}
+
+		// Check the value of the Form field matches the input provided.
+		$I->seeOptionIsSelected('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
+
+		// Edit the Test User.
+		$I->amOnAdminPage('user-edit.php?user_id=' . $userID . '&wp_http_referer=%2Fwp-admin%2Fusers.php');
+
+		// Map the User to the Bronze WLM Level.
+		$I->checkOption('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
+
+		// Save Changes.
+		$I->click('Update Member Profile');
+
+		// Confirm that the User is still assigned to the Bronze WLM Level.
+		$I->seeCheckboxIsChecked('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
+
+		// Confirm that the email address was added to ConvertKit.
+		$I->apiCheckSubscriberExists($I, $emailAddress);
+	}
+
+	/**
 	 * Returns the WishList Member Level ID created when setupWishListMemberPlugin() was called.
 	 *
 	 * @since   1.9.6

--- a/tests/wpunit/ResourceFormsTest.php
+++ b/tests/wpunit/ResourceFormsTest.php
@@ -346,4 +346,37 @@ class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertStringContainsString('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">', $result);
 	}
+
+	/**
+	 * Test that the is_legacy() function returns true for a Legacy Form ID.
+	 *
+	 * @since   2.5.0
+	 */
+	public function testIsLegacyFormWithLegacyFormID()
+	{
+		$this->resource->refresh();
+		$this->assertTrue($this->resource->is_legacy($_ENV['CONVERTKIT_API_LEGACY_FORM_ID']));
+	}
+
+	/**
+	 * Test that the is_legacy() function returns false for a non-Legacy Form ID.
+	 *
+	 * @since   2.5.0
+	 */
+	public function testIsLegacyFormWithFormID()
+	{
+		$this->resource->refresh();
+		$this->assertFalse($this->resource->is_legacy($_ENV['CONVERTKIT_API_FORM_ID']));
+	}
+
+	/**
+	 * Test that the is_legacy() function returns false for an invalid Form ID.
+	 *
+	 * @since   2.5.0
+	 */
+	public function testIsLegacyFormWithInvalidFormID()
+	{
+		$this->resource->refresh();
+		$this->assertFalse($this->resource->is_legacy(12345));
+	}
 }


### PR DESCRIPTION
## Summary

Uses [this PR](https://github.com/ConvertKit/convertkit-wordpress-libraries/pull/69) and some logic to call the applicable v4 API method, depending on whether the Plugin needs to add the subscriber to a Form or Legacy Form.

## Testing

- `testSettingsContactForm7ToConvertKitLegacyFormMapping`: Test that Contact Form 7 to Legacy Form subscribing/mapping works
- `testSettingsForminatorFormToConvertKitLegacyFormMapping`: Test that Forminator to Legacy Form subscribing/mapping works
- `testSettingsWishListMemberLevelToConvertKitLegacyFormMapping`: Test that WishList Member to Legacy Form subscribing/mapping works

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)