### PR TITLE
WishList Member: Update options

### DIFF
--- a/includes/class-convertkit-setup.php
+++ b/includes/class-convertkit-setup.php
@@ -168,13 +168,10 @@ class ConvertKit_Setup {
 				case 'unsubscribe':
 					// This is the action to perform when the user is removed from the WLM Level.
 					// < 2.5.4, tags were the only option here, so prefix the resource ID with `tag:`.
-					$settings[ $wlm_level_id . '_subscribe' ] = 'form:' . $convertkit_form_or_tag_id;
+					$settings[ $wlm_level_id . '_unsubscribe' ] = 'tag:' . $convertkit_form_or_tag_id;
 					break;
 			}
 		}
-
-		var_dump( $settings );
-		die();
 
 		// Update settings.
 		update_option( $convertkit_wlm_settings::SETTINGS_NAME, $settings );

--- a/includes/class-convertkit-setup.php
+++ b/includes/class-convertkit-setup.php
@@ -48,6 +48,7 @@ class ConvertKit_Setup {
 		 * 2.5.4: Migrate WishList Member to ConvertKit Form Mappings
 		 */
 		if ( ! $current_version || version_compare( $current_version, '2.5.4', '<' ) ) {
+			$this->migrate_wlm_none_setting();
 			$this->migrate_wlm_form_tag_mapping_settings();
 		}
 
@@ -143,11 +144,6 @@ class ConvertKit_Setup {
 
 		// Iterate through settings.
 		foreach ( $convertkit_wlm_settings->get() as $key => $convertkit_form_or_tag_id ) {
-			// Skip values that are blank i.e. no ConvertKit Form or Tag ID specified.
-			if ( empty( $convertkit_form_or_tag_id ) ) {
-				continue;
-			}
-
 			// Skip values that are non-numeric i.e. the `form:` / `tag:` prefix was already added.
 			// This should never happen as this routine runs once, but this is a sanity check.
 			if ( ! is_numeric( $convertkit_form_or_tag_id ) ) {
@@ -162,13 +158,14 @@ class ConvertKit_Setup {
 					// This is the action to perform when the user is added to the WLM Level.
 					// Use a new name for the setting key to reflect this.
 					// < 2.5.4, forms were the only option here, so prefix the resource ID with `form:`.
-					$settings[ $wlm_level_id . '_subscribe' ] = 'form:' . $convertkit_form_or_tag_id;
+					$settings[ $wlm_level_id . '_add' ] = 'form:' . $convertkit_form_or_tag_id;
 					break;
 
 				case 'unsubscribe':
 					// This is the action to perform when the user is removed from the WLM Level.
+					// Use a new name for the setting key to reflect this.
 					// < 2.5.4, tags were the only option here, so prefix the resource ID with `tag:`.
-					$settings[ $wlm_level_id . '_unsubscribe' ] = 'tag:' . $convertkit_form_or_tag_id;
+					$settings[ $wlm_level_id . '_remove' ] = 'tag:' . $convertkit_form_or_tag_id;
 					break;
 			}
 		}

--- a/includes/class-convertkit-setup.php
+++ b/includes/class-convertkit-setup.php
@@ -45,6 +45,13 @@ class ConvertKit_Setup {
 		}
 
 		/**
+		 * 2.5.4: Migrate WishList Member to ConvertKit Form Mappings
+		 */
+		if ( ! $current_version || version_compare( $current_version, '2.5.4', '<' ) ) {
+			$this->migrate_wlm_form_tag_mapping_settings();
+		}
+
+		/**
 		 * 2.5.3: Migrate Third Party Form integrations' 'None' option values from `default` to blank.
 		 */
 		if ( ! $current_version || version_compare( $current_version, '2.5.3', '<' ) ) {
@@ -110,6 +117,67 @@ class ConvertKit_Setup {
 
 		// Update the installed version number in the options table.
 		update_option( 'convertkit_version', CONVERTKIT_PLUGIN_VERSION );
+
+	}
+
+	/**
+	 * 2.5.4: Migrate WLM settings:
+	 * - Prefix any WishList Member to ConvertKit Form ID mappings with `form:`,
+	 * - Prefix any WishList Member to ConvertKit Tag ID mappings with `tag:`,
+	 * - Standardise the settings keys to the format {wlm_level_id}_subscribe
+	 * and {wlm_level_id}_unsubscribe.
+	 *
+	 * @since   2.5.4
+	 */
+	private function migrate_wlm_form_tag_mapping_settings() {
+
+		$convertkit_wlm_settings = new ConvertKit_Wishlist_Settings();
+
+		// Bail if no settings exist.
+		if ( ! $convertkit_wlm_settings->has_settings() ) {
+			return;
+		}
+
+		// Define new array for settings.
+		$settings = array();
+
+		// Iterate through settings.
+		foreach ( $convertkit_wlm_settings->get() as $key => $convertkit_form_or_tag_id ) {
+			// Skip values that are blank i.e. no ConvertKit Form or Tag ID specified.
+			if ( empty( $convertkit_form_or_tag_id ) ) {
+				continue;
+			}
+
+			// Skip values that are non-numeric i.e. the `form:` / `tag:` prefix was already added.
+			// This should never happen as this routine runs once, but this is a sanity check.
+			if ( ! is_numeric( $convertkit_form_or_tag_id ) ) {
+				continue;
+			}
+
+			// Split the settings key.
+			list( $wlm_level_id, $type ) = explode( '_', $key );
+
+			switch ( $type ) {
+				case 'form':
+					// This is the action to perform when the user is added to the WLM Level.
+					// Use a new name for the setting key to reflect this.
+					// < 2.5.4, forms were the only option here, so prefix the resource ID with `form:`.
+					$settings[ $wlm_level_id . '_subscribe' ] = 'form:' . $convertkit_form_or_tag_id;
+					break;
+
+				case 'unsubscribe':
+					// This is the action to perform when the user is removed from the WLM Level.
+					// < 2.5.4, tags were the only option here, so prefix the resource ID with `tag:`.
+					$settings[ $wlm_level_id . '_subscribe' ] = 'form:' . $convertkit_form_or_tag_id;
+					break;
+			}
+		}
+
+		var_dump( $settings );
+		die();
+
+		// Update settings.
+		update_option( $convertkit_wlm_settings::SETTINGS_NAME, $settings );
 
 	}
 

--- a/includes/class-convertkit-setup.php
+++ b/includes/class-convertkit-setup.php
@@ -144,12 +144,6 @@ class ConvertKit_Setup {
 
 		// Iterate through settings.
 		foreach ( $convertkit_wlm_settings->get() as $key => $convertkit_form_or_tag_id ) {
-			// Skip values that are non-numeric i.e. the `form:` / `tag:` prefix was already added.
-			// This should never happen as this routine runs once, but this is a sanity check.
-			if ( ! is_numeric( $convertkit_form_or_tag_id ) ) {
-				continue;
-			}
-
 			// Split the settings key.
 			list( $wlm_level_id, $type ) = explode( '_', $key );
 
@@ -158,14 +152,14 @@ class ConvertKit_Setup {
 					// This is the action to perform when the user is added to the WLM Level.
 					// Use a new name for the setting key to reflect this.
 					// < 2.5.4, forms were the only option here, so prefix the resource ID with `form:`.
-					$settings[ $wlm_level_id . '_add' ] = 'form:' . $convertkit_form_or_tag_id;
+					$settings[ $wlm_level_id . '_add' ] = ( empty( $convertkit_form_or_tag_id ) ? '' : 'form:' . $convertkit_form_or_tag_id );
 					break;
 
 				case 'unsubscribe':
 					// This is the action to perform when the user is removed from the WLM Level.
 					// Use a new name for the setting key to reflect this.
 					// < 2.5.4, tags were the only option here, so prefix the resource ID with `tag:`.
-					$settings[ $wlm_level_id . '_remove' ] = 'tag:' . $convertkit_form_or_tag_id;
+					$settings[ $wlm_level_id . '_remove' ] = ( empty( $convertkit_form_or_tag_id ) ? '' : 'tag:' . $convertkit_form_or_tag_id );
 					break;
 			}
 		}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -544,12 +544,12 @@ function convertkit_get_file_contents( $local_file ) {
  *
  * @since   2.5.2
  *
- * @param   string $name                Field name.
- * @param   string $value               Field value.
- * @param   string $id                  Field ID attribute.
- * @param   string $css_class           Field CSS class(es).
- * @param   string $context             Resource context.
- * @param   bool   $additional_options  Additional <option> key/value pairs.
+ * @param   string     $name                Field name.
+ * @param   string     $value               Field value.
+ * @param   string     $id                  Field ID attribute.
+ * @param   string     $css_class           Field CSS class(es).
+ * @param   string     $context             Resource context.
+ * @param   bool|array $additional_options  Additional <option> key/value pairs.
  */
 function convertkit_get_subscription_dropdown_field( $name, $value, $id, $css_class = '', $context = '', $additional_options = false ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -544,12 +544,12 @@ function convertkit_get_file_contents( $local_file ) {
  *
  * @since   2.5.2
  *
- * @param   string $name        	    Field name.
- * @param   string $value       	    Field value.
- * @param   string $id          	    Field ID attribute.
- * @param   string $css_class   	    Field CSS class(es).
- * @param   string $context     	    Resource context.
- * @param 	bool   $additional_options 	Additional <option> key/value pairs.
+ * @param   string $name                Field name.
+ * @param   string $value               Field value.
+ * @param   string $id                  Field ID attribute.
+ * @param   string $css_class           Field CSS class(es).
+ * @param   string $context             Resource context.
+ * @param   bool   $additional_options  Additional <option> key/value pairs.
  */
 function convertkit_get_subscription_dropdown_field( $name, $value, $id, $css_class = '', $context = '', $additional_options = false ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -544,13 +544,14 @@ function convertkit_get_file_contents( $local_file ) {
  *
  * @since   2.5.2
  *
- * @param   string $name        Field name.
- * @param   string $value       Field value.
- * @param   string $id          Field ID attribute.
- * @param   string $css_class   Field CSS class(es).
- * @param   string $context     Resource context.
+ * @param   string $name        	    Field name.
+ * @param   string $value       	    Field value.
+ * @param   string $id          	    Field ID attribute.
+ * @param   string $css_class   	    Field CSS class(es).
+ * @param   string $context     	    Resource context.
+ * @param 	bool   $additional_options 	Additional <option> key/value pairs.
  */
-function convertkit_get_subscription_dropdown_field( $name, $value, $id, $css_class = '', $context = '' ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
+function convertkit_get_subscription_dropdown_field( $name, $value, $id, $css_class = '', $context = '', $additional_options = false ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
 
 	// Load resource classes.
 	$forms     = new ConvertKit_Resource_Forms( $context );

--- a/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7-admin-settings.php
@@ -74,11 +74,11 @@ class ConvertKit_ContactForm7_Admin_Settings extends ConvertKit_Settings_Base {
 			<br />
 			<code><?php esc_html_e( 'Subscribe', 'convertkit' ); ?></code>: <?php esc_html_e( 'Subscribes the email address to ConvertKit', 'convertkit' ); ?>
 			<br />
-			<code><?php esc_html_e( 'Form', 'convertkit' ); ?></code>: <?php esc_html_e( 'Susbcribes the email address to ConvertKit, and adds the subscriber to the ConvertKit form', 'convertkit' ); ?>
+			<code><?php esc_html_e( 'Form', 'convertkit' ); ?></code>: <?php esc_html_e( 'Subscribes the email address to ConvertKit, and adds the subscriber to the ConvertKit form', 'convertkit' ); ?>
 			<br />
-			<code><?php esc_html_e( 'Tag', 'convertkit' ); ?></code>: <?php esc_html_e( 'Susbcribes the email address to ConvertKit, tagging the subscriber', 'convertkit' ); ?>
+			<code><?php esc_html_e( 'Tag', 'convertkit' ); ?></code>: <?php esc_html_e( 'Subscribes the email address to ConvertKit, tagging the subscriber', 'convertkit' ); ?>
 			<br />
-			<code><?php esc_html_e( 'Sequence', 'convertkit' ); ?></code>: <?php esc_html_e( 'Susbcribes the email address to ConvertKit, and adds the subscriber to the ConvertKit sequence', 'convertkit' ); ?>
+			<code><?php esc_html_e( 'Sequence', 'convertkit' ); ?></code>: <?php esc_html_e( 'Subscribes the email address to ConvertKit, and adds the subscriber to the ConvertKit sequence', 'convertkit' ); ?>
 		</p>
 		<?php
 

--- a/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
+++ b/includes/integrations/forminator/class-convertkit-forminator-admin-settings.php
@@ -73,11 +73,11 @@ class ConvertKit_Forminator_Admin_Settings extends ConvertKit_Settings_Base {
 			<br />
 			<code><?php esc_html_e( 'Subscribe', 'convertkit' ); ?></code>: <?php esc_html_e( 'Subscribes the email address to ConvertKit', 'convertkit' ); ?>
 			<br />
-			<code><?php esc_html_e( 'Form', 'convertkit' ); ?></code>: <?php esc_html_e( 'Susbcribes the email address to ConvertKit, and adds the subscriber to the ConvertKit form', 'convertkit' ); ?>
+			<code><?php esc_html_e( 'Form', 'convertkit' ); ?></code>: <?php esc_html_e( 'Subscribes the email address to ConvertKit, and adds the subscriber to the ConvertKit form', 'convertkit' ); ?>
 			<br />
-			<code><?php esc_html_e( 'Tag', 'convertkit' ); ?></code>: <?php esc_html_e( 'Susbcribes the email address to ConvertKit, tagging the subscriber', 'convertkit' ); ?>
+			<code><?php esc_html_e( 'Tag', 'convertkit' ); ?></code>: <?php esc_html_e( 'Subscribes the email address to ConvertKit, tagging the subscriber', 'convertkit' ); ?>
 			<br />
-			<code><?php esc_html_e( 'Sequence', 'convertkit' ); ?></code>: <?php esc_html_e( 'Susbcribes the email address to ConvertKit, and adds the subscriber to the ConvertKit sequence', 'convertkit' ); ?>
+			<code><?php esc_html_e( 'Sequence', 'convertkit' ); ?></code>: <?php esc_html_e( 'Subscribes the email address to ConvertKit, and adds the subscriber to the ConvertKit sequence', 'convertkit' ); ?>
 		</p>
 		<?php
 

--- a/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php
@@ -61,6 +61,19 @@ class ConvertKit_Wishlist_Admin_Settings extends ConvertKit_Settings_Base {
 			esc_html_e( 'ConvertKit seamlessly integrates with WishList Member to let you capture all of your WishList Membership registrations within your ConvertKit forms.', 'convertkit' );
 			?>
 		</p>
+		<p>
+			<?php esc_html_e( 'Each membership level has the following ConvertKit options:', 'convertkit' ); ?>
+			<br />
+			<code><?php esc_html_e( 'Do not subscribe', 'convertkit' ); ?></code>: <?php esc_html_e( 'Do not subscribe the email address to ConvertKit', 'convertkit' ); ?>
+			<br />
+			<code><?php esc_html_e( 'Subscribe', 'convertkit' ); ?></code>: <?php esc_html_e( 'Subscribes the email address to ConvertKit', 'convertkit' ); ?>
+			<br />
+			<code><?php esc_html_e( 'Form', 'convertkit' ); ?></code>: <?php esc_html_e( 'Subscribes the email address to ConvertKit, and adds the subscriber to the ConvertKit form', 'convertkit' ); ?>
+			<br />
+			<code><?php esc_html_e( 'Tag', 'convertkit' ); ?></code>: <?php esc_html_e( 'Subscribes the email address to ConvertKit, tagging the subscriber', 'convertkit' ); ?>
+			<br />
+			<code><?php esc_html_e( 'Sequence', 'convertkit' ); ?></code>: <?php esc_html_e( 'Subscribes the email address to ConvertKit, and adds the subscriber to the ConvertKit sequence', 'convertkit' ); ?>
+		</p>
 		<?php
 
 	}
@@ -131,7 +144,7 @@ class ConvertKit_Wishlist_Admin_Settings extends ConvertKit_Settings_Base {
 		// Setup WP_List_Table.
 		$table = new Multi_Value_Field_Table();
 		$table->add_column( 'title', __( 'WishList Membership Level', 'convertkit' ), true );
-		$table->add_column( 'form', __( 'ConvertKit Form', 'convertkit' ), false );
+		$table->add_column( 'form', __( 'Subscribe Action', 'convertkit' ), false );
 		$table->add_column( 'unsubscribe', __( 'Unsubscribe Action', 'convertkit' ), false );
 
 		// Iterate through WishList Member Levels, adding a table row for each Level.
@@ -139,19 +152,19 @@ class ConvertKit_Wishlist_Admin_Settings extends ConvertKit_Settings_Base {
 			$table->add_item(
 				array(
 					'title'       => $wlm_level['name'],
-					'form'        => $forms->get_select_field_all(
+					'form'  => convertkit_get_subscription_dropdown_field(
 						'_wp_convertkit_integration_wishlistmember_settings[' . $wlm_level['id'] . '_form]',
-						'_wp_convertkit_integration_wishlistmember_settings_' . $wlm_level['id'] . '_form',
-						false,
 						(string) $this->settings->get_convertkit_form_id_by_wishlist_member_level_id( $wlm_level['id'] ),
-						array(
-							'' => __( 'None', 'convertkit' ),
-						)
+						'_wp_convertkit_integration_wishlistmember_settings_' . $wlm_level['id'] . '_form',
+						'widefat',
+						'wlm'
 					),
-					'unsubscribe' => $this->get_select_field(
-						$wlm_level['id'] . '_unsubscribe',
+					'unsubscribe'  => convertkit_get_subscription_dropdown_field(
+						'_wp_convertkit_integration_wishlistmember_settings[' . $wlm_level['id'] . '_unsubscribe]',
 						(string) $this->settings->get_convertkit_tag_id_by_wishlist_member_level_id( $wlm_level['id'] ),
-						$tag_options
+						'_wp_convertkit_integration_wishlistmember_settings_' . $wlm_level['id'] . '_unsubscribe',
+						'widefat',
+						'wlm'
 					),
 				)
 			);

--- a/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php
@@ -68,6 +68,8 @@ class ConvertKit_Wishlist_Admin_Settings extends ConvertKit_Settings_Base {
 			<br />
 			<code><?php esc_html_e( 'Subscribe', 'convertkit' ); ?></code>: <?php esc_html_e( 'Subscribes the email address to ConvertKit', 'convertkit' ); ?>
 			<br />
+			<code><?php esc_html_e( 'Unsubscribe', 'convertkit' ); ?></code>: <?php esc_html_e( 'Unsubscribes the email address from ConvertKit', 'convertkit' ); ?>
+			<br />
 			<code><?php esc_html_e( 'Form', 'convertkit' ); ?></code>: <?php esc_html_e( 'Subscribes the email address to ConvertKit, and adds the subscriber to the ConvertKit form', 'convertkit' ); ?>
 			<br />
 			<code><?php esc_html_e( 'Tag', 'convertkit' ); ?></code>: <?php esc_html_e( 'Subscribes the email address to ConvertKit, tagging the subscriber', 'convertkit' ); ?>
@@ -114,37 +116,10 @@ class ConvertKit_Wishlist_Admin_Settings extends ConvertKit_Settings_Base {
 			return;
 		}
 
-		// Get Forms and Tags.
-		$forms = new ConvertKit_Resource_Forms( 'wishlist_member' );
-		$tags  = new ConvertKit_Resource_Tags( 'wishlist_member' );
-
-		// Bail with an error if no ConvertKit Forms exist.
-		if ( ! $forms->exist() ) {
-			$this->output_error( __( 'No Forms exist on ConvertKit.', 'convertkit' ) );
-			$this->render_container_end();
-			return;
-		}
-
-		// Bail with an error if no ConvertKit Tags exist.
-		if ( ! $tags->exist() ) {
-			$this->output_error( __( 'No Tags exist on ConvertKit.', 'convertkit' ) );
-			$this->render_container_end();
-			return;
-		}
-
-		// Build array of select options for Tags.
-		$tag_options = array(
-			'0' => __( 'None', 'convertkit' ),
-		);
-		foreach ( $tags->get() as $tag ) {
-			$tag_options[ esc_attr( $tag['id'] ) ] = esc_html( $tag['name'] );
-		}
-		$tag_options['unsubscribe'] = __( 'Unsubscribe from all', 'convertkit' );
-
 		// Setup WP_List_Table.
 		$table = new Multi_Value_Field_Table();
 		$table->add_column( 'title', __( 'WishList Membership Level', 'convertkit' ), true );
-		$table->add_column( 'form', __( 'Subscribe Action', 'convertkit' ), false );
+		$table->add_column( 'subscribe', __( 'Subscribe Action', 'convertkit' ), false );
 		$table->add_column( 'unsubscribe', __( 'Unsubscribe Action', 'convertkit' ), false );
 
 		// Iterate through WishList Member Levels, adding a table row for each Level.
@@ -152,19 +127,22 @@ class ConvertKit_Wishlist_Admin_Settings extends ConvertKit_Settings_Base {
 			$table->add_item(
 				array(
 					'title'       => $wlm_level['name'],
-					'form'  => convertkit_get_subscription_dropdown_field(
-						'_wp_convertkit_integration_wishlistmember_settings[' . $wlm_level['id'] . '_form]',
-						(string) $this->settings->get_convertkit_form_id_by_wishlist_member_level_id( $wlm_level['id'] ),
-						'_wp_convertkit_integration_wishlistmember_settings_' . $wlm_level['id'] . '_form',
+					'subscribe'  => convertkit_get_subscription_dropdown_field(
+						'_wp_convertkit_integration_wishlistmember_settings[' . $wlm_level['id'] . '_subscribe]',
+						(string) $this->settings->get_convertkit_subscribe_setting_by_wishlist_member_level_id( $wlm_level['id'] ),
+						'_wp_convertkit_integration_wishlistmember_settings_' . $wlm_level['id'] . '_subscribe',
 						'widefat',
 						'wlm'
 					),
 					'unsubscribe'  => convertkit_get_subscription_dropdown_field(
 						'_wp_convertkit_integration_wishlistmember_settings[' . $wlm_level['id'] . '_unsubscribe]',
-						(string) $this->settings->get_convertkit_tag_id_by_wishlist_member_level_id( $wlm_level['id'] ),
+						(string) $this->settings->get_convertkit_unsubscribe_setting_by_wishlist_member_level_id( $wlm_level['id'] ),
 						'_wp_convertkit_integration_wishlistmember_settings_' . $wlm_level['id'] . '_unsubscribe',
 						'widefat',
-						'wlm'
+						'wlm',
+						array(
+							'unsubscribe' => __( 'Unsubscribe', 'convertkit' ),
+						)
 					),
 				)
 			);

--- a/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php
@@ -128,16 +128,16 @@ class ConvertKit_Wishlist_Admin_Settings extends ConvertKit_Settings_Base {
 				array(
 					'title'       => $wlm_level['name'],
 					'subscribe'   => convertkit_get_subscription_dropdown_field(
-						'_wp_convertkit_integration_wishlistmember_settings[' . $wlm_level['id'] . '_subscribe]',
-						(string) $this->settings->get_convertkit_subscribe_setting_by_wishlist_member_level_id( $wlm_level['id'] ),
-						'_wp_convertkit_integration_wishlistmember_settings_' . $wlm_level['id'] . '_subscribe',
+						'_wp_convertkit_integration_wishlistmember_settings[' . $wlm_level['id'] . '_add]',
+						(string) $this->settings->get_convertkit_add_setting_by_wishlist_member_level_id( $wlm_level['id'] ),
+						'_wp_convertkit_integration_wishlistmember_settings_' . $wlm_level['id'] . '_add',
 						'widefat',
 						'wlm'
 					),
 					'unsubscribe' => convertkit_get_subscription_dropdown_field(
-						'_wp_convertkit_integration_wishlistmember_settings[' . $wlm_level['id'] . '_unsubscribe]',
-						(string) $this->settings->get_convertkit_unsubscribe_setting_by_wishlist_member_level_id( $wlm_level['id'] ),
-						'_wp_convertkit_integration_wishlistmember_settings_' . $wlm_level['id'] . '_unsubscribe',
+						'_wp_convertkit_integration_wishlistmember_settings[' . $wlm_level['id'] . '_remove]',
+						(string) $this->settings->get_convertkit_remove_setting_by_wishlist_member_level_id( $wlm_level['id'] ),
+						'_wp_convertkit_integration_wishlistmember_settings_' . $wlm_level['id'] . '_remove',
 						'widefat',
 						'wlm',
 						array(

--- a/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php
@@ -119,22 +119,22 @@ class ConvertKit_Wishlist_Admin_Settings extends ConvertKit_Settings_Base {
 		// Setup WP_List_Table.
 		$table = new Multi_Value_Field_Table();
 		$table->add_column( 'title', __( 'WishList Membership Level', 'convertkit' ), true );
-		$table->add_column( 'subscribe', __( 'Subscribe Action', 'convertkit' ), false );
-		$table->add_column( 'unsubscribe', __( 'Unsubscribe Action', 'convertkit' ), false );
+		$table->add_column( 'add', __( 'Assign to member', 'convertkit' ), false );
+		$table->add_column( 'remove', __( 'Remove from member', 'convertkit' ), false );
 
 		// Iterate through WishList Member Levels, adding a table row for each Level.
 		foreach ( $wlm_levels as $wlm_level ) {
 			$table->add_item(
 				array(
-					'title'       => $wlm_level['name'],
-					'subscribe'   => convertkit_get_subscription_dropdown_field(
+					'title'  => $wlm_level['name'],
+					'add'    => convertkit_get_subscription_dropdown_field(
 						'_wp_convertkit_integration_wishlistmember_settings[' . $wlm_level['id'] . '_add]',
 						(string) $this->settings->get_convertkit_add_setting_by_wishlist_member_level_id( $wlm_level['id'] ),
 						'_wp_convertkit_integration_wishlistmember_settings_' . $wlm_level['id'] . '_add',
 						'widefat',
 						'wlm'
 					),
-					'unsubscribe' => convertkit_get_subscription_dropdown_field(
+					'remove' => convertkit_get_subscription_dropdown_field(
 						'_wp_convertkit_integration_wishlistmember_settings[' . $wlm_level['id'] . '_remove]',
 						(string) $this->settings->get_convertkit_remove_setting_by_wishlist_member_level_id( $wlm_level['id'] ),
 						'_wp_convertkit_integration_wishlistmember_settings_' . $wlm_level['id'] . '_remove',

--- a/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist-admin-settings.php
@@ -127,14 +127,14 @@ class ConvertKit_Wishlist_Admin_Settings extends ConvertKit_Settings_Base {
 			$table->add_item(
 				array(
 					'title'       => $wlm_level['name'],
-					'subscribe'  => convertkit_get_subscription_dropdown_field(
+					'subscribe'   => convertkit_get_subscription_dropdown_field(
 						'_wp_convertkit_integration_wishlistmember_settings[' . $wlm_level['id'] . '_subscribe]',
 						(string) $this->settings->get_convertkit_subscribe_setting_by_wishlist_member_level_id( $wlm_level['id'] ),
 						'_wp_convertkit_integration_wishlistmember_settings_' . $wlm_level['id'] . '_subscribe',
 						'widefat',
 						'wlm'
 					),
-					'unsubscribe'  => convertkit_get_subscription_dropdown_field(
+					'unsubscribe' => convertkit_get_subscription_dropdown_field(
 						'_wp_convertkit_integration_wishlistmember_settings[' . $wlm_level['id'] . '_unsubscribe]',
 						(string) $this->settings->get_convertkit_unsubscribe_setting_by_wishlist_member_level_id( $wlm_level['id'] ),
 						'_wp_convertkit_integration_wishlistmember_settings_' . $wlm_level['id'] . '_unsubscribe',

--- a/includes/integrations/wishlist/class-convertkit-wishlist-settings.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist-settings.php
@@ -83,9 +83,9 @@ class ConvertKit_Wishlist_Settings {
 	 * @since   2.5.4
 	 *
 	 * @param   int $wlm_level_id   WishList Member Level ID.
-	 * @return  bool|int
+	 * @return  bool|string     	false|subscribe|form:id|tag:id|sequence:id.
 	 */
-	public function get_convertkit_subscribe_setting_by_wishlist_member_level_id( $wlm_level_id ) {
+	public function get_convertkit_add_setting_by_wishlist_member_level_id( $wlm_level_id ) {
 
 		// Bail if no settings exist.
 		if ( ! $this->has_settings() ) {
@@ -93,23 +93,23 @@ class ConvertKit_Wishlist_Settings {
 		}
 
 		// Bail if no mapping exists.
-		if ( ! array_key_exists( $wlm_level_id . '_subscribe', $this->get() ) ) {
+		if ( ! array_key_exists( $wlm_level_id . '_add', $this->get() ) ) {
 			return false;
 		}
 
-		return $this->get()[ $wlm_level_id . '_subscribe' ];
+		return $this->get()[ $wlm_level_id . '_add' ];
 
 	}
 
 	/**
-	 * Returns the ConvertKit unsubscribe setting that is mapped against the given WishList Member Level ID.
+	 * Returns the ConvertKit remove setting that is mapped against the given WishList Member Level ID.
 	 *
 	 * @since   1.9.6
 	 *
 	 * @param   int $wlm_level_id   WishList Member Level ID.
-	 * @return  bool|string|int     false|'unsubscribe'|Tag ID
+	 * @return  bool|string     	false|subscribe|unsubscribe|form:id|tag:id|sequence:id.
 	 */
-	public function get_convertkit_unsubscribe_setting_by_wishlist_member_level_id( $wlm_level_id ) {
+	public function get_convertkit_remove_setting_by_wishlist_member_level_id( $wlm_level_id ) {
 
 		// Bail if no settings exist.
 		if ( ! $this->has_settings() ) {
@@ -117,11 +117,11 @@ class ConvertKit_Wishlist_Settings {
 		}
 
 		// Bail if no mapping exists.
-		if ( ! array_key_exists( $wlm_level_id . '_unsubscribe', $this->get() ) ) {
+		if ( ! array_key_exists( $wlm_level_id . '_remove', $this->get() ) ) {
 			return false;
 		}
 
-		return $this->get()[ $wlm_level_id . '_unsubscribe' ];
+		return $this->get()[ $wlm_level_id . '_remove' ];
 
 	}
 

--- a/includes/integrations/wishlist/class-convertkit-wishlist-settings.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist-settings.php
@@ -78,14 +78,14 @@ class ConvertKit_Wishlist_Settings {
 	}
 
 	/**
-	 * Returns the ConvertKit Form ID that is mapped against the given WishList Member Level ID.
+	 * Returns the ConvertKit subscribe setting that is mapped against the given WishList Member Level ID.
 	 *
-	 * @since   1.9.6
+	 * @since   2.5.4
 	 *
 	 * @param   int $wlm_level_id   WishList Member Level ID.
 	 * @return  bool|int
 	 */
-	public function get_convertkit_form_id_by_wishlist_member_level_id( $wlm_level_id ) {
+	public function get_convertkit_subscribe_setting_by_wishlist_member_level_id( $wlm_level_id ) {
 
 		// Bail if no settings exist.
 		if ( ! $this->has_settings() ) {
@@ -102,14 +102,14 @@ class ConvertKit_Wishlist_Settings {
 	}
 
 	/**
-	 * Returns the ConvertKit Tag ID that is mapped against the given WishList Member Level ID.
+	 * Returns the ConvertKit unsubscribe setting that is mapped against the given WishList Member Level ID.
 	 *
 	 * @since   1.9.6
 	 *
 	 * @param   int $wlm_level_id   WishList Member Level ID.
 	 * @return  bool|string|int     false|'unsubscribe'|Tag ID
 	 */
-	public function get_convertkit_tag_id_by_wishlist_member_level_id( $wlm_level_id ) {
+	public function get_convertkit_unsubscribe_setting_wishlist_member_level_id( $wlm_level_id ) {
 
 		// Bail if no settings exist.
 		if ( ! $this->has_settings() ) {

--- a/includes/integrations/wishlist/class-convertkit-wishlist-settings.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist-settings.php
@@ -109,7 +109,7 @@ class ConvertKit_Wishlist_Settings {
 	 * @param   int $wlm_level_id   WishList Member Level ID.
 	 * @return  bool|string|int     false|'unsubscribe'|Tag ID
 	 */
-	public function get_convertkit_unsubscribe_setting_wishlist_member_level_id( $wlm_level_id ) {
+	public function get_convertkit_unsubscribe_setting_by_wishlist_member_level_id( $wlm_level_id ) {
 
 		// Bail if no settings exist.
 		if ( ! $this->has_settings() ) {

--- a/includes/integrations/wishlist/class-convertkit-wishlist-settings.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist-settings.php
@@ -93,11 +93,11 @@ class ConvertKit_Wishlist_Settings {
 		}
 
 		// Bail if no mapping exists.
-		if ( ! array_key_exists( $wlm_level_id . '_form', $this->get() ) ) {
+		if ( ! array_key_exists( $wlm_level_id . '_subscribe', $this->get() ) ) {
 			return false;
 		}
 
-		return $this->get()[ $wlm_level_id . '_form' ];
+		return $this->get()[ $wlm_level_id . '_subscribe' ];
 
 	}
 

--- a/includes/integrations/wishlist/class-convertkit-wishlist-settings.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist-settings.php
@@ -83,7 +83,7 @@ class ConvertKit_Wishlist_Settings {
 	 * @since   2.5.4
 	 *
 	 * @param   int $wlm_level_id   WishList Member Level ID.
-	 * @return  bool|string     	false|subscribe|form:id|tag:id|sequence:id.
+	 * @return  bool|string         false|subscribe|form:id|tag:id|sequence:id.
 	 */
 	public function get_convertkit_add_setting_by_wishlist_member_level_id( $wlm_level_id ) {
 
@@ -107,7 +107,7 @@ class ConvertKit_Wishlist_Settings {
 	 * @since   1.9.6
 	 *
 	 * @param   int $wlm_level_id   WishList Member Level ID.
-	 * @return  bool|string     	false|subscribe|unsubscribe|form:id|tag:id|sequence:id.
+	 * @return  bool|string         false|subscribe|unsubscribe|form:id|tag:id|sequence:id.
 	 */
 	public function get_convertkit_remove_setting_by_wishlist_member_level_id( $wlm_level_id ) {
 

--- a/includes/integrations/wishlist/class-convertkit-wishlist.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist.php
@@ -21,12 +21,11 @@ class ConvertKit_Wishlist {
 	 */
 	public function __construct() {
 
-		// When a user has levels added or registers check for a mapping to a ConvertKit form.
-		add_action( 'wishlistmember_add_user_levels', array( $this, 'add_user_levels' ), 10, 2 );
+		// When a user has levels added or registers, perform actions on ConvertKit.
+		add_action( 'wishlistmember_add_user_levels', array( $this, 'manage_member' ), 10, 2 );
 
-		// When a user has levels removed check for a mapping to a ConvertKit tag, or if the subscriber
-		// should be removed from ConvertKit.
-		add_action( 'wishlistmember_remove_user_levels', array( $this, 'remove_user_levels' ), 10, 2 );
+		// When a user has levels removed check, perform actions on ConvertKit.
+		add_action( 'wishlistmember_remove_user_levels', array( $this, 'manage_member' ), 10, 2 );
 
 	}
 
@@ -39,7 +38,7 @@ class ConvertKit_Wishlist {
 	 * @param   string $member_id  ID for member that has just had levels added.
 	 * @param   array  $levels     Levels to which member was added.
 	 */
-	public function add_user_levels( $member_id, $levels ) {
+	public function manage_member( $member_id, $levels ) {
 
 		// Get WishList Member.
 		$member = $this->get_member( $member_id );
@@ -48,91 +47,11 @@ class ConvertKit_Wishlist {
 		if ( ! $member ) {
 			return;
 		}
-
-		// Initialize Wishlist Settings class.
-		$wlm_settings = new ConvertKit_Wishlist_Settings();
-
-		// Iterate through the member's levels.
-		foreach ( $levels as $wlm_level_id ) {
-			// If no ConvertKit resource is mapped to this level, skip it.
-			$resource_type_id = $wlm_settings->get_convertkit_subscribe_setting_by_wishlist_member_level_id( $resource_type_and_id );
-			if ( ! $resource_type_and_id ) {
-				continue;
-			}
-
-			// If the resource setting is 'subscribe', just subscribe the member.
-			if ( $resource_type_id === 'subscribe' ) {
-				$this->member_resource_subscribe( $member );
-				continue;
-			}
-
-			// Extract resource type and ID from the setting.
-			list( $resource_type, $resource_id ) = explode( ':', $resource_type_and_id  );
-
-			// Subscribe the member to ConvertKit, and assign them to the resource (Form, Tag, Sequence).
-			$this->member_resource_subscribe( $member, $resource_id, $resource_type );
-		}
-
-	}
-
-	/**
-	 * Note: Form level unsubscribe is not available in v3 of the API.
-	 *
-	 * Callback function for wishlistmember_remove_user_levels action
-	 *
-	 * @param  string $member_id ID for member that has just had levels removed.
-	 * @param  array  $levels Levels from which member was removed.
-	 */
-	public function remove_user_levels( $member_id, $levels ) {
-
-		// Get WishList Member.
-		$member = $this->get_member( $member_id );
-
-		// Bail if no Member was returned.
-		if ( ! $member ) {
-			return;
-		}
-
-		// Initialize Wishlist Settings class.
-		$wlm_settings = new ConvertKit_Wishlist_Settings();
-
-		// Iterate through the member's levels.
-		foreach ( $levels as $wlm_level_id ) {
-			// If no ConvertKit resource is mapped to this level, skip it.
-			$resource_type_id = $wlm_settings->get_convertkit_unsubscribe_setting_by_wishlist_member_level_id( $wlm_level_id );
-			if ( ! $resource_type_id ) {
-				continue;
-			}
-
-			// If the resource setting is 'unsubscribe', unsubscribe the member.
-			if ( $resource_type_id === 'unsubscribe' ) {
-				$this->member_resource_unsubscribe( $member );
-				continue;
-			}
-
-			// Extract resource type and ID from the setting.
-			list( $resource_type, $resource_id ) = explode( ':', $resource_type_and_id  );
-
-			// Subscribe the member to ConvertKit, and assign them to the resource (Form, Tag, Sequence).
-			$this->member_resource_subscribe( $member, $resource_id, $resource_type );
-		}
-
-	}
-
-	/**
-	 * Subscribes a member to ConvertKit, and optionally assigns them to the given resource
-	 * (Form, Tag or Sequence).
-	 *
-	 * @param   array $member  UserInfo from WishList Member.
-	 * @param   int   $form_id ConvertKit Form ID.
-	 * @return  bool|WP_Error|array
-	 */
-	public function member_resource_subscribe( $member, $resource_id = false, $resource_type = false ) {
 
 		// Bail if the API hasn't been configured.
 		$settings = new ConvertKit_Settings();
 		if ( ! $settings->has_access_and_refresh_token() ) {
-			return false;
+			return;
 		}
 
 		// Initialize the API.
@@ -159,87 +78,70 @@ class ConvertKit_Wishlist {
 			$first_name = $name[0];
 		}
 
-		// Subscribe the email address.
-		$subscriber = $api->create_subscriber( $email, $first_name );
-		if ( is_wp_error( $subscriber ) ) {
-			return;
+		// Initialize Wishlist Settings class.
+		$wlm_settings = new ConvertKit_Wishlist_Settings();
+
+		// Iterate through the member's levels.
+		foreach ( $levels as $wlm_level_id ) {
+			// If no ConvertKit resource is mapped to this level, skip it.
+			$resource_type_id = $wlm_settings->get_convertkit_subscribe_setting_by_wishlist_member_level_id( $resource_type_and_id );
+			if ( ! $resource_type_and_id ) {
+				continue;
+			}
+
+			// If the resource setting is 'unsubscribe', just unsubscribe the member.
+			if ( $resource_type_id === 'unsubscribe' ) {
+				$api->unsubscribe( $email );
+				continue;
+			}
+
+			// If the resource setting is 'subscribe', just subscribe the member.
+			if ( $resource_type_id === 'subscribe' ) {
+				$api->create_subscriber( $email, $first_name );
+				continue;
+			}
+
+			// Extract resource type and ID from the setting.
+			list( $resource_type, $resource_id ) = explode( ':', $resource_type_and_id  );
+
+			// Cast ID.
+			$resource_id = absint( $resource_id );
+
+			// Add the subscriber to the resource type (form, tag etc).
+			switch ( $resource_type ) {
+
+				/**
+				 * Form
+				 */
+				case 'form':
+					// For Legacy Forms, a different endpoint is used.
+					$forms = new ConvertKit_Resource_Forms();
+					if ( $forms->is_legacy( $resource_id ) ) {
+						$api->add_subscriber_to_legacy_form( $resource_id, $subscriber['subscriber']['id'] );
+					}
+
+					// Add subscriber to form.
+					$api->add_subscriber_to_form( $resource_id, $subscriber['subscriber']['id'] );
+					break;
+
+				/**
+				 * Sequence
+				 */
+				case 'sequence':
+					// Add subscriber to sequence.
+					$api->add_subscriber_to_sequence( $resource_id, $subscriber['subscriber']['id'] );
+					break;
+
+				/**
+				 * Tag
+				 */
+				case 'tag':
+					// Add subscriber to tag.
+					$api->tag_subscriber( $resource_id, $subscriber['subscriber']['id'] );
+					break;
+
+			}
 		}
-
-		// If no resource type or ID, no need to do anything else.
-		if ( ! $resource_type || ! $resource_id ) {
-			return;
-		}
-
-		// Cast ID.
-		$resource_id = absint( $resource_id );
-
-		// Add the subscriber to the resource type (form, tag etc).
-		switch ( $resource_type ) {
-
-			/**
-			 * Form
-			 */
-			case 'form':
-				// For Legacy Forms, a different endpoint is used.
-				$forms = new ConvertKit_Resource_Forms();
-				if ( $forms->is_legacy( $resource_id ) ) {
-					return $api->add_subscriber_to_legacy_form( $resource_id, $subscriber['subscriber']['id'] );
-				}
-
-				// Add subscriber to form.
-				return $api->add_subscriber_to_form( $resource_id, $subscriber['subscriber']['id'] );
-
-			/**
-			 * Sequence
-			 */
-			case 'sequence':
-				// Add subscriber to sequence.
-				return $api->add_subscriber_to_sequence( $resource_id, $subscriber['subscriber']['id'] );
-
-			/**
-			 * Tag
-			 */
-			case 'tag':
-				// Add subscriber to tag.
-				return $api->tag_subscriber( $resource_id, $subscriber['subscriber']['id'] );
-
-		}
-
-	}
-
-	/**
-	 * Unsubscribes a member from ConvertKit.
-	 *
-	 * @param   array $member  UserInfo from WishList Member.
-	 * @return  bool|WP_Error|array
-	 */
-	public function member_resource_unsubscribe( $member ) {
-
-		// Bail if the API hasn't been configured.
-		$settings = new ConvertKit_Settings();
-		if ( ! $settings->has_access_and_refresh_token() ) {
-			return false;
-		}
-
-		// Initialize the API.
-		$api = new ConvertKit_API_V4(
-			CONVERTKIT_OAUTH_CLIENT_ID,
-			CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
-			$settings->get_access_token(),
-			$settings->get_refresh_token(),
-			$settings->debug_enabled(),
-			'wishlist_member'
-		);
-
-		// Check for temp email.
-		if ( preg_match( '/temp_[a-f0-9]{32}/', $member['user_email'] ) ) {
-			$email = $member['wlm_origemail'];
-		} else {
-			$email = $member['user_email'];
-		}
-
-		// Unsubscribe the email.
-		return $api->unsubscribe( $email );
 
 	}
 

--- a/includes/integrations/wishlist/class-convertkit-wishlist.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist.php
@@ -41,7 +41,7 @@ class ConvertKit_Wishlist {
 	 */
 	public function add_user_levels( $member_id, $levels ) {
 
-		$this->manage_member( $member_id, $levels, 'subscribe' );
+		$this->manage_member( $member_id, $levels, 'add' );
 
 	}
 
@@ -57,7 +57,7 @@ class ConvertKit_Wishlist {
 	 */
 	public function remove_user_levels( $member_id, $levels ) {
 
-		$this->manage_member( $member_id, $levels, 'unsubscribe' );
+		$this->manage_member( $member_id, $levels, 'remove' );
 
 	}
 
@@ -69,9 +69,9 @@ class ConvertKit_Wishlist {
 	 *
 	 * @param   string $member_id  ID for member that has just had levels added.
 	 * @param   array  $levels     Levels to which member was added.
-	 * @param   string $wlm_action  WishList Member action (subscribe,unsubscribe).
+	 * @param   string $wlm_action  WishList Member action (add,remove).
 	 */
-	private function manage_member( $member_id, $levels, $wlm_action = 'subscribe' ) {
+	private function manage_member( $member_id, $levels, $wlm_action = 'add' ) {
 
 		// Get WishList Member.
 		$member = $this->get_member( $member_id );
@@ -118,16 +118,17 @@ class ConvertKit_Wishlist {
 		foreach ( $levels as $wlm_level_id ) {
 			// Fetch action setting.
 			switch ( $wlm_action ) {
-				case 'subscribe':
+				case 'add':
 					$setting = $wlm_settings->get_convertkit_add_setting_by_wishlist_member_level_id( $wlm_level_id );
 					break;
 
-				case 'unsubscribe':
+				case 'remove':
 					$setting = $wlm_settings->get_convertkit_remove_setting_by_wishlist_member_level_id( $wlm_level_id );
 					break;
 
 				default:
-					continue;
+					$setting = false;
+					break;
 			}
 
 			// If no setting / action exists, skip this level.
@@ -146,6 +147,7 @@ class ConvertKit_Wishlist {
 				}
 
 				// Unsubscribe.
+				$api->unsubscribe( $subscriber_id );
 				continue;
 			}
 

--- a/includes/integrations/wishlist/class-convertkit-wishlist.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist.php
@@ -69,13 +69,9 @@ class ConvertKit_Wishlist {
 	 *
 	 * @param   string $member_id  ID for member that has just had levels added.
 	 * @param   array  $levels     Levels to which member was added.
-	 * @param 	string $wlm_action 	WishList Member action (subscribe,unsubscribe).
+	 * @param   string $wlm_action  WishList Member action (subscribe,unsubscribe).
 	 */
 	private function manage_member( $member_id, $levels, $wlm_action = 'subscribe' ) {
-
-		error_log( $member_id );
-		error_log( print_r( $levels, true ) );
-		error_log( $wlm_action );
 
 		// Get WishList Member.
 		$member = $this->get_member( $member_id );
@@ -123,18 +119,16 @@ class ConvertKit_Wishlist {
 			// Fetch action setting.
 			switch ( $wlm_action ) {
 				case 'subscribe':
-					$setting = $wlm_settings->get_convertkit_subscribe_setting_by_wishlist_member_level_id( $wlm_level_id );
+					$setting = $wlm_settings->get_convertkit_add_setting_by_wishlist_member_level_id( $wlm_level_id );
 					break;
 
 				case 'unsubscribe':
-					$setting = $wlm_settings->get_convertkit_unsubscribe_setting_by_wishlist_member_level_id( $wlm_level_id );
+					$setting = $wlm_settings->get_convertkit_remove_setting_by_wishlist_member_level_id( $wlm_level_id );
 					break;
 
 				default:
 					continue;
 			}
-
-			error_log( $setting );
 
 			// If no setting / action exists, skip this level.
 			if ( ! $setting ) {
@@ -143,8 +137,6 @@ class ConvertKit_Wishlist {
 
 			// If the resource setting is 'unsubscribe', just unsubscribe the member.
 			if ( $setting === 'unsubscribe' ) {
-				error_log( 'unsubscribe only' );
-
 				// Get subscriber ID.
 				$subscriber_id = $api->get_subscriber_id( $email );
 
@@ -154,7 +146,6 @@ class ConvertKit_Wishlist {
 				}
 
 				// Unsubscribe.
-				error_log( print_r( $api->unsubscribe( $subscriber_id ), true ) );
 				continue;
 			}
 
@@ -163,7 +154,6 @@ class ConvertKit_Wishlist {
 
 			// If the resource setting is 'subscribe', don't assign to a resource.
 			if ( $setting === 'subscribe' ) {
-				error_log( 'subscribe only' );
 				continue;
 			}
 

--- a/includes/integrations/wishlist/class-convertkit-wishlist.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist.php
@@ -84,25 +84,29 @@ class ConvertKit_Wishlist {
 		// Iterate through the member's levels.
 		foreach ( $levels as $wlm_level_id ) {
 			// If no ConvertKit resource is mapped to this level, skip it.
-			$resource_type_id = $wlm_settings->get_convertkit_subscribe_setting_by_wishlist_member_level_id( $resource_type_and_id );
-			if ( ! $resource_type_and_id ) {
+			$resource_type_id = $wlm_settings->get_convertkit_subscribe_setting_by_wishlist_member_level_id( $wlm_level_id );
+			if ( ! $resource_type_id ) {
 				continue;
 			}
 
 			// If the resource setting is 'unsubscribe', just unsubscribe the member.
 			if ( $resource_type_id === 'unsubscribe' ) {
-				$api->unsubscribe( $email );
+				error_log( 'unsubscribe only' );
+				error_log( print_r( $api->unsubscribe( $email ), true ) );
 				continue;
 			}
 
-			// If the resource setting is 'subscribe', just subscribe the member.
+			// Subscribe.
+			$subscriber = $api->create_subscriber( $email, $first_name );
+
+			// If the resource setting is 'subscribe', don't assign to a resource.
 			if ( $resource_type_id === 'subscribe' ) {
-				$api->create_subscriber( $email, $first_name );
+				error_log( 'subscribe only' );
 				continue;
 			}
 
 			// Extract resource type and ID from the setting.
-			list( $resource_type, $resource_id ) = explode( ':', $resource_type_and_id  );
+			list( $resource_type, $resource_id ) = explode( ':', $resource_type_id );
 
 			// Cast ID.
 			$resource_id = absint( $resource_id );

--- a/includes/integrations/wishlist/class-convertkit-wishlist.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist.php
@@ -54,14 +54,17 @@ class ConvertKit_Wishlist {
 
 		// Iterate through the member's levels.
 		foreach ( $levels as $wlm_level_id ) {
-			// If no ConvertKit Form is mapped to this level, skip it.
-			$convertkit_form_id = $wlm_settings->get_convertkit_form_id_by_wishlist_member_level_id( $wlm_level_id );
-			if ( ! $convertkit_form_id ) {
+			// If no ConvertKit resource is mapped to this level, skip it.
+			$resource_type_id = $wlm_settings->get_convertkit_form_id_by_wishlist_member_level_id( $resource_type_and_id );
+			if ( ! $resource_type_and_id ) {
 				continue;
 			}
 
-			// Subscribe the user to the ConvertKit Form for this level.
-			$this->member_resource_subscribe( $member, $convertkit_form_id );
+			// Extract resource type and ID from the setting.
+			list( $resource_type, $resource_id ) = explode( ':', $resource_type_and_id  );
+
+			// Subscribe the user to ConvertKit for this level.
+			$this->member_resource_subscribe( $member, $resource_id, $resource_type );
 		}
 
 	}
@@ -108,7 +111,7 @@ class ConvertKit_Wishlist {
 	}
 
 	/**
-	 * Subscribes a member to a ConvertKit Form.
+	 * Subscribes a member to ConvertKit.
 	 *
 	 * @param   array $member  UserInfo from WishList Member.
 	 * @param   int   $form_id ConvertKit Form ID.
@@ -145,6 +148,8 @@ class ConvertKit_Wishlist {
 			$name       = explode( ' ', $member['display_name'] );
 			$first_name = $name[0];
 		}
+
+
 
 		// Note Wishlist Member combines first and last name into 'display_name'.
 		// For Legacy Forms, a different endpoint is used.

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -152,9 +152,6 @@ class ConvertKitAPI extends \Codeception\Module
 			]
 		);
 
-		var_dump($results);
-		die();
-
 		// Check no subscribers are returned by this request.
 		$I->assertEquals(0, $results['pagination']['total_count']);
 	}

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -152,6 +152,9 @@ class ConvertKitAPI extends \Codeception\Module
 			]
 		);
 
+		var_dump($results);
+		die();
+
 		// Check no subscribers are returned by this request.
 		$I->assertEquals(0, $results['pagination']['total_count']);
 	}

--- a/tests/acceptance/integrations/wlm/WishListMemberCest.php
+++ b/tests/acceptance/integrations/wlm/WishListMemberCest.php
@@ -172,6 +172,187 @@ class WishListMemberCest
 	}
 
 	/**
+	 * Test that WishList Member Level to ConvertKit Form Mapping works,
+	 * and the email address is added to ConvertKit when removed from the WishList Member Level
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testWLMToConvertKitFormMappingOnLevelRemoved(AcceptanceTester $I)
+	{
+		// Get WishList Member Level ID defined.
+		$wlmLevelID = $this->_getWishListMemberLevelID($I);
+
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Create a test WordPress User.
+		$userID = $this->_createUser($I, $emailAddress);
+
+		// Configure mapping.
+		$this->_configureMapping($I, $wlmLevelID, 'remove', $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME']);
+
+		// Assign level to user.
+		$this->_assignLevelToUser($I, $wlmLevelID, $userID);
+
+		// Confirm that the email address was not added to ConvertKit.
+		$I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
+
+		// Remove level from user.
+		$this->_removeLevelFromUser($I, $wlmLevelID, $userID);
+
+		// Confirm that the email address was added to ConvertKit.
+		$I->apiCheckSubscriberExists($I, $emailAddress);
+	}
+
+	/**
+	 * Test that WishList Member Level to ConvertKit Legacy Form Mapping works,
+	 * and the email address is added to ConvertKit when removed from the WishList Member Level
+	 *
+	 * @since   2.5.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testWLMToConvertKitLegacyFormMappingOnLevelRemoved(AcceptanceTester $I)
+	{
+		// Get WishList Member Level ID defined.
+		$wlmLevelID = $this->_getWishListMemberLevelID($I);
+
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Create a test WordPress User.
+		$userID = $this->_createUser($I, $emailAddress);
+
+		// Configure mapping.
+		$this->_configureMapping($I, $wlmLevelID, 'remove', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
+
+		// Assign level to user.
+		$this->_assignLevelToUser($I, $wlmLevelID, $userID);
+
+		// Confirm that the email address was not added to ConvertKit.
+		$I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
+
+		// Remove level from user.
+		$this->_removeLevelFromUser($I, $wlmLevelID, $userID);
+
+		// Confirm that the email address was added to ConvertKit.
+		$I->apiCheckSubscriberExists($I, $emailAddress);
+	}
+
+	/**
+	 * Test that WishList Member Level to ConvertKit Tag Mapping works,
+	 * and the email address is added to ConvertKit when removed from the WishList Member Level
+	 *
+	 * @since   2.5.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testWLMToConvertKitTagMappingOnLevelRemoved(AcceptanceTester $I)
+	{
+		// Get WishList Member Level ID defined.
+		$wlmLevelID = $this->_getWishListMemberLevelID($I);
+
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Create a test WordPress User.
+		$userID = $this->_createUser($I, $emailAddress);
+
+		// Configure mapping.
+		$this->_configureMapping($I, $wlmLevelID, 'remove', $_ENV['CONVERTKIT_API_TAG_NAME']);
+
+		// Assign level to user.
+		$this->_assignLevelToUser($I, $wlmLevelID, $userID);
+
+		// Confirm that the email address was not added to ConvertKit.
+		$I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
+
+		// Remove level from user.
+		$this->_removeLevelFromUser($I, $wlmLevelID, $userID);
+
+		// Confirm that the email address was added to ConvertKit.
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+
+		// Check subscriber assigned to tag.
+		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
+	}
+
+	/**
+	 * Test that WishList Member Level to ConvertKit Sequence Mapping works,
+	 * and the email address is added to ConvertKit when removed from the WishList Member Level
+	 *
+	 * @since   2.5.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testWLMToConvertKitSequenceMappingOnLevelRemoved(AcceptanceTester $I)
+	{
+		// Get WishList Member Level ID defined.
+		$wlmLevelID = $this->_getWishListMemberLevelID($I);
+
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Create a test WordPress User.
+		$userID = $this->_createUser($I, $emailAddress);
+
+		// Configure mapping.
+		$this->_configureMapping($I, $wlmLevelID, 'remove', $_ENV['CONVERTKIT_API_SEQUENCE_NAME']);
+
+		// Assign level to user.
+		$this->_assignLevelToUser($I, $wlmLevelID, $userID);
+
+		// Confirm that the email address was not added to ConvertKit.
+		$I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
+
+		// Remove level from user.
+		$this->_removeLevelFromUser($I, $wlmLevelID, $userID);
+
+		// Confirm that the email address was added to ConvertKit.
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+
+		// Check that the subscriber has been assigned to the sequence.
+		$I->apiCheckSubscriberHasSequence($I, $subscriberID, $_ENV['CONVERTKIT_API_SEQUENCE_ID']);
+	}
+
+	/**
+	 * Test that the email address is removed from to ConvertKit when removed from the WishList Member Level.
+	 *
+	 * @since   2.5.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testWLMToConvertKitUnsubscribeMappingOnLevelRemoved(AcceptanceTester $I)
+	{
+		// Get WishList Member Level ID defined.
+		$wlmLevelID = $this->_getWishListMemberLevelID($I);
+
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Create a test WordPress User.
+		$userID = $this->_createUser($I, $emailAddress);
+
+		// Configure mapping.
+		$this->_configureMapping($I, $wlmLevelID, 'add', 'Subscribe');
+		$this->_configureMapping($I, $wlmLevelID, 'remove', 'Unsubscribe');
+		
+		// Assign level to user.
+		$this->_assignLevelToUser($I, $wlmLevelID, $userID);
+
+		// Confirm that the email address was added to ConvertKit.
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+
+		// Remove level from user.
+		$this->_removeLevelFromUser($I, $wlmLevelID, $userID);
+
+		// Confirm that the email address was not added to ConvertKit.
+		$I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
+	}
+
+	/**
 	 * Tests that existing settings are automatically migrated when updating
 	 * the Plugin to 2.5.3 or higher, with:
 	 * - Form IDs with value `default` are changed to a blank string
@@ -324,7 +505,7 @@ class WishListMemberCest
 		$I->acceptPopup(); // @TODO REMOVE
 
 		// Confirm that the User is no longer assigned to the WLM Level.
-		$I->seeCheckboxIsNotChecked('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
+		$I->dontSeeCheckboxIsChecked('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
 	}
 
 	/**

--- a/tests/acceptance/integrations/wlm/WishListMemberCest.php
+++ b/tests/acceptance/integrations/wlm/WishListMemberCest.php
@@ -22,13 +22,14 @@ class WishListMemberCest
 	}
 
 	/**
-	 * Test that saving a WishList Member Level to ConvertKit Form Mapping works.
+	 * Test that WishList Member Level to ConvertKit Form Mapping works,
+	 * and the email address is added to ConvertKit when assigned the WishList Member Level
 	 *
 	 * @since   1.9.6
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testSettingsWishListMemberLevelToConvertKitFormMapping(AcceptanceTester $I)
+	public function testWLMToConvertKitFormMappingOnLevelAssigned(AcceptanceTester $I)
 	{
 		// Get WishList Member Level ID defined.
 		$wlmLevelID = $this->_getWishListMemberLevelID($I);
@@ -39,45 +40,156 @@ class WishListMemberCest
 		// Create a test WordPress User.
 		$userID = $this->_createUser($I, $emailAddress);
 
+		// Configure mapping.
+		$I->_configureMapping($I, 'subscribe', $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME']);
+
+		// Assign level to user.
+		$I->_assignLevelToUser($I, $wlmLevelID, $userID);
+
+		// Confirm that the email address was added to ConvertKit.
+		$I->apiCheckSubscriberExists($I, $emailAddress);
+	}
+
+	/**
+	 * Test that WishList Member Level to ConvertKit Legacy Form Mapping works,
+	 * and the email address is added to ConvertKit when assigned the WishList Member Level
+	 *
+	 * @since   2.5.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testWLMToConvertKitLegacyFormMappingOnLevelAssigned(AcceptanceTester $I)
+	{
+		// Get WishList Member Level ID defined.
+		$wlmLevelID = $this->_getWishListMemberLevelID($I);
+
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Create a test WordPress User.
+		$userID = $this->_createUser($I, $emailAddress);
+
+		// Configure mapping.
+		$I->_configureMapping($I, 'subscribe', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
+
+		// Assign level to user.
+		$I->_assignLevelToUser($I, $wlmLevelID, $userID);
+
+		// Confirm that the email address was added to ConvertKit.
+		$I->apiCheckSubscriberExists($I, $emailAddress);
+	}
+
+	/**
+	 * Test that WishList Member Level to ConvertKit Tag Mapping works,
+	 * and the email address is added to ConvertKit when assigned the WishList Member Level
+	 *
+	 * @since   2.5.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testWLMToConvertKitTagMappingOnLevelAssigned(AcceptanceTester $I)
+	{
+		// Get WishList Member Level ID defined.
+		$wlmLevelID = $this->_getWishListMemberLevelID($I);
+
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Create a test WordPress User.
+		$userID = $this->_createUser($I, $emailAddress);
+
+		// Configure mapping.
+		$I->_configureMapping($I, 'subscribe', $_ENV['CONVERTKIT_API_TAG_NAME']);
+
+		// Assign level to user.
+		$I->_assignLevelToUser($I, $wlmLevelID, $userID);
+
+		// Confirm that the email address was added to ConvertKit.
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+
+		// Check subscriber assigned to tag.
+		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
+	}
+
+	/**
+	 * Test that WishList Member Level to ConvertKit Sequence Mapping works,
+	 * and the email address is added to ConvertKit when assigned the WishList Member Level
+	 *
+	 * @since   2.5.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testWLMToConvertKitSequenceMappingOnLevelAssigned(AcceptanceTester $I)
+	{
+		// Get WishList Member Level ID defined.
+		$wlmLevelID = $this->_getWishListMemberLevelID($I);
+
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Create a test WordPress User.
+		$userID = $this->_createUser($I, $emailAddress);
+
+		// Configure mapping.
+		$I->_configureMapping($I, 'subscribe', $_ENV['CONVERTKIT_API_SEQUENCE_NAME']);
+
+		// Assign level to user.
+		$I->_assignLevelToUser($I, $wlmLevelID, $userID);
+
+		// Confirm that the email address was added to ConvertKit.
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+
+		// Check that the subscriber has been assigned to the sequence.
+		$I->apiCheckSubscriberHasSequence($I, $subscriberID, $_ENV['CONVERTKIT_API_SEQUENCE_ID']);
+	}
+
+	/**
+	 * Test that the email address is added to ConvertKit when assigned the WishList Member Level.
+	 *
+	 * @since   2.5.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testWLMToConvertKitSubscribeMappingOnLevelAssigned(AcceptanceTester $I)
+	{
+		// Get WishList Member Level ID defined.
+		$wlmLevelID = $this->_getWishListMemberLevelID($I);
+
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Create a test WordPress User.
+		$userID = $this->_createUser($I, $emailAddress);
+
+		// Configure mapping.
+		$I->_configureMapping($I, 'subscribe', 'Subscribe');
+
+		// Assign level to user.
+		$I->_assignLevelToUser($I, $wlmLevelID, $userID);
+
+		// Confirm that the email address was added to ConvertKit.
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+	}
+
+	// @TODO Tests for remove level.
+
+
+	private function _configureMapping(AcceptanceTester $I, $wlmLevelID, $action, $resourceName)
+	{
 		// Load WishList Member Plugin Settings.
 		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=wishlist-member');
 
-		// Check that no PHP warnings or notices were output, if we're on PHP < 8.1 (WLM will throw errors in 8.1+, outside of our control).
-		if (version_compare( phpversion(), '8.1', '<' )) {
-			$I->checkNoWarningsAndNoticesOnScreen($I);
-		}
-
 		// Check that a Form Mapping option is displayed.
-		$I->seeElementInDOM('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form');
+		$I->seeElementInDOM('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_' . $action);
 
 		// Change Form to value specified in the .env file.
-		$I->selectOption('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form', $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME']);
+		$I->selectOption('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_' . $action, $resourceName);
 
 		// Save Changes.
 		$I->click('Save Changes');
 
-		// Check that no PHP warnings or notices were output, if we're on PHP < 8.1 (WLM will throw errors in 8.1+, outside of our control).
-		if (version_compare( phpversion(), '8.1', '<' )) {
-			$I->checkNoWarningsAndNoticesOnScreen($I);
-		}
-
 		// Check the value of the Form field matches the input provided.
-		$I->seeOptionIsSelected('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form', $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME']);
-
-		// Edit the Test User.
-		$I->amOnAdminPage('user-edit.php?user_id=' . $userID . '&wp_http_referer=%2Fwp-admin%2Fusers.php');
-
-		// Map the User to the Bronze WLM Level.
-		$I->checkOption('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
-
-		// Save Changes.
-		$I->click('Update Member Profile');
-
-		// Confirm that the User is still assigned to the Bronze WLM Level.
-		$I->seeCheckboxIsChecked('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
-
-		// Confirm that the email address was added to ConvertKit.
-		$I->apiCheckSubscriberExists($I, $emailAddress);
+		$I->seeOptionIsSelected('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_' . $action, $resourceName);
 	}
 
 	/**
@@ -340,6 +452,56 @@ class WishListMemberCest
 				'display_name' => 'Test User',
 			]
 		);
+	}
+
+	/**
+	 * Assigns the given WLM Level to the given WordPress User.
+	 *
+	 * @since   2.5.4
+	 *
+	 * @param   AcceptanceTester $I              Tester.
+	 * @param 	int 			 $wlmLevelID 	 WishList Member Level ID.
+	 * @param 	int 			 $userID 		 WordPress User ID.
+	 */
+	private function _assignLevelToUser(AcceptanceTester $I, $wlmLevelID, $userID)
+	{
+		// Edit the Test User.
+		$I->amOnAdminPage('user-edit.php?user_id=' . $userID . '&wp_http_referer=%2Fwp-admin%2Fusers.php');
+
+		// Map the User to the WLM Level.
+		$I->checkOption('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
+
+		// Save Changes.
+		$I->click('Update Member Profile');
+
+		// Confirm that the User is still assigned to the WLM Level.
+		$I->seeCheckboxIsChecked('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
+	}
+
+	/**
+	 * Removes the given WLM Level from the given WordPress User.
+	 *
+	 * @since   2.5.4
+	 *
+	 * @param   AcceptanceTester $I              Tester.
+	 * @param 	int 			 $wlmLevelID 	 WishList Member Level ID.
+	 * @param 	int 			 $userID 		 WordPress User ID.
+	 */
+	private function _removeLevelFromUser(AcceptanceTester $I, $wlmLevelID, $userID)
+	{
+		// @TODO.
+		
+		// Edit the Test User.
+		$I->amOnAdminPage('user-edit.php?user_id=' . $userID . '&wp_http_referer=%2Fwp-admin%2Fusers.php');
+
+		// Map the User to the WLM Level.
+		$I->checkOption('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
+
+		// Save Changes.
+		$I->click('Update Member Profile');
+
+		// Confirm that the User is still assigned to the WLM Level.
+		$I->seeCheckboxIsChecked('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
 	}
 
 	/**

--- a/tests/acceptance/integrations/wlm/WishListMemberCest.php
+++ b/tests/acceptance/integrations/wlm/WishListMemberCest.php
@@ -29,7 +29,7 @@ class WishListMemberCest
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testWLMToConvertKitFormMappingOnLevelAssigned(AcceptanceTester $I)
+	public function testWLMToConvertKitFormMappingOnLevelAdded(AcceptanceTester $I)
 	{
 		// Get WishList Member Level ID defined.
 		$wlmLevelID = $this->_getWishListMemberLevelID($I);
@@ -41,10 +41,10 @@ class WishListMemberCest
 		$userID = $this->_createUser($I, $emailAddress);
 
 		// Configure mapping.
-		$I->_configureMapping($I, 'subscribe', $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME']);
+		$this->_configureMapping($I, $wlmLevelID, 'add', $_ENV['CONVERTKIT_API_THIRD_PARTY_INTEGRATIONS_FORM_NAME']);
 
 		// Assign level to user.
-		$I->_assignLevelToUser($I, $wlmLevelID, $userID);
+		$this->_assignLevelToUser($I, $wlmLevelID, $userID);
 
 		// Confirm that the email address was added to ConvertKit.
 		$I->apiCheckSubscriberExists($I, $emailAddress);
@@ -58,7 +58,7 @@ class WishListMemberCest
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testWLMToConvertKitLegacyFormMappingOnLevelAssigned(AcceptanceTester $I)
+	public function testWLMToConvertKitLegacyFormMappingOnLevelAdded(AcceptanceTester $I)
 	{
 		// Get WishList Member Level ID defined.
 		$wlmLevelID = $this->_getWishListMemberLevelID($I);
@@ -70,10 +70,10 @@ class WishListMemberCest
 		$userID = $this->_createUser($I, $emailAddress);
 
 		// Configure mapping.
-		$I->_configureMapping($I, 'subscribe', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
+		$this->_configureMapping($I, $wlmLevelID, 'add', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
 
 		// Assign level to user.
-		$I->_assignLevelToUser($I, $wlmLevelID, $userID);
+		$this->_assignLevelToUser($I, $wlmLevelID, $userID);
 
 		// Confirm that the email address was added to ConvertKit.
 		$I->apiCheckSubscriberExists($I, $emailAddress);
@@ -87,7 +87,7 @@ class WishListMemberCest
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testWLMToConvertKitTagMappingOnLevelAssigned(AcceptanceTester $I)
+	public function testWLMToConvertKitTagMappingOnLevelAdded(AcceptanceTester $I)
 	{
 		// Get WishList Member Level ID defined.
 		$wlmLevelID = $this->_getWishListMemberLevelID($I);
@@ -99,10 +99,10 @@ class WishListMemberCest
 		$userID = $this->_createUser($I, $emailAddress);
 
 		// Configure mapping.
-		$I->_configureMapping($I, 'subscribe', $_ENV['CONVERTKIT_API_TAG_NAME']);
+		$this->_configureMapping($I, $wlmLevelID, 'add', $_ENV['CONVERTKIT_API_TAG_NAME']);
 
 		// Assign level to user.
-		$I->_assignLevelToUser($I, $wlmLevelID, $userID);
+		$this->_assignLevelToUser($I, $wlmLevelID, $userID);
 
 		// Confirm that the email address was added to ConvertKit.
 		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
@@ -119,7 +119,7 @@ class WishListMemberCest
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testWLMToConvertKitSequenceMappingOnLevelAssigned(AcceptanceTester $I)
+	public function testWLMToConvertKitSequenceMappingOnLevelAdded(AcceptanceTester $I)
 	{
 		// Get WishList Member Level ID defined.
 		$wlmLevelID = $this->_getWishListMemberLevelID($I);
@@ -131,10 +131,10 @@ class WishListMemberCest
 		$userID = $this->_createUser($I, $emailAddress);
 
 		// Configure mapping.
-		$I->_configureMapping($I, 'subscribe', $_ENV['CONVERTKIT_API_SEQUENCE_NAME']);
+		$this->_configureMapping($I, $wlmLevelID, 'add', $_ENV['CONVERTKIT_API_SEQUENCE_NAME']);
 
 		// Assign level to user.
-		$I->_assignLevelToUser($I, $wlmLevelID, $userID);
+		$this->_assignLevelToUser($I, $wlmLevelID, $userID);
 
 		// Confirm that the email address was added to ConvertKit.
 		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
@@ -150,7 +150,7 @@ class WishListMemberCest
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testWLMToConvertKitSubscribeMappingOnLevelAssigned(AcceptanceTester $I)
+	public function testWLMToConvertKitSubscribeMappingOnLevelAdded(AcceptanceTester $I)
 	{
 		// Get WishList Member Level ID defined.
 		$wlmLevelID = $this->_getWishListMemberLevelID($I);
@@ -162,217 +162,13 @@ class WishListMemberCest
 		$userID = $this->_createUser($I, $emailAddress);
 
 		// Configure mapping.
-		$I->_configureMapping($I, 'subscribe', 'Subscribe');
+		$this->_configureMapping($I, $wlmLevelID, 'add', 'Subscribe');
 
 		// Assign level to user.
-		$I->_assignLevelToUser($I, $wlmLevelID, $userID);
+		$this->_assignLevelToUser($I, $wlmLevelID, $userID);
 
 		// Confirm that the email address was added to ConvertKit.
 		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
-	}
-
-	// @TODO Tests for remove level.
-
-
-	private function _configureMapping(AcceptanceTester $I, $wlmLevelID, $action, $resourceName)
-	{
-		// Load WishList Member Plugin Settings.
-		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=wishlist-member');
-
-		// Check that a Form Mapping option is displayed.
-		$I->seeElementInDOM('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_' . $action);
-
-		// Change Form to value specified in the .env file.
-		$I->selectOption('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_' . $action, $resourceName);
-
-		// Save Changes.
-		$I->click('Save Changes');
-
-		// Check the value of the Form field matches the input provided.
-		$I->seeOptionIsSelected('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_' . $action, $resourceName);
-	}
-
-	/**
-	 * Test that saving a WishList Member Level to ConvertKit Legacy Form Mapping works.
-	 *
-	 * @since   2.5.0
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 */
-	public function testSettingsWishListMemberLevelToConvertKitLegacyFormMapping(AcceptanceTester $I)
-	{
-		// Get WishList Member Level ID defined.
-		$wlmLevelID = $this->_getWishListMemberLevelID($I);
-
-		// Define email address for this test.
-		$emailAddress = $I->generateEmailAddress();
-
-		// Create a test WordPress User.
-		$userID = $this->_createUser($I, $emailAddress);
-
-		// Load WishList Member Plugin Settings.
-		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=wishlist-member');
-
-		// Check that no PHP warnings or notices were output, if we're on PHP < 8.1 (WLM will throw errors in 8.1+, outside of our control).
-		if (version_compare( phpversion(), '8.1', '<' )) {
-			$I->checkNoWarningsAndNoticesOnScreen($I);
-		}
-
-		// Check that a Form Mapping option is displayed.
-		$I->seeElementInDOM('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form');
-
-		// Change Form to value specified in the .env file.
-		$I->selectOption('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
-
-		// Save Changes.
-		$I->click('Save Changes');
-
-		// Check that no PHP warnings or notices were output, if we're on PHP < 8.1 (WLM will throw errors in 8.1+, outside of our control).
-		if (version_compare( phpversion(), '8.1', '<' )) {
-			$I->checkNoWarningsAndNoticesOnScreen($I);
-		}
-
-		// Check the value of the Form field matches the input provided.
-		$I->seeOptionIsSelected('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME']);
-
-		// Edit the Test User.
-		$I->amOnAdminPage('user-edit.php?user_id=' . $userID . '&wp_http_referer=%2Fwp-admin%2Fusers.php');
-
-		// Map the User to the Bronze WLM Level.
-		$I->checkOption('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
-
-		// Save Changes.
-		$I->click('Update Member Profile');
-
-		// Confirm that the User is still assigned to the Bronze WLM Level.
-		$I->seeCheckboxIsChecked('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
-
-		// Confirm that the email address was added to ConvertKit.
-		$I->apiCheckSubscriberExists($I, $emailAddress);
-	}
-
-	/**
-	 * Test that saving a WishList Member Level to ConvertKit Tag Mapping works.
-	 *
-	 * @since   2.5.4
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 */
-	public function testSettingsWishListMemberLevelToConvertKitTagMapping(AcceptanceTester $I)
-	{
-		// Get WishList Member Level ID defined.
-		$wlmLevelID = $this->_getWishListMemberLevelID($I);
-
-		// Define email address for this test.
-		$emailAddress = $I->generateEmailAddress();
-
-		// Create a test WordPress User.
-		$userID = $this->_createUser($I, $emailAddress);
-
-		// Load WishList Member Plugin Settings.
-		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=wishlist-member');
-
-		// Check that no PHP warnings or notices were output, if we're on PHP < 8.1 (WLM will throw errors in 8.1+, outside of our control).
-		if (version_compare( phpversion(), '8.1', '<' )) {
-			$I->checkNoWarningsAndNoticesOnScreen($I);
-		}
-
-		// Check that the mapping option is displayed.
-		$I->seeElementInDOM('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form');
-
-		// Change Tag to value specified in the .env file.
-		$I->selectOption('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form', $_ENV['CONVERTKIT_API_TAG_NAME']);
-
-		// Save Changes.
-		$I->click('Save Changes');
-
-		// Check that no PHP warnings or notices were output, if we're on PHP < 8.1 (WLM will throw errors in 8.1+, outside of our control).
-		if (version_compare( phpversion(), '8.1', '<' )) {
-			$I->checkNoWarningsAndNoticesOnScreen($I);
-		}
-
-		// Check the value of the Tag field matches the input provided.
-		$I->seeOptionIsSelected('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form', $_ENV['CONVERTKIT_API_TAG_NAME']);
-
-		// Edit the Test User.
-		$I->amOnAdminPage('user-edit.php?user_id=' . $userID . '&wp_http_referer=%2Fwp-admin%2Fusers.php');
-
-		// Map the User to the Bronze WLM Level.
-		$I->checkOption('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
-
-		// Save Changes.
-		$I->click('Update Member Profile');
-
-		// Confirm that the User is still assigned to the Bronze WLM Level.
-		$I->seeCheckboxIsChecked('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
-
-		// Confirm that the email address was added to ConvertKit.
-		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
-
-		// Check subscriber assigned to tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
-	}
-
-	/**
-	 * Test that saving a WishList Member Level to ConvertKit Sequence Mapping works.
-	 *
-	 * @since   2.5.4
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 */
-	public function testSettingsWishListMemberLevelToConvertKitSequenceMapping(AcceptanceTester $I)
-	{
-		// Get WishList Member Level ID defined.
-		$wlmLevelID = $this->_getWishListMemberLevelID($I);
-
-		// Define email address for this test.
-		$emailAddress = $I->generateEmailAddress();
-
-		// Create a test WordPress User.
-		$userID = $this->_createUser($I, $emailAddress);
-
-		// Load WishList Member Plugin Settings.
-		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=wishlist-member');
-
-		// Check that no PHP warnings or notices were output, if we're on PHP < 8.1 (WLM will throw errors in 8.1+, outside of our control).
-		if (version_compare( phpversion(), '8.1', '<' )) {
-			$I->checkNoWarningsAndNoticesOnScreen($I);
-		}
-
-		// Check that the mapping option is displayed.
-		$I->seeElementInDOM('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form');
-
-		// Change Tag to value specified in the .env file.
-		$I->selectOption('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form', $_ENV['CONVERTKIT_API_SEQUENCE_NAME']);
-
-		// Save Changes.
-		$I->click('Save Changes');
-
-		// Check that no PHP warnings or notices were output, if we're on PHP < 8.1 (WLM will throw errors in 8.1+, outside of our control).
-		if (version_compare( phpversion(), '8.1', '<' )) {
-			$I->checkNoWarningsAndNoticesOnScreen($I);
-		}
-
-		// Check the value of the Tag field matches the input provided.
-		$I->seeOptionIsSelected('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form', $_ENV['CONVERTKIT_API_SEQUENCE_NAME']);
-
-		// Edit the Test User.
-		$I->amOnAdminPage('user-edit.php?user_id=' . $userID . '&wp_http_referer=%2Fwp-admin%2Fusers.php');
-
-		// Map the User to the Bronze WLM Level.
-		$I->checkOption('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
-
-		// Save Changes.
-		$I->click('Update Member Profile');
-
-		// Confirm that the User is still assigned to the Bronze WLM Level.
-		$I->seeCheckboxIsChecked('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
-
-		// Confirm that the email address was added to ConvertKit.
-		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
-
-		// Check subscriber assigned to sequence.
-		$I->apiCheckSubscriberHasSequence($I, $subscriberID, $_ENV['CONVERTKIT_API_SEQUENCE_ID']);
 	}
 
 	/**
@@ -391,10 +187,10 @@ class WishListMemberCest
 		$I->haveOptionInDatabase(
 			'_wp_convertkit_integration_wishlistmember_settings',
 			[
-				'1_form' 		=> $_ENV['CONVERTKIT_API_FORM_ID'],
-				'2_form' 		=> '',
-				'3_form' 		=> 'default',
-				'4_unsubscribe' => $_ENV['CONVERTKIT_APIT_TAG_ID'],
+				'1_form'        => $_ENV['CONVERTKIT_API_FORM_ID'],
+				'2_form'        => '',
+				'3_form'        => 'default',
+				'4_unsubscribe' => $_ENV['CONVERTKIT_API_TAG_ID'],
 			]
 		);
 
@@ -406,13 +202,13 @@ class WishListMemberCest
 
 		// Check settings structure has been updated.
 		$settings = $I->grabOptionFromDatabase('_wp_convertkit_integration_wishlistmember_settings');
-		$I->assertArrayHasKey('1', $settings);
-		$I->assertArrayHasKey('2', $settings);
-		$I->assertArrayHasKey('3', $settings);
-		$I->assertEquals($settings['1_form'], 'form:' . $_ENV['CONVERTKIT_API_FORM_ID']);
-		$I->assertEquals($settings['2_form'], '');
-		$I->assertEquals($settings['3_form'], '');
-		$I->assertEquals($settings['4_unsubscribe'], 'tag:' . $_ENV['CONVERTKIT_API_TAG_ID']);
+		var_dump( $settings );
+		die();
+
+		$I->assertEquals($settings['1_add'], 'form:' . $_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->assertEquals($settings['2_add'], '');
+		$I->assertEquals($settings['3_add'], '');
+		$I->assertEquals($settings['4_remove'], 'tag:' . $_ENV['CONVERTKIT_API_TAG_ID']);
 	}
 
 	/**
@@ -455,13 +251,41 @@ class WishListMemberCest
 	}
 
 	/**
+	 * Configure WishList Member Levels to ConvertKit settings mapping.
+	 *
+	 * @since   2.5.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 * @param   int              $wlmLevelID    WishList Member Level ID.
+	 * @param   string           $action        Action (subscribe,unsubscribe).
+	 * @param   string           $resourceName  Resource option to select (subscribe, form, tag, sequence etc).
+	 */
+	private function _configureMapping(AcceptanceTester $I, $wlmLevelID, $action, $resourceName)
+	{
+		// Load WishList Member Plugin Settings.
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=wishlist-member');
+
+		// Check that a Form Mapping option is displayed.
+		$I->seeElementInDOM('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_' . $action);
+
+		// Change Form to value specified in the .env file.
+		$I->selectOption('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_' . $action, $resourceName);
+
+		// Save Changes.
+		$I->click('Save Changes');
+
+		// Check the value of the Form field matches the input provided.
+		$I->seeOptionIsSelected('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_' . $action, $resourceName);
+	}
+
+	/**
 	 * Assigns the given WLM Level to the given WordPress User.
 	 *
 	 * @since   2.5.4
 	 *
 	 * @param   AcceptanceTester $I              Tester.
-	 * @param 	int 			 $wlmLevelID 	 WishList Member Level ID.
-	 * @param 	int 			 $userID 		 WordPress User ID.
+	 * @param   int              $wlmLevelID     WishList Member Level ID.
+	 * @param   int              $userID         WordPress User ID.
 	 */
 	private function _assignLevelToUser(AcceptanceTester $I, $wlmLevelID, $userID)
 	{
@@ -474,6 +298,8 @@ class WishListMemberCest
 		// Save Changes.
 		$I->click('Update Member Profile');
 
+		$I->acceptPopup(); // @TODO REMOVE
+
 		// Confirm that the User is still assigned to the WLM Level.
 		$I->seeCheckboxIsChecked('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
 	}
@@ -484,24 +310,24 @@ class WishListMemberCest
 	 * @since   2.5.4
 	 *
 	 * @param   AcceptanceTester $I              Tester.
-	 * @param 	int 			 $wlmLevelID 	 WishList Member Level ID.
-	 * @param 	int 			 $userID 		 WordPress User ID.
+	 * @param   int              $wlmLevelID     WishList Member Level ID.
+	 * @param   int              $userID         WordPress User ID.
 	 */
 	private function _removeLevelFromUser(AcceptanceTester $I, $wlmLevelID, $userID)
 	{
-		// @TODO.
-		
 		// Edit the Test User.
 		$I->amOnAdminPage('user-edit.php?user_id=' . $userID . '&wp_http_referer=%2Fwp-admin%2Fusers.php');
 
-		// Map the User to the WLM Level.
-		$I->checkOption('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
+		// Unmap the User to the WLM Level.
+		$I->uncheckOption('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
 
 		// Save Changes.
 		$I->click('Update Member Profile');
 
-		// Confirm that the User is still assigned to the WLM Level.
-		$I->seeCheckboxIsChecked('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
+		$I->acceptPopup(); // @TODO REMOVE
+
+		// Confirm that the User is no longer assigned to the WLM Level.
+		$I->seeCheckboxIsNotChecked('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
 	}
 
 	/**

--- a/tests/acceptance/integrations/wlm/WishListMemberCest.php
+++ b/tests/acceptance/integrations/wlm/WishListMemberCest.php
@@ -202,9 +202,6 @@ class WishListMemberCest
 
 		// Check settings structure has been updated.
 		$settings = $I->grabOptionFromDatabase('_wp_convertkit_integration_wishlistmember_settings');
-		var_dump( $settings );
-		die();
-
 		$I->assertEquals($settings['1_add'], 'form:' . $_ENV['CONVERTKIT_API_FORM_ID']);
 		$I->assertEquals($settings['2_add'], '');
 		$I->assertEquals($settings['3_add'], '');

--- a/tests/acceptance/integrations/wlm/WishListMemberCest.php
+++ b/tests/acceptance/integrations/wlm/WishListMemberCest.php
@@ -338,7 +338,7 @@ class WishListMemberCest
 		// Configure mapping.
 		$this->_configureMapping($I, $wlmLevelID, 'add', 'Subscribe');
 		$this->_configureMapping($I, $wlmLevelID, 'remove', 'Unsubscribe');
-		
+
 		// Assign level to user.
 		$this->_assignLevelToUser($I, $wlmLevelID, $userID);
 
@@ -476,8 +476,6 @@ class WishListMemberCest
 		// Save Changes.
 		$I->click('Update Member Profile');
 
-		$I->acceptPopup(); // @TODO REMOVE
-
 		// Confirm that the User is still assigned to the WLM Level.
 		$I->seeCheckboxIsChecked('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
 	}
@@ -501,8 +499,6 @@ class WishListMemberCest
 
 		// Save Changes.
 		$I->click('Update Member Profile');
-
-		$I->acceptPopup(); // @TODO REMOVE
 
 		// Confirm that the User is no longer assigned to the WLM Level.
 		$I->dontSeeCheckboxIsChecked('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');

--- a/tests/acceptance/integrations/wlm/WishListMemberCest.php
+++ b/tests/acceptance/integrations/wlm/WishListMemberCest.php
@@ -140,6 +140,130 @@ class WishListMemberCest
 	}
 
 	/**
+	 * Test that saving a WishList Member Level to ConvertKit Tag Mapping works.
+	 *
+	 * @since   2.5.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSettingsWishListMemberLevelToConvertKitTagMapping(AcceptanceTester $I)
+	{
+		// Get WishList Member Level ID defined.
+		$wlmLevelID = $this->_getWishListMemberLevelID($I);
+
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Create a test WordPress User.
+		$userID = $this->_createUser($I, $emailAddress);
+
+		// Load WishList Member Plugin Settings.
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=wishlist-member');
+
+		// Check that no PHP warnings or notices were output, if we're on PHP < 8.1 (WLM will throw errors in 8.1+, outside of our control).
+		if (version_compare( phpversion(), '8.1', '<' )) {
+			$I->checkNoWarningsAndNoticesOnScreen($I);
+		}
+
+		// Check that the mapping option is displayed.
+		$I->seeElementInDOM('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form');
+
+		// Change Tag to value specified in the .env file.
+		$I->selectOption('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form', $_ENV['CONVERTKIT_API_TAG_NAME']);
+
+		// Save Changes.
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output, if we're on PHP < 8.1 (WLM will throw errors in 8.1+, outside of our control).
+		if (version_compare( phpversion(), '8.1', '<' )) {
+			$I->checkNoWarningsAndNoticesOnScreen($I);
+		}
+
+		// Check the value of the Tag field matches the input provided.
+		$I->seeOptionIsSelected('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form', $_ENV['CONVERTKIT_API_TAG_NAME']);
+
+		// Edit the Test User.
+		$I->amOnAdminPage('user-edit.php?user_id=' . $userID . '&wp_http_referer=%2Fwp-admin%2Fusers.php');
+
+		// Map the User to the Bronze WLM Level.
+		$I->checkOption('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
+
+		// Save Changes.
+		$I->click('Update Member Profile');
+
+		// Confirm that the User is still assigned to the Bronze WLM Level.
+		$I->seeCheckboxIsChecked('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
+
+		// Confirm that the email address was added to ConvertKit.
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+
+		// Check subscriber assigned to tag.
+		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
+	}
+
+	/**
+	 * Test that saving a WishList Member Level to ConvertKit Sequence Mapping works.
+	 *
+	 * @since   2.5.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSettingsWishListMemberLevelToConvertKitSequenceMapping(AcceptanceTester $I)
+	{
+		// Get WishList Member Level ID defined.
+		$wlmLevelID = $this->_getWishListMemberLevelID($I);
+
+		// Define email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Create a test WordPress User.
+		$userID = $this->_createUser($I, $emailAddress);
+
+		// Load WishList Member Plugin Settings.
+		$I->amOnAdminPage('options-general.php?page=_wp_convertkit_settings&tab=wishlist-member');
+
+		// Check that no PHP warnings or notices were output, if we're on PHP < 8.1 (WLM will throw errors in 8.1+, outside of our control).
+		if (version_compare( phpversion(), '8.1', '<' )) {
+			$I->checkNoWarningsAndNoticesOnScreen($I);
+		}
+
+		// Check that the mapping option is displayed.
+		$I->seeElementInDOM('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form');
+
+		// Change Tag to value specified in the .env file.
+		$I->selectOption('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form', $_ENV['CONVERTKIT_API_SEQUENCE_NAME']);
+
+		// Save Changes.
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output, if we're on PHP < 8.1 (WLM will throw errors in 8.1+, outside of our control).
+		if (version_compare( phpversion(), '8.1', '<' )) {
+			$I->checkNoWarningsAndNoticesOnScreen($I);
+		}
+
+		// Check the value of the Tag field matches the input provided.
+		$I->seeOptionIsSelected('#_wp_convertkit_integration_wishlistmember_settings_' . $wlmLevelID . '_form', $_ENV['CONVERTKIT_API_SEQUENCE_NAME']);
+
+		// Edit the Test User.
+		$I->amOnAdminPage('user-edit.php?user_id=' . $userID . '&wp_http_referer=%2Fwp-admin%2Fusers.php');
+
+		// Map the User to the Bronze WLM Level.
+		$I->checkOption('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
+
+		// Save Changes.
+		$I->click('Update Member Profile');
+
+		// Confirm that the User is still assigned to the Bronze WLM Level.
+		$I->seeCheckboxIsChecked('#WishListMemberUserProfile input[value="' . $wlmLevelID . '"]');
+
+		// Confirm that the email address was added to ConvertKit.
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+
+		// Check subscriber assigned to sequence.
+		$I->apiCheckSubscriberHasSequence($I, $subscriberID, $_ENV['CONVERTKIT_API_SEQUENCE_ID']);
+	}
+
+	/**
 	 * Tests that existing settings are automatically migrated when updating
 	 * the Plugin to 2.5.3 or higher, with:
 	 * - Form IDs with value `default` are changed to a blank string
@@ -155,9 +279,10 @@ class WishListMemberCest
 		$I->haveOptionInDatabase(
 			'_wp_convertkit_integration_wishlistmember_settings',
 			[
-				'1' => $_ENV['CONVERTKIT_API_FORM_ID'],
-				'2' => '',
-				'3' => 'default',
+				'1_form' 		=> $_ENV['CONVERTKIT_API_FORM_ID'],
+				'2_form' 		=> '',
+				'3_form' 		=> 'default',
+				'4_unsubscribe' => $_ENV['CONVERTKIT_APIT_TAG_ID'],
 			]
 		);
 
@@ -172,9 +297,10 @@ class WishListMemberCest
 		$I->assertArrayHasKey('1', $settings);
 		$I->assertArrayHasKey('2', $settings);
 		$I->assertArrayHasKey('3', $settings);
-		$I->assertEquals($settings['1'], $_ENV['CONVERTKIT_API_FORM_ID']);
-		$I->assertEquals($settings['2'], '');
-		$I->assertEquals($settings['3'], '');
+		$I->assertEquals($settings['1_form'], 'form:' . $_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->assertEquals($settings['2_form'], '');
+		$I->assertEquals($settings['3_form'], '');
+		$I->assertEquals($settings['4_unsubscribe'], 'tag:' . $_ENV['CONVERTKIT_API_TAG_ID']);
 	}
 
 	/**

--- a/views/backend/subscription-dropdown-field.php
+++ b/views/backend/subscription-dropdown-field.php
@@ -19,6 +19,20 @@
 		<?php esc_html_e( 'Subscribe', 'convertkit' ); ?>
 	</option>
 
+	<?php
+	// Output additional options, if defined.
+	if ( is_array( $additional_options ) ) {
+		foreach ( $additional_options as $additional_option_key => $additional_option_value ) {
+			printf(
+				'<option value="%s"%s>%s</option>',
+				esc_attr( $additional_option_key ),
+				selected( $additional_option_key, $value, false ),
+				esc_attr( $additional_option_value )
+			);
+		}
+	}
+	?>
+
 	<optgroup label="<?php esc_attr_e( 'Forms', 'convertkit' ); ?>" id="convertkit-forms" data-option-value-prefix="form:">
 		<?php
 		if ( $forms->exist() ) {

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -9,7 +9,7 @@
  * Plugin Name: ConvertKit
  * Plugin URI: https://convertkit.com/
  * Description: Display ConvertKit email subscription forms, landing pages, products, broadcasts and more.
- * Version: 2.5.3
+ * Version: 2.5.4
  * Author: ConvertKit
  * Author URI: https://convertkit.com/
  * Text Domain: convertkit
@@ -25,7 +25,7 @@ define( 'CONVERTKIT_PLUGIN_NAME', 'ConvertKit' ); // Used for user-agent in API 
 define( 'CONVERTKIT_PLUGIN_FILE', plugin_basename( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_PATH', __DIR__ );
-define( 'CONVERTKIT_PLUGIN_VERSION', '2.5.3' );
+define( 'CONVERTKIT_PLUGIN_VERSION', '2.5.4' );
 define( 'CONVERTKIT_OAUTH_CLIENT_ID', 'HXZlOCj-K5r0ufuWCtyoyo3f688VmMAYSsKg1eGvw0Y' );
 define( 'CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI', 'https://app.convertkit.com/wordpress/redirect' );
 


### PR DESCRIPTION
## Summary

Currently, the WLM integration provides the option to:
- Subscribe a user to a ConvertKit Form when added to a WLM Membership Level
- Tag a subscriber in ConvertKit when removed from a WLM Membership Level

These options seem inconsistent, so this PR resolves by:
- Adding options to only subscribe, or subscribe and add a Form, Tag or Sequence when added to a WLM Membership Level, bringing this in line with the Contact Form 7 + Forminator options
- Adding options to unsubscribe, or assign a Form, Tag or Sequence when removed from a WLM Membership Level, bringing this in line with the Contact Form 7 + Forminator options
- Renaming the `ConvertKit Form` table heading to `Assign to member`
- Renaming the `Unsubscribe Action` table heading to `Remove from member`
- Rename the settings key from `{wlmLevelID}_form` to `{wlmLevelID}_add`
- Rename the settings key from `{wlmLevelID}_unsubscribe` to `{wlmLevelID}_remove`
- Add an upgrade routine to change settings key for existing installations
- Fix typos with the word `subscribe`
- Refactoring logic 

## Testing

- `testWLMToConvertKitFormMappingOnLevelAdded`
- `testWLMToConvertKitLegacyFormMappingOnLevelAdded`
- `testWLMToConvertKitTagMappingOnLevelAdded`
- `testWLMToConvertKitSequenceMappingOnLevelAdded`
- `testWLMToConvertKitSubscribeMappingOnLevelAdded`
- `testWLMToConvertKitFormMappingOnLevelRemoved`
- `testWLMToConvertKitLegacyFormMappingOnLevelRemoved`
- `testWLMToConvertKitTagMappingOnLevelRemoved`
- `testWLMToConvertKitSequenceMappingOnLevelRemoved`
- `testWLMToConvertKitUnsubscribeMappingOnLevelRemoved`
- `testSettingsMigratedOnUpgrade`

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)