### PR TITLE
v4 API: Tag Subscriber Logic

### DIFF
--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -128,23 +128,17 @@ class ConvertKit_Output {
 		}
 
 		// Initialize the API.
-		$api = new ConvertKit_API(
-			$this->settings->get_api_key(),
-			$this->settings->get_api_secret(),
+		$api = new ConvertKit_API_V4(
+			CONVERTKIT_OAUTH_CLIENT_ID,
+			CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
+			$this->settings->get_access_token(),
+			$this->settings->get_refresh_token(),
 			$this->settings->debug_enabled(),
 			'output'
 		);
 
-		// Get subscriber's email address by subscriber ID.
-		$subscriber = $api->get_subscriber_by_id( $this->subscriber_id );
-
-		// Bail if the subscriber could not be found.
-		if ( is_wp_error( $subscriber ) ) {
-			return;
-		}
-
 		// Tag subscriber.
-		$api->tag_subscribe( $this->post_settings->get_tag(), $subscriber['email_address'] );
+		$api->tag_subscriber( $this->post_settings->get_tag(), $this->subscriber_id );
 
 	}
 


### PR DESCRIPTION
## Summary

Use v4 API for the [tagging a subscriber code](https://github.com/ConvertKit/convertkit-wordpress/pull/675) introduced in 2.4.9.1

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)