### PR TITLE
Divi: Display Form Icon

### DIFF
--- a/includes/integrations/divi/class-convertkit-divi-module.php
+++ b/includes/integrations/divi/class-convertkit-divi-module.php
@@ -42,6 +42,15 @@ class ConvertKit_Divi_Module extends ET_Builder_Module {
 	public $slug = '';
 
 	/**
+	 * The full path to the SVG icon for this Divi module.
+	 *
+	 * @since   2.5.7
+	 *
+	 * @var     string
+	 */
+	public $icon_path = '';
+
+	/**
 	 * Holds the block definition, properties and fields.
 	 *
 	 * @since   2.5.6
@@ -70,9 +79,10 @@ class ConvertKit_Divi_Module extends ET_Builder_Module {
 			return;
 		}
 
-		// Define the block and its name.
-		$this->block = $blocks[ $this->block_name ];
-		$this->name  = esc_html( $this->block['title'] );
+		// Define the block, name and icon.
+		$this->block     = $blocks[ $this->block_name ];
+		$this->name      = esc_html( $this->block['title'] );
+		$this->icon_path = CONVERTKIT_PLUGIN_PATH . '/' . $this->block['icon'];
 
 	}
 


### PR DESCRIPTION
## Summary

Displays the Form icon on the Divi module:

<img width="418" alt="Screenshot 2024-08-30 at 15 24 37" src="https://github.com/user-attachments/assets/caa46da1-896d-4a8f-9b1f-db1a254138c7">

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)