### PR TITLE
Divi: Display notice for no credentials / forms

### DIFF
--- a/includes/blocks/class-convertkit-block-form.php
+++ b/includes/blocks/class-convertkit-block-form.php
@@ -132,14 +132,16 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 
 			// Help descriptions, displayed when no API key / resources exist and this block/shortcode is added.
 			'no_access_token'                   => array(
-				'notice'    => __( 'Not connected to ConvertKit.', 'convertkit' ),
-				'link'      => convertkit_get_setup_wizard_plugin_link(),
-				'link_text' => __( 'Click here to connect your ConvertKit account.', 'convertkit' ),
+				'notice'           => __( 'Not connected to ConvertKit.', 'convertkit' ),
+				'link'             => convertkit_get_setup_wizard_plugin_link(),
+				'link_text'        => __( 'Click here to connect your ConvertKit account.', 'convertkit' ),
+				'instruction_text' => __( 'Connect your ConvertKit account at Settings > ConvertKit, and then refresh this page to select a Form.', 'convertkit' ),
 			),
 			'no_resources'                      => array(
-				'notice'    => __( 'No forms exist in ConvertKit.', 'convertkit' ),
-				'link'      => convertkit_get_new_form_url(),
-				'link_text' => __( 'Click here to create your first form.', 'convertkit' ),
+				'notice'           => __( 'No forms exist in ConvertKit.', 'convertkit' ),
+				'link'             => convertkit_get_new_form_url(),
+				'link_text'        => __( 'Click here to create your first form.', 'convertkit' ),
+				'instruction_text' => __( 'Add a Form to your ConvertKit account, and then refresh this page to select a Form.', 'convertkit' ),
 			),
 
 			// Gutenberg: Help descriptions, displayed when no settings defined for a newly added Block.

--- a/includes/blocks/class-convertkit-block-form.php
+++ b/includes/blocks/class-convertkit-block-form.php
@@ -135,13 +135,13 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 				'notice'           => __( 'Not connected to ConvertKit.', 'convertkit' ),
 				'link'             => convertkit_get_setup_wizard_plugin_link(),
 				'link_text'        => __( 'Click here to connect your ConvertKit account.', 'convertkit' ),
-				'instruction_text' => __( 'Connect your ConvertKit account at Settings > ConvertKit, and then refresh this page to select a Form.', 'convertkit' ),
+				'instruction_text' => __( 'Connect your ConvertKit account at Settings > ConvertKit, and then refresh this page to select a form.', 'convertkit' ),
 			),
 			'no_resources'                      => array(
 				'notice'           => __( 'No forms exist in ConvertKit.', 'convertkit' ),
 				'link'             => convertkit_get_new_form_url(),
 				'link_text'        => __( 'Click here to create your first form.', 'convertkit' ),
-				'instruction_text' => __( 'Add a Form to your ConvertKit account, and then refresh this page to select a Form.', 'convertkit' ),
+				'instruction_text' => __( 'Add a form to your ConvertKit account, and then refresh this page to select a form.', 'convertkit' ),
 			),
 
 			// Gutenberg: Help descriptions, displayed when no settings defined for a newly added Block.

--- a/includes/integrations/divi/class-convertkit-divi-module-form.php
+++ b/includes/integrations/divi/class-convertkit-divi-module-form.php
@@ -32,6 +32,45 @@ class ConvertKit_Divi_Module_Form extends ConvertKit_Divi_Module {
 	 */
 	public $slug = 'convertkit_form';
 
+	/**
+	 * Checks if any Forms exist in ConvertKit.
+	 *
+	 * If no fields exist, shows on screen instructions
+	 * instead of the configuration fields.
+	 *
+	 * @since   2.5.6
+	 */
+	public function getxxxx_fields() {
+
+		// Bail if no block.
+		if ( is_wp_error( $this->block ) ) {
+			return array();
+		}
+
+		// Bail if no fields.
+		if ( ! is_array( $this->block['fields'] ) ) {
+			return array();
+		}
+
+		// If no Forms exist, return a description field with instructions.
+		$convertkit_forms = new ConvertKit_Resource_Forms( 'divi' );
+		if ( ! $convertkit_forms->exist() ) {
+			return array(
+				'form' => array(
+					'type'        => 'text',
+					'default'     => '',
+					'description' => 'No Forms exist in ConvertKit. Instructions here.',
+					'label'       => __( 'Form', 'convertkit' ),
+					'toggle_slug' => 'main_content',
+				),
+			);
+		}
+
+		// Call parent function to build configuration fields in Divi.
+		parent::get_fields();
+
+	}
+
 }
 
 new ConvertKit_Divi_Module_Form();

--- a/includes/integrations/divi/class-convertkit-divi-module-form.php
+++ b/includes/integrations/divi/class-convertkit-divi-module-form.php
@@ -32,45 +32,6 @@ class ConvertKit_Divi_Module_Form extends ConvertKit_Divi_Module {
 	 */
 	public $slug = 'convertkit_form';
 
-	/**
-	 * Checks if any Forms exist in ConvertKit.
-	 *
-	 * If no fields exist, shows on screen instructions
-	 * instead of the configuration fields.
-	 *
-	 * @since   2.5.6
-	 */
-	public function getxxxx_fields() {
-
-		// Bail if no block.
-		if ( is_wp_error( $this->block ) ) {
-			return array();
-		}
-
-		// Bail if no fields.
-		if ( ! is_array( $this->block['fields'] ) ) {
-			return array();
-		}
-
-		// If no Forms exist, return a description field with instructions.
-		$convertkit_forms = new ConvertKit_Resource_Forms( 'divi' );
-		if ( ! $convertkit_forms->exist() ) {
-			return array(
-				'form' => array(
-					'type'        => 'text',
-					'default'     => '',
-					'description' => 'No Forms exist in ConvertKit. Instructions here.',
-					'label'       => __( 'Form', 'convertkit' ),
-					'toggle_slug' => 'main_content',
-				),
-			);
-		}
-
-		// Call parent function to build configuration fields in Divi.
-		parent::get_fields();
-
-	}
-
 }
 
 new ConvertKit_Divi_Module_Form();

--- a/includes/integrations/divi/scripts/builder-bundle.min.js
+++ b/includes/integrations/divi/scripts/builder-bundle.min.js
@@ -18,6 +18,29 @@ class ConvertKitForm extends React.Component {
 	 */
 	render() {
 
+		// Get the Form block configuration.
+		const block = window.ConvertkitDiviBuilderData.form;
+
+		// If no Access Token has been defined in the Plugin, show a message in the module to tell the user what to do.
+		if ( ! block.has_access_token ) {
+			return React.createElement( 'div', {
+				className: 'convertkit-divi-module convertkit-no-content'
+			}, [
+				React.createElement( 'p', {}, block.no_access_token.notice ),
+				React.createElement( 'p', {}, block.no_access_token.instruction_text )
+			]  );
+		}
+
+		// If no resources exist in ConvertKit, show a message in the module to tell the user what to do.
+		if ( ! block.has_resources ) {
+			return React.createElement( 'div', {
+				className: 'convertkit-divi-module convertkit-no-content'
+			}, [
+				React.createElement( 'p', {}, block.no_resources.notice ),
+				React.createElement( 'p', {}, block.no_resources.instruction_text )
+			]  );
+		}
+
 		// Show instructions if no form selected.
 		if ( this.props.form.length === 0 ) {
 			// Return module with text.
@@ -27,7 +50,7 @@ class ConvertKitForm extends React.Component {
 		}
 
 		// Get selected form.
-		const form = window.ConvertkitDiviBuilderData.form.fields.form.data.forms[ this.props.form ];
+		const form = block.fields.form.data.forms[ this.props.form ];
 
 		// Return module with text.
 		return React.createElement( 'div', {

--- a/tests/acceptance/integrations/other/DiviFormCest.php
+++ b/tests/acceptance/integrations/other/DiviFormCest.php
@@ -17,10 +17,6 @@ class DiviFormCest
 	{
 		$I->activateConvertKitPlugin($I);
 		$I->activateThirdPartyPlugin($I, 'divi-builder');
-
-		// Setup Plugin, without defining default Forms.
-		$I->setupConvertKitPluginNoDefaultForms($I);
-		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**
@@ -33,6 +29,10 @@ class DiviFormCest
 	 */
 	public function testFormModuleInBackendEditor(AcceptanceTester $I)
 	{
+		// Setup Plugin, without defining default Forms.
+		$I->setupConvertKitPluginNoDefaultForms($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Activate Classic Editor Plugin.
 		$I->activateThirdPartyPlugin($I, 'classic-editor');
 
@@ -127,6 +127,10 @@ class DiviFormCest
 	 */
 	public function testFormModuleInFrontendEditor(AcceptanceTester $I)
 	{
+		// Setup Plugin, without defining default Forms.
+		$I->setupConvertKitPluginNoDefaultForms($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Divi: Frontend');
 
@@ -191,6 +195,97 @@ class DiviFormCest
 	}
 
 	/**
+	 * Test the Form widget displays the expected message when the Plugin has no credentials
+	 *
+	 * @since   2.5.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFormModuleInFrontendEditorWhenNoCredentials(AcceptanceTester $I)
+	{
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Divi: Frontend: No Credentials');
+
+		// Publish Page.
+		$url = $I->publishGutenbergPage($I);
+
+		// Click Divi Builder button.
+		$I->click('Use Divi Builder');
+
+		// Reload page to dismiss modal.
+		$I->wait(5);
+		$I->amOnUrl($url . '?et_fb=1&PageSpeed=off');
+
+		// Click Build from scratch button.
+		$I->waitForElementVisible('.et-fb-page-creation-card-build_from_scratch', 30);
+		$I->click('Start Building', '.et-fb-page-creation-card-build_from_scratch');
+
+		// Insert row.
+		$I->waitForElementVisible('li[data-layout="4_4"]');
+		$I->click('li[data-layout="4_4"]');
+
+		// Search for module.
+		$I->waitForElementVisible('input[name="filterByTitle"]');
+		$I->fillField('filterByTitle', 'ConvertKit Form');
+
+		// Insert module.
+		$I->waitForElementVisible('li.convertkit_form');
+		$I->click('li.convertkit_form');
+
+		// Confirm the on screen message displays.
+		$I->seeInSource('Not connected to ConvertKit');
+		$I->seeInSource('Connect your ConvertKit account at Settings > ConvertKit, and then refresh this page to select a form.');
+	}
+
+	/**
+	 * Test the Form widget displays the expected message when the ConvertKit account
+	 * has no forms.
+	 *
+	 * @since   2.5.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFormModuleInFrontendEditorWhenNoForms(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPluginCredentialsNoData($I);
+		$I->setupConvertKitPluginResourcesNoData($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Divi: Frontend: No Forms');
+
+		// Publish Page.
+		$url = $I->publishGutenbergPage($I);
+
+		// Click Divi Builder button.
+		$I->click('Use Divi Builder');
+
+		// Reload page to dismiss modal.
+		$I->wait(5);
+		$I->amOnUrl($url . '?et_fb=1&PageSpeed=off');
+
+		// Click Build from scratch button.
+		$I->waitForElementVisible('.et-fb-page-creation-card-build_from_scratch', 30);
+		$I->click('Start Building', '.et-fb-page-creation-card-build_from_scratch');
+
+		// Insert row.
+		$I->waitForElementVisible('li[data-layout="4_4"]');
+		$I->click('li[data-layout="4_4"]');
+
+		// Search for module.
+		$I->waitForElementVisible('input[name="filterByTitle"]');
+		$I->fillField('filterByTitle', 'ConvertKit Form');
+
+		// Insert module.
+		$I->waitForElementVisible('li.convertkit_form');
+		$I->click('li.convertkit_form');
+
+		// Confirm the on screen message displays.
+		$I->seeInSource('No forms exist in ConvertKit');
+		$I->seeInSource('Add a form to your ConvertKit account, and then refresh this page to select a form.');
+	}
+
+	/**
 	 * Test the Form module works when a valid Legacy Form is selected.
 	 *
 	 * @since   2.5.6
@@ -199,6 +294,10 @@ class DiviFormCest
 	 */
 	public function testFormModuleWithValidLegacyFormParameter(AcceptanceTester $I)
 	{
+		// Setup Plugin, without defining default Forms.
+		$I->setupConvertKitPluginNoDefaultForms($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Create Page with Form module in Divi.
 		$pageID = $this->_createPageWithFormModule($I, 'ConvertKit: Legacy Form: Divi Module: Valid Form Param', $_ENV['CONVERTKIT_API_LEGACY_FORM_ID']);
 
@@ -221,6 +320,10 @@ class DiviFormCest
 	 */
 	public function testFormModuleWithNoFormParameter(AcceptanceTester $I)
 	{
+		// Setup Plugin, without defining default Forms.
+		$I->setupConvertKitPluginNoDefaultForms($I);
+		$I->setupConvertKitPluginResources($I);
+
 		// Create Page with Form module in Divi.
 		$pageID = $this->_createPageWithFormModule($I, 'ConvertKit: Page: Form: Divi Module: No Form Param', '');
 


### PR DESCRIPTION
## Summary

Displays a notice on the Divi Form Module, instructing the user what to do when either:
- the ConvertKit Plugin isn't connected via OAuth,
- no Forms exist in ConvertKit

<img width="1041" alt="Screenshot 2024-08-29 at 17 06 31" src="https://github.com/user-attachments/assets/87e3aa17-d43c-4367-9d9a-89d43468114b">
<img width="1058" alt="Screenshot 2024-08-29 at 17 10 59" src="https://github.com/user-attachments/assets/333e4f92-84b0-4498-bc75-1881eab08a22">

## Testing

- `testFormModuleInFrontendEditorWhenNoCredentials`: Test that the expected message displays in the module when the Plugin is not connected via OAuth
- `testFormModuleInFrontendEditorWhenNoForms`: Test that the expected message displays in the module when the ConvertKit account has no Forms.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)