### PR TITLE
Settings: Improve Notices and Screen Detection

### DIFF
--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -54,11 +54,11 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 	/**
 	 * Registers success and error notices for the Tools screen, to be displayed
 	 * depending on the action.
-	 * 
-	 * @since 	2.5.1
-	 * 
-	 * @param 	array 	$notices 	Regsitered success and error notices.
-	 * @return 	array
+	 *
+	 * @since   2.5.1
+	 *
+	 * @param   array $notices    Regsitered success and error notices.
+	 * @return  array
 	 */
 	public function register_notices( $notices ) {
 

--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -69,13 +69,14 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 
 		// If an error occured, show it now.
 		if ( is_wp_error( $result ) ) {
-			// Redirect to Broadcasts screen.
-			$this->redirect( 'broadcast_import_error' );
+			// Redirect to Broadcasts screen with error.
+			$this->redirect_with_error_description( $result->get_error_message() );
 			return;
 		}
 
 		// If here, the task scheduled.
-		$this->redirect( false, 'broadcast_import_success' );
+		// Redirect with success notice.
+		$this->redirect_with_success_notice( 'broadcast_import_success' );
 
 	}
 

--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -35,11 +35,11 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 		// Identify that this is beta functionality.
 		$this->is_beta = true;
 
-		// Register notices for this settings screen.
-		add_action( 'convertkit_settings_base_register_notices', array( $this, 'register_notices' ) );
-
-		// Output notices.
-		add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
+		// Register and maybe output notices for this settings screen.
+		if ( $this->on_settings_screen() ) {
+			add_action( 'convertkit_settings_base_register_notices', array( $this, 'register_notices' ) );
+			add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
+		}
 
 		// Enqueue scripts and CSS.
 		add_action( 'convertkit_admin_settings_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
@@ -65,10 +65,8 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 		return array_merge(
 			$notices,
 			array(
-				'import_configuration_upload_error'      => __( 'An error occured uploading the configuration file.', 'convertkit' ),
-				'import_configuration_invalid_file_type' => __( 'The uploaded configuration file isn\'t valid.', 'convertkit' ),
-				'import_configuration_empty'             => __( 'The uploaded configuration file contains no settings.', 'convertkit' ),
-				'import_configuration_success'           => __( 'Configuration imported successfully.', 'convertkit' ),
+				'broadcast_import_error'   => __( 'Broadcasts import failed. Please try again.', 'convertkit' ),
+				'broadcast_import_success' => __( 'Broadcasts import started. Check the Posts screen shortly to confirm Broadcasts imported successfully.', 'convertkit' ),
 			)
 		);
 

--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -35,6 +35,9 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 		// Identify that this is beta functionality.
 		$this->is_beta = true;
 
+		// Register notices for this settings screen.
+		add_action( 'convertkit_settings_base_register_notices', array( $this, 'register_notices' ) );
+
 		// Output notices.
 		add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
 
@@ -45,6 +48,29 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 		parent::__construct();
 
 		$this->maybe_import_now();
+
+	}
+
+	/**
+	 * Registers success and error notices for the Tools screen, to be displayed
+	 * depending on the action.
+	 * 
+	 * @since 	2.5.1
+	 * 
+	 * @param 	array 	$notices 	Regsitered success and error notices.
+	 * @return 	array
+	 */
+	public function register_notices( $notices ) {
+
+		return array_merge(
+			$notices,
+			array(
+				'import_configuration_upload_error'      => __( 'An error occured uploading the configuration file.', 'convertkit' ),
+				'import_configuration_invalid_file_type' => __( 'The uploaded configuration file isn\'t valid.', 'convertkit' ),
+				'import_configuration_empty'             => __( 'The uploaded configuration file contains no settings.', 'convertkit' ),
+				'import_configuration_success'           => __( 'Configuration imported successfully.', 'convertkit' ),
+			)
+		);
 
 	}
 
@@ -68,6 +94,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 		$result = $cron->run( 'convertkit_resource_refresh_posts' );
 
 		// If an error occured, show it now.
+		$result = new WP_Error( 'foo', 'something went wrong oops!' ); // @TODO Remove.
 		if ( is_wp_error( $result ) ) {
 			// Redirect to Broadcasts screen with error.
 			$this->redirect_with_error_description( $result->get_error_message() );
@@ -118,31 +145,6 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 
 		// Enqueue Select2 CSS.
 		convertkit_select2_enqueue_styles();
-
-	}
-
-	/**
-	 * Outputs success and/or error notices if required.
-	 *
-	 * @since   2.2.9
-	 */
-	public function maybe_output_notices() {
-
-		// Define messages that might be displayed as a notification.
-		$messages = array(
-			'broadcast_import_error'   => __( 'Broadcasts import failed. Please try again.', 'convertkit' ),
-			'broadcast_import_success' => __( 'Broadcasts import started. Check the Posts screen shortly to confirm Broadcasts imported successfully.', 'convertkit' ),
-		);
-
-		// Output error notification if defined.
-		if ( isset( $_REQUEST['error'] ) && array_key_exists( sanitize_text_field( $_REQUEST['error'] ), $messages ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$this->output_error( $messages[ sanitize_text_field( $_REQUEST['error'] ) ] ); // phpcs:ignore WordPress.Security.NonceVerification
-		}
-
-		// Output success notification if defined.
-		if ( isset( $_REQUEST['success'] ) && array_key_exists( sanitize_text_field( $_REQUEST['success'] ), $messages ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$this->output_success( $messages[ sanitize_text_field( $_REQUEST['success'] ) ] ); // phpcs:ignore WordPress.Security.NonceVerification
-		}
 
 	}
 

--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -37,7 +37,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 
 		// Register and maybe output notices for this settings screen.
 		if ( $this->on_settings_screen( $this->name ) ) {
-			add_action( 'convertkit_settings_base_register_notices', array( $this, 'register_notices' ) );
+			add_filter( 'convertkit_settings_base_register_notices', array( $this, 'register_notices' ) );
 			add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
 		}
 

--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -36,7 +36,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 		$this->is_beta = true;
 
 		// Register and maybe output notices for this settings screen.
-		if ( $this->on_settings_screen() ) {
+		if ( $this->on_settings_screen( $this->name ) ) {
 			add_action( 'convertkit_settings_base_register_notices', array( $this, 'register_notices' ) );
 			add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
 		}
@@ -92,7 +92,6 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 		$result = $cron->run( 'convertkit_resource_refresh_posts' );
 
 		// If an error occured, show it now.
-		$result = new WP_Error( 'foo', 'something went wrong oops!' ); // @TODO Remove.
 		if ( is_wp_error( $result ) ) {
 			// Redirect to Broadcasts screen with error.
 			$this->redirect_with_error_description( $result->get_error_message() );
@@ -162,7 +161,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 			$this->save_disabled = true;
 
 			// Return if we're not on the Plugin settings screen.
-			if ( ! $this->on_settings_screen() ) {
+			if ( ! $this->on_settings_screen( 'broadcasts' ) ) {
 				return;
 			}
 

--- a/admin/section/class-convertkit-settings-base.php
+++ b/admin/section/class-convertkit-settings-base.php
@@ -83,9 +83,6 @@ abstract class ConvertKit_Settings_Base {
 		// Register the settings section.
 		$this->register_section();
 
-		// Output notices.
-		add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
-
 	}
 
 	/**
@@ -155,10 +152,7 @@ abstract class ConvertKit_Settings_Base {
 	public function maybe_output_notices() {
 
 		// Define notices that might be displayed as a notification.
-		$notices = array(
-			// OAuth.
-			'oauth2_success' => __( 'Successfully authorized with ConvertKit.', 'convertkit' ),
-		);
+		$notices = array();
 
 		/**
 		 * Register success and error notices for settings screens.
@@ -260,7 +254,7 @@ abstract class ConvertKit_Settings_Base {
 		wp_safe_redirect( add_query_arg( array(
 			'page' => '_wp_convertkit_settings',
 			'tab'  => $this->name,
-		) 'options-general.php' ) );
+		), 'options-general.php' ) );
 		exit();
 
 	}
@@ -281,7 +275,7 @@ abstract class ConvertKit_Settings_Base {
 			'page' => '_wp_convertkit_settings',
 			'tab'  => $this->name,
 			'error' => $error,
-		) 'options-general.php' ) );
+		), 'options-general.php' ) );
 		exit();
 
 	}
@@ -299,7 +293,7 @@ abstract class ConvertKit_Settings_Base {
 			'page' => '_wp_convertkit_settings',
 			'tab'  => $this->name,
 			'error_description' => $error_description,
-		) 'options-general.php' ) );
+		), 'options-general.php' ) );
 		exit();
 
 	}
@@ -320,7 +314,7 @@ abstract class ConvertKit_Settings_Base {
 			'page' => '_wp_convertkit_settings',
 			'tab'  => $this->name,
 			'success' => $success,
-		) 'options-general.php' ) );
+		), 'options-general.php' ) );
 		exit();
 
 	}

--- a/admin/section/class-convertkit-settings-base.php
+++ b/admin/section/class-convertkit-settings-base.php
@@ -83,6 +83,9 @@ abstract class ConvertKit_Settings_Base {
 		// Register the settings section.
 		$this->register_section();
 
+		// Output notices.
+		add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
+
 	}
 
 	/**
@@ -151,30 +154,35 @@ abstract class ConvertKit_Settings_Base {
 	 */
 	public function maybe_output_notices() {
 
-		// Define messages that might be displayed as a notification.
-		$messages = array(
+		// Define notices that might be displayed as a notification.
+		$notices = array(
 			// OAuth.
-			'oauth2_success'                         => __( 'Successfully authorized with ConvertKit.', 'convertkit' ),
-			// Tools.
-			'import_configuration_upload_error'      => __( 'An error occured uploading the configuration file.', 'convertkit' ),
-			'import_configuration_invalid_file_type' => __( 'The uploaded configuration file isn\'t valid.', 'convertkit' ),
-			'import_configuration_empty'             => __( 'The uploaded configuration file contains no settings.', 'convertkit' ),
-			'import_configuration_success'           => __( 'Configuration imported successfully.', 'convertkit' ),
+			'oauth2_success' => __( 'Successfully authorized with ConvertKit.', 'convertkit' ),
 		);
 
-		// Output OAuth error notification if defined.
+		/**
+		 * Register success and error notices for settings screens.
+		 * 
+		 * @since 	2.5.1
+		 * 
+		 * @param 	array 	$notices 	Regsitered success and error notices.
+		 * @return 	array
+		 */
+		$notices = apply_filters( 'convertkit_settings_base_register_notices', $notices );
+
+		// Output the verbose error description if supplied (e.g. OAuth).
 		if ( isset( $_REQUEST['error_description'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$this->output_error( sanitize_text_field( $_REQUEST['error_description'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
 		}
 
-		// Output plugin error notification if defined.
-		if ( isset( $_REQUEST['error'] ) && array_key_exists( sanitize_text_field( $_REQUEST['error'] ), $messages ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$this->output_error( $messages[ sanitize_text_field( $_REQUEST['error'] ) ] ); // phpcs:ignore WordPress.Security.NonceVerification
+		// Output error notification if defined.
+		if ( isset( $_REQUEST['error'] ) && array_key_exists( sanitize_text_field( $_REQUEST['error'] ), $notices ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			$this->output_error( $notices[ sanitize_text_field( $_REQUEST['error'] ) ] ); // phpcs:ignore WordPress.Security.NonceVerification
 		}
 
 		// Output success notification if defined.
-		if ( isset( $_REQUEST['success'] ) && array_key_exists( sanitize_text_field( $_REQUEST['success'] ), $messages ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$this->output_success( $messages[ sanitize_text_field( $_REQUEST['success'] ) ] ); // phpcs:ignore WordPress.Security.NonceVerification
+		if ( isset( $_REQUEST['success'] ) && array_key_exists( sanitize_text_field( $_REQUEST['success'] ), $notices ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			$this->output_success( $notices[ sanitize_text_field( $_REQUEST['success'] ) ] ); // phpcs:ignore WordPress.Security.NonceVerification
 		}
 
 	}
@@ -243,29 +251,76 @@ abstract class ConvertKit_Settings_Base {
 	}
 
 	/**
-	 * Redirects to the settings screen, with an option success or error message.
+	 * Redirects to the settings screen.
 	 *
 	 * @since   2.2.9
-	 *
-	 * @param   false|string $error      The error message key.
-	 * @param   false|string $success    The success message key.
 	 */
 	public function redirect( $error = false, $success = false ) {
 
-		// Build URL to redirect to, depending on whether a message is included.
-		$args = array(
+		wp_safe_redirect( add_query_arg( array(
 			'page' => '_wp_convertkit_settings',
 			'tab'  => $this->name,
-		);
-		if ( $error !== false ) {
-			$args['error'] = $error;
-		}
-		if ( $success !== false ) {
-			$args['success'] = $success;
-		}
+		) 'options-general.php' ) );
+		exit();
 
-		// Redirect.
-		wp_safe_redirect( add_query_arg( $args, 'options-general.php' ) );
+	}
+
+	/**
+	 * Redirects to the settings screen with an error notice key.
+	 * 
+	 * maybe_output_notices() will then output the translated error notice
+	 * based on the supplied key.
+	 *
+	 * @since   2.5.1
+	 *
+	 * @param   string $error      The error notice key, registered using `convertkit_settings_base_register_notices`.
+	 */
+	public function redirect_with_error_notice( $error ) {
+
+		wp_safe_redirect( add_query_arg( array(
+			'page' => '_wp_convertkit_settings',
+			'tab'  => $this->name,
+			'error' => $error,
+		) 'options-general.php' ) );
+		exit();
+
+	}
+
+	/**
+	 * Redirects to the settings screen with the verbose error description.
+	 *
+	 * @since   2.5.1
+	 *
+	 * @param   string $error      The error description.
+	 */
+	public function redirect_with_error_description( $error_description ) {
+
+		wp_safe_redirect( add_query_arg( array(
+			'page' => '_wp_convertkit_settings',
+			'tab'  => $this->name,
+			'error_description' => $error_description,
+		) 'options-general.php' ) );
+		exit();
+
+	}
+
+	/**
+	 * Redirects to the settings screen with a success notice key.
+	 * 
+	 * maybe_output_notices() will then output the translated success notice
+	 * based on the supplied key.
+	 *
+	 * @since   2.5.1
+	 *
+	 * @param   string $success      The success notice key, registered using `convertkit_settings_base_register_notices`.
+	 */
+	public function redirect_with_success_notice( $success ) {
+
+		wp_safe_redirect( add_query_arg( array(
+			'page' => '_wp_convertkit_settings',
+			'tab'  => $this->name,
+			'success' => $success,
+		) 'options-general.php' ) );
 		exit();
 
 	}

--- a/admin/section/class-convertkit-settings-base.php
+++ b/admin/section/class-convertkit-settings-base.php
@@ -90,6 +90,7 @@ abstract class ConvertKit_Settings_Base {
 	 *
 	 * @since   2.5.0
 	 *
+	 * @param   string $tab    Current settings tab (general|tools|restrict-content|broadcasts).
 	 * @return  bool
 	 */
 	public function on_settings_screen( $tab ) {
@@ -164,11 +165,11 @@ abstract class ConvertKit_Settings_Base {
 
 		/**
 		 * Register success and error notices for settings screens.
-		 * 
-		 * @since 	2.5.1
-		 * 
-		 * @param 	array 	$notices 	Regsitered success and error notices.
-		 * @return 	array
+		 *
+		 * @since   2.5.1
+		 *
+		 * @param   array   $notices    Regsitered success and error notices.
+		 * @return  array
 		 */
 		$notices = apply_filters( 'convertkit_settings_base_register_notices', $notices );
 
@@ -257,20 +258,25 @@ abstract class ConvertKit_Settings_Base {
 	 *
 	 * @since   2.2.9
 	 */
-	public function redirect( $error = false, $success = false ) {
+	public function redirect() {
 
-		wp_safe_redirect( add_query_arg( array(
-			'page' => '_wp_convertkit_settings',
-			'tab'  => $this->name,
-		), 'options-general.php' ) );
+		wp_safe_redirect(
+			add_query_arg(
+				array(
+					'page' => '_wp_convertkit_settings',
+					'tab'  => $this->name,
+				),
+				'options-general.php'
+			)
+		);
 		exit();
 
 	}
 
 	/**
 	 * Redirects to the settings screen with an error notice key.
-	 * 
-	 * maybe_output_notices() will then output the translated error notice
+	 *
+	 * The function maybe_output_notices() will then output the translated error notice
 	 * based on the supplied key.
 	 *
 	 * @since   2.5.1
@@ -279,11 +285,16 @@ abstract class ConvertKit_Settings_Base {
 	 */
 	public function redirect_with_error_notice( $error ) {
 
-		wp_safe_redirect( add_query_arg( array(
-			'page' => '_wp_convertkit_settings',
-			'tab'  => $this->name,
-			'error' => $error,
-		), 'options-general.php' ) );
+		wp_safe_redirect(
+			add_query_arg(
+				array(
+					'page'  => '_wp_convertkit_settings',
+					'tab'   => $this->name,
+					'error' => $error,
+				),
+				'options-general.php'
+			)
+		);
 		exit();
 
 	}
@@ -293,23 +304,28 @@ abstract class ConvertKit_Settings_Base {
 	 *
 	 * @since   2.5.1
 	 *
-	 * @param   string $error      The error description.
+	 * @param   string $error_description      The error description.
 	 */
 	public function redirect_with_error_description( $error_description ) {
 
-		wp_safe_redirect( add_query_arg( array(
-			'page' => '_wp_convertkit_settings',
-			'tab'  => $this->name,
-			'error_description' => $error_description,
-		), 'options-general.php' ) );
+		wp_safe_redirect(
+			add_query_arg(
+				array(
+					'page'              => '_wp_convertkit_settings',
+					'tab'               => $this->name,
+					'error_description' => $error_description,
+				),
+				'options-general.php'
+			)
+		);
 		exit();
 
 	}
 
 	/**
 	 * Redirects to the settings screen with a success notice key.
-	 * 
-	 * maybe_output_notices() will then output the translated success notice
+	 *
+	 * The function maybe_output_notices() will then output the translated success notice
 	 * based on the supplied key.
 	 *
 	 * @since   2.5.1
@@ -318,11 +334,16 @@ abstract class ConvertKit_Settings_Base {
 	 */
 	public function redirect_with_success_notice( $success ) {
 
-		wp_safe_redirect( add_query_arg( array(
-			'page' => '_wp_convertkit_settings',
-			'tab'  => $this->name,
-			'success' => $success,
-		), 'options-general.php' ) );
+		wp_safe_redirect(
+			add_query_arg(
+				array(
+					'page'    => '_wp_convertkit_settings',
+					'tab'     => $this->name,
+					'success' => $success,
+				),
+				'options-general.php'
+			)
+		);
 		exit();
 
 	}

--- a/admin/section/class-convertkit-settings-base.php
+++ b/admin/section/class-convertkit-settings-base.php
@@ -92,18 +92,26 @@ abstract class ConvertKit_Settings_Base {
 	 *
 	 * @return  bool
 	 */
-	public function on_settings_screen() {
+	public function on_settings_screen( $tab ) {
+
+		// phpcs:disable WordPress.Security.NonceVerification
 
 		// Bail if we're not on the settings screen.
-		if ( ! array_key_exists( 'page', $_REQUEST ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		if ( ! array_key_exists( 'page', $_REQUEST ) ) {
 			return false;
 		}
-		$page = sanitize_text_field( $_REQUEST['page'] );  // phpcs:ignore WordPress.Security.NonceVerification
-		if ( $page !== $this->settings_key ) {
+		if ( sanitize_text_field( $_REQUEST['page'] ) !== '_wp_convertkit_settings' ) {
 			return false;
 		}
 
-		return true;
+		// Define current settings tab.
+		// General screen won't always be loaded with a `tab` parameter.
+		$current_tab = ( array_key_exists( 'tab', $_REQUEST ) ? sanitize_text_field( $_REQUEST['tab'] ) : 'general' );
+
+		// Return whether the request is for the current settings tab.
+		return ( $current_tab === $tab );
+
+		// phpcs:enable
 
 	}
 

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -59,7 +59,7 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 
 		// Register and maybe output notices for this settings screen.
 		if ( $this->on_settings_screen( $this->name ) ) {
-			add_action( 'convertkit_settings_base_register_notices', array( $this, 'register_notices' ) );
+			add_filter( 'convertkit_settings_base_register_notices', array( $this, 'register_notices' ) );
 			add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
 		}
 

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -57,11 +57,11 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 		$this->title    = __( 'General Settings', 'convertkit' );
 		$this->tab_text = __( 'General', 'convertkit' );
 
-		// Register notices for this settings screen.
-		add_action( 'convertkit_settings_base_register_notices', array( $this, 'register_notices' ) );
-
-		// Output notices.
-		add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
+		// Register and maybe output notices for this settings screen.
+		if ( $this->on_settings_screen() ) {
+			add_action( 'convertkit_settings_base_register_notices', array( $this, 'register_notices' ) );
+			add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
+		}
 
 		// Enqueue scripts and CSS.
 		add_action( 'convertkit_admin_settings_enqueue_scripts', array( $this, 'enqueue_scripts' ) );

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -57,6 +57,12 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 		$this->title    = __( 'General Settings', 'convertkit' );
 		$this->tab_text = __( 'General', 'convertkit' );
 
+		// Register notices for this settings screen.
+		add_action( 'convertkit_settings_base_register_notices', array( $this, 'register_notices' ) );
+
+		// Output notices.
+		add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
+
 		// Enqueue scripts and CSS.
 		add_action( 'convertkit_admin_settings_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 		add_action( 'convertkit_admin_settings_enqueue_styles', array( $this, 'enqueue_styles' ) );
@@ -65,6 +71,26 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 
 		$this->check_credentials();
 		$this->maybe_disconnect();
+
+	}
+
+	/**
+	 * Registers success and error notices for the General screen, to be displayed
+	 * depending on the action.
+	 * 
+	 * @since 	2.5.1
+	 * 
+	 * @param 	array 	$notices 	Regsitered success and error notices.
+	 * @return 	array
+	 */
+	public function register_notices( $notices ) {
+
+		return array_merge(
+			$notices,
+			array(
+				'oauth2_success' => __( 'Successfully authorized with ConvertKit.', 'convertkit' ),
+			)
+		);
 
 	}
 

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -58,7 +58,7 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 		$this->tab_text = __( 'General', 'convertkit' );
 
 		// Register and maybe output notices for this settings screen.
-		if ( $this->on_settings_screen() ) {
+		if ( $this->on_settings_screen( $this->name ) ) {
 			add_action( 'convertkit_settings_base_register_notices', array( $this, 'register_notices' ) );
 			add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
 		}
@@ -103,7 +103,7 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 	private function check_credentials() {
 
 		// Bail if we're not on the settings screen.
-		if ( ! $this->on_settings_screen() ) {
+		if ( ! $this->on_settings_screen( $this->name ) ) {
 			return;
 		}
 
@@ -172,7 +172,7 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 	private function maybe_disconnect() {
 
 		// Bail if we're not on the settings screen.
-		if ( ! $this->on_settings_screen() ) {
+		if ( ! $this->on_settings_screen( $this->name ) ) {
 			return;
 		}
 

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -77,11 +77,11 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 	/**
 	 * Registers success and error notices for the General screen, to be displayed
 	 * depending on the action.
-	 * 
-	 * @since 	2.5.1
-	 * 
-	 * @param 	array 	$notices 	Regsitered success and error notices.
-	 * @return 	array
+	 *
+	 * @since   2.5.1
+	 *
+	 * @param   array $notices    Regsitered success and error notices.
+	 * @return  array
 	 */
 	public function register_notices( $notices ) {
 

--- a/admin/section/class-convertkit-settings-oauth.php
+++ b/admin/section/class-convertkit-settings-oauth.php
@@ -63,7 +63,16 @@ class ConvertKit_Settings_OAuth extends ConvertKit_Settings_Base {
 
 		// Redirect with an error if we could not fetch the access token.
 		if ( is_wp_error( $result ) ) {
-			$this->redirect_with_error_description( $result->get_error_message() );
+			wp_safe_redirect(
+				add_query_arg(
+					array(
+						'page'              => '_wp_convertkit_settings',
+						'error_description' => $result->get_error_message(),
+					),
+					'options-general.php'
+				)
+			);
+			exit();
 		}
 
 		// Store Access Token, Refresh Token and expiry.
@@ -77,7 +86,16 @@ class ConvertKit_Settings_OAuth extends ConvertKit_Settings_Base {
 
 		// Redirect to General screen, which will now show the Plugin's settings, because the Plugin
 		// is now authenticated.
-		$this->redirect_with_success_notice( 'oauth2_success' );
+		wp_safe_redirect(
+			add_query_arg(
+				array(
+					'page'    => '_wp_convertkit_settings',
+					'success' => 'oauth2_success',
+				),
+				'options-general.php'
+			)
+		);
+		exit();
 
 	}
 

--- a/admin/section/class-convertkit-settings-oauth.php
+++ b/admin/section/class-convertkit-settings-oauth.php
@@ -45,7 +45,7 @@ class ConvertKit_Settings_OAuth extends ConvertKit_Settings_Base {
 	private function maybe_get_and_store_access_token() {
 
 		// Bail if we're not on the settings screen.
-		if ( ! $this->on_settings_screen() ) {
+		if ( ! $this->on_settings_screen( 'general' ) ) {
 			return;
 		}
 
@@ -63,6 +63,7 @@ class ConvertKit_Settings_OAuth extends ConvertKit_Settings_Base {
 
 		// Redirect with an error if we could not fetch the access token.
 		if ( is_wp_error( $result ) ) {
+			// @TODO Use helpers.
 			wp_safe_redirect(
 				add_query_arg(
 					array(

--- a/admin/section/class-convertkit-settings-oauth.php
+++ b/admin/section/class-convertkit-settings-oauth.php
@@ -32,6 +32,11 @@ class ConvertKit_Settings_OAuth extends ConvertKit_Settings_Base {
 		$this->title    = __( 'OAuth', 'convertkit' );
 		$this->tab_text = __( 'OAuth', 'convertkit' );
 
+		// Output notices for this settings screen.
+		if ( $this->on_settings_screen( 'general' ) ) {
+			add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
+		}
+
 		parent::__construct();
 
 		$this->maybe_get_and_store_access_token();

--- a/admin/section/class-convertkit-settings-oauth.php
+++ b/admin/section/class-convertkit-settings-oauth.php
@@ -63,17 +63,7 @@ class ConvertKit_Settings_OAuth extends ConvertKit_Settings_Base {
 
 		// Redirect with an error if we could not fetch the access token.
 		if ( is_wp_error( $result ) ) {
-			// @TODO Use helpers.
-			wp_safe_redirect(
-				add_query_arg(
-					array(
-						'page'              => '_wp_convertkit_settings',
-						'error_description' => $result->get_error_message(),
-					),
-					'options-general.php'
-				)
-			);
-			exit();
+			$this->redirect_with_error_description( $result->get_error_message() );
 		}
 
 		// Store Access Token, Refresh Token and expiry.
@@ -87,16 +77,7 @@ class ConvertKit_Settings_OAuth extends ConvertKit_Settings_Base {
 
 		// Redirect to General screen, which will now show the Plugin's settings, because the Plugin
 		// is now authenticated.
-		wp_safe_redirect(
-			add_query_arg(
-				array(
-					'page'    => '_wp_convertkit_settings',
-					'success' => 'oauth2_success',
-				),
-				'options-general.php'
-			)
-		);
-		exit();
+		$this->redirect_with_success_notice( 'oauth2_success' );
 
 	}
 

--- a/admin/section/class-convertkit-settings-oauth.php
+++ b/admin/section/class-convertkit-settings-oauth.php
@@ -32,9 +32,6 @@ class ConvertKit_Settings_OAuth extends ConvertKit_Settings_Base {
 		$this->title    = __( 'OAuth', 'convertkit' );
 		$this->tab_text = __( 'OAuth', 'convertkit' );
 
-		// Output notices.
-		add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
-
 		parent::__construct();
 
 		$this->maybe_get_and_store_access_token();

--- a/admin/section/class-convertkit-settings-tools.php
+++ b/admin/section/class-convertkit-settings-tools.php
@@ -30,7 +30,7 @@ class ConvertKit_Settings_Tools extends ConvertKit_Settings_Base {
 
 		// Register and maybe output notices for this settings screen.
 		if ( $this->on_settings_screen( $this->name ) ) {
-			add_action( 'convertkit_settings_base_register_notices', array( $this, 'register_notices' ) );
+			add_filter( 'convertkit_settings_base_register_notices', array( $this, 'register_notices' ) );
 			add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
 		}
 

--- a/admin/section/class-convertkit-settings-tools.php
+++ b/admin/section/class-convertkit-settings-tools.php
@@ -42,11 +42,11 @@ class ConvertKit_Settings_Tools extends ConvertKit_Settings_Base {
 	/**
 	 * Registers success and error notices for the Tools screen, to be displayed
 	 * depending on the action.
-	 * 
-	 * @since 	2.5.1
-	 * 
-	 * @param 	array 	$notices 	Regsitered success and error notices.
-	 * @return 	array
+	 *
+	 * @since   2.5.1
+	 *
+	 * @param   array $notices    Regsitered success and error notices.
+	 * @return  array
 	 */
 	public function register_notices( $notices ) {
 

--- a/admin/section/class-convertkit-settings-tools.php
+++ b/admin/section/class-convertkit-settings-tools.php
@@ -29,7 +29,7 @@ class ConvertKit_Settings_Tools extends ConvertKit_Settings_Base {
 		$this->tab_text     = __( 'Tools', 'convertkit' );
 
 		// Register and maybe output notices for this settings screen.
-		if ( $this->on_settings_screen() ) {
+		if ( $this->on_settings_screen( $this->name ) ) {
 			add_action( 'convertkit_settings_base_register_notices', array( $this, 'register_notices' ) );
 			add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
 		}

--- a/admin/section/class-convertkit-settings-tools.php
+++ b/admin/section/class-convertkit-settings-tools.php
@@ -28,11 +28,11 @@ class ConvertKit_Settings_Tools extends ConvertKit_Settings_Base {
 		$this->title        = __( 'Tools', 'convertkit' );
 		$this->tab_text     = __( 'Tools', 'convertkit' );
 
-		// Register notices for this settings screen.
-		add_action( 'convertkit_settings_base_register_notices', array( $this, 'register_notices' ) );
-
-		// Output notices.
-		add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
+		// Register and maybe output notices for this settings screen.
+		if ( $this->on_settings_screen() ) {
+			add_action( 'convertkit_settings_base_register_notices', array( $this, 'register_notices' ) );
+			add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
+		}
 
 		parent::__construct();
 

--- a/admin/section/class-convertkit-settings-tools.php
+++ b/admin/section/class-convertkit-settings-tools.php
@@ -28,8 +28,11 @@ class ConvertKit_Settings_Tools extends ConvertKit_Settings_Base {
 		$this->title        = __( 'Tools', 'convertkit' );
 		$this->tab_text     = __( 'Tools', 'convertkit' );
 
-		// Register action notices for this settings screen.
-		add_action( 'convertkit_settings_base_register_notices' array( $this, 'register_notices' ) );
+		// Register notices for this settings screen.
+		add_action( 'convertkit_settings_base_register_notices', array( $this, 'register_notices' ) );
+
+		// Output notices.
+		add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
 
 		parent::__construct();
 

--- a/admin/section/class-convertkit-settings-tools.php
+++ b/admin/section/class-convertkit-settings-tools.php
@@ -28,12 +28,35 @@ class ConvertKit_Settings_Tools extends ConvertKit_Settings_Base {
 		$this->title        = __( 'Tools', 'convertkit' );
 		$this->tab_text     = __( 'Tools', 'convertkit' );
 
-		// Output notices.
-		add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
+		// Register action notices for this settings screen.
+		add_action( 'convertkit_settings_base_register_notices' array( $this, 'register_notices' ) );
 
 		parent::__construct();
 
 		$this->maybe_perform_actions();
+	}
+
+	/**
+	 * Registers success and error notices for the Tools screen, to be displayed
+	 * depending on the action.
+	 * 
+	 * @since 	2.5.1
+	 * 
+	 * @param 	array 	$notices 	Regsitered success and error notices.
+	 * @return 	array
+	 */
+	public function register_notices( $notices ) {
+
+		return array_merge(
+			$notices,
+			array(
+				'import_configuration_upload_error'      => __( 'An error occured uploading the configuration file.', 'convertkit' ),
+				'import_configuration_invalid_file_type' => __( 'The uploaded configuration file isn\'t valid.', 'convertkit' ),
+				'import_configuration_empty'             => __( 'The uploaded configuration file contains no settings.', 'convertkit' ),
+				'import_configuration_success'           => __( 'Configuration imported successfully.', 'convertkit' ),
+			)
+		);
+
 	}
 
 	/**
@@ -206,7 +229,7 @@ class ConvertKit_Settings_Tools extends ConvertKit_Settings_Base {
 			$this->redirect();
 		}
 		if ( $_FILES['import']['error'] !== 0 ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
-			$this->redirect( 'import_configuration_upload_error' );
+			$this->redirect_with_error_notice( 'import_configuration_upload_error' );
 		}
 
 		// Read file.
@@ -217,12 +240,12 @@ class ConvertKit_Settings_Tools extends ConvertKit_Settings_Base {
 
 		// Bail if the data isn't JSON.
 		if ( is_null( $import ) ) {
-			$this->redirect( 'import_configuration_invalid_file_type' );
+			$this->redirect_with_error_notice( 'import_configuration_invalid_file_type' );
 		}
 
 		// Bail if no settings exist.
 		if ( ! array_key_exists( 'settings', $import ) ) {
-			$this->redirect( 'import_configuration_empty' );
+			$this->redirect_with_error_notice( 'import_configuration_empty' );
 		}
 
 		// Import: Settings.
@@ -238,7 +261,7 @@ class ConvertKit_Settings_Tools extends ConvertKit_Settings_Base {
 		}
 
 		// Redirect to Tools screen.
-		$this->redirect( false, 'import_configuration_success' );
+		$this->redirect_with_success_notice( 'import_configuration_success' );
 
 	}
 


### PR DESCRIPTION
## Summary

The current notices system in the Plugin only supports predefined success / error messages, based on the `error` key.  This isn't helpful when a function (such as importing Broadcasts) returns a verbose `WP_Error`, and we want to display the precise error message instead of a generic e.g. `Broadcast import failed` (as is the case with [this ticket](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/12263833624191?view=List)).

This PR:
- refactors the notices system in the Plugin settings screen, to support both predefined and verbose error messages,
- moves registration of predefined success and error messages to each individual settings class,
- improves the `on_settings_screen` helper method, to better determine precisely which screen is requested (General, Tools, Broadcasts etc)
- conditionally registers outputting notices based on the current settings screen that is requested, to avoid the same notice being displayed multiple times on screen.

## Testing

Not sure how to perform testing, or perhaps didn't include a test in this PR? Walk through the following in order for a beginner-friendly guide:
- [Setup](SETUP.md) - setting up your local environment for development and testing
- [Development](DEVELOPMENT.md) - best practices for development
- [Testing](TESTING.md) - how to write and run tests

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)