### PR TITLE
Create subscriber with `inactive` state when a Form option is selected

### DIFF
--- a/includes/integrations/contactform7/class-convertkit-contactform7.php
+++ b/includes/integrations/contactform7/class-convertkit-contactform7.php
@@ -129,14 +129,9 @@ class ConvertKit_ContactForm7 {
 			'contact_form_7'
 		);
 
-		// Subscribe the email address.
-		$subscriber = $api->create_subscriber( $email, $first_name );
-		if ( is_wp_error( $subscriber ) ) {
-			return;
-		}
-
-		// If the setting is 'Subscribe', no Form needs to be assigned to the subscriber.
+		// If the resource setting is 'subscribe', create the subscriber in an active state and don't assign to a resource.
 		if ( $convertkit_subscribe_setting === 'subscribe' ) {
+			$api->create_subscriber( $email, $first_name );
 			return;
 		}
 
@@ -153,6 +148,14 @@ class ConvertKit_ContactForm7 {
 			 * Form
 			 */
 			case 'form':
+				// Subscribe with inactive state.
+				$subscriber = $api->create_subscriber( $email, $first_name, 'inactive' );
+
+				// If an error occured, don't attempt to add the subscriber to the Form, as it won't work.
+				if ( is_wp_error( $subscriber ) ) {
+					return;
+				}
+
 				// For Legacy Forms, a different endpoint is used.
 				$forms = new ConvertKit_Resource_Forms();
 				if ( $forms->is_legacy( $resource_id ) ) {
@@ -166,6 +169,14 @@ class ConvertKit_ContactForm7 {
 			 * Sequence
 			 */
 			case 'sequence':
+				// Subscribe.
+				$subscriber = $api->create_subscriber( $email, $first_name );
+
+				// If an error occured, don't attempt to add the subscriber to the Form, as it won't work.
+				if ( is_wp_error( $subscriber ) ) {
+					return;
+				}
+
 				// Add subscriber to sequence.
 				return $api->add_subscriber_to_sequence( $resource_id, $subscriber['subscriber']['id'] );
 
@@ -173,6 +184,14 @@ class ConvertKit_ContactForm7 {
 			 * Tag
 			 */
 			case 'tag':
+				// Subscribe.
+				$subscriber = $api->create_subscriber( $email, $first_name );
+
+				// If an error occured, don't attempt to add the subscriber to the Form, as it won't work.
+				if ( is_wp_error( $subscriber ) ) {
+					return;
+				}
+
 				// Add subscriber to tag.
 				return $api->tag_subscriber( $resource_id, $subscriber['subscriber']['id'] );
 

--- a/includes/integrations/forminator/class-convertkit-forminator.php
+++ b/includes/integrations/forminator/class-convertkit-forminator.php
@@ -132,14 +132,9 @@ class ConvertKit_Forminator {
 			'forminator'
 		);
 
-		// Subscribe the email address.
-		$subscriber = $api->create_subscriber( $email, $first_name );
-		if ( is_wp_error( $subscriber ) ) {
-			return;
-		}
-
-		// If the setting is 'Subscribe', no Form needs to be assigned to the subscriber.
+		// If the resource setting is 'subscribe', create the subscriber in an active state and don't assign to a resource.
 		if ( $convertkit_subscribe_setting === 'subscribe' ) {
+			$api->create_subscriber( $email, $first_name );
 			return;
 		}
 
@@ -169,6 +164,14 @@ class ConvertKit_Forminator {
 			 * Sequence
 			 */
 			case 'sequence':
+				// Subscribe.
+				$subscriber = $api->create_subscriber( $email, $first_name );
+
+				// If an error occured, don't attempt to add the subscriber to the Form, as it won't work.
+				if ( is_wp_error( $subscriber ) ) {
+					return;
+				}
+
 				// Add subscriber to sequence.
 				return $api->add_subscriber_to_sequence( $resource_id, $subscriber['subscriber']['id'] );
 
@@ -176,6 +179,14 @@ class ConvertKit_Forminator {
 			 * Tag
 			 */
 			case 'tag':
+				// Subscribe.
+				$subscriber = $api->create_subscriber( $email, $first_name );
+
+				// If an error occured, don't attempt to add the subscriber to the Form, as it won't work.
+				if ( is_wp_error( $subscriber ) ) {
+					return;
+				}
+
 				// Add subscriber to tag.
 				return $api->tag_subscriber( $resource_id, $subscriber['subscriber']['id'] );
 

--- a/includes/integrations/forminator/class-convertkit-forminator.php
+++ b/includes/integrations/forminator/class-convertkit-forminator.php
@@ -151,6 +151,9 @@ class ConvertKit_Forminator {
 			 * Form
 			 */
 			case 'form':
+				// Subscribe with inactive state.
+				$subscriber = $api->create_subscriber( $email, $first_name, 'inactive' );
+
 				// For Legacy Forms, a different endpoint is used.
 				$forms = new ConvertKit_Resource_Forms();
 				if ( $forms->is_legacy( $resource_id ) ) {

--- a/includes/integrations/wishlist/class-convertkit-wishlist.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist.php
@@ -151,11 +151,9 @@ class ConvertKit_Wishlist {
 				continue;
 			}
 
-			// Subscribe.
-			$subscriber = $api->create_subscriber( $email, $first_name );
-
-			// If the resource setting is 'subscribe', don't assign to a resource.
+			// If the resource setting is 'subscribe', create the subscriber in an active state and don't assign to a resource.
 			if ( $setting === 'subscribe' ) {
+				$api->create_subscriber( $email, $first_name );
 				continue;
 			}
 
@@ -172,6 +170,14 @@ class ConvertKit_Wishlist {
 				 * Form
 				 */
 				case 'form':
+					// Subscribe with inactive state.
+					$subscriber = $api->create_subscriber( $email, $first_name, 'inactive' );
+
+					// If an error occured, don't attempt to add the subscriber to the Form, as it won't work.
+					if ( is_wp_error( $subscriber ) ) {
+						break;
+					}
+
 					// For Legacy Forms, a different endpoint is used.
 					$forms = new ConvertKit_Resource_Forms();
 					if ( $forms->is_legacy( $resource_id ) ) {
@@ -186,6 +192,14 @@ class ConvertKit_Wishlist {
 				 * Sequence
 				 */
 				case 'sequence':
+					// Subscribe.
+					$subscriber = $api->create_subscriber( $email, $first_name );
+
+					// If an error occured, don't attempt to add the subscriber to the Form, as it won't work.
+					if ( is_wp_error( $subscriber ) ) {
+						break;
+					}
+
 					// Add subscriber to sequence.
 					$api->add_subscriber_to_sequence( $resource_id, $subscriber['subscriber']['id'] );
 					break;
@@ -194,6 +208,14 @@ class ConvertKit_Wishlist {
 				 * Tag
 				 */
 				case 'tag':
+					// Subscribe with inactive state.
+					$subscriber = $api->create_subscriber( $email, $first_name );
+
+					// If an error occured, don't attempt to add the subscriber to the Form, as it won't work.
+					if ( is_wp_error( $subscriber ) ) {
+						break;
+					}
+
 					// Add subscriber to tag.
 					$api->tag_subscriber( $resource_id, $subscriber['subscriber']['id'] );
 					break;

--- a/includes/integrations/wishlist/class-convertkit-wishlist.php
+++ b/includes/integrations/wishlist/class-convertkit-wishlist.php
@@ -182,6 +182,7 @@ class ConvertKit_Wishlist {
 					$forms = new ConvertKit_Resource_Forms();
 					if ( $forms->is_legacy( $resource_id ) ) {
 						$api->add_subscriber_to_legacy_form( $resource_id, $subscriber['subscriber']['id'] );
+						break;
 					}
 
 					// Add subscriber to form.

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -54,6 +54,9 @@ class ConvertKitAPI extends \Codeception\Module
 			[
 				'email_address'       => $emailAddress,
 				'include_total_count' => true,
+
+				// Check all subscriber states.
+				'status'              => 'all',
 			]
 		);
 


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://linear.app/kit/issue/PLAT-2027/platform-v4-api-issue-post-to-create-a-subscriber-doesnt-appear-to), by calling `create_subscriber` with `state` = `inactive` when a Form is selected as the resource to assign to the subscriber in Contact Form 7, Forminator and WishList Member.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)