### PR TITLE
v4 API: Use ConvertKit-hosted redirect URI

### DIFF
--- a/admin/section/class-convertkit-settings-oauth.php
+++ b/admin/section/class-convertkit-settings-oauth.php
@@ -48,9 +48,11 @@ class ConvertKit_Settings_OAuth extends ConvertKit_Settings_Base {
 	private function maybe_get_and_store_access_token() {
 
 		// Bail if we're not on the settings screen.
+		/*
 		if ( ! $this->on_settings_screen() ) {
 			return;
 		}
+		*/
 
 		// Bail if no authorization code is included in the request.
 		if ( ! array_key_exists( 'code', $_REQUEST ) ) { // phpcs:ignore WordPress.Security.NonceVerification

--- a/admin/section/class-convertkit-settings-oauth.php
+++ b/admin/section/class-convertkit-settings-oauth.php
@@ -48,11 +48,9 @@ class ConvertKit_Settings_OAuth extends ConvertKit_Settings_Base {
 	private function maybe_get_and_store_access_token() {
 
 		// Bail if we're not on the settings screen.
-		/*
 		if ( ! $this->on_settings_screen() ) {
 			return;
 		}
-		*/
 
 		// Bail if no authorization code is included in the request.
 		if ( ! array_key_exists( 'code', $_REQUEST ) ) { // phpcs:ignore WordPress.Security.NonceVerification

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "dev-v4-api"
+        "convertkit/convertkit-wordpress-libraries": "dev-v4-api-encoded-state"
     },
     "require-dev": {
         "lucatume/wp-browser": "<3.5",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "dev-v4-api"
+        "convertkit/convertkit-wordpress-libraries": "2.0.0"
     },
     "require-dev": {
         "lucatume/wp-browser": "<3.5",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "dev-v4-api-encoded-state"
+        "convertkit/convertkit-wordpress-libraries": "dev-v4-api"
     },
     "require-dev": {
         "lucatume/wp-browser": "<3.5",

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -10,6 +10,36 @@ namespace Helper\Acceptance;
 class ConvertKitAPI extends \Codeception\Module
 {
 	/**
+	 * Returns an encoded `state` parameter compatible with OAuth.
+	 *
+	 * @since   2.5.0
+	 *
+	 * @param   string $returnTo   Return URL.
+	 * @param   string $clientID   OAuth Client ID.
+	 * @return  string
+	 */
+	public function apiEncodeState($returnTo, $clientID)
+	{
+		$str = json_encode( // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
+			array(
+				'return_to' => $returnTo,
+				'client_id' => $clientID,
+			)
+		);
+
+		// Encode to Base64 string.
+		$str = base64_encode( $str ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions
+
+		// Convert Base64 to Base64URL by replacing “+” with “-” and “/” with “_”.
+		$str = strtr( $str, '+/', '-_' );
+
+		// Remove padding character from the end of line.
+		$str = rtrim( $str, '=' );
+
+		return $str;
+	}
+
+	/**
 	 * Check the given email address exists as a subscriber.
 	 *
 	 * @param   AcceptanceTester $I             AcceptanceTester.

--- a/tests/acceptance/general/PageCest.php
+++ b/tests/acceptance/general/PageCest.php
@@ -48,7 +48,12 @@ class PageCest
 
 		// Check that a link to the OAuth auth screen exists and includes the state parameter.
 		$I->seeInSource('<a href="https://app.convertkit.com/oauth/authorize?client_id=' . $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'] . '&amp;response_type=code&amp;redirect_uri=' . urlencode( $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'] ) );
-		$I->seeInSource('&amp;state=' . urlencode( $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/options-general.php?page=_wp_convertkit_settings' ) );
+		$I->seeInSource(
+			'&amp;state=' . $I->apiEncodeState(
+				$_ENV['TEST_SITE_WP_URL'] . '/wp-admin/options-general.php?page=_wp_convertkit_settings',
+				$_ENV['CONVERTKIT_OAUTH_CLIENT_ID']
+			)
+		);
 
 		// Click the link.
 		$I->click('connect your ConvertKit account.');

--- a/tests/acceptance/general/PluginSettingsGeneralCest.php
+++ b/tests/acceptance/general/PluginSettingsGeneralCest.php
@@ -68,7 +68,12 @@ class PluginSettingsGeneralCest
 
 		// Check that a link to the OAuth auth screen exists and includes the state parameter.
 		$I->seeInSource('<a href="https://app.convertkit.com/oauth/authorize?client_id=' . $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'] . '&amp;response_type=code&amp;redirect_uri=' . urlencode( $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'] ) );
-		$I->seeInSource('&amp;state=' . urlencode( $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/options-general.php?page=_wp_convertkit_settings' ) );
+		$I->seeInSource(
+			'&amp;state=' . $I->apiEncodeState(
+				$_ENV['TEST_SITE_WP_URL'] . '/wp-admin/options-general.php?page=_wp_convertkit_settings',
+				$_ENV['CONVERTKIT_OAUTH_CLIENT_ID']
+			)
+		);
 
 		// Click the connect button.
 		$I->click('Connect');

--- a/tests/acceptance/general/PostCest.php
+++ b/tests/acceptance/general/PostCest.php
@@ -48,7 +48,12 @@ class PostCest
 
 		// Check that a link to the OAuth auth screen exists and includes the state parameter.
 		$I->seeInSource('<a href="https://app.convertkit.com/oauth/authorize?client_id=' . $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'] . '&amp;response_type=code&amp;redirect_uri=' . urlencode( $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'] ) );
-		$I->seeInSource('&amp;state=' . urlencode( $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/options-general.php?page=_wp_convertkit_settings' ) );
+		$I->seeInSource(
+			'&amp;state=' . $I->apiEncodeState(
+				$_ENV['TEST_SITE_WP_URL'] . '/wp-admin/options-general.php?page=_wp_convertkit_settings',
+				$_ENV['CONVERTKIT_OAUTH_CLIENT_ID']
+			)
+		);
 
 		// Click the link.
 		$I->click('connect your ConvertKit account.');

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -27,7 +27,7 @@ define( 'CONVERTKIT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_PATH', __DIR__ );
 define( 'CONVERTKIT_PLUGIN_VERSION', '2.5.0' );
 define( 'CONVERTKIT_OAUTH_CLIENT_ID', 'HXZlOCj-K5r0ufuWCtyoyo3f688VmMAYSsKg1eGvw0Y' );
-define( 'CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI', 'https://cktestplugins.wpengine.com/' );
+define( 'CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI', 'https://app.convertkit.com/wordpress/redirect' );
 
 // Load shared classes, if they have not been included by another ConvertKit Plugin.
 if ( ! trait_exists( 'ConvertKit_API_Traits' ) ) {


### PR DESCRIPTION
## Summary

Use the ConvertKit-hosted redirect URL with the `2.0` WordPress Libraries.

## Testing

Updates tests that check the `state` parameter for beginning the OAuth process to its new encoded version.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)