### PR TITLE
Perfmatters: Disable lazy loading assets on landing pages

### DIFF
--- a/includes/class-convertkit-cache-plugins.php
+++ b/includes/class-convertkit-cache-plugins.php
@@ -61,6 +61,7 @@ class ConvertKit_Cache_Plugins {
 		// Perfmatters: Exclude Forms from Delay JavaScript.
 		add_filter( 'convertkit_output_script_footer', array( $this, 'perfmatters_exclude_delay_js' ) );
 		add_filter( 'convertkit_resource_forms_output_script', array( $this, 'perfmatters_exclude_delay_js' ) );
+		add_filter( 'perfmatters_lazyload', array( $this, 'perfmatters_disable_lazy_loading_on_landing_pages' ) );
 
 		// Siteground Speed Optimizer: Exclude Forms from JS combine.
 		add_filter( 'convertkit_output_script_footer', array( $this, 'siteground_speed_optimizer_exclude_js_combine' ) );
@@ -162,6 +163,34 @@ class ConvertKit_Cache_Plugins {
 
 		// Return original script.
 		return $script;
+
+	}
+
+	/**
+	 * Disable lazy loading in Perfmatters when a WordPress Page configured to display a
+	 * ConvertKit Landing Page is viewed.
+	 *
+	 * @since   2.5.1
+	 *
+	 * @param   bool $enabled    Lazy loading enabled.
+	 * @return  bool
+	 */
+	public function perfmatters_disable_lazy_loading_on_landing_pages( $enabled ) {
+
+		// If the request isn't for a Page, don't change lazy loading settings.
+		if ( ! is_page( get_the_ID() ) ) {
+			return $enabled;
+		}
+
+		// If no landing page is specified for the Post, don't change lazy loading settings.
+		$post_settings = new ConvertKit_Post( get_the_ID() );
+		if ( ! $post_settings->has_landing_page() ) {
+			return $enabled;
+		}
+
+		// ConvertKit Landing Page is going to be displayed.
+		// Disable Perfmatters Lazy Loading so that the Landing Page images display.
+		return false;
 
 	}
 


### PR DESCRIPTION
## Summary

Resolves [this reported issue](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/12263833689206?view=List), where Perfmatters attempts to lazy load images and background images when a Landing Page is specified to be displayed on a WordPress Page.

Unchecking the `Lazy Loading` option on Perfmatter's settings on the WordPress Page resolves, however this PR will automatically always disable lazy loading when outputting a ConvertKit Landing Page.

Before:
![before](https://github.com/user-attachments/assets/9e51c320-4ec1-4aab-b72f-a78a5416f294)

After:
![after](https://github.com/user-attachments/assets/74e3d034-f115-41a0-83a5-89375d31bf5b)

## Testing

- `testAddNewPageUsingDefinedLandingPageWithPerfmattersPlugin`: Test that images and background image elements do not have the `perfmatters-lazy` CSS class applied to them when viewing a Landing Page.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)