### PR TITLE
Fix Third Party Form Integrations `default` value

### DIFF
--- a/includes/class-convertkit-setup.php
+++ b/includes/class-convertkit-setup.php
@@ -45,6 +45,15 @@ class ConvertKit_Setup {
 		}
 
 		/**
+		 * 2.5.3: Migrate Third Party Form integrations' 'None' option values from `default` to blank.
+		 */
+		if ( ! $current_version || version_compare( $current_version, '2.5.3', '<' ) ) {
+			$this->migrate_contact_form_7_none_setting();
+			$this->migrate_forminator_none_setting();
+			$this->migrate_wlm_none_setting();
+		}
+
+		/**
 		 * 2.5.2: Migrate Forminator to ConvertKit Form Mappings
 		 */
 		if ( ! $current_version || version_compare( $current_version, '2.5.2', '<' ) ) {
@@ -101,6 +110,133 @@ class ConvertKit_Setup {
 
 		// Update the installed version number in the options table.
 		update_option( 'convertkit_version', CONVERTKIT_PLUGIN_VERSION );
+
+	}
+
+	/**
+	 * 2.5.3: Migrate Third Party Form integrations' 'None' option values from `default` to blank.
+	 *
+	 * 2.4.9 changed the 'None' label's value from `default` to a blank string, as the v4 API's
+	 * `add_subscriber_to_form()` method introduces type declarations, which would result in
+	 * an uncaught TypeError when passing a non integer value.
+	 *
+	 * The PR for that (https://github.com/ConvertKit/convertkit-wordpress/pull/655) didn't include
+	 * any tests or upgrade/migration routines to change any existing saved settings where the 'None'
+	 * label's value was stored as `default`.
+	 */
+	private function migrate_contact_form_7_none_setting() {
+
+		$convertkit_contact_form_7_settings = new ConvertKit_ContactForm7_Settings();
+
+		// Bail if no settings exist.
+		if ( ! $convertkit_contact_form_7_settings->has_settings() ) {
+			return;
+		}
+
+		// Get settings.
+		$settings = $convertkit_contact_form_7_settings->get();
+
+		// Iterate through settings.
+		foreach ( $settings as $contact_form_7_form_id => $convertkit_form_id ) {
+			// Skip keys that are non-numeric e.g. `creator_network_recommendations_*`.
+			if ( ! is_numeric( $contact_form_7_form_id ) ) {
+				continue;
+			}
+
+			// Skip values that are not 'default'.
+			if ( $convertkit_form_id !== 'default' ) {
+				continue;
+			}
+
+			// Change 'default' to a blank string.
+			$settings[ $contact_form_7_form_id ] = '';
+		}
+
+		// Update settings.
+		update_option( $convertkit_contact_form_7_settings::SETTINGS_NAME, $settings );
+
+	}
+
+	/**
+	 * 2.5.3: Migrate Third Party Form integrations' 'None' option values from `default` to blank.
+	 *
+	 * 2.4.9 changed the 'None' label's value from `default` to a blank string, as the v4 API's
+	 * `add_subscriber_to_form()` method introduces type declarations, which would result in
+	 * an uncaught TypeError when passing a non integer value.
+	 *
+	 * The PR for that (https://github.com/ConvertKit/convertkit-wordpress/pull/655) didn't include
+	 * any tests or upgrade/migration routines to change any existing saved settings where the 'None'
+	 * label's value was stored as `default`.
+	 */
+	private function migrate_forminator_none_setting() {
+
+		$convertkit_forminator_settings = new ConvertKit_Forminator_Settings();
+
+		// Bail if no settings exist.
+		if ( ! $convertkit_forminator_settings->has_settings() ) {
+			return;
+		}
+
+		// Get settings.
+		$settings = $convertkit_forminator_settings->get();
+
+		// Iterate through settings.
+		foreach ( $settings as $forminator_form_id => $convertkit_form_id ) {
+			// Skip keys that are non-numeric e.g. `creator_network_recommendations_*`.
+			if ( ! is_numeric( $forminator_form_id ) ) {
+				continue;
+			}
+
+			// Skip values that are not 'default'.
+			if ( $convertkit_form_id !== 'default' ) {
+				continue;
+			}
+
+			// Change 'default' to a blank string.
+			$settings[ $forminator_form_id ] = '';
+		}
+
+		// Update settings.
+		update_option( $convertkit_forminator_settings::SETTINGS_NAME, $settings );
+
+	}
+
+	/**
+	 * 2.5.3: Migrate Third Party Form integrations' 'None' option values from `default` to blank.
+	 *
+	 * 2.4.9 changed the 'None' label's value from `default` to a blank string, as the v4 API's
+	 * `add_subscriber_to_form()` method introduces type declarations, which would result in
+	 * an uncaught TypeError when passing a non integer value.
+	 *
+	 * The PR for that (https://github.com/ConvertKit/convertkit-wordpress/pull/655) didn't include
+	 * any tests or upgrade/migration routines to change any existing saved settings where the 'None'
+	 * label's value was stored as `default`.
+	 */
+	private function migrate_wlm_none_setting() {
+
+		$convertkit_wlm_settings = new ConvertKit_Wishlist_Settings();
+
+		// Bail if no settings exist.
+		if ( ! $convertkit_wlm_settings->has_settings() ) {
+			return;
+		}
+
+		// Get settings.
+		$settings = $convertkit_wlm_settings->get();
+
+		// Iterate through settings.
+		foreach ( $settings as $wlm_level_id => $value ) {
+			// Skip values that are not 'default'.
+			if ( $value !== 'default' ) {
+				continue;
+			}
+
+			// Change 'default' to a blank string.
+			$settings[ $wlm_level_id ] = '';
+		}
+
+		// Update settings.
+		update_option( $convertkit_wlm_settings::SETTINGS_NAME, $settings );
 
 	}
 

--- a/tests/acceptance/integrations/other/ContactForm7FormCest.php
+++ b/tests/acceptance/integrations/other/ContactForm7FormCest.php
@@ -353,7 +353,9 @@ class ContactForm7FormCest
 
 	/**
 	 * Tests that existing settings are automatically migrated when updating
-	 * the Plugin to 2.5.2 or higher.
+	 * the Plugin to 2.5.2 or higher, with:
+	 * - Form IDs prefixed with 'form:',
+	 * - Form IDs with value `default` are changed to a blank string
 	 *
 	 * @since   2.5.2
 	 *
@@ -369,6 +371,7 @@ class ContactForm7FormCest
 				'1'                                 => $_ENV['CONVERTKIT_API_FORM_ID'],
 				'creator_network_recommendations_1' => '1',
 				'2'                                 => '',
+				'3'                                 => 'default',
 			]
 		);
 
@@ -386,6 +389,7 @@ class ContactForm7FormCest
 		$I->assertEquals($settings['1'], 'form:' . $_ENV['CONVERTKIT_API_FORM_ID']);
 		$I->assertEquals($settings['creator_network_recommendations_1'], '1');
 		$I->assertEquals($settings['2'], '');
+		$I->assertEquals($settings['3'], '');
 	}
 
 	/**

--- a/tests/acceptance/integrations/other/ForminatorCest.php
+++ b/tests/acceptance/integrations/other/ForminatorCest.php
@@ -479,7 +479,9 @@ class ForminatorCest
 
 	/**
 	 * Tests that existing settings are automatically migrated when updating
-	 * the Plugin to 2.5.2 or higher.
+	 * the Plugin to 2.5.2 or higher, with:
+	 * - Form IDs prefixed with 'form:',
+	 * - Form IDs with value `default` are changed to a blank string
 	 *
 	 * @since   2.5.2
 	 *
@@ -495,6 +497,7 @@ class ForminatorCest
 				'1'                                 => $_ENV['CONVERTKIT_API_FORM_ID'],
 				'creator_network_recommendations_1' => '1',
 				'2'                                 => '',
+				'3'                                 => 'default',
 			]
 		);
 
@@ -512,6 +515,7 @@ class ForminatorCest
 		$I->assertEquals($settings['1'], 'form:' . $_ENV['CONVERTKIT_API_FORM_ID']);
 		$I->assertEquals($settings['creator_network_recommendations_1'], '1');
 		$I->assertEquals($settings['2'], '');
+		$I->assertEquals($settings['3'], '');
 	}
 
 	/**

--- a/tests/acceptance/integrations/wlm/WishListMemberCest.php
+++ b/tests/acceptance/integrations/wlm/WishListMemberCest.php
@@ -73,9 +73,6 @@ class WishListMemberCest
 		// Save Changes.
 		$I->click('Update Member Profile');
 
-		// WordPress 6.6 introduces a 'navigate away from this page' warning when using WLM.
-		$I->acceptPopup();
-
 		// Confirm that the User is still assigned to the Bronze WLM Level.
 		$I->seeCheckboxIsChecked('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
 
@@ -134,9 +131,6 @@ class WishListMemberCest
 
 		// Save Changes.
 		$I->click('Update Member Profile');
-
-		// WordPress 6.6 introduces a 'navigate away from this page' warning when using WLM.
-		$I->acceptPopup();
 
 		// Confirm that the User is still assigned to the Bronze WLM Level.
 		$I->seeCheckboxIsChecked('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');

--- a/tests/acceptance/integrations/wlm/WishListMemberCest.php
+++ b/tests/acceptance/integrations/wlm/WishListMemberCest.php
@@ -146,6 +146,44 @@ class WishListMemberCest
 	}
 
 	/**
+	 * Tests that existing settings are automatically migrated when updating
+	 * the Plugin to 2.5.3 or higher, with:
+	 * - Form IDs with value `default` are changed to a blank string
+	 *
+	 * @since   2.5.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSettingsMigratedOnUpgrade(AcceptanceTester $I)
+	{
+		// Create settings as if they were created / edited when the ConvertKit Plugin < 2.5.3
+		// was active.
+		$I->haveOptionInDatabase(
+			'_wp_convertkit_integration_wishlistmember_settings',
+			[
+				'1' => $_ENV['CONVERTKIT_API_FORM_ID'],
+				'2' => '',
+				'3' => 'default',
+			]
+		);
+
+		// Downgrade the Plugin version to simulate an upgrade.
+		$I->haveOptionInDatabase('convertkit_version', '2.4.9');
+
+		// Load admin screen.
+		$I->amOnAdminPage('index.php');
+
+		// Check settings structure has been updated.
+		$settings = $I->grabOptionFromDatabase('_wp_convertkit_integration_wishlistmember_settings');
+		$I->assertArrayHasKey('1', $settings);
+		$I->assertArrayHasKey('2', $settings);
+		$I->assertArrayHasKey('3', $settings);
+		$I->assertEquals($settings['1'], $_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->assertEquals($settings['2'], '');
+		$I->assertEquals($settings['3'], '');
+	}
+
+	/**
 	 * Returns the WishList Member Level ID created when setupWishListMemberPlugin() was called.
 	 *
 	 * @since   1.9.6


### PR DESCRIPTION
## Summary

Contact Form 7, Forminator and WishList Member would have their `None` settings saved as `default`.

2.4.9 added a fix to the settings forms for the three integrations by changing the value of 'None' from `default` to a blank string:
https://github.com/ConvertKit/convertkit-wordpress/pull/655

However, no tests or automatic changes to existing saved settings were included, resulting in [this reported error](https://wordpress.org/support/topic/php-fatal-error-440/#post-17928655), where 'default' is still present in the settings:

```
[02-Aug-2024 05:23:16 UTC] PHP Fatal error: Uncaught TypeError: ConvertKit_API_V4::add_subscriber_to_form(): Argument #1 ($form_id) must be of type int, string given, called in /private/wp-content/plugins/convertkit/vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-api-v4.php on line 517 and defined in /private/wp-content/plugins/convertkit/vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-api-traits.php:253


Stack trace:

ConvertKit_API_V4->add_subscriber_to_form(‘default’, 2836704309)
```

This PR resolves by:
- checking existing saved settings on upgrade, replacing `default` with a blank string to match how the UI functions
- adds / updates the `testSettingsMigratedOnUpgrade` tests to confirm the changes are made.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)