### PR TITLE
Move tag subscriber logic to backend

### DIFF
--- a/includes/class-convertkit-ajax.php
+++ b/includes/class-convertkit-ajax.php
@@ -28,9 +28,6 @@ class ConvertKit_AJAX {
 		add_action( 'wp_ajax_nopriv_convertkit_store_subscriber_email_as_id_in_cookie', array( $this, 'store_subscriber_email_as_id_in_cookie' ) );
 		add_action( 'wp_ajax_convertkit_store_subscriber_email_as_id_in_cookie', array( $this, 'store_subscriber_email_as_id_in_cookie' ) );
 
-		add_action( 'wp_ajax_nopriv_convertkit_tag_subscriber', array( $this, 'tag_subscriber' ) );
-		add_action( 'wp_ajax_convertkit_tag_subscriber', array( $this, 'tag_subscriber' ) );
-
 		add_action( 'wp_ajax_nopriv_convertkit_subscriber_authentication_send_code', array( $this, 'subscriber_authentication_send_code' ) );
 		add_action( 'wp_ajax_convertkit_subscriber_authentication_send_code', array( $this, 'subscriber_authentication_send_code' ) );
 
@@ -155,71 +152,6 @@ class ConvertKit_AJAX {
 				'id' => $subscriber_id,
 			)
 		);
-
-	}
-
-	/**
-	 * Tags a subscriber when their subscriber ID is present in the cookie or URL,
-	 * and the Page's ConvertKit Settings specify a Tag.
-	 *
-	 * @since   1.9.6
-	 */
-	public function tag_subscriber() {
-
-		// Check nonce.
-		check_ajax_referer( 'convertkit', 'convertkit_nonce' );
-
-		// Bail if required request parameters not submitted.
-		if ( ! isset( $_REQUEST['subscriber_id'] ) ) {
-			wp_send_json_error( __( 'ConvertKit: Required parameter `subscriber_id` not included in AJAX request.', 'convertkit' ) );
-		}
-		if ( ! isset( $_REQUEST['tag'] ) ) {
-			wp_send_json_error( __( 'ConvertKit: Required parameter `tag` not included in AJAX request.', 'convertkit' ) );
-		}
-		$subscriber_id = absint( sanitize_text_field( $_REQUEST['subscriber_id'] ) );
-		$tag_id        = absint( sanitize_text_field( $_REQUEST['tag'] ) );
-
-		// Bail if no subscriber ID or tag provided.
-		if ( empty( $subscriber_id ) ) {
-			wp_send_json_error( __( 'ConvertKit: Required parameter `subscriber_id` empty in AJAX request.', 'convertkit' ) );
-		}
-		if ( empty( $tag_id ) ) {
-			wp_send_json_error( __( 'ConvertKit: Required parameter `tag` empty in AJAX request.', 'convertkit' ) );
-		}
-
-		// Bail if the API hasn't been configured.
-		$settings = new ConvertKit_Settings();
-		if ( ! $settings->has_api_key_and_secret() ) {
-			wp_send_json_error( __( 'ConvertKit: API Keys not defined in Plugin Settings.', 'convertkit' ) );
-		}
-
-		// Initialize the API.
-		$api = new ConvertKit_API( $settings->get_api_key(), $settings->get_api_secret(), $settings->debug_enabled() );
-
-		// Get subscriber's email address by subscriber ID.
-		$subscriber = $api->get_subscriber_by_id( $subscriber_id );
-
-		// Bail if the subscriber could not be found.
-		if ( is_wp_error( $subscriber ) ) {
-			wp_send_json_error( $subscriber->get_error_message() );
-		}
-
-		// Extract the subscriber's email.
-		$email = $subscriber['email_address'];
-
-		// Store the subscriber ID as a cookie.
-		$subscriber = new ConvertKit_Subscriber();
-		$subscriber->set( $subscriber_id );
-
-		// Tag the subscriber with the Post's tag.
-		$tag = $api->tag_subscribe( $tag_id, $email );
-
-		// Bail if an error occured tagging the subscriber.
-		if ( is_wp_error( $tag ) ) {
-			wp_send_json_error( $tag );
-		}
-
-		wp_send_json_success( $tag );
 
 	}
 

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -593,10 +593,6 @@ class ConvertKit_Output {
 				'debug'         => $settings->debug_enabled(),
 				'nonce'         => wp_create_nonce( 'convertkit' ),
 				'subscriber_id' => $this->subscriber_id,
-
-				// @TODO Check if we need these.
-				'tag'           => ( ( is_singular() && $convertkit_post->has_tag() ) ? $convertkit_post->get_tag() : false ),
-				'post_id'       => $post->ID,
 			)
 		);
 

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -67,7 +67,8 @@ class ConvertKit_Output {
 	 */
 	public function __construct() {
 
-		add_action( 'init', array( $this, 'get_subscriber_id_from_request' ), 1 );
+		add_action( 'init', array( $this, 'get_subscriber_id_from_request' ) );
+		add_action( 'wp', array( $this, 'maybe_tag_subscriber' ) );
 		add_action( 'template_redirect', array( $this, 'output_form' ) );
 		add_action( 'template_redirect', array( $this, 'page_takeover' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
@@ -76,6 +77,74 @@ class ConvertKit_Output {
 		add_filter( 'hooked_block_convertkit/form', array( $this, 'append_form_block_to_category_archive' ), 10, 1 );
 		add_action( 'wp_footer', array( $this, 'output_global_non_inline_form' ), 1 );
 		add_action( 'wp_footer', array( $this, 'output_scripts_footer' ) );
+
+	}
+
+	/**
+	 * Tags the subscriber, if:
+	 * - a subscriber ID exists in the cookie or URL,
+	 * - the WordPress Page has the "Add a Tag" setting specified
+	 *
+	 * @since   2.4.9.1
+	 */
+	public function maybe_tag_subscriber() {
+
+		// Bail if no subscriber ID detected.
+		if ( ! $this->subscriber_id ) {
+			return;
+		}
+
+		// Bail if not a singular Post Type supported by ConvertKit.
+		if ( ! is_singular( convertkit_get_supported_post_types() ) ) {
+			return;
+		}
+
+		// Get Post ID.
+		$post_id = get_the_ID();
+
+		// Bail if a Post ID couldn't be identified.
+		if ( ! $post_id ) {
+			return;
+		}
+
+		// Get Settings, if they have not yet been loaded.
+		if ( ! $this->settings ) {
+			$this->settings = new ConvertKit_Settings();
+		}
+
+		// Bail if the API if an API Key and Secret is not defined.
+		if ( ! $this->settings->has_api_key_and_secret() ) {
+			return;
+		}
+
+		// Get ConvertKit Post's Settings, if they have not yet been loaded.
+		if ( ! $this->post_settings ) {
+			$this->post_settings = new ConvertKit_Post( $post_id );
+		}
+
+		// Bail if no "Add a Tag" setting specified for this Page.
+		if ( ! $this->post_settings->has_tag() ) {
+			return;
+		}
+
+		// Initialize the API.
+		$api = new ConvertKit_API(
+			$this->settings->get_api_key(),
+			$this->settings->get_api_secret(),
+			$this->settings->debug_enabled(),
+			'output'
+		);
+
+		// Get subscriber's email address by subscriber ID.
+		$subscriber = $api->get_subscriber_by_id( $this->subscriber_id );
+
+		// Bail if the subscriber could not be found.
+		if ( is_wp_error( $subscriber ) ) {
+			return;
+		}
+
+		// Tag subscriber.
+		$api->tag_subscribe( $this->post_settings->get_tag(), $subscriber['email_address'] );
 
 	}
 
@@ -524,6 +593,8 @@ class ConvertKit_Output {
 				'debug'         => $settings->debug_enabled(),
 				'nonce'         => wp_create_nonce( 'convertkit' ),
 				'subscriber_id' => $this->subscriber_id,
+
+				// @TODO Check if we need these.
 				'tag'           => ( ( is_singular() && $convertkit_post->has_tag() ) ? $convertkit_post->get_tag() : false ),
 				'post_id'       => $post->ID,
 			)

--- a/resources/frontend/js/convertkit.js
+++ b/resources/frontend/js/convertkit.js
@@ -8,73 +8,6 @@
  */
 
 /**
- * Tags the given subscriber ID with the given tag
- *
- * @since   1.9.6
- *
- * @param   int     subscriber_id   Subscriber ID
- * @param   string  tag             Tag
- * @param   int     post_id         WordPress Post ID
- */
-function convertKitTagSubscriber( subscriber_id, tag, post_id ) {
-
-	if ( convertkit.debug ) {
-		console.log( 'convertKitTagSubscriber' );
-		console.log( convertkit );
-		console.log( subscriber_id );
-		console.log( tag );
-		console.log( post_id );
-	}
-
-	fetch(
-		convertkit.ajaxurl,
-		{
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/x-www-form-urlencoded',
-			},
-			body: new URLSearchParams(
-				{
-					action: 'convertkit_tag_subscriber',
-					convertkit_nonce: convertkit.nonce,
-					subscriber_id: subscriber_id,
-					tag: tag,
-					post_id: post_id,
-				}
-			)
-		}
-	)
-	.then(
-		function ( response ) {
-			if ( convertkit.debug ) {
-				console.log( response );
-			}
-
-			return response.json();
-		}
-	)
-	.then(
-		function ( result ) {
-			if ( convertkit.debug ) {
-				console.log( result );
-			}
-
-			convertKitRemoveSubscriberIDFromURL( window.location.href );
-		}
-	)
-	.catch(
-		function ( error ) {
-			if ( convertkit.debug ) {
-				console.error( error );
-			}
-
-			convertKitRemoveSubscriberIDFromURL( window.location.href );
-		}
-	);
-
-}
-
-/**
  * Gets the subscriber ID for the given email address, storing
  * it in the `ck_subscriber_id` cookie if it exists.
  *
@@ -245,11 +178,7 @@ document.addEventListener(
 	'DOMContentLoaded',
 	function () {
 
-		if ( convertkit.subscriber_id > 0 && convertkit.tag && convertkit.post_id ) {
-			// If the user can be detected as a ConvertKit Subscriber (i.e. their Subscriber ID is in a cookie or the URL),
-			// and the Page/Post they are viewing has a Tag specified, subscribe them to the tag.
-			convertKitTagSubscriber( convertkit.subscriber_id, convertkit.tag, convertkit.post_id );
-		} else if ( convertkit.subscriber_id > 0 ) {
+		if ( convertkit.subscriber_id > 0 ) {
 			// If the user can be detected as a ConvertKit Subscriber (i.e. their Subscriber ID is in a cookie or the URL),
 			// update the cookie now.
 			convertStoreSubscriberIDInCookie( convertkit.subscriber_id );

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -51,6 +51,26 @@ class ConvertKitAPI extends \Codeception\Module
 	}
 
 	/**
+	 * Check the given subscriber ID has no tags assigned.
+	 *
+	 * @since   2.4.9.1
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester.
+	 * @param   int              $subscriberID  Subscriber ID.
+	 */
+	public function apiCheckSubscriberHasNoTags($I, $subscriberID)
+	{
+		// Run request.
+		$results = $this->apiRequest(
+			'subscribers/' . $subscriberID . '/tags',
+			'GET'
+		);
+
+		// Confirm no tags have been assigned to the subscriber.
+		$I->assertCount(0, $results['tags']);
+	}
+
+	/**
 	 * Check the given email address does not exists as a subscriber.
 	 *
 	 * @param   AcceptanceTester $I             AcceptanceTester.

--- a/tests/acceptance/tags/PageTagCest.php
+++ b/tests/acceptance/tags/PageTagCest.php
@@ -161,6 +161,13 @@ class PageTagCest
 	 */
 	public function testQuickEditUsingDefinedTag(AcceptanceTester $I)
 	{
+		// Programmatically create a subscriber in ConvertKit.
+		// Must be a domain email doesn't bounce on, otherwise subscriber won't be confirmed even if the Form's
+		// "Auto-confirm new subscribers" setting is enabled.
+		// We need the subscriber to be confirmed so they can then be tagged.
+		$emailAddress = $I->generateEmailAddress('n7studios.com');
+		$subscriberID = $I->apiSubscribe($emailAddress, $_ENV['CONVERTKIT_API_FORM_ID']);
+
 		// Programmatically create a Page.
 		$pageID = $I->havePostInDatabase(
 			[
@@ -180,13 +187,13 @@ class PageTagCest
 		);
 
 		// Load the Page on the frontend site.
-		$I->amOnPage('/?p=' . $pageID);
+		$I->amOnPage('/?p=' . $pageID . '&ck_subscriber_id=' . $subscriberID);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the post_has_tag parameter is set to true in the source code.
-		$I->seeInSource('"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"');
+		// Check that the subscriber has been assigned to the tag.
+		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
 	}
 
 	/**
@@ -227,14 +234,21 @@ class PageTagCest
 
 		// Iterate through Pages to run frontend tests.
 		foreach ($pageIDs as $pageID) {
+			// Programmatically create a subscriber in ConvertKit.
+			// Must be a domain email doesn't bounce on, otherwise subscriber won't be confirmed even if the Form's
+			// "Auto-confirm new subscribers" setting is enabled.
+			// We need the subscriber to be confirmed so they can then be tagged.
+			$emailAddress = $I->generateEmailAddress('n7studios.com');
+			$subscriberID = $I->apiSubscribe($emailAddress, $_ENV['CONVERTKIT_API_FORM_ID']);
+
 			// Load the Page on the frontend site.
-			$I->amOnPage('/?p=' . $pageID);
+			$I->amOnPage('/?p=' . $pageID . '&ck_subscriber_id=' . $subscriberID);
 
 			// Check that no PHP warnings or notices were output.
 			$I->checkNoWarningsAndNoticesOnScreen($I);
 
-			// Confirm that the post_has_tag parameter is set to true in the source code.
-			$I->seeInSource('"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"');
+			// Check that the subscriber has been assigned to the tag.
+			$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
 		}
 	}
 
@@ -290,14 +304,21 @@ class PageTagCest
 
 		// Iterate through Pages to run frontend tests.
 		foreach ($pageIDs as $pageID) {
+			// Programmatically create a subscriber in ConvertKit.
+			// Must be a domain email doesn't bounce on, otherwise subscriber won't be confirmed even if the Form's
+			// "Auto-confirm new subscribers" setting is enabled.
+			// We need the subscriber to be confirmed so they can then be tagged.
+			$emailAddress = $I->generateEmailAddress('n7studios.com');
+			$subscriberID = $I->apiSubscribe($emailAddress, $_ENV['CONVERTKIT_API_FORM_ID']);
+
 			// Load the Page on the frontend site.
-			$I->amOnPage('/?p=' . $pageID);
+			$I->amOnPage('/?p=' . $pageID . '&ck_subscriber_id=' . $subscriberID);
 
 			// Check that no PHP warnings or notices were output.
 			$I->checkNoWarningsAndNoticesOnScreen($I);
 
-			// Confirm that the post_has_tag parameter is set to true in the source code.
-			$I->seeInSource('"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"');
+			// Check that the subscriber has been assigned to the tag.
+			$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
 		}
 	}
 

--- a/tests/acceptance/tags/PageTagCest.php
+++ b/tests/acceptance/tags/PageTagCest.php
@@ -106,6 +106,8 @@ class PageTagCest
 	 */
 	public function testDefinedTagAppliesToValidSubscriberID(AcceptanceTester $I)
 	{
+		// @TODO Check this still works when moving logic to backend.
+
 		// Add Page, configured to tag subscribers to visit it with the given tag ID.
 		$pageID = $I->havePageInDatabase(
 			[
@@ -133,12 +135,6 @@ class PageTagCest
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm that the post_has_tag parameter is set to true in the source code.
-		$I->seeInSource('"tag":"' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"');
-
-		// Wait a moment for the AJAX request to complete the API request to tag the subscriber.
-		$I->wait(2);
 
 		// Check that the subscriber has been assigned to the tag.
 		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);

--- a/tests/acceptance/tags/PageTagCest.php
+++ b/tests/acceptance/tags/PageTagCest.php
@@ -106,8 +106,6 @@ class PageTagCest
 	 */
 	public function testDefinedTagAppliesToValidSubscriberID(AcceptanceTester $I)
 	{
-		// @TODO Check this still works when moving logic to backend.
-
 		// Add Page, configured to tag subscribers to visit it with the given tag ID.
 		$pageID = $I->havePageInDatabase(
 			[


### PR DESCRIPTION
## Summary

Moves logic from the frontend (JS) to the backend (PHP) that would apply a tag to a subscriber when viewing a WordPress Page or Post with the `Add a Tag` option set.

We've had this functionality in the Plugin since 1.5.0, released 13th October 2017. However, [this reported security vulnerability](https://inky-knuckle-2c2.notion.site/ConvertKit-Plugin-is-Vulnerable-to-Missing-Authorization-1d6a790950bf4f78ae368294e6de9017?pvs=4) suggests the AJAX endpoint could be exploited to tag subscribers, if the Tag ID and Subscriber IDs are known.

Theoretically there is nothing to stop someone incrementing the `ck_subscriber_id` URL parameter to tag subscribers (e.g. https://example.com/a-page/?ck_subscriber_id). However, the attacker would need to know that a WordPress Page/Post is set to add a tag to a subscriber.

## Testing

- `testAddNewPageUsingNoTag`: Updated to confirm a valid subscriber ID is not tagged, as no tag specified in the test.
- `testAddNewPageUsingDefinedTag`: Updated to confirm a valid subscriber ID is tagged
- `testAddNewPageUsingDefinedTagWithInvalidSubscriberID`: Added to confirm no errors output when an invalid subscriber ID is specified

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)