### PR TITLE
Register Filter for `Add New` buttons

### DIFF
--- a/admin/class-convertkit-admin-post.php
+++ b/admin/class-convertkit-admin-post.php
@@ -33,7 +33,8 @@ class ConvertKit_Admin_Post {
 	}
 
 	/**
-	 * Registers dropdown options for the ConvertKit 'Add New' button.
+	 * Registers 'Add New' buttons for the given Post Type's admin screen.
+	 *
 	 * If no options are registered, no button is displayed.
 	 *
 	 * JS will move this button to be displayed next to the "Add New" button when viewing the table of Pages or Posts,
@@ -58,7 +59,7 @@ class ConvertKit_Admin_Post {
 		$buttons = array();
 
 		/**
-		 * Registers dropdown options for the ConvertKit 'Add New' button.
+		 * Registers 'Add New' buttons for the given Post Type's admin screen.
 		 *
 		 * @since   2.5.5
 		 *

--- a/admin/class-convertkit-admin-post.php
+++ b/admin/class-convertkit-admin-post.php
@@ -64,6 +64,7 @@ class ConvertKit_Admin_Post {
 		 * @since   2.5.5
 		 *
 		 * @param   array   $buttons    Buttons.
+		 * @param   string  $post_type  Post Type.
 		 */
 		$buttons = apply_filters( 'convertkit_admin_post_register_add_new_buttons', $buttons, $post_type );
 

--- a/admin/class-convertkit-admin-post.php
+++ b/admin/class-convertkit-admin-post.php
@@ -23,9 +23,69 @@ class ConvertKit_Admin_Post {
 	 */
 	public function __construct() {
 
+		// Register "Add New" ConvertKit button on Pages.
+		add_filter( 'views_edit-page', array( $this, 'output_wp_list_table_buttons' ) );
+
 		add_action( 'post_submitbox_misc_actions', array( $this, 'output_pre_publish_actions' ) );
 		add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ) );
 		add_action( 'save_post', array( $this, 'save_post_meta' ) );
+
+	}
+
+	/**
+	 * Registers dropdown options for the ConvertKit 'Add New' button.
+	 * If no options are registered, no button is displayed.
+	 *
+	 * JS will move this button to be displayed next to the "Add New" button when viewing the table of Pages or Posts,
+	 * as there is not a native WordPress action/filter for registering buttons next to the "Add New" button.
+	 *
+	 * @since   2.5.5
+	 *
+	 * @param   array $views  Views.
+	 * @return  array           Views
+	 */
+	public function output_wp_list_table_buttons( $views ) {
+
+		// Get current post type that we're viewing.
+		$post_type = $this->get_current_post_type();
+
+		// Don't output any buttons if we couldn't determine the current post type.
+		if ( ! $post_type ) {
+			return $views;
+		}
+
+		// Define a blank array of buttons to be filtered.
+		$buttons = array();
+
+		/**
+		 * Registers dropdown options for the ConvertKit 'Add New' button.
+		 *
+		 * @since   2.5.5
+		 *
+		 * @param   array   $buttons    Buttons.
+		 */
+		$buttons = apply_filters( 'convertkit_admin_post_register_add_new_buttons', $buttons, $post_type );
+
+		// Bail if no buttons are registered for display.
+		if ( ! count( $buttons ) ) {
+			return $views;
+		}
+
+		// Enqueue JS and CSS.
+		wp_enqueue_script( 'convertkit-admin-wp-list-table-buttons', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/wp-list-table-buttons.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
+		wp_enqueue_style( 'convertkit-admin-wp-list-table-buttons', CONVERTKIT_PLUGIN_URL . 'resources/backend/css/wp-list-table-buttons.css', array(), CONVERTKIT_PLUGIN_VERSION );
+
+		// Register buttons.
+		foreach ( $buttons as $button_name => $button ) {
+			$views[ $button_name ] = sprintf(
+				'<a href="%s" class="convertkit-action page-title-action hidden">%s</a>',
+				esc_attr( $button['url'] ),
+				esc_html( $button['label'] )
+			);
+
+		}
+
+		return $views;
 
 	}
 
@@ -256,6 +316,28 @@ class ConvertKit_Admin_Post {
 		if ( $meta['form'] || $meta['landing_page'] ) {
 			WP_ConvertKit()->get_class( 'review_request' )->request_review();
 		}
+
+	}
+
+	/**
+	 * Get the current post type based on the screen that is viewed.
+	 *
+	 * @since   2.5.5
+	 *
+	 * @return  bool|string
+	 */
+	private function get_current_post_type() {
+
+		// Bail if we cannot determine the screen.
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return false;
+		}
+
+		// Get screen.
+		$screen = get_current_screen();
+
+		// Return post type.
+		return $screen->post_type;
 
 	}
 

--- a/admin/class-convertkit-admin-restrict-content.php
+++ b/admin/class-convertkit-admin-restrict-content.php
@@ -62,35 +62,15 @@ class ConvertKit_Admin_Restrict_Content {
 	public function __construct() {
 
 		// Add New Member Content Wizard button to Pages.
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts_and_css' ) );
-		add_filter( 'views_edit-page', array( $this, 'output_wp_list_table_buttons' ) );
-
-		// Filter WP_List_Table by Restrict Content setting.
-		add_action( 'pre_get_posts', array( $this, 'filter_wp_list_table_output' ) );
-		add_action( 'restrict_manage_posts', array( $this, 'output_wp_list_table_filters' ) );
-
-	}
-
-	/**
-	 * Enqueue JavaScript and CSS when viewing a list of Pages, Posts or Custom Post Types
-	 * in a WP_List_Table that supports Restrict Content functionality.
-	 *
-	 * @since   2.1.0
-	 */
-	public function enqueue_scripts_and_css() {
-
-		// Bail if we're not on a WP_List_Table screen for a supported Post Type.
-		if ( ! $this->is_wp_list_table_request_for_supported_post_type() ) {
-			return;
-		}
-
-		// Enqueue JS and CSS.
-		wp_enqueue_script( 'convertkit-admin-wp-list-table-buttons', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/wp-list-table-buttons.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
-		wp_enqueue_style( 'convertkit-admin-wp-list-table-buttons', CONVERTKIT_PLUGIN_URL . 'resources/backend/css/wp-list-table-buttons.css', array(), CONVERTKIT_PLUGIN_VERSION );
+		add_filter( 'convertkit_admin_post_register_add_new_buttons', array( $this, 'register_add_new_button' ), 10, 2 );
 
 		// Filter Page's post state to maybe include a label denoting that Restricted Content is enabled.
 		// We do this here so we don't run this on Post Types that don't support Restricted Content.
 		add_filter( 'display_post_states', array( $this, 'maybe_display_restrict_content_post_state' ), 10, 2 );
+
+		// Filter WP_List_Table by Restrict Content setting.
+		add_action( 'pre_get_posts', array( $this, 'filter_wp_list_table_output' ) );
+		add_action( 'restrict_manage_posts', array( $this, 'output_wp_list_table_filters' ) );
 
 	}
 
@@ -155,43 +135,35 @@ class ConvertKit_Admin_Restrict_Content {
 	}
 
 	/**
-	 * Outputs a button in the WP_List_Table filters to run the Restrict Content Setup process.
+	 * Registers a button in the Pages WP_List_Table linking to the the Restrict Content Setup Wizard.
 	 *
-	 * JS will move this button to be displayed next to the "Add New" button when viewing the table of Pages or Posts,
-	 * as there is not a native WordPress action/filter for registering buttons next to the "Add New" button.
+	 * @since   2.5.5
 	 *
-	 * @since   2.1.0
-	 *
-	 * @param   array $views  Views.
-	 * @return  array           Views
+	 * @param   array  $buttons    Buttons.
+	 * @param   string $post_type  Post Type.
+	 * @return  array               Views
 	 */
-	public function output_wp_list_table_buttons( $views ) {
+	public function register_add_new_button( $buttons, $post_type ) {
 
 		// If no API credentials have been set, don't output the button.
 		$settings = new ConvertKit_Settings();
 		if ( ! $settings->has_access_and_refresh_token() ) {
-			return $views;
+			return $buttons;
 		}
 
-		// Get current post type that we're viewing.
-		$post_type = $this->get_current_post_type();
-
-		// Don't output button if we couldn't determine the current post type.
-		if ( ! $post_type ) {
-			return $views;
-		}
-
-		// Build URL for Restrict Content Setup Wizard.
-		$url = add_query_arg(
-			array(
-				'page'         => 'convertkit-restrict-content-setup',
-				'ck_post_type' => $post_type,
+		// Register button.
+		$buttons['convertkit_restrict_content_setup'] = array(
+			'url'   => add_query_arg(
+				array(
+					'page'         => 'convertkit-restrict-content-setup',
+					'ck_post_type' => $post_type,
+				),
+				admin_url( 'options.php' )
 			),
-			admin_url( 'options.php' )
+			'label' => __( 'Add New Member Content', 'convertkit' ),
 		);
 
-		$views['convertkit_restrict_content_setup'] = '<a href="' . esc_attr( $url ) . '" class="convertkit-action page-title-action hidden">' . esc_html__( 'Add New Member Content', 'convertkit' ) . '</a>';
-		return $views;
+		return $buttons;
 
 	}
 
@@ -240,6 +212,11 @@ class ConvertKit_Admin_Restrict_Content {
 	 */
 	public function maybe_display_restrict_content_post_state( $post_states, $post ) {
 
+		// Bail if we're not on a WP_List_Table screen for a supported Post Type.
+		if ( ! $this->is_wp_list_table_request_for_supported_post_type() ) {
+			return $post_states;
+		}
+
 		// Fetch Post's settings.
 		$convertkit_post = new ConvertKit_Post( $post->ID );
 
@@ -281,28 +258,6 @@ class ConvertKit_Admin_Restrict_Content {
 
 		// Return whether Post Type is supported for Restrict Content functionality.
 		return in_array( $screen->post_type, convertkit_get_supported_post_types(), true );
-
-	}
-
-	/**
-	 * Get the current post type based on the screen that is viewed.
-	 *
-	 * @since   2.1.0
-	 *
-	 * @return  bool|string
-	 */
-	private function get_current_post_type() {
-
-		// Bail if we cannot determine the screen.
-		if ( ! function_exists( 'get_current_screen' ) ) {
-			return false;
-		}
-
-		// Get screen.
-		$screen = get_current_screen();
-
-		// Return post type.
-		return $screen->post_type;
 
 	}
 

--- a/admin/class-convertkit-admin-restrict-content.php
+++ b/admin/class-convertkit-admin-restrict-content.php
@@ -151,6 +151,11 @@ class ConvertKit_Admin_Restrict_Content {
 			return $buttons;
 		}
 
+		// Bail if the Post Type isn't supported.
+		if ( ! in_array( $post_type, convertkit_get_supported_post_types(), true ) ) {
+			return $buttons;
+		}
+
 		// Register button.
 		$buttons['convertkit_restrict_content_setup'] = array(
 			'url'   => add_query_arg(


### PR DESCRIPTION
## Summary

Adds a new `convertkit_admin_post_register_add_new_buttons` filter hook for the Plugin to register buttons (i.e. Add New Member Content, [Add New Landing Page](https://github.com/ConvertKit/convertkit-wordpress/pull/697)).

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)