### PR TITLE
Tests: Disable Welcome Message

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       DB_USER: root
       DB_PASS: root
       DB_HOST: localhost
-      INSTALL_PLUGINS: "admin-menu-editor autoptimize beaver-builder-lite-version contact-form-7 classic-editor custom-post-type-ui disable-welcome-messages-and-tips elementor forminator jetpack-boost woocommerce wordpress-seo wpforms-lite litespeed-cache wp-crontrol wp-super-cache w3-total-cache wp-fastest-cache wp-optimize sg-cachepress" # Don't include this repository's Plugin here.
+      INSTALL_PLUGINS: "admin-menu-editor autoptimize beaver-builder-lite-version contact-form-7 classic-editor custom-post-type-ui elementor forminator jetpack-boost woocommerce wordpress-seo wpforms-lite litespeed-cache wp-crontrol wp-super-cache w3-total-cache wp-fastest-cache wp-optimize sg-cachepress" # Don't include this repository's Plugin here.
       INSTALL_PLUGINS_URLS: "https://downloads.wordpress.org/plugin/convertkit-for-woocommerce.1.6.4.zip http://cktestplugins.wpengine.com/wp-content/uploads/2024/01/convertkit-action-filter-tests.zip" # URLs to specific third party Plugins
       CONVERTKIT_API_KEY: ${{ secrets.CONVERTKIT_API_KEY }} # ConvertKit API Key, stored in the repository's Settings > Secrets
       CONVERTKIT_API_SECRET: ${{ secrets.CONVERTKIT_API_SECRET }} # ConvertKit API Secret, stored in the repository's Settings > Secrets

--- a/TESTING.md
+++ b/TESTING.md
@@ -293,7 +293,6 @@ Our Acceptance Tests can now call `$I->checkNoWarningsAndNoticesOnScreen($I)`, i
 error check for every test.
 
 Further Acceptance Test Helpers that are provided include:
-- `maybeCloseGutenbergWelcomeModal($I)`: Closes the Gutenberg welcome modal when adding a Page or Post.
 - `activateConvertKitPlugin($I)`: Logs in to WordPress as the `admin` user, and activates the ConvertKit Plugin.
 - `deactivateConvertKitPlugin($I)`: Logs in to WordPress as the `admin` user, and deactivates the ConvertKit Plugin.
 - `activateThirdPartyPlugin($I, $name)`: Logs in to WordPress as the `admin` user, and activates the given third party Plugin by its slug.

--- a/tests/_data/dump.sql
+++ b/tests/_data/dump.sql
@@ -369,7 +369,8 @@ INSERT INTO `wp_usermeta` (`umeta_id`, `user_id`, `meta_key`, `meta_value`) VALU
 (18,  1,  'wp_user-settings-time',  '1676637417'),
 (19,  1,  'wp_dashboard_quick_press_last_post_id',  '1'),
 (20,  1,  'edit_page_per_page',  '100'),
-(21,  1,  'edit_post_per_page',  '100');
+(21,  1,  'edit_post_per_page',  '100'),
+(22,  1,  'wp_persisted_preferences', 'a:3:{s:4:"core";a:1:{s:26:"isComplementaryAreaVisible";b:1;}s:14:"core/edit-post";a:1:{s:12:"welcomeGuide";b:0;}s:9:"_modified";s:24:"2024-07-18T02:22:36.743Z";}');
 
 DROP TABLE IF EXISTS `wp_users`;
 CREATE TABLE `wp_users` (

--- a/tests/_data/dump.sql
+++ b/tests/_data/dump.sql
@@ -370,7 +370,7 @@ INSERT INTO `wp_usermeta` (`umeta_id`, `user_id`, `meta_key`, `meta_value`) VALU
 (19,  1,  'wp_dashboard_quick_press_last_post_id',  '1'),
 (20,  1,  'edit_page_per_page',  '100'),
 (21,  1,  'edit_post_per_page',  '100'),
-(22,  1,  'wp_persisted_preferences', 'a:3:{s:4:"core";a:1:{s:26:"isComplementaryAreaVisible";b:1;}s:14:"core/edit-post";a:1:{s:12:"welcomeGuide";b:0;}s:9:"_modified";s:24:"2024-07-18T02:22:36.743Z";}');
+(22,  1,  'wp_persisted_preferences', 'a:4:{s:4:"core";a:1:{s:26:"isComplementaryAreaVisible";b:1;}s:14:"core/edit-post";a:1:{s:12:"welcomeGuide";b:0;}s:9:"_modified";s:24:"2024-07-18T02:45:41.491Z";s:17:"core/edit-widgets";a:2:{s:26:"isComplementaryAreaVisible";b:1;s:12:"welcomeGuide";b:0;}}');
 
 DROP TABLE IF EXISTS `wp_users`;
 CREATE TABLE `wp_users` (

--- a/tests/_support/Helper/Acceptance/WPGutenberg.php
+++ b/tests/_support/Helper/Acceptance/WPGutenberg.php
@@ -10,30 +10,6 @@ namespace Helper\Acceptance;
 class WPGutenberg extends \Codeception\Module
 {
 	/**
-	 * Helper method to close the Gutenberg "Welcome to the block editor" dialog, which
-	 * might show for each Page/Post test performed due to there being no persistence
-	 * remembering that the user dismissed the dialog.
-	 *
-	 * @since   1.9.6
-	 *
-	 * @param   AcceptanceTester $I Acceptance Tester.
-	 */
-	public function maybeCloseGutenbergWelcomeModal($I)
-	{
-		try {
-			$I->performOn(
-				'.components-modal__screen-overlay',
-				[
-					'click' => '.components-modal__screen-overlay .components-modal__header button.components-button',
-				],
-				3
-			);
-		} catch ( \Facebook\WebDriver\Exception\TimeoutException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-			// No modal exists, so nothing to dismiss.
-		}
-	}
-
-	/**
 	 * Add a Page, Post or Custom Post Type using Gutenberg in WordPress.
 	 *
 	 * @since   1.9.7.5
@@ -46,9 +22,6 @@ class WPGutenberg extends \Codeception\Module
 	{
 		// Navigate to Post Type (e.g. Pages / Posts) > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=' . $postType);
-
-		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed.
-		$I->maybeCloseGutenbergWelcomeModal($I);
 
 		// Define the Title.
 		$I->fillField('.editor-post-title__input', $title);

--- a/tests/_support/Helper/Acceptance/WPWidget.php
+++ b/tests/_support/Helper/Acceptance/WPWidget.php
@@ -24,9 +24,6 @@ class WPWidget extends \Codeception\Module
 		// Navigate to Appearance > Widgets.
 		$I->amOnAdminPage('widgets.php');
 
-		// Dismiss welcome message.
-		$I->maybeCloseGutenbergWelcomeModal($I);
-
 		// Click Add Block Button.
 		$I->click('button.edit-widgets-header-toolbar__inserter-toggle');
 
@@ -110,9 +107,6 @@ class WPWidget extends \Codeception\Module
 	{
 		// Navigate to Appearance > Widgets.
 		$I->amOnAdminPage('widgets.php');
-
-		// Dismiss welcome message.
-		$I->maybeCloseGutenbergWelcomeModal($I);
 
 		// Click Add Block Button.
 		$I->click('button.edit-widgets-header-toolbar__inserter-toggle');

--- a/tests/acceptance/broadcasts/import-export/BroadcastsToPostsCest.php
+++ b/tests/acceptance/broadcasts/import-export/BroadcastsToPostsCest.php
@@ -549,9 +549,6 @@ class BroadcastsToPostsCest
 		// Confirm the HTML Template Test's Restrict Content setting is correct.
 		$I->click($_ENV['CONVERTKIT_API_BROADCAST_FIRST_TITLE']);
 
-		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed.
-		$I->maybeCloseGutenbergWelcomeModal($I);
-
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 

--- a/tests/acceptance/forms/post-types/PageNoFormCest.php
+++ b/tests/acceptance/forms/post-types/PageNoFormCest.php
@@ -23,9 +23,6 @@ class PageNoFormCest
 		// Navigate to Pages > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=page');
 
-		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed.
-		$I->maybeCloseGutenbergWelcomeModal($I);
-
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 	}

--- a/tests/acceptance/general/PageCest.php
+++ b/tests/acceptance/general/PageCest.php
@@ -31,9 +31,6 @@ class PageCest
 		// Navigate to Pages > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=page');
 
-		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed.
-		$I->maybeCloseGutenbergWelcomeModal($I);
-
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 

--- a/tests/acceptance/general/PostCest.php
+++ b/tests/acceptance/general/PostCest.php
@@ -31,9 +31,6 @@ class PostCest
 		// Navigate to Posts > Add New.
 		$I->amOnAdminPage('post-new.php');
 
-		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed.
-		$I->maybeCloseGutenbergWelcomeModal($I);
-
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 

--- a/tests/acceptance/general/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/general/RefreshResourcesButtonCest.php
@@ -36,9 +36,6 @@ class RefreshResourcesButtonCest
 		// Navigate to Pages > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=page');
 
-		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed.
-		$I->maybeCloseGutenbergWelcomeModal($I);
-
 		// Click the Forms refresh button.
 		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
 
@@ -365,9 +362,6 @@ class RefreshResourcesButtonCest
 
 		// Navigate to Pages > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=page');
-
-		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed.
-		$I->maybeCloseGutenbergWelcomeModal($I);
 
 		// Click the Forms refresh button.
 		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');


### PR DESCRIPTION
## Summary

For tests, adds `wp_persisted_preferences` in the dump SQL file to disable welcome messages and tips, and removes the `disable-welcome-messages-and-tips` Plugin now that the settings are persisted directly to the database.

This replaces using the `maybeCloseGutenbergWelcomeModal`, which was proving unreliable in tests run on WordPress 6.6, resulting in the modal still displaying:

![RestrictContentProductCPTCest testRestrictContentWhenDisabled fail](https://github.com/user-attachments/assets/0963bcaf-e962-4fbe-aad7-8647117d5625)

## Testing

Existing tests pass

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)