### PR TITLE
Change `Add New` buttons to dropdown

### DIFF
--- a/admin/class-convertkit-admin-landing-page.php
+++ b/admin/class-convertkit-admin-landing-page.php
@@ -58,7 +58,7 @@ class ConvertKit_Admin_Landing_Page {
 				),
 				admin_url( 'options.php' )
 			),
-			'label' => __( 'Add New Landing Page', 'convertkit' ),
+			'label' => __( 'Landing Page', 'convertkit' ),
 		);
 
 		return $buttons;

--- a/admin/class-convertkit-admin-post.php
+++ b/admin/class-convertkit-admin-post.php
@@ -77,15 +77,22 @@ class ConvertKit_Admin_Post {
 		wp_enqueue_script( 'convertkit-admin-wp-list-table-buttons', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/wp-list-table-buttons.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
 		wp_enqueue_style( 'convertkit-admin-wp-list-table-buttons', CONVERTKIT_PLUGIN_URL . 'resources/backend/css/wp-list-table-buttons.css', array(), CONVERTKIT_PLUGIN_VERSION );
 
-		// Register buttons.
+		// Build buttons HTML.
+		$html = '';
 		foreach ( $buttons as $button_name => $button ) {
-			$views[ $button_name ] = sprintf(
-				'<a href="%s" class="convertkit-action page-title-action hidden">%s</a>',
+			$html .= sprintf(
+				'<a href="%s">%s</a>',
 				esc_attr( $button['url'] ),
 				esc_html( $button['label'] )
 			);
-
 		}
+
+		// Register an 'Add New' dropdown button, with buttons HTML.
+		$views['convertkit'] = sprintf(
+			'<span class="convertkit-action page-title-action hidden">%s<span class="convertkit-actions hidden">%s</span></span>',
+			__( 'Add New', 'convertkit' ),
+			$html
+		);
 
 		return $views;
 

--- a/admin/class-convertkit-admin-restrict-content.php
+++ b/admin/class-convertkit-admin-restrict-content.php
@@ -165,7 +165,7 @@ class ConvertKit_Admin_Restrict_Content {
 				),
 				admin_url( 'options.php' )
 			),
-			'label' => __( 'Add New Member Content', 'convertkit' ),
+			'label' => __( 'Member Content', 'convertkit' ),
 		);
 
 		return $buttons;

--- a/resources/backend/css/wp-list-table-buttons.css
+++ b/resources/backend/css/wp-list-table-buttons.css
@@ -1,7 +1,37 @@
 .wrap .page-title-action.convertkit-action {
+	width: 124px;
 	background: url(../images/logomark-red.svg);
 	background-repeat: no-repeat;
 	background-size: 16px 16px;
 	background-position: 8px 50%;
 	padding-left: 30px;
+}
+.wrap .page-title-action.convertkit-action:after {
+	float: right;
+	font: 400 20px/1 dashicons!important;
+	content: "\f347";
+	padding: 5px 0 0 0;
+}
+.wrap .page-title-action.convertkit-action span {
+	visibility: hidden;
+	display: none;
+	opacity: 0;
+	position: absolute;
+	margin: 0;
+	padding: 10px;
+	left: -1px;
+	background-color: #f0f0f1;
+	border-left: 1px solid #0a4b78;
+	border-right: 1px solid #0a4b78;
+	border-bottom: 1px solid #0a4b78;
+}
+.wrap .page-title-action.convertkit-action span a {
+	display: block;
+	text-decoration: none;
+}
+.wrap .page-title-action.convertkit-action:hover > span,
+.wrap .page-title-action.convertkit-action span:hover {
+	visibility: visible;
+	opacity: 1;
+	display: block;
 }

--- a/resources/backend/js/wp-list-table-buttons.js
+++ b/resources/backend/js/wp-list-table-buttons.js
@@ -10,7 +10,7 @@ jQuery( document ).ready(
 	function ( $ ) {
 
 		// Move any buttons from the filter list to display next to the Add New button.
-		$( 'ul.subsubsub a' ).each(
+		$( 'ul.subsubsub span' ).each(
 			function () {
 
 				// Ignore if not a ConvertKit Group Action.

--- a/tests/acceptance/landing-pages/PageLandingPageSetupWizardCest.php
+++ b/tests/acceptance/landing-pages/PageLandingPageSetupWizardCest.php
@@ -32,8 +32,8 @@ class PageLandingPageSetupWizardCest
 		// Navigate to Pages.
 		$I->amOnAdminPage('edit.php?post_type=page');
 
-		// Check the button isn't displayed.
-		$I->dontSeeElementInDOM('a.convertkit-action.page-title-action');
+		// Check the buttons are not displayed.
+		$I->dontSeeElementInDOM('span.convertkit-action.page-title-action');
 	}
 
 	/**
@@ -51,8 +51,8 @@ class PageLandingPageSetupWizardCest
 		// Navigate to Posts.
 		$I->amOnAdminPage('edit.php?post_type=post');
 
-		// Check the button isn't displayed.
-		$I->dontSeeElementInDOM('a.convertkit-action');
+		// Check the buttons are not displayed.
+		$I->dontSeeElementInDOM('span.convertkit-action.page-title-action');
 	}
 
 	/**
@@ -102,7 +102,9 @@ class PageLandingPageSetupWizardCest
 		$I->amOnAdminPage('edit.php?post_type=page');
 
 		// Click Add New Landing Page button.
-		$I->click('Add New Landing Page');
+		$I->moveMouseOver('span.convertkit-action');
+		$I->waitForElementVisible('span.convertkit-action span.convertkit-actions a');
+		$I->click('Landing Page');
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -152,7 +154,9 @@ class PageLandingPageSetupWizardCest
 
 		// Confirm the Pages screen is displayed.
 		$I->see('Pages');
-		$I->see('Add New Landing Page');
+		$I->moveMouseOver('span.convertkit-action');
+		$I->waitForElementVisible('span.convertkit-action span.convertkit-actions a');
+		$I->see('Landing Page');
 	}
 
 	/**
@@ -242,7 +246,9 @@ class PageLandingPageSetupWizardCest
 		$I->amOnAdminPage('edit.php?post_type=page');
 
 		// Click Add New Landing Page button.
-		$I->click('Add New Landing Page');
+		$I->moveMouseOver('span.convertkit-action');
+		$I->waitForElementVisible('span.convertkit-action span.convertkit-actions a');
+		$I->click('Landing Page');
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);

--- a/tests/acceptance/restrict-content/general/RestrictContentSetupCest.php
+++ b/tests/acceptance/restrict-content/general/RestrictContentSetupCest.php
@@ -32,8 +32,8 @@ class RestrictContentSetupCest
 		// Navigate to Pages.
 		$I->amOnAdminPage('edit.php?post_type=page');
 
-		// Check the button isn't displayed.
-		$I->dontSeeElementInDOM('a.convertkit-action.page-title-action');
+		// Check the buttons are not displayed.
+		$I->dontSeeElementInDOM('span.convertkit-action.page-title-action');
 	}
 
 	/**
@@ -51,8 +51,8 @@ class RestrictContentSetupCest
 		// Navigate to Posts.
 		$I->amOnAdminPage('edit.php?post_type=post');
 
-		// Check the button isn't displayed.
-		$I->dontSeeElementInDOM('a.convertkit-action');
+		// Check the buttons are not displayed.
+		$I->dontSeeElementInDOM('span.convertkit-action.page-title-action');
 	}
 
 	/**
@@ -102,7 +102,9 @@ class RestrictContentSetupCest
 		$I->amOnAdminPage('edit.php?post_type=page');
 
 		// Click Add New Member Content button.
-		$I->click('Add New Member Content');
+		$I->moveMouseOver('span.convertkit-action');
+		$I->waitForElementVisible('span.convertkit-action span.convertkit-actions a');
+		$I->click('Member Content');
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -154,7 +156,9 @@ class RestrictContentSetupCest
 
 		// Confirm the Pages screen is displayed.
 		$I->see('Pages');
-		$I->see('Add New Member Content');
+		$I->moveMouseOver('span.convertkit-action');
+		$I->waitForElementVisible('span.convertkit-action span.convertkit-actions a');
+		$I->see('Member Content');
 	}
 
 	/**
@@ -473,7 +477,9 @@ class RestrictContentSetupCest
 		$I->amOnAdminPage('edit.php?post_type=page');
 
 		// Click Add New Member Content button.
-		$I->click('Add New Member Content');
+		$I->moveMouseOver('span.convertkit-action');
+		$I->waitForElementVisible('span.convertkit-action span.convertkit-actions a');
+		$I->click('Member Content');
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);


### PR DESCRIPTION
## Summary

Introduces an `Add New` dropdown button for setup wizards registered in WordPress.  This allows easier addition of possible future setup / configuration wizards without cluttering the UI.

Before:
<img width="947" alt="Screenshot 2024-08-19 at 12 40 33" src="https://github.com/user-attachments/assets/10093f03-520e-48c1-8f7f-0c2122f7292f">

After:
<img width="946" alt="Screenshot 2024-08-19 at 12 40 41" src="https://github.com/user-attachments/assets/3f292cc7-4773-4b4d-87ff-b031abdbae9a">

## Testing

Updated tests to interact with the new dropdown.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)