### PR TITLE
v4 API: Show OAuth Errors

### DIFF
--- a/admin/section/class-convertkit-settings-base.php
+++ b/admin/section/class-convertkit-settings-base.php
@@ -155,8 +155,6 @@ abstract class ConvertKit_Settings_Base {
 		$messages = array(
 			// OAuth.
 			'oauth2_success'                         => __( 'Successfully authorized with ConvertKit.', 'convertkit' ),
-			'convertkit_api_get_access_token_invalid_grant' => __( 'The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.', 'convertkit' ),
-			'convertkit_api_get_access_token_invalid_client' => __( 'Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.', 'convertkit' ),
 			// Tools.
 			'import_configuration_upload_error'      => __( 'An error occured uploading the configuration file.', 'convertkit' ),
 			'import_configuration_invalid_file_type' => __( 'The uploaded configuration file isn\'t valid.', 'convertkit' ),
@@ -164,7 +162,12 @@ abstract class ConvertKit_Settings_Base {
 			'import_configuration_success'           => __( 'Configuration imported successfully.', 'convertkit' ),
 		);
 
-		// Output error notification if defined.
+		// Output OAuth error notification if defined.
+		if ( isset( $_REQUEST['error_description'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			$this->output_error( sanitize_text_field( $_REQUEST['error_description'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+		}
+
+		// Output plugin error notification if defined.
 		if ( isset( $_REQUEST['error'] ) && array_key_exists( sanitize_text_field( $_REQUEST['error'] ), $messages ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$this->output_error( $messages[ sanitize_text_field( $_REQUEST['error'] ) ] ); // phpcs:ignore WordPress.Security.NonceVerification
 		}

--- a/admin/section/class-convertkit-settings-oauth.php
+++ b/admin/section/class-convertkit-settings-oauth.php
@@ -69,8 +69,8 @@ class ConvertKit_Settings_OAuth extends ConvertKit_Settings_Base {
 			wp_safe_redirect(
 				add_query_arg(
 					array(
-						'page'  => '_wp_convertkit_settings',
-						'error' => $result->get_error_code(),
+						'page'              => '_wp_convertkit_settings',
+						'error_description' => $result->get_error_message(),
 					),
 					'options-general.php'
 				)

--- a/tests/acceptance/general/PluginSettingsGeneralCest.php
+++ b/tests/acceptance/general/PluginSettingsGeneralCest.php
@@ -180,6 +180,29 @@ class PluginSettingsGeneralCest
 	}
 
 	/**
+	 * Test that an error notice displays when the `error_description` is present in the URL,
+	 * typically when the user denies access via OAuth or exchanging a code for an access token failed.
+	 *
+	 * @since   2.5.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testErrorNoticeDisplaysOnOAuthFailure($I)
+	{
+		// Go to the Plugin's Settings Screen, as if we came back from OAuth where the user did not
+		// grant access, or exchanging a code for an access token failed.
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&error_description=Client+authentication+failed+due+to+unknown+client%2C+no+client+authentication+included%2C+or+unsupported+authentication+method.');
+
+		// Check that a notice is displayed that the API credentials are invalid.
+		$I->seeErrorNotice($I, 'Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.');
+
+		// Confirm the Connect button displays.
+		$I->see('Connect');
+		$I->dontSee('Disconnect');
+		$I->dontSeeElementInDOM('input#submit');
+	}
+
+	/**
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
 	 * when the Default Form for Pages and Posts are changed, and that the preview links
 	 * work when the Default Form is changed.


### PR DESCRIPTION
## Summary

Returns the `error_description` from OAuth, displaying it as an error notice on the settings screen when the user begins the OAuth flow and either:
- the user denies access to the application,
- exchanging the code for an access token fails.

<img width="954" alt="Screenshot 2024-06-26 at 17 27 18" src="https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/e4396bcf-3602-4983-b87c-5000030dc6e7">
<img width="735" alt="Screenshot 2024-06-26 at 17 27 27" src="https://github.com/ConvertKit/convertkit-wordpress/assets/1462305/e066b111-0413-4242-8cb3-a143a0cd174f">

## Testing

- `testErrorNoticeDisplaysOnOAuthFailure`: Test that an error notice displays when the `error_description` is present in the URL, typically when the user denies access via OAuth or exchanging a code for an access token failed.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)