### PR TITLE
Update Form Integration Descriptions

### DIFF
--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
@@ -68,13 +68,17 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 			?>
 		</p>
 		<p>
-			<?php echo esc_html_e( 'Each Contact Form 7 Form has the following ConvertKit options:', 'convertkit' ); ?>
+			<?php esc_html_e( 'Each Contact Form 7 Form has the following ConvertKit options:', 'convertkit' ); ?>
 			<br />
-			<code><?php echo esc_html_e( 'Do not subscribe', 'convertkit' ); ?></code>: <?php esc_html_e( 'Do not subscribe the email address to ConvertKit', 'convertkit' ); ?>
+			<code><?php esc_html_e( 'Do not subscribe', 'convertkit' ); ?></code>: <?php esc_html_e( 'Do not subscribe the email address to ConvertKit', 'convertkit' ); ?>
 			<br />
-			<code><?php echo esc_html_e( 'Subscribe', 'convertkit' ); ?></code>: <?php esc_html_e( 'Subscribes the email address to ConvertKit', 'convertkit' ); ?>
+			<code><?php esc_html_e( 'Subscribe', 'convertkit' ); ?></code>: <?php esc_html_e( 'Subscribes the email address to ConvertKit', 'convertkit' ); ?>
 			<br />
-			<code><?php echo esc_html_e( 'Form', 'convertkit' ); ?></code>: <?php esc_html_e( 'Susbcribes the email address to ConvertKit, and adds the subscriber to the ConvertKit Form', 'convertkit' ); ?>
+			<code><?php esc_html_e( 'Form', 'convertkit' ); ?></code>: <?php esc_html_e( 'Susbcribes the email address to ConvertKit, and adds the subscriber to the ConvertKit form', 'convertkit' ); ?>
+			<br />
+			<code><?php esc_html_e( 'Tag', 'convertkit' ); ?></code>: <?php esc_html_e( 'Susbcribes the email address to ConvertKit, tagging the subscriber', 'convertkit' ); ?>
+			<br />
+			<code><?php esc_html_e( 'Sequence', 'convertkit' ); ?></code>: <?php esc_html_e( 'Susbcribes the email address to ConvertKit, and adds the subscriber to the ConvertKit sequence', 'convertkit' ); ?>
 		</p>
 		<?php
 

--- a/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
+++ b/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
@@ -66,6 +66,19 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 			esc_html_e( 'The Forminator form must have Name and Email fields. These fields will be sent to ConvertKit for the subscription', 'convertkit' );
 			?>
 		</p>
+		<p>
+			<?php esc_html_e( 'Each Forminator form and quiz has the following ConvertKit options:', 'convertkit' ); ?>
+			<br />
+			<code><?php esc_html_e( 'Do not subscribe', 'convertkit' ); ?></code>: <?php esc_html_e( 'Do not subscribe the email address to ConvertKit', 'convertkit' ); ?>
+			<br />
+			<code><?php esc_html_e( 'Subscribe', 'convertkit' ); ?></code>: <?php esc_html_e( 'Subscribes the email address to ConvertKit', 'convertkit' ); ?>
+			<br />
+			<code><?php esc_html_e( 'Form', 'convertkit' ); ?></code>: <?php esc_html_e( 'Susbcribes the email address to ConvertKit, and adds the subscriber to the ConvertKit form', 'convertkit' ); ?>
+			<br />
+			<code><?php esc_html_e( 'Tag', 'convertkit' ); ?></code>: <?php esc_html_e( 'Susbcribes the email address to ConvertKit, tagging the subscriber', 'convertkit' ); ?>
+			<br />
+			<code><?php esc_html_e( 'Sequence', 'convertkit' ); ?></code>: <?php esc_html_e( 'Susbcribes the email address to ConvertKit, and adds the subscriber to the ConvertKit sequence', 'convertkit' ); ?>
+		</p>
 		<?php
 
 	}

--- a/views/backend/setup-wizard/footer.php
+++ b/views/backend/setup-wizard/footer.php
@@ -16,7 +16,7 @@
 							?>
 							<div class="left">
 								<a href="<?php echo esc_url( $this->previous_step_url ); ?>" class="button button-hero">
-									<?php echo esc_html_e( 'Back', 'convertkit' ); ?>
+									<?php esc_html_e( 'Back', 'convertkit' ); ?>
 								</a>
 							</div>
 							<?php


### PR DESCRIPTION
## Summary

Updates description text for Contact Form 7 and Forminator Form integration settings screens.

Removes errant `echo` statements, as `esc_html_e` will echo anyway.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)