### PR TITLE
Forminator: Option to Subscribe; add Tag / Sequence to Subscriber

### DIFF
--- a/includes/class-convertkit-setup.php
+++ b/includes/class-convertkit-setup.php
@@ -45,6 +45,13 @@ class ConvertKit_Setup {
 		}
 
 		/**
+		 * 2.5.2: Migrate Forminator to ConvertKit Form Mappings
+		 */
+		if ( ! $current_version || version_compare( $current_version, '2.5.2', '<' ) ) {
+			$this->migrate_forminator_form_mapping_settings();
+		}
+
+		/**
 		 * 2.5.2: Migrate Contact Form 7 to ConvertKit Form Mappings
 		 */
 		if ( ! $current_version || version_compare( $current_version, '2.5.2', '<' ) ) {
@@ -98,7 +105,52 @@ class ConvertKit_Setup {
 	}
 
 	/**
-	 * 2.5.2: Prefix any Contact Form 7 to ConvertKit Form ID mappings with `form_`, now that
+	 * 2.5.2: Prefix any Forminator to ConvertKit Form ID mappings with `form:`, now that
+	 * the Plugin supports adding a subscriber to a Form, Tag or Sequence.
+	 *
+	 * @since   2.5.2
+	 */
+	private function migrate_forminator_form_mapping_settings() {
+
+		$convertkit_forminator_settings = new ConvertKit_Forminator_Settings();
+
+		// Bail if no settings exist.
+		if ( ! $convertkit_forminator_settings->has_settings() ) {
+			return;
+		}
+
+		// Get settings.
+		$settings = $convertkit_forminator_settings->get();
+
+		// Iterate through settings.
+		foreach ( $settings as $forminator_form_id => $convertkit_form_id ) {
+			// Skip keys that are non-numeric e.g. `creator_network_recommendations_*`.
+			if ( ! is_numeric( $forminator_form_id ) ) {
+				continue;
+			}
+
+			// Skip values that are blank i.e. no ConvertKit Form ID specified.
+			if ( empty( $convertkit_form_id ) ) {
+				continue;
+			}
+
+			// Skip values that are non-numeric i.e. the `form_` prefix was already added.
+			// This should never happen as this routine runs once, but this is a sanity check.
+			if ( ! is_numeric( $convertkit_form_id ) ) {
+				continue;
+			}
+
+			// Prefix the ConvertKit Form ID with `form_`.
+			$settings[ $forminator_form_id ] = 'form:' . $convertkit_form_id;
+		}
+
+		// Update settings.
+		update_option( $convertkit_forminator_settings::SETTINGS_NAME, $settings );
+
+	}
+
+	/**
+	 * 2.5.2: Prefix any Contact Form 7 to ConvertKit Form ID mappings with `form:`, now that
 	 * the Plugin supports adding a subscriber to a Form, Tag or Sequence.
 	 *
 	 * @since   2.5.2

--- a/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
+++ b/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
@@ -96,20 +96,6 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 
 		do_settings_sections( $this->settings_key );
 
-		// Get Forms.
-		$forms                           = new ConvertKit_Resource_Forms( 'forminator' );
-		$creator_network_recommendations = new ConvertKit_Resource_Creator_Network_Recommendations( 'forminator' );
-
-		// Bail with an error if no ConvertKit Forms exist.
-		if ( ! $forms->exist() ) {
-			$this->output_error( __( 'No Forms exist on ConvertKit.', 'convertkit' ) );
-			$this->render_container_end();
-			return;
-		}
-
-		// Get Creator Network Recommendations script.
-		$creator_network_recommendations_enabled = $creator_network_recommendations->enabled();
-
 		// Get Forminator Forms.
 		$forminator_forms = $this->get_forminator_forms();
 
@@ -120,10 +106,14 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 			return;
 		}
 
+		// Get Creator Network Recommendations script.
+		$creator_network_recommendations         = new ConvertKit_Resource_Creator_Network_Recommendations( 'forminator' );
+		$creator_network_recommendations_enabled = $creator_network_recommendations->enabled();
+
 		// Setup WP_List_Table.
 		$table = new Multi_Value_Field_Table();
 		$table->add_column( 'title', __( 'Forminator Form', 'convertkit' ), true );
-		$table->add_column( 'form', __( 'ConvertKit Form', 'convertkit' ), false );
+		$table->add_column( 'form', __( 'ConvertKit', 'convertkit' ), false );
 		$table->add_column( 'creator_network_recommendations', __( 'Enable Creator Network Recommendations', 'convertkit' ), false );
 
 		// Iterate through Forminator Forms, adding a table row for each Forminator Form.
@@ -131,14 +121,12 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 			// Build row.
 			$table_row = array(
 				'title' => $forminator_form['name'],
-				'form'  => $forms->get_select_field_all(
-					'_wp_convertkit_integration_forminator_settings[' . $forminator_form['id'] . ']',
-					'_wp_convertkit_integration_forminator_settings_' . $forminator_form['id'] . '',
-					false,
+				'form'  => convertkit_get_subscription_dropdown_field(
+					'_wp_convertkit_integration_contactform7_settings[' . $forminator_form['id'] . ']',
 					(string) $this->settings->get_convertkit_form_id_by_forminator_form_id( $forminator_form['id'] ),
-					array(
-						'' => __( 'None', 'convertkit' ),
-					)
+					'_wp_convertkit_integration_contactform7_settings_' . $forminator_form['id'],
+					'widefat',
+					'forminator'
 				),
 			);
 

--- a/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
+++ b/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
@@ -124,7 +124,7 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 				'form'  => convertkit_get_subscription_dropdown_field(
 					'_wp_convertkit_integration_forminator_settings[' . $forminator_form['id'] . ']',
 					(string) $this->settings->get_convertkit_subscribe_setting_by_forminator_form_id( $forminator_form['id'] ),
-					'_wp_convertkit_integration_forminator_settings' . $forminator_form['id'],
+					'_wp_convertkit_integration_forminator_settings_' . $forminator_form['id'],
 					'widefat',
 					'forminator'
 				),

--- a/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
+++ b/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
@@ -122,9 +122,9 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 			$table_row = array(
 				'title' => $forminator_form['name'],
 				'form'  => convertkit_get_subscription_dropdown_field(
-					'_wp_convertkit_integration_contactform7_settings[' . $forminator_form['id'] . ']',
-					(string) $this->settings->get_convertkit_form_id_by_forminator_form_id( $forminator_form['id'] ),
-					'_wp_convertkit_integration_contactform7_settings_' . $forminator_form['id'],
+					'_wp_convertkit_integration_forminator_settings[' . $forminator_form['id'] . ']',
+					(string) $this->settings->get_convertkit_subscribe_setting_by_forminator_form_id( $forminator_form['id'] ),
+					'_wp_convertkit_integration_forminator_settings' . $forminator_form['id'],
 					'widefat',
 					'forminator'
 				),

--- a/includes/integrations/forminator/class-convertkit-forminator-settings.php
+++ b/includes/integrations/forminator/class-convertkit-forminator-settings.php
@@ -87,9 +87,9 @@ class ConvertKit_Forminator_Settings {
 	 * @since   2.3.0
 	 *
 	 * @param   int $forminator_form_id    Forminator Form ID.
-	 * @return  bool|int
+	 * @return  bool|string|int
 	 */
-	public function get_convertkit_form_id_by_forminator_form_id( $forminator_form_id ) {
+	public function get_convertkit_subscribe_setting_by_forminator_form_id( $forminator_form_id ) {
 
 		// Bail if no settings exist.
 		if ( ! $this->has_settings() ) {

--- a/includes/integrations/forminator/class-convertkit-forminator.php
+++ b/includes/integrations/forminator/class-convertkit-forminator.php
@@ -132,21 +132,54 @@ class ConvertKit_Forminator {
 			'forminator'
 		);
 
-		// For Legacy Forms, a different endpoint is used.
-		$forms = new ConvertKit_Resource_Forms();
-		if ( $forms->is_legacy( $convertkit_form_id ) ) {
-			return $api->legacy_form_subscribe(
-				$convertkit_form_id,
-				$email,
-				$first_name
-			);
+		// Subscribe the email address.
+		$subscriber = $api->create_subscriber( $email, $first_name );
+		if ( is_wp_error( $subscriber ) ) {
+			return;
 		}
 
-		return $api->form_subscribe(
-			$convertkit_form_id,
-			$email,
-			$first_name
-		);
+		// If the setting is 'Subscribe', no Form needs to be assigned to the subscriber.
+		if ( $convertkit_subscribe_setting === 'subscribe' ) {
+			return;
+		}
+
+		// Determine the resource type and ID to assign to the subscriber.
+		list( $resource_type, $resource_id ) = explode( ':', $convertkit_subscribe_setting );
+
+		// Cast ID.
+		$resource_id = absint( $resource_id );
+
+		// Add the subscriber to the resource type (form, tag etc).
+		switch ( $resource_type ) {
+
+			/**
+			 * Form
+			 */
+			case 'form':
+				// For Legacy Forms, a different endpoint is used.
+				$forms = new ConvertKit_Resource_Forms();
+				if ( $forms->is_legacy( $resource_id ) ) {
+					return $api->add_subscriber_to_legacy_form( $resource_id, $subscriber['subscriber']['id'] );
+				}
+
+				// Add subscriber to form.
+				return $api->add_subscriber_to_form( $resource_id, $subscriber['subscriber']['id'] );
+
+			/**
+			 * Sequence
+			 */
+			case 'sequence':
+				// Add subscriber to sequence.
+				return $api->add_subscriber_to_sequence( $resource_id, $subscriber['subscriber']['id'] );
+
+			/**
+			 * Tag
+			 */
+			case 'tag':
+				// Add subscriber to tag.
+				return $api->tag_subscriber( $resource_id, $subscriber['subscriber']['id'] );
+
+		}
 
 	}
 

--- a/includes/integrations/forminator/class-convertkit-forminator.php
+++ b/includes/integrations/forminator/class-convertkit-forminator.php
@@ -81,7 +81,7 @@ class ConvertKit_Forminator {
 		// We deliberately use the entry's form ID, as $form_id for a Quiz will point to a lead generation form, which
 		// has a different Form ID.
 		$forminator_settings = new ConvertKit_Forminator_Settings();
-		$convertkit_form_id  = $forminator_settings->get_convertkit_form_id_by_forminator_form_id( $entry->form_id );
+		$convertkit_subscribe_setting  = $forminator_settings->get_convertkit_subscribe_setting_by_forminator_form_id( $entry->form_id );
 
 		// If no ConvertKit Form is mapped to this Forminator Form, bail.
 		if ( ! $convertkit_form_id ) {

--- a/includes/integrations/forminator/class-convertkit-forminator.php
+++ b/includes/integrations/forminator/class-convertkit-forminator.php
@@ -83,8 +83,8 @@ class ConvertKit_Forminator {
 		$forminator_settings = new ConvertKit_Forminator_Settings();
 		$convertkit_subscribe_setting  = $forminator_settings->get_convertkit_subscribe_setting_by_forminator_form_id( $entry->form_id );
 
-		// If no ConvertKit Form is mapped to this Forminator Form, bail.
-		if ( ! $convertkit_form_id ) {
+		// If no ConvertKit subscribe setting is defined, bail.
+		if ( ! $convertkit_subscribe_setting ) {
 			return;
 		}
 

--- a/includes/integrations/forminator/class-convertkit-forminator.php
+++ b/includes/integrations/forminator/class-convertkit-forminator.php
@@ -80,8 +80,8 @@ class ConvertKit_Forminator {
 		// Get ConvertKit Form ID mapped to this Forminator Form.
 		// We deliberately use the entry's form ID, as $form_id for a Quiz will point to a lead generation form, which
 		// has a different Form ID.
-		$forminator_settings = new ConvertKit_Forminator_Settings();
-		$convertkit_subscribe_setting  = $forminator_settings->get_convertkit_subscribe_setting_by_forminator_form_id( $entry->form_id );
+		$forminator_settings          = new ConvertKit_Forminator_Settings();
+		$convertkit_subscribe_setting = $forminator_settings->get_convertkit_subscribe_setting_by_forminator_form_id( $entry->form_id );
 
 		// If no ConvertKit subscribe setting is defined, bail.
 		if ( ! $convertkit_subscribe_setting ) {

--- a/tests/acceptance/integrations/other/ForminatorCest.php
+++ b/tests/acceptance/integrations/other/ForminatorCest.php
@@ -991,6 +991,43 @@ class ForminatorCest
 	}
 
 	/**
+	 * Tests that existing settings are automatically migrated when updating
+	 * the Plugin to 2.5.2 or higher.
+	 *
+	 * @since   2.5.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSettingsMigratedOnUpgrade(AcceptanceTester $I)
+	{
+		// Create settings as if they were created / edited when the ConvertKit Plugin < 2.5.2
+		// was active.
+		$I->haveOptionInDatabase(
+			'_wp_convertkit_integration_forminator_settings',
+			[
+				'1'                                 => $_ENV['CONVERTKIT_API_FORM_ID'],
+				'creator_network_recommendations_1' => '1',
+				'2'                                 => '',
+			]
+		);
+
+		// Downgrade the Plugin version to simulate an upgrade.
+		$I->haveOptionInDatabase('convertkit_version', '2.4.9');
+
+		// Load admin screen.
+		$I->amOnAdminPage('index.php');
+
+		// Check settings structure has been updated.
+		$settings = $I->grabOptionFromDatabase('_wp_convertkit_integration_forminator_settings');
+		$I->assertArrayHasKey('1', $settings);
+		$I->assertArrayHasKey('creator_network_recommendations_1', $settings);
+		$I->assertArrayHasKey('2', $settings);
+		$I->assertEquals($settings['1'], 'form:' . $_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->assertEquals($settings['creator_network_recommendations_1'], '1');
+		$I->assertEquals($settings['2'], '');
+	}
+
+	/**
 	 * Creates a Forminator Form
 	 *
 	 * @since   2.3.0

--- a/tests/acceptance/integrations/other/ForminatorCest.php
+++ b/tests/acceptance/integrations/other/ForminatorCest.php
@@ -199,6 +199,75 @@ class ForminatorCest
 	 */
 	public function testSettingsForminatorFormToConvertKitTagMapping(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPluginNoDefaultForms($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Create Forminator Form.
+		$forminatorFormID = $this->_createForminatorForm($I);
+
+		// Load Forminator Plugin Settings.
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=forminator');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check that a Form Mapping option is displayed.
+		$I->seeElementInDOM('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID);
+
+		// Change Form to value specified in the .env file.
+		$I->selectOption('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID, $_ENV['CONVERTKIT_API_TAG_NAME']);
+
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check the value of the Form field matches the input provided.
+		$I->seeOptionIsSelected('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID, $_ENV['CONVERTKIT_API_TAG_NAME']);
+
+		// Create Page with Forminator Shortcode.
+		$I->havePageInDatabase(
+			[
+				'post_title'   => 'ConvertKit: Forminator Shortcode: Tag',
+				'post_name'    => 'convertkit-forminator-form-shortcode-tag',
+				'post_content' => 'Form:
+[forminator_form id="' . $forminatorFormID . '"]',
+			]
+		);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/convertkit-forminator-form-shortcode-tag');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Complete Name and Email.
+		$I->fillField('input[name=name-1]', 'ConvertKit Name');
+		$I->fillField('input[name=email-1]', $emailAddress);
+
+		// Submit Form.
+		$I->click('button.forminator-button-submit');
+
+		// Wait for response message.
+		$I->waitForElementVisible('.forminator-response-message');
+
+		// Confirm the form submitted without errors.
+		$I->performOn(
+			'.forminator-response-message',
+			function($I) {
+				$I->see('Form entry saved');
+			}
+		);
+
+		// Confirm that the email address was added to ConvertKit.
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+
+		// Check that the subscriber has been assigned to the tag.
+		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
 	}
 
 	/**
@@ -210,6 +279,75 @@ class ForminatorCest
 	 */
 	public function testSettingsForminatorFormToConvertKitSequenceMapping(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPluginNoDefaultForms($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Create Forminator Form.
+		$forminatorFormID = $this->_createForminatorForm($I);
+
+		// Load Forminator Plugin Settings.
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=forminator');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check that a Form Mapping option is displayed.
+		$I->seeElementInDOM('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID);
+
+		// Change Form to value specified in the .env file.
+		$I->selectOption('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID, $_ENV['CONVERTKIT_API_SEQUENCE_NAME']);
+
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check the value of the Form field matches the input provided.
+		$I->seeOptionIsSelected('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID, $_ENV['CONVERTKIT_API_SEQUENCE_NAME']);
+
+		// Create Page with Forminator Shortcode.
+		$I->havePageInDatabase(
+			[
+				'post_title'   => 'ConvertKit: Forminator Shortcode: Sequence',
+				'post_name'    => 'convertkit-forminator-form-shortcode-sequence',
+				'post_content' => 'Form:
+[forminator_form id="' . $forminatorFormID . '"]',
+			]
+		);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/convertkit-forminator-form-shortcode-sequence');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Complete Name and Email.
+		$I->fillField('input[name=name-1]', 'ConvertKit Name');
+		$I->fillField('input[name=email-1]', $emailAddress);
+
+		// Submit Form.
+		$I->click('button.forminator-button-submit');
+
+		// Wait for response message.
+		$I->waitForElementVisible('.forminator-response-message');
+
+		// Confirm the form submitted without errors.
+		$I->performOn(
+			'.forminator-response-message',
+			function($I) {
+				$I->see('Form entry saved');
+			}
+		);
+
+		// Confirm that the email address was added to ConvertKit.
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+
+		// Check that the subscriber has been assigned to the sequence.
+		$I->apiCheckSubscriberHasSequence($I, $subscriberID, $_ENV['CONVERTKIT_API_SEQUENCE_ID']);
 	}
 
 	/**
@@ -221,6 +359,72 @@ class ForminatorCest
 	 */
 	public function testSettingsForminatorFormDoNotSubscribeOption(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPluginNoDefaultForms($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Create Forminator Form.
+		$forminatorFormID = $this->_createForminatorForm($I);
+
+		// Load Forminator Plugin Settings.
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=forminator');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check that a Form Mapping option is displayed.
+		$I->seeElementInDOM('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID);
+
+		// Change Form to value specified in the .env file.
+		$I->selectOption('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID, '(Do not subscribe)');
+
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check the value of the Form field matches the input provided.
+		$I->seeOptionIsSelected('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID, '(Do not subscribe)');
+
+		// Create Page with Forminator Shortcode.
+		$I->havePageInDatabase(
+			[
+				'post_title'   => 'ConvertKit: Forminator Shortcode: Do not subscribe',
+				'post_name'    => 'convertkit-forminator-form-shortcode-do-not-subscribe',
+				'post_content' => 'Form:
+[forminator_form id="' . $forminatorFormID . '"]',
+			]
+		);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/convertkit-forminator-form-shortcode-do-not-subscribe');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Complete Name and Email.
+		$I->fillField('input[name=name-1]', 'ConvertKit Name');
+		$I->fillField('input[name=email-1]', $emailAddress);
+
+		// Submit Form.
+		$I->click('button.forminator-button-submit');
+
+		// Wait for response message.
+		$I->waitForElementVisible('.forminator-response-message');
+
+		// Confirm the form submitted without errors.
+		$I->performOn(
+			'.forminator-response-message',
+			function($I) {
+				$I->see('Form entry saved');
+			}
+		);
+
+		// Confirm that the email address was not added to ConvertKit.
+		$I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
 	}
 
 	/**
@@ -232,6 +436,72 @@ class ForminatorCest
 	 */
 	public function testSettingsForminatorFormSubscribeOption(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPluginNoDefaultForms($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Create Forminator Form.
+		$forminatorFormID = $this->_createForminatorForm($I);
+
+		// Load Forminator Plugin Settings.
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=forminator');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check that a Form Mapping option is displayed.
+		$I->seeElementInDOM('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID);
+
+		// Change Form to value specified in the .env file.
+		$I->selectOption('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID, 'Subscribe');
+
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check the value of the Form field matches the input provided.
+		$I->seeOptionIsSelected('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID, 'Subscribe');
+
+		// Create Page with Forminator Shortcode.
+		$I->havePageInDatabase(
+			[
+				'post_title'   => 'ConvertKit: Forminator Shortcode: Subscribe',
+				'post_name'    => 'convertkit-forminator-form-shortcode-subscribe',
+				'post_content' => 'Form:
+[forminator_form id="' . $forminatorFormID . '"]',
+			]
+		);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/convertkit-forminator-form-shortcode-subscribe');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Complete Name and Email.
+		$I->fillField('input[name=name-1]', 'ConvertKit Name');
+		$I->fillField('input[name=email-1]', $emailAddress);
+
+		// Submit Form.
+		$I->click('button.forminator-button-submit');
+
+		// Wait for response message.
+		$I->waitForElementVisible('.forminator-response-message');
+
+		// Confirm the form submitted without errors.
+		$I->performOn(
+			'.forminator-response-message',
+			function($I) {
+				$I->see('Form entry saved');
+			}
+		);
+
+		// Confirm that the email address was added to ConvertKit.
+		$I->apiCheckSubscriberExists($I, $emailAddress);
 	}
 
 	/**
@@ -317,6 +587,72 @@ class ForminatorCest
 	 */
 	public function testSettingsForminatorQuizToConvertKitTagMapping(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPluginNoDefaultForms($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Create Forminator Quiz.
+		$forminatorFormID = $this->_createForminatorQuiz($I);
+
+		// Load Forminator Plugin Settings.
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=forminator');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check that a Form Mapping option is displayed.
+		$I->seeElementInDOM('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID);
+
+		// Change Form to value specified in the .env file.
+		$I->selectOption('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID, $_ENV['CONVERTKIT_API_TAG_NAME']);
+
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check the value of the Form field matches the input provided.
+		$I->seeOptionIsSelected('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID, $_ENV['CONVERTKIT_API_TAG_NAME']);
+
+		// Create Page with Forminator Shortcode.
+		$I->havePageInDatabase(
+			[
+				'post_title'   => 'ConvertKit: Forminator Quiz Shortcode: Tag',
+				'post_name'    => 'convertkit-forminator-quiz-shortcode-tag',
+				'post_content' => 'Form:
+[forminator_quiz id="' . $forminatorFormID . '"]',
+			]
+		);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/convertkit-forminator-quiz-shortcode-tag');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Complete quiz.
+		$I->checkOption('answers[question-1-0]', '0');
+		$I->click('View Results');
+
+		// Complete Name and Email.
+		$I->waitForElementVisible('input[name=name-1]');
+		$I->fillField('input[name=name-1]', 'ConvertKit Name');
+		$I->fillField('input[name=email-1]', $emailAddress);
+
+		// Submit Form.
+		$I->click('Submit');
+
+		// Wait for submission to complete.
+		$I->waitForElementVisible('.forminator-icon-check');
+
+		// Confirm that the email address was added to ConvertKit.
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+
+		// Check that the subscriber has been assigned to the tag.
+		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
 	}
 
 	/**
@@ -328,6 +664,72 @@ class ForminatorCest
 	 */
 	public function testSettingsForminatorQuizToConvertKitSequenceMapping(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPluginNoDefaultForms($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Create Forminator Quiz.
+		$forminatorFormID = $this->_createForminatorQuiz($I);
+
+		// Load Forminator Plugin Settings.
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=forminator');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check that a Form Mapping option is displayed.
+		$I->seeElementInDOM('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID);
+
+		// Change Form to value specified in the .env file.
+		$I->selectOption('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID, $_ENV['CONVERTKIT_API_SEQUENCE_NAME']);
+
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check the value of the Form field matches the input provided.
+		$I->seeOptionIsSelected('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID, $_ENV['CONVERTKIT_API_SEQUENCE_NAME']);
+
+		// Create Page with Forminator Shortcode.
+		$I->havePageInDatabase(
+			[
+				'post_title'   => 'ConvertKit: Forminator Quiz Shortcode: Sequence',
+				'post_name'    => 'convertkit-forminator-quiz-shortcode-sequence',
+				'post_content' => 'Form:
+[forminator_quiz id="' . $forminatorFormID . '"]',
+			]
+		);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/convertkit-forminator-quiz-shortcode-sequence');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Complete quiz.
+		$I->checkOption('answers[question-1-0]', '0');
+		$I->click('View Results');
+
+		// Complete Name and Email.
+		$I->waitForElementVisible('input[name=name-1]');
+		$I->fillField('input[name=name-1]', 'ConvertKit Name');
+		$I->fillField('input[name=email-1]', $emailAddress);
+
+		// Submit Form.
+		$I->click('Submit');
+
+		// Wait for submission to complete.
+		$I->waitForElementVisible('.forminator-icon-check');
+
+		// Confirm that the email address was added to ConvertKit.
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+
+		// Check that the subscriber has been assigned to the sequence.
+		$I->apiCheckSubscriberHasSequence($I, $subscriberID, $_ENV['CONVERTKIT_API_SEQUENCE_ID']);
 	}
 
 	/**
@@ -339,6 +741,69 @@ class ForminatorCest
 	 */
 	public function testSettingsForminatorQuizDoNotSubscribeOption(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPluginNoDefaultForms($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Create Forminator Quiz.
+		$forminatorFormID = $this->_createForminatorQuiz($I);
+
+		// Load Forminator Plugin Settings.
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=forminator');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check that a Form Mapping option is displayed.
+		$I->seeElementInDOM('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID);
+
+		// Change Form to value specified in the .env file.
+		$I->selectOption('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID, '(Do not subscribe)');
+
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check the value of the Form field matches the input provided.
+		$I->seeOptionIsSelected('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID, '(Do not subscribe)');
+
+		// Create Page with Forminator Shortcode.
+		$I->havePageInDatabase(
+			[
+				'post_title'   => 'ConvertKit: Forminator Quiz Shortcode: Do not subscribe',
+				'post_name'    => 'convertkit-forminator-quiz-shortcode-do-not-subscribe',
+				'post_content' => 'Form:
+[forminator_quiz id="' . $forminatorFormID . '"]',
+			]
+		);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/convertkit-forminator-quiz-shortcode-do-not-subscribe');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Complete quiz.
+		$I->checkOption('answers[question-1-0]', '0');
+		$I->click('View Results');
+
+		// Complete Name and Email.
+		$I->waitForElementVisible('input[name=name-1]');
+		$I->fillField('input[name=name-1]', 'ConvertKit Name');
+		$I->fillField('input[name=email-1]', $emailAddress);
+
+		// Submit Form.
+		$I->click('Submit');
+
+		// Wait for submission to complete.
+		$I->waitForElementVisible('.forminator-icon-check');
+
+		// Confirm that the email address was not added to ConvertKit.
+		$I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
 	}
 
 	/**
@@ -350,6 +815,69 @@ class ForminatorCest
 	 */
 	public function testSettingsForminatorQuizSubscribeOption(AcceptanceTester $I)
 	{
+		// Setup ConvertKit Plugin.
+		$I->setupConvertKitPluginNoDefaultForms($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Create Forminator Quiz.
+		$forminatorFormID = $this->_createForminatorQuiz($I);
+
+		// Load Forminator Plugin Settings.
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=forminator');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check that a Form Mapping option is displayed.
+		$I->seeElementInDOM('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID);
+
+		// Change Form to value specified in the .env file.
+		$I->selectOption('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID, '(Do not subscribe)');
+
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check the value of the Form field matches the input provided.
+		$I->seeOptionIsSelected('#_wp_convertkit_integration_forminator_settings_' . $forminatorFormID, '(Do not subscribe)');
+
+		// Create Page with Forminator Shortcode.
+		$I->havePageInDatabase(
+			[
+				'post_title'   => 'ConvertKit: Forminator Quiz Shortcode: Subscribe',
+				'post_name'    => 'convertkit-forminator-quiz-shortcode-subscribe',
+				'post_content' => 'Form:
+[forminator_quiz id="' . $forminatorFormID . '"]',
+			]
+		);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/convertkit-forminator-quiz-shortcode-subscribe');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Complete quiz.
+		$I->checkOption('answers[question-1-0]', '0');
+		$I->click('View Results');
+
+		// Complete Name and Email.
+		$I->waitForElementVisible('input[name=name-1]');
+		$I->fillField('input[name=name-1]', 'ConvertKit Name');
+		$I->fillField('input[name=email-1]', $emailAddress);
+
+		// Submit Form.
+		$I->click('Submit');
+
+		// Wait for submission to complete.
+		$I->waitForElementVisible('.forminator-icon-check');
+
+		// Confirm that the email address was not added to ConvertKit.
+		$I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
 	}
 
 	/**

--- a/tests/acceptance/integrations/other/ForminatorCest.php
+++ b/tests/acceptance/integrations/other/ForminatorCest.php
@@ -351,7 +351,7 @@ class ForminatorCest
 	}
 
 	/**
-	 * Test that setting a Forminator Form Form to the '(Do not subscribe)' option works.
+	 * Test that setting a Forminator Form to the '(Do not subscribe)' option works.
 	 *
 	 * @since   2.5.2
 	 *

--- a/tests/acceptance/integrations/other/ForminatorCest.php
+++ b/tests/acceptance/integrations/other/ForminatorCest.php
@@ -37,30 +37,6 @@ class ForminatorCest
 	}
 
 	/**
-	 * Tests that no Forminator settings display and a 'No Forms exist on ConvertKit'
-	 * notification displays when no Forms exist.
-	 *
-	 * @since   2.3.0
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 */
-	public function testSettingsForminatorWhenNoForms(AcceptanceTester $I)
-	{
-		// Setup Plugin.
-		$I->setupConvertKitPluginCredentialsNoData($I);
-		$I->setupConvertKitPluginResourcesNoData($I);
-
-		// Load Forminator Plugin Settings.
-		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=forminator');
-
-		// Confirm notice is displayed.
-		$I->see('No Forms exist on ConvertKit.');
-
-		// Confirm no settings table is displayed.
-		$I->dontSeeElementInDOM('table.wp-list-table');
-	}
-
-	/**
 	 * Test that saving a Forminator Form to ConvertKit Form Mapping works.
 	 *
 	 * @since   2.3.0
@@ -215,6 +191,50 @@ class ForminatorCest
 	}
 
 	/**
+	 * Test that saving a Forminator Form to ConvertKit Tag Mapping works.
+	 *
+	 * @since   2.5.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSettingsForminatorFormToConvertKitTagMapping(AcceptanceTester $I)
+	{
+	}
+
+	/**
+	 * Test that saving a Forminator Form to ConvertKit Sequence Mapping works.
+	 *
+	 * @since   2.5.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSettingsForminatorFormToConvertKitSequenceMapping(AcceptanceTester $I)
+	{
+	}
+
+	/**
+	 * Test that setting a Forminator Form Form to the '(Do not subscribe)' option works.
+	 *
+	 * @since   2.5.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSettingsForminatorFormDoNotSubscribeOption(AcceptanceTester $I)
+	{
+	}
+
+	/**
+	 * Test that setting a Forminator Form to the 'Subscribe' option works.
+	 *
+	 * @since   2.5.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSettingsForminatorFormSubscribeOption(AcceptanceTester $I)
+	{
+	}
+
+	/**
 	 * Test that saving a Forminator Quiz to ConvertKit Form Mapping works.
 	 *
 	 * @since   2.4.3
@@ -286,6 +306,50 @@ class ForminatorCest
 
 		// Confirm that the email address was added to ConvertKit.
 		$I->apiCheckSubscriberExists($I, $emailAddress);
+	}
+
+	/**
+	 * Test that saving a Forminator Quiz to ConvertKit Tag Mapping works.
+	 *
+	 * @since   2.5.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSettingsForminatorQuizToConvertKitTagMapping(AcceptanceTester $I)
+	{
+	}
+
+	/**
+	 * Test that saving a Forminator Quiz to ConvertKit Sequence Mapping works.
+	 *
+	 * @since   2.5.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSettingsForminatorQuizToConvertKitSequenceMapping(AcceptanceTester $I)
+	{
+	}
+
+	/**
+	 * Test that setting a Forminator Quiz Form to the '(Do not subscribe)' option works.
+	 *
+	 * @since   2.5.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSettingsForminatorQuizDoNotSubscribeOption(AcceptanceTester $I)
+	{
+	}
+
+	/**
+	 * Test that setting a Forminator Quiz to the 'Subscribe' option works.
+	 *
+	 * @since   2.5.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSettingsForminatorQuizSubscribeOption(AcceptanceTester $I)
+	{
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Matching the Contact Form 7 PR's, this PR:
- Adds a `Subscribe` option
- Renames `None` to `(Do not subscribe)`
- Adds options to add a Tag or Sequence to the subscriber
- Migrates settings data to use the `form:` prefix on Plugin upgrade

<img width="971" alt="Screenshot 2024-07-24 at 14 17 27" src="https://github.com/user-attachments/assets/af25672b-b952-45bb-a25f-86efefad14b3">

## Testing

- `testSettingsForminatorFormToConvertKitTagMapping`: Test that saving a Forminator Form to ConvertKit Tag Mapping works.
- `testSettingsForminatorFormToConvertKitSequenceMapping`: Test that saving a Forminator Form to ConvertKit Sequence Mapping works.
- `testSettingsForminatorFormDoNotSubscribeOption`: Test that setting a Forminator Form to the '(Do not subscribe)' option works.
- `testSettingsForminatorFormSubscribeOption`: Test that setting a Forminator Form to the 'Subscribe' option works.
- `testSettingsForminatorQuizToConvertKitTagMapping`: Test that saving a Forminator Quiz to ConvertKit Tag Mapping works.
- `testSettingsForminatorQuizToConvertKitSequenceMapping`: Test that saving a Forminator Quiz to ConvertKit Sequence Mapping works.
- `testSettingsForminatorQuizDoNotSubscribeOption`: Test that setting a Forminator Quiz Form to the '(Do not subscribe)' option works.
- `testSettingsForminatorQuizSubscribeOption`: Test that setting a Forminator Quiz to the 'Subscribe' option works.

A lot of this test code is repetitive; I think a separate PR would be good to put most of the repeated steps in a single method.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)