### PR TITLE
Contact Form 7: Add `Subscribe` option

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -535,3 +535,28 @@ function convertkit_get_file_contents( $local_file ) {
 	return $contents;
 
 }
+
+/**
+ * Returns a dropdown field commonly used for settings, comprising of:
+ * - Do not subscribe
+ * - Subscribe
+ * - Subscribe to Form
+ * - Subscribe to Tag
+ * - Subscribe to Sequence
+ * 
+ * @since 	2.5.2
+ */
+function convertkit_get_subscription_dropdown_field( $name, $value, $id, $class, $is_bulk_edit = false ) {
+
+	// Load resource classes.
+	$forms  = new ConvertKit_Resource_Forms( 'contact_form_7' );
+	$tags   = new ConvertKit_Resource_Tags( 'contact_form_7' );
+
+	ob_start();
+	include CONVERTKIT_PLUGIN_PATH . '/views/backend/subscription-dropdown-field.php';
+	$output = trim( ob_get_clean() );
+
+	// Return output.
+	return $output;
+
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -541,13 +541,18 @@ function convertkit_get_file_contents( $local_file ) {
  * - Do not subscribe
  * - Subscribe
  * - Subscribe to Form
- * 
- * @since 	2.5.2
+ *
+ * @since   2.5.2
+ *
+ * @param   string $name   Field name.
+ * @param   string $value  Field value.
+ * @param   string $id     Field ID attribute.
+ * @param   string $class  Field CSS class(es).
  */
-function convertkit_get_subscription_dropdown_field( $name, $value, $id, $class, $is_bulk_edit = false ) {
+function convertkit_get_subscription_dropdown_field( $name, $value, $id, $class = '' ) {
 
 	// Load resource classes.
-	$forms  = new ConvertKit_Resource_Forms( 'contact_form_7' );
+	$forms = new ConvertKit_Resource_Forms( 'contact_form_7' );
 
 	ob_start();
 	include CONVERTKIT_PLUGIN_PATH . '/views/backend/subscription-dropdown-field.php';

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -541,8 +541,6 @@ function convertkit_get_file_contents( $local_file ) {
  * - Do not subscribe
  * - Subscribe
  * - Subscribe to Form
- * - Subscribe to Tag
- * - Subscribe to Sequence
  * 
  * @since 	2.5.2
  */
@@ -550,7 +548,6 @@ function convertkit_get_subscription_dropdown_field( $name, $value, $id, $class,
 
 	// Load resource classes.
 	$forms  = new ConvertKit_Resource_Forms( 'contact_form_7' );
-	$tags   = new ConvertKit_Resource_Tags( 'contact_form_7' );
 
 	ob_start();
 	include CONVERTKIT_PLUGIN_PATH . '/views/backend/subscription-dropdown-field.php';

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -544,12 +544,12 @@ function convertkit_get_file_contents( $local_file ) {
  *
  * @since   2.5.2
  *
- * @param   string $name   Field name.
- * @param   string $value  Field value.
- * @param   string $id     Field ID attribute.
- * @param   string $class  Field CSS class(es).
+ * @param   string $name        Field name.
+ * @param   string $value       Field value.
+ * @param   string $id          Field ID attribute.
+ * @param   string $css_class   Field CSS class(es).
  */
-function convertkit_get_subscription_dropdown_field( $name, $value, $id, $class = '' ) {
+function convertkit_get_subscription_dropdown_field( $name, $value, $id, $css_class = '' ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
 
 	// Load resource classes.
 	$forms = new ConvertKit_Resource_Forms( 'contact_form_7' );

--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
@@ -137,7 +137,7 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 					'_wp_convertkit_integration_contactform7_settings[' . $cf7_form['id'] . ']',
 					(string) $this->settings->get_convertkit_subscribe_setting_by_cf7_form_id( $cf7_form['id'] ),
 					'_wp_convertkit_integration_contactform7_settings_' . $cf7_form['id'],
-					'widefat',
+					'widefat'
 				),
 				'email' => 'your-email',
 				'name'  => 'your-name',

--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
@@ -117,7 +117,7 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 		}
 
 		// Get Creator Network Recommendations script.
-		$creator_network_recommendations = new ConvertKit_Resource_Creator_Network_Recommendations( 'contact_form_7' );
+		$creator_network_recommendations         = new ConvertKit_Resource_Creator_Network_Recommendations( 'contact_form_7' );
 		$creator_network_recommendations_enabled = $creator_network_recommendations->enabled();
 
 		// Setup WP_List_Table.

--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
@@ -67,6 +67,15 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 			);
 			?>
 		</p>
+		<p>
+			<?php echo esc_html_e( 'Each Contact Form 7 Form has the following ConvertKit options:', 'convertkit' ); ?>
+			<br />
+			<code><?php echo esc_html_e( 'Do not subscribe', 'convertkit' ); ?></code>: <?php esc_html_e( 'Do not subscribe the email address to ConvertKit', 'convertkit' ); ?>
+			<br />
+			<code><?php echo esc_html_e( 'Subscribe', 'convertkit' ); ?></code>: <?php esc_html_e( 'Subscribes the email address to ConvertKit', 'convertkit' ); ?>
+			<br />
+			<code><?php echo esc_html_e( 'Form', 'convertkit' ); ?></code>: <?php esc_html_e( 'Susbcribes the email address to ConvertKit, and adds the subscriber to the ConvertKit Form', 'convertkit' ); ?>
+		</p>
 		<?php
 
 	}
@@ -97,20 +106,6 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 
 		do_settings_sections( $this->settings_key );
 
-		// Get Forms.
-		$forms                           = new ConvertKit_Resource_Forms( 'contact_form_7' );
-		$creator_network_recommendations = new ConvertKit_Resource_Creator_Network_Recommendations( 'contact_form_7' );
-
-		// Bail with an error if no ConvertKit Forms exist.
-		if ( ! $forms->exist() ) {
-			$this->output_error( __( 'No Forms exist on ConvertKit.', 'convertkit' ) );
-			$this->render_container_end();
-			return;
-		}
-
-		// Get Creator Network Recommendations script.
-		$creator_network_recommendations_enabled = $creator_network_recommendations->enabled();
-
 		// Get Contact Form 7 Forms.
 		$cf7_forms = $this->get_cf7_forms();
 
@@ -121,10 +116,14 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 			return;
 		}
 
+		// Get Creator Network Recommendations script.
+		$creator_network_recommendations = new ConvertKit_Resource_Creator_Network_Recommendations( 'contact_form_7' );
+		$creator_network_recommendations_enabled = $creator_network_recommendations->enabled();
+
 		// Setup WP_List_Table.
 		$table = new Multi_Value_Field_Table();
 		$table->add_column( 'title', __( 'Contact Form 7 Form', 'convertkit' ), true );
-		$table->add_column( 'form', __( 'ConvertKit Form', 'convertkit' ), false );
+		$table->add_column( 'form', __( 'ConvertKit', 'convertkit' ), false );
 		$table->add_column( 'email', __( 'Contact Form 7 Email Field', 'convertkit' ), false );
 		$table->add_column( 'name', __( 'Contact Form 7 Name Field', 'convertkit' ), false );
 		$table->add_column( 'creator_network_recommendations', __( 'Enable Creator Network Recommendations', 'convertkit' ), false );
@@ -134,14 +133,11 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 			// Build row.
 			$table_row = array(
 				'title' => $cf7_form['name'],
-				'form'  => $forms->get_select_field_all(
+				'form'  => convertkit_get_subscription_dropdown_field(
 					'_wp_convertkit_integration_contactform7_settings[' . $cf7_form['id'] . ']',
-					'_wp_convertkit_integration_contactform7_settings_' . $cf7_form['id'],
-					false,
 					(string) $this->settings->get_convertkit_form_id_by_cf7_form_id( $cf7_form['id'] ),
-					array(
-						'' => __( 'None', 'convertkit' ),
-					)
+					'_wp_convertkit_integration_contactform7_settings_' . $cf7_form['id'],
+					'ckwc-select2 widefat',
 				),
 				'email' => 'your-email',
 				'name'  => 'your-name',

--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
@@ -137,7 +137,7 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 					'_wp_convertkit_integration_contactform7_settings[' . $cf7_form['id'] . ']',
 					(string) $this->settings->get_convertkit_subscribe_setting_by_cf7_form_id( $cf7_form['id'] ),
 					'_wp_convertkit_integration_contactform7_settings_' . $cf7_form['id'],
-					'ckwc-select2 widefat',
+					'widefat',
 				),
 				'email' => 'your-email',
 				'name'  => 'your-name',

--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
@@ -135,7 +135,7 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 				'title' => $cf7_form['name'],
 				'form'  => convertkit_get_subscription_dropdown_field(
 					'_wp_convertkit_integration_contactform7_settings[' . $cf7_form['id'] . ']',
-					(string) $this->settings->get_convertkit_form_id_by_cf7_form_id( $cf7_form['id'] ),
+					(string) $this->settings->get_convertkit_subscribe_setting_by_cf7_form_id( $cf7_form['id'] ),
 					'_wp_convertkit_integration_contactform7_settings_' . $cf7_form['id'],
 					'ckwc-select2 widefat',
 				),

--- a/includes/integrations/contactform7/class-convertkit-contactform7-settings.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-settings.php
@@ -83,7 +83,7 @@ class ConvertKit_ContactForm7_Settings {
 	 * @since   1.9.6
 	 *
 	 * @param   int $cf7_form_id    Contact Form 7 Form ID.
-	 * @return  bool|int
+	 * @return  bool|string|int
 	 */
 	public function get_convertkit_subscribe_setting_by_cf7_form_id( $cf7_form_id ) {
 

--- a/includes/integrations/contactform7/class-convertkit-contactform7-settings.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-settings.php
@@ -78,14 +78,14 @@ class ConvertKit_ContactForm7_Settings {
 	}
 
 	/**
-	 * Returns the ConvertKit Form ID that is mapped against the given Contact Form 7 Form ID.
+	 * Returns the ConvertKit subscription setting for the given Contact Form 7 Form ID.
 	 *
 	 * @since   1.9.6
 	 *
 	 * @param   int $cf7_form_id    Contact Form 7 Form ID.
 	 * @return  bool|int
 	 */
-	public function get_convertkit_form_id_by_cf7_form_id( $cf7_form_id ) {
+	public function get_convertkit_subscribe_setting_by_cf7_form_id( $cf7_form_id ) {
 
 		// Bail if no settings exist.
 		if ( ! $this->has_settings() ) {

--- a/includes/integrations/contactform7/class-convertkit-contactform7.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7.php
@@ -88,7 +88,7 @@ class ConvertKit_ContactForm7 {
 		}
 
 		// Get ConvertKit Form ID mapped to this Contact Form 7 Form.
-		$contact_form_7_settings = new ConvertKit_ContactForm7_Settings();
+		$contact_form_7_settings      = new ConvertKit_ContactForm7_Settings();
 		$convertkit_subscribe_setting = $contact_form_7_settings->get_convertkit_subscribe_setting_by_cf7_form_id( $contact_form->id() );
 
 		// If no ConvertKit subscribe setting is defined, bail.
@@ -129,10 +129,10 @@ class ConvertKit_ContactForm7 {
 			'contact_form_7'
 		);
 
-		// If the 'Subscribe' option is set, just create the subscriber without assigning to a resource.
+		// If the setting is 'Subscribe', just create the subscriber without assigning to a resource.
 		if ( $convertkit_subscribe_setting === 'subscribe' ) {
 			return $api->create_subscriber(
-			    $email,
+				$email,
 				$first_name
 			);
 		}

--- a/includes/integrations/contactform7/class-convertkit-contactform7.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7.php
@@ -89,10 +89,10 @@ class ConvertKit_ContactForm7 {
 
 		// Get ConvertKit Form ID mapped to this Contact Form 7 Form.
 		$contact_form_7_settings = new ConvertKit_ContactForm7_Settings();
-		$convertkit_form_id      = $contact_form_7_settings->get_convertkit_form_id_by_cf7_form_id( $contact_form->id() );
+		$convertkit_subscribe_setting = $contact_form_7_settings->get_convertkit_subscribe_setting_by_cf7_form_id( $contact_form->id() );
 
-		// If no ConvertKit Form is mapped to this Contact Form 7 Form, bail.
-		if ( ! $convertkit_form_id ) {
+		// If no ConvertKit subscribe setting is defined, bail.
+		if ( ! $convertkit_subscribe_setting ) {
 			return;
 		}
 
@@ -129,18 +129,26 @@ class ConvertKit_ContactForm7 {
 			'contact_form_7'
 		);
 
+		// If the 'Subscribe' option is set, just create the subscriber without assigning to a resource.
+		if ( $convertkit_subscribe_setting === 'subscribe' ) {
+			return $api->create_subscriber(
+			    $email,
+				$first_name
+			);
+		}
+
 		// For Legacy Forms, a different endpoint is used.
 		$forms = new ConvertKit_Resource_Forms();
-		if ( $forms->is_legacy( $convertkit_form_id ) ) {
+		if ( $forms->is_legacy( $convertkit_subscribe_setting ) ) {
 			return $api->legacy_form_subscribe(
-				$convertkit_form_id,
+				(int) $convertkit_subscribe_setting,
 				$email,
 				$first_name
 			);
 		}
 
 		return $api->form_subscribe(
-			$convertkit_form_id,
+			(int) $convertkit_subscribe_setting,
 			$email,
 			$first_name
 		);

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -61,7 +61,6 @@ class ConvertKitAPI extends \Codeception\Module
 		$I->assertGreaterThan(0, $results['pagination']['total_count']);
 		$I->assertEquals($emailAddress, $results['subscribers'][0]['email_address']);
 	}
-
 	/**
 	 * Check the given subscriber ID has been assigned to the given tag ID.
 	 *

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -114,11 +114,12 @@ class ConvertKitAPI extends \Codeception\Module
 			'GET',
 			[
 				'email_address' => $emailAddress,
+				'include_total_count' => true,
 			]
 		);
 
 		// Check no subscribers are returned by this request.
-		$I->assertEquals(0, $results['total_subscribers']);
+		$I->assertEquals(0, $results['pagination']['total_count']);
 	}
 
 	/**

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -113,7 +113,7 @@ class ConvertKitAPI extends \Codeception\Module
 			'subscribers',
 			'GET',
 			[
-				'email_address' => $emailAddress,
+				'email_address'       => $emailAddress,
 				'include_total_count' => true,
 			]
 		);

--- a/tests/acceptance/integrations/other/ContactForm7FormCest.php
+++ b/tests/acceptance/integrations/other/ContactForm7FormCest.php
@@ -37,30 +37,6 @@ class ContactForm7FormCest
 	}
 
 	/**
-	 * Tests that no Contact Form 7 settings display and a 'No Forms exist on ConvertKit'
-	 * notification displays when no Forms exist.
-	 *
-	 * @since   2.2.7
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 */
-	public function testSettingsContactForm7WhenNoForms(AcceptanceTester $I)
-	{
-		// Setup Plugin.
-		$I->setupConvertKitPluginCredentialsNoData($I);
-		$I->setupConvertKitPluginResourcesNoData($I);
-
-		// Load Contact Form 7 Plugin Settings.
-		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=contactform7');
-
-		// Confirm notice is displayed.
-		$I->see('No Forms exist on ConvertKit.');
-
-		// Confirm no settings table is displayed.
-		$I->dontSeeElementInDOM('table.wp-list-table');
-	}
-
-	/**
 	 * Test that saving a Contact Form 7 to ConvertKit Form Mapping works.
 	 *
 	 * @since   1.9.6
@@ -183,6 +159,156 @@ class ContactForm7FormCest
 
 		// Load the Page on the frontend site.
 		$I->amOnPage('/convertkit-contact-form-7-shortcode-legacy-form');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Complete Name and Email.
+		$I->fillField('input[name=your-name]', 'ConvertKit Name');
+		$I->fillField('input[name=your-email]', $emailAddress);
+		$I->fillField('input[name=your-subject]', 'ConvertKit Subject');
+
+		// Submit Form.
+		$I->click('Submit');
+
+		// Confirm the form submitted without errors.
+		$I->performOn(
+			'form.sent',
+			function($I) {
+				$I->see('Thank you for your message. It has been sent.');
+			}
+		);
+
+		// Confirm that the email address was added to ConvertKit.
+		$I->apiCheckSubscriberExists($I, $emailAddress);
+	}
+
+	/**
+	 * Test that setting a Contact Form 7 Form to the '(Do not subscribe)' option works.
+	 *
+	 * @since   2.5.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSettingsContactForm7DoNotSubscribeOption(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Create Contact Form 7 Form.
+		$contactForm7ID = $this->_createContactForm7Form($I);
+
+		// Load Contact Form 7 Plugin Settings.
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=contactform7');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check that a Form Mapping option is displayed.
+		$I->seeElementInDOM('#_wp_convertkit_integration_contactform7_settings_' . $contactForm7ID);
+
+		// Set Contact Form 7 setting to subscribe.
+		$I->selectOption('#_wp_convertkit_integration_contactform7_settings_' . $contactForm7ID, '(Do not subscribe)');
+
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check the value of the Form field matches the input provided.
+		$I->seeOptionIsSelected('#_wp_convertkit_integration_contactform7_settings_' . $contactForm7ID, '(Do not subscribe)');
+
+		// Create Page with Contact Form 7 Shortcode.
+		$I->havePageInDatabase(
+			[
+				'post_title'   => 'ConvertKit: Contact Form 7: Do Not Subscribe',
+				'post_name'    => 'convertkit-contact-form-7-do-not-subscribe',
+				'post_content' => 'Form:
+[contact-form-7 id="' . $contactForm7ID . '"]',
+			]
+		);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/convertkit-contact-form-7-do-not-subscribe');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Complete Name and Email.
+		$I->fillField('input[name=your-name]', 'ConvertKit Name');
+		$I->fillField('input[name=your-email]', $emailAddress);
+		$I->fillField('input[name=your-subject]', 'ConvertKit Subject');
+
+		// Submit Form.
+		$I->click('Submit');
+
+		// Confirm the form submitted without errors.
+		$I->performOn(
+			'form.sent',
+			function($I) {
+				$I->see('Thank you for your message. It has been sent.');
+			}
+		);
+
+		// Confirm that the email address was not added to ConvertKit.
+		$I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
+	}
+
+	/**
+	 * Test that setting a Contact Form 7 Form to the 'Subscribe' option works.
+	 *
+	 * @since   2.5.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSettingsContactForm7SubscribeOption(AcceptanceTester $I)
+	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Create Contact Form 7 Form.
+		$contactForm7ID = $this->_createContactForm7Form($I);
+
+		// Load Contact Form 7 Plugin Settings.
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=contactform7');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check that a Form Mapping option is displayed.
+		$I->seeElementInDOM('#_wp_convertkit_integration_contactform7_settings_' . $contactForm7ID);
+
+		// Set Contact Form 7 setting to subscribe.
+		$I->selectOption('#_wp_convertkit_integration_contactform7_settings_' . $contactForm7ID, 'Subscribe');
+
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check the value of the Form field matches the input provided.
+		$I->seeOptionIsSelected('#_wp_convertkit_integration_contactform7_settings_' . $contactForm7ID, 'Subscribe');
+
+		// Create Page with Contact Form 7 Shortcode.
+		$I->havePageInDatabase(
+			[
+				'post_title'   => 'ConvertKit: Contact Form 7: Subscribe',
+				'post_name'    => 'convertkit-contact-form-7-subscribe',
+				'post_content' => 'Form:
+[contact-form-7 id="' . $contactForm7ID . '"]',
+			]
+		);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/convertkit-contact-form-7-subscribe');
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);

--- a/views/backend/subscription-dropdown-field.php
+++ b/views/backend/subscription-dropdown-field.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Outputs a dropdown field comprising of options covering:
+ * - Do not subscribe
+ * - Subscribe
+ * - Forms
+ * - Tags
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+?>
+<select class="<?php echo esc_attr( $class ); ?>" id="<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $name ); ?>">
+	<?php
+	// If Bulk Edit is true, add a No Change option and select it.
+	if ( $is_bulk_edit === true ) {
+		?>
+		<option value="-1" data-preserve-on-refresh="1"<?php selected( '', $name ); ?>><?php esc_html_e( '— No Change —', 'convertkit' ); ?></option>
+		<?php
+	}
+	?>
+
+	<option <?php selected( '', $name ); ?> value="" data-preserve-on-refresh="1">
+		<?php esc_html_e( '(Do not subscribe)', 'convertkit' ); ?>
+	</option>
+
+	<option <?php selected( '', $name ); ?> value="" data-preserve-on-refresh="1">
+		<?php esc_html_e( 'Subscribe', 'convertkit' ); ?>
+	</option>
+
+	<optgroup label="<?php esc_attr_e( 'Forms', 'convertkit' ); ?>" id="ckwc-forms" data-option-value-prefix="form_">
+		<?php
+		if ( $forms->exist() ) {
+			foreach ( $forms->get() as $form ) {
+				?>
+				<option value="form_<?php echo esc_attr( $form['id'] ); ?>"<?php selected( 'form_' . esc_attr( $form['id'] ), $name ); ?>><?php echo esc_html( $form['name'] ); ?></option>
+				<?php
+			}
+		}
+		?>
+	</optgroup>
+
+	<optgroup label="<?php esc_attr_e( 'Tags', 'convertkit' ); ?>" id="ckwc-tags" data-option-value-prefix="tag_">
+		<?php
+		if ( $tags->exist() ) {
+			foreach ( $tags->get() as $convertkit_tag ) {
+				?>
+				<option value="tag_<?php echo esc_attr( $convertkit_tag['id'] ); ?>"<?php selected( 'tag_' . esc_attr( $convertkit_tag['id'] ), $name ); ?>><?php echo esc_html( $convertkit_tag['name'] ); ?></option>
+				<?php
+			}
+		}
+		?>
+	</optgroup>
+</select>

--- a/views/backend/subscription-dropdown-field.php
+++ b/views/backend/subscription-dropdown-field.php
@@ -11,15 +11,6 @@
 
 ?>
 <select class="<?php echo esc_attr( $class ); ?>" id="<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $name ); ?>">
-	<?php
-	// If Bulk Edit is true, add a No Change option and select it.
-	if ( $is_bulk_edit === true ) {
-		?>
-		<option value="-1" data-preserve-on-refresh="1"<?php selected( '', $value ); ?>><?php esc_html_e( '— No Change —', 'convertkit' ); ?></option>
-		<?php
-	}
-	?>
-
 	<option <?php selected( '', $value ); ?> value="" data-preserve-on-refresh="1">
 		<?php esc_html_e( '(Do not subscribe)', 'convertkit' ); ?>
 	</option>
@@ -32,9 +23,13 @@
 		<?php
 		if ( $forms->exist() ) {
 			foreach ( $forms->get() as $form ) {
-				?>
-				<option value="<?php echo esc_attr( $form['id'] ); ?>"<?php selected( esc_attr( $form['id'] ), $value ); ?>><?php echo esc_html( $form['name'] ); ?></option>
-				<?php
+				echo sprintf(
+					'<option value="%s"%s>%s [%s]</option>',
+					esc_attr( $form['id'] ),
+					selected( $form['id'], $value, false ),
+					esc_attr( $form['name'] ),
+					( ! empty( $form['format'] ) ? esc_attr( $form['format'] ) : 'inline' )
+				);
 			}
 		}
 		?>

--- a/views/backend/subscription-dropdown-field.php
+++ b/views/backend/subscription-dropdown-field.php
@@ -10,7 +10,7 @@
  */
 
 ?>
-<select class="<?php echo esc_attr( $class ); ?>" id="<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $name ); ?>">
+<select class="<?php echo esc_attr( $css_class ); ?>" id="<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $name ); ?>">
 	<option <?php selected( '', $value ); ?> value="" data-preserve-on-refresh="1">
 		<?php esc_html_e( '(Do not subscribe)', 'convertkit' ); ?>
 	</option>
@@ -23,7 +23,7 @@
 		<?php
 		if ( $forms->exist() ) {
 			foreach ( $forms->get() as $form ) {
-				echo sprintf(
+				printf(
 					'<option value="%s"%s>%s [%s]</option>',
 					esc_attr( $form['id'] ),
 					selected( $form['id'], $value, false ),

--- a/views/backend/subscription-dropdown-field.php
+++ b/views/backend/subscription-dropdown-field.php
@@ -4,7 +4,6 @@
  * - Do not subscribe
  * - Subscribe
  * - Forms
- * - Tags
  *
  * @package ConvertKit
  * @author ConvertKit
@@ -16,16 +15,16 @@
 	// If Bulk Edit is true, add a No Change option and select it.
 	if ( $is_bulk_edit === true ) {
 		?>
-		<option value="-1" data-preserve-on-refresh="1"<?php selected( '', $name ); ?>><?php esc_html_e( '— No Change —', 'convertkit' ); ?></option>
+		<option value="-1" data-preserve-on-refresh="1"<?php selected( '', $value ); ?>><?php esc_html_e( '— No Change —', 'convertkit' ); ?></option>
 		<?php
 	}
 	?>
 
-	<option <?php selected( '', $name ); ?> value="" data-preserve-on-refresh="1">
+	<option <?php selected( '', $value ); ?> value="" data-preserve-on-refresh="1">
 		<?php esc_html_e( '(Do not subscribe)', 'convertkit' ); ?>
 	</option>
 
-	<option <?php selected( '', $name ); ?> value="" data-preserve-on-refresh="1">
+	<option <?php selected( 'subscribe', $value ); ?> value="subscribe" data-preserve-on-refresh="1">
 		<?php esc_html_e( 'Subscribe', 'convertkit' ); ?>
 	</option>
 
@@ -34,19 +33,7 @@
 		if ( $forms->exist() ) {
 			foreach ( $forms->get() as $form ) {
 				?>
-				<option value="form_<?php echo esc_attr( $form['id'] ); ?>"<?php selected( 'form_' . esc_attr( $form['id'] ), $name ); ?>><?php echo esc_html( $form['name'] ); ?></option>
-				<?php
-			}
-		}
-		?>
-	</optgroup>
-
-	<optgroup label="<?php esc_attr_e( 'Tags', 'convertkit' ); ?>" id="ckwc-tags" data-option-value-prefix="tag_">
-		<?php
-		if ( $tags->exist() ) {
-			foreach ( $tags->get() as $convertkit_tag ) {
-				?>
-				<option value="tag_<?php echo esc_attr( $convertkit_tag['id'] ); ?>"<?php selected( 'tag_' . esc_attr( $convertkit_tag['id'] ), $name ); ?>><?php echo esc_html( $convertkit_tag['name'] ); ?></option>
+				<option value="<?php echo esc_attr( $form['id'] ); ?>"<?php selected( esc_attr( $form['id'] ), $value ); ?>><?php echo esc_html( $form['name'] ); ?></option>
 				<?php
 			}
 		}


### PR DESCRIPTION
## Summary

With the v4 API introducing the [create subscriber](https://developers.convertkit.com/v4.html#create-a-subscriber) method (without needing to subscribe to a Form), this PR:
- adds an option to create a subscriber
- renames the `None` option to `Do not subscribe`
- introduces the `convertkit_get_subscription_dropdown_field` helper method, which will be used in later PR's for other integrations, and introducing the option to subscribe to other resources, such as Tags or Sequences.

Before:
<img width="1519" alt="Screenshot 2024-07-17 at 12 41 59" src="https://github.com/user-attachments/assets/b654cfa3-a932-408a-8124-0f904f63ce64">

After:
<img width="1509" alt="Screenshot 2024-07-17 at 12 41 26" src="https://github.com/user-attachments/assets/f8d8c2e6-6c70-4c85-8182-66f860d6b9b5">

## Testing

- `testSettingsContactForm7WhenNoForms`: Removed this test, as Forms are no longer required to create a subscriber
- `testSettingsContactForm7DoNotSubscribeOption`: Test that no subscriber is created when the `Do not subscribe` option is selected and a Contact Form 7 Form is submitted
- `testSettingsContactForm7SubscribeOption`: Test that a subscriber is created when the `Subscribe` option is selected and a Contact Form 7 Form is submitted

Two tests fail, due to the test code that dismisses the welcome modal not working correctly.  [This is fixed in this separate PR](https://github.com/ConvertKit/convertkit-wordpress/pull/684); tests will be re-rerun to confirm before merging.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)