### PR TITLE
Divi: Add Product Module

### DIFF
--- a/includes/blocks/class-convertkit-block-product.php
+++ b/includes/blocks/class-convertkit-block-product.php
@@ -135,14 +135,16 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 
 			// Help descriptions, displayed when no Access Token / resources exist and this block/shortcode is added.
 			'no_access_token'                   => array(
-				'notice'    => __( 'Not connected to ConvertKit.', 'convertkit' ),
-				'link'      => convertkit_get_setup_wizard_plugin_link(),
-				'link_text' => __( 'Click here to connect your ConvertKit account.', 'convertkit' ),
+				'notice'           => __( 'Not connected to ConvertKit.', 'convertkit' ),
+				'link'             => convertkit_get_setup_wizard_plugin_link(),
+				'link_text'        => __( 'Click here to connect your ConvertKit account.', 'convertkit' ),
+				'instruction_text' => __( 'Connect your ConvertKit account at Settings > ConvertKit, and then refresh this page to select a product.', 'convertkit' ),
 			),
 			'no_resources'                      => array(
-				'notice'    => __( 'No products exist in ConvertKit.', 'convertkit' ),
-				'link'      => convertkit_get_new_product_url(),
-				'link_text' => __( 'Click here to create your first product.', 'convertkit' ),
+				'notice'           => __( 'No products exist in ConvertKit.', 'convertkit' ),
+				'link'             => convertkit_get_new_product_url(),
+				'link_text'        => __( 'Click here to create your first product.', 'convertkit' ),
+				'instruction_text' => __( 'Add a product to your ConvertKit account, and then refresh this page to select a product.', 'convertkit' ),
 			),
 
 			// Gutenberg: Help descriptions, displayed when no settings defined for a newly added Block.

--- a/includes/integrations/divi/class-convertkit-divi-module-product.php
+++ b/includes/integrations/divi/class-convertkit-divi-module-product.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Divi Module: ConvertKit Product.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Registers the ConvertKit Product Block as a Divi Module.
+ *
+ * @package ConvertKit
+ * @author  ConvertKit
+ */
+class ConvertKit_Divi_Module_Product extends ConvertKit_Divi_Module {
+
+	/**
+	 * The ConvertKit block name.
+	 *
+	 * @since   2.5.7
+	 *
+	 * @var     string
+	 */
+	public $block_name = 'product';
+
+	/**
+	 * The ConvertKit Divi module name.
+	 *
+	 * @since   2.5.7
+	 *
+	 * @var     string
+	 */
+	public $slug = 'convertkit_product';
+
+}
+
+new ConvertKit_Divi_Module_Product();

--- a/includes/integrations/divi/class-convertkit-divi-module.php
+++ b/includes/integrations/divi/class-convertkit-divi-module.php
@@ -140,6 +140,13 @@ class ConvertKit_Divi_Module extends ET_Builder_Module {
 				 */
 				case 'select':
 					$fields[ $field_name ]['options'] = $field['values'];
+
+					// For select dropdowns, if no default value exists, we have to force the first
+					// value as the default, otherwise Divi will show that the first value is selected,
+					// but its underlying value won't be saved unless the user changes the chosen selection.
+					if ( ! $this->get_default_value( $field ) ) {
+						$fields[ $field_name ]['default'] = array_key_first( $field['values'] );
+					}
 					break;
 
 				/**

--- a/includes/integrations/divi/loader.php
+++ b/includes/integrations/divi/loader.php
@@ -17,3 +17,4 @@ if ( ! class_exists( 'ET_Builder_Element' ) ) {
 // Load Divi modules.
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/divi/class-convertkit-divi-module.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/divi/class-convertkit-divi-module-form.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/divi/class-convertkit-divi-module-product.php';

--- a/includes/integrations/divi/scripts/builder-bundle.min.js
+++ b/includes/integrations/divi/scripts/builder-bundle.min.js
@@ -1,7 +1,7 @@
 /**
  * ConvertKit Form Divi Module.
  */
-class ConvertKitForm extends React.Component {
+class ConvertKitDiviForm extends React.Component {
 
 	/**
 	 * The Divi module name. Must match the slug defined in
@@ -18,8 +18,38 @@ class ConvertKitForm extends React.Component {
 	 */
 	render() {
 
-		// Get the Form block configuration.
-		const block = window.ConvertkitDiviBuilderData.form;
+		return ConvertKitDiviRenderModule(
+			window.ConvertkitDiviBuilderData.form,
+			this.props.form,
+			( this.props.form.length > 0 ? block.fields.form.data.forms[ this.props.form ].name : '' )
+		);
+
+	}
+
+}
+
+/**
+ * ConvertKit Product Divi Module.
+ */
+class ConvertKitDiviProduct extends React.Component {
+
+	/**
+	 * The Divi module name. Must match the slug defined in
+	 * the PHP class ConvertKit_Divi_Module_Product.
+	 * 
+	 * @since 	2.5.7
+	 */
+	static slug = 'convertkit_product';
+
+	/**
+	 * Renders the frontend output for this module.
+	 * 
+	 * @since 	2.5.7
+	 */
+	render() {
+
+		// Get the Product block configuration.
+		const block = window.ConvertkitDiviBuilderData.product;
 
 		// If no Access Token has been defined in the Plugin, show a message in the module to tell the user what to do.
 		if ( ! block.has_access_token ) {
@@ -41,15 +71,57 @@ class ConvertKitForm extends React.Component {
 			]  );
 		}
 
-		// Show instructions if no form selected.
-		if ( this.props.form.length === 0 ) {
+		// Show instructions if no product selected.
+		if ( this.props.product.length === 0 ) {
 			// Return module with text.
 			return React.createElement( 'div', {
 				className: 'convertkit-divi-module'
-			}, 'Select a Form using the Form option in this module.' );
+			}, 'Select a Product using the Product option in this module.' );
 		}
 
-		// Get selected form.
+		// Get selected product.
+		const product = block.fields.product.data.products[ this.props.product ];
+
+		// Return module with text.
+		return React.createElement( 'div', {
+			className: 'convertkit-divi-module'
+		}, 'ConvertKit Product "' + form.name + '" selected. View on the frontend site to see the product.' );
+
+	}
+
+}
+
+function ConvertKitDiviRenderModule( block, value, resource ) {
+
+	// If no Access Token has been defined in the Plugin, show a message in the module to tell the user what to do.
+	if ( ! block.has_access_token ) {
+		return React.createElement( 'div', {
+			className: 'convertkit-divi-module convertkit-no-content'
+		}, [
+			React.createElement( 'p', {}, block.no_access_token.notice ),
+			React.createElement( 'p', {}, block.no_access_token.instruction_text )
+		]  );
+	}
+
+	// If no resources exist in ConvertKit, show a message in the module to tell the user what to do.
+	if ( ! block.has_resources ) {
+		return React.createElement( 'div', {
+			className: 'convertkit-divi-module convertkit-no-content'
+		}, [
+			React.createElement( 'p', {}, block.no_resources.notice ),
+			React.createElement( 'p', {}, block.no_resources.instruction_text )
+		]  );
+	}
+
+	// Show instructions if no resource selected.
+	if ( value.length === 0 ) {
+		// Return module with text.
+		return React.createElement( 'div', {
+			className: 'convertkit-divi-module'
+		}, 'Configure this module by clicking the settings cog.' );
+	}
+
+			// Get selected form.
 		const form = block.fields.form.data.forms[ this.props.form ];
 
 		// Return module with text.
@@ -57,9 +129,14 @@ class ConvertKitForm extends React.Component {
 			className: 'convertkit-divi-module'
 		}, 'ConvertKit Form "' + form.name + '" selected. View on the frontend site to see the form.' );
 
-	}
+	// Return module with text.
+	// @TODO.
+	return React.createElement( 'div', {
+		className: 'convertkit-divi-module'
+	}, 'ConvertKit Product "' + label + '" selected. View on the frontend site to see the product.' ); 
 
 }
+
 
 /**
  * Register Divi modules when the Divi Builder API is ready.
@@ -73,7 +150,8 @@ jQuery( window ).on( 'et_builder_api_ready', function ( event, API ) {
 
 	// Register Divi modules.
   	API.registerModules( [
-  		ConvertKitForm
+  		ConvertKitDiviForm,
+  		ConvertKitDiviProduct
   	] );
 
 } );

--- a/includes/integrations/divi/scripts/builder-bundle.min.js
+++ b/includes/integrations/divi/scripts/builder-bundle.min.js
@@ -21,7 +21,8 @@ class ConvertKitDiviForm extends React.Component {
 		return ConvertKitDiviRenderModule(
 			window.ConvertkitDiviBuilderData.form,
 			this.props.form,
-			( this.props.form.length > 0 ? block.fields.form.data.forms[ this.props.form ].name : '' )
+			( this.props.form.length > 0 ? window.ConvertkitDiviBuilderData.form.fields.form.data.forms[ this.props.form ].name : '' ),
+			window.ConvertkitDiviBuilderData.form.fields.form.label
 		);
 
 	}
@@ -48,50 +49,29 @@ class ConvertKitDiviProduct extends React.Component {
 	 */
 	render() {
 
-		// Get the Product block configuration.
-		const block = window.ConvertkitDiviBuilderData.product;
-
-		// If no Access Token has been defined in the Plugin, show a message in the module to tell the user what to do.
-		if ( ! block.has_access_token ) {
-			return React.createElement( 'div', {
-				className: 'convertkit-divi-module convertkit-no-content'
-			}, [
-				React.createElement( 'p', {}, block.no_access_token.notice ),
-				React.createElement( 'p', {}, block.no_access_token.instruction_text )
-			]  );
-		}
-
-		// If no resources exist in ConvertKit, show a message in the module to tell the user what to do.
-		if ( ! block.has_resources ) {
-			return React.createElement( 'div', {
-				className: 'convertkit-divi-module convertkit-no-content'
-			}, [
-				React.createElement( 'p', {}, block.no_resources.notice ),
-				React.createElement( 'p', {}, block.no_resources.instruction_text )
-			]  );
-		}
-
-		// Show instructions if no product selected.
-		if ( this.props.product.length === 0 ) {
-			// Return module with text.
-			return React.createElement( 'div', {
-				className: 'convertkit-divi-module'
-			}, 'Select a Product using the Product option in this module.' );
-		}
-
-		// Get selected product.
-		const product = block.fields.product.data.products[ this.props.product ];
-
-		// Return module with text.
-		return React.createElement( 'div', {
-			className: 'convertkit-divi-module'
-		}, 'ConvertKit Product "' + form.name + '" selected. View on the frontend site to see the product.' );
+		return ConvertKitDiviRenderModule(
+			window.ConvertkitDiviBuilderData.form,
+			this.props.product,
+			( this.props.product.length > 0 ? window.ConvertkitDiviBuilderData.product.fields.product.values[ this.props.product ] : '' ),
+			window.ConvertkitDiviBuilderData.product.fields.product.label
+		);
 
 	}
 
 }
 
-function ConvertKitDiviRenderModule( block, value, resource ) {
+/**
+ * Renders the Divi module for the given ConvertKit block (form, product, broadcast etc).
+ * and message, based on the Plugin and Divi module's configuration.
+ * 
+ * @since 	2.5.7
+ * 
+ * @param 	object 	block 			Block.
+ * @param 	string  value   		Selected value.
+ * @param 	string 	valueLabel 		Selected value's label.
+ * @param 	string 	resourceName 	Resource name (form,product).
+ */
+function ConvertKitDiviRenderModule( block, value, valueLabel, resourceName ) {
 
 	// If no Access Token has been defined in the Plugin, show a message in the module to tell the user what to do.
 	if ( ! block.has_access_token ) {
@@ -121,19 +101,10 @@ function ConvertKitDiviRenderModule( block, value, resource ) {
 		}, 'Configure this module by clicking the settings cog.' );
 	}
 
-			// Get selected form.
-		const form = block.fields.form.data.forms[ this.props.form ];
-
-		// Return module with text.
-		return React.createElement( 'div', {
-			className: 'convertkit-divi-module'
-		}, 'ConvertKit Form "' + form.name + '" selected. View on the frontend site to see the form.' );
-
 	// Return module with text.
-	// @TODO.
 	return React.createElement( 'div', {
 		className: 'convertkit-divi-module'
-	}, 'ConvertKit Product "' + label + '" selected. View on the frontend site to see the product.' ); 
+	}, 'ConvertKit ' + resourceName + ' "' + valueLabel + '" selected. View on the frontend site to see the product.' ); 
 
 }
 

--- a/includes/integrations/divi/scripts/builder-bundle.min.js
+++ b/includes/integrations/divi/scripts/builder-bundle.min.js
@@ -18,10 +18,12 @@ class ConvertKitDiviForm extends React.Component {
 	 */
 	render() {
 
+		const form = ( typeof this.props.form !== 'undefined' ? this.props.form : '' );
+
 		return ConvertKitDiviRenderModule(
 			window.ConvertkitDiviBuilderData.form,
-			this.props.form,
-			( this.props.form.length > 0 ? window.ConvertkitDiviBuilderData.form.fields.form.data.forms[ this.props.form ].name : '' ),
+			form,
+			( form ? window.ConvertkitDiviBuilderData.form.fields.form.data.forms[ form ].name : '' ),
 			window.ConvertkitDiviBuilderData.form.fields.form.label
 		);
 
@@ -49,10 +51,12 @@ class ConvertKitDiviProduct extends React.Component {
 	 */
 	render() {
 
+		const product = ( typeof this.props.product !== 'undefined' ? this.props.product : '' );
+
 		return ConvertKitDiviRenderModule(
-			window.ConvertkitDiviBuilderData.form,
-			this.props.product,
-			( this.props.product.length > 0 ? window.ConvertkitDiviBuilderData.product.fields.product.values[ this.props.product ] : '' ),
+			window.ConvertkitDiviBuilderData.product,
+			product,
+			( product ? window.ConvertkitDiviBuilderData.product.fields.product.values[ product ] : '' ),
 			window.ConvertkitDiviBuilderData.product.fields.product.label
 		);
 

--- a/tests/_support/Helper/Acceptance/ConvertKitPlugin.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitPlugin.php
@@ -396,6 +396,12 @@ class ConvertKitPlugin extends \Codeception\Module
 		$I->haveOptionInDatabase(
 			'convertkit_products',
 			[
+				42847 => [
+					'id'        => 42847,
+					'name'      => 'Example Tip Jar',
+					'url'       => 'https://cheerful-architect-3237.ck.page/products/example-tip-jar',
+					'published' => true,
+				],
 				36377 => [
 					'id'        => 36377,
 					'name'      => 'Newsletter Subscription',

--- a/tests/acceptance/integrations/other/DiviProductCest.php
+++ b/tests/acceptance/integrations/other/DiviProductCest.php
@@ -297,7 +297,7 @@ class DiviProductCest
 		$I->setupConvertKitPluginResources($I);
 
 		// Create Page with Product module in Divi.
-		$pageID = $this->_createPageWithFormModule($I, 'ConvertKit: Page: Product: Divi Module: No Product Param', '');
+		$pageID = $this->_createPageWithProductModule($I, 'ConvertKit: Page: Product: Divi Module: No Product Param', '');
 
 		// Load Page.
 		$I->amOnPage('?p=' . $pageID);

--- a/tests/acceptance/integrations/other/DiviProductCest.php
+++ b/tests/acceptance/integrations/other/DiviProductCest.php
@@ -1,15 +1,15 @@
 <?php
 /**
- * Tests for the ConvertKit Form's Divi Module.
+ * Tests for the ConvertKit Product's Divi Module.
  *
- * @since   2.5.6
+ * @since   2.5.7
  */
-class DiviFormCest
+class DiviProductCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
 	 *
-	 * @since   2.5.6
+	 * @since   2.5.7
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
@@ -20,14 +20,14 @@ class DiviFormCest
 	}
 
 	/**
-	 * Test the Form module works when a valid Form is selected
+	 * Test the Product module works when a valid Product is selected
 	 * using Divi's backend editor.
 	 *
-	 * @since   2.5.6
+	 * @since   2.5.7
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testFormModuleInBackendEditor(AcceptanceTester $I)
+	public function testProductModuleInBackendEditor(AcceptanceTester $I)
 	{
 		// Setup Plugin, without defining default Forms.
 		$I->setupConvertKitPluginNoDefaultForms($I);
@@ -82,16 +82,16 @@ class DiviFormCest
 
 		// Search for module.
 		$I->waitForElementVisible('input[name="filterByTitle"]');
-		$I->fillField('filterByTitle', 'ConvertKit Form');
+		$I->fillField('filterByTitle', 'ConvertKit Product');
 
 		// Insert module.
-		$I->waitForElementVisible('li.convertkit_form');
-		$I->click('li.convertkit_form');
+		$I->waitForElementVisible('li.convertkit_product');
+		$I->click('li.convertkit_product');
 
-		// Select Form.
-		$I->waitForElementVisible('#et-fb-form');
-		$I->click('#et-fb-form');
-		$I->click('li[data-value="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', '#et-fb-form');
+		// Select Product.
+		$I->waitForElementVisible('#et-fb-product');
+		$I->click('#et-fb-product');
+		$I->click('li[data-value="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '"]', '#et-fb-product');
 
 		// Save module.
 		$I->click('button[data-tip="Save Changes"]');
@@ -109,23 +109,22 @@ class DiviFormCest
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that one ConvertKit Form is output in the DOM.
-		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		// Confirm that the module displays.
+		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
 
 		// Deactivate Classic Editor.
 		$I->deactivateThirdPartyPlugin($I, 'classic-editor');
 	}
 
 	/**
-	 * Test the Form module works when a valid Form is selected
+	 * Test the Product module works when a valid Product is selected
 	 * using Divi's backend editor.
 	 *
-	 * @since   2.5.6
+	 * @since   2.5.7
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testFormModuleInFrontendEditor(AcceptanceTester $I)
+	public function testProductModuleInFrontendEditor(AcceptanceTester $I)
 	{
 		// Setup Plugin, without defining default Forms.
 		$I->setupConvertKitPluginNoDefaultForms($I);
@@ -163,16 +162,16 @@ class DiviFormCest
 
 		// Search for module.
 		$I->waitForElementVisible('input[name="filterByTitle"]');
-		$I->fillField('filterByTitle', 'ConvertKit Form');
+		$I->fillField('filterByTitle', 'ConvertKit Product');
 
 		// Insert module.
-		$I->waitForElementVisible('li.convertkit_form');
-		$I->click('li.convertkit_form');
+		$I->waitForElementVisible('li.convertkit_product');
+		$I->click('li.convertkit_product');
 
-		// Select Form.
-		$I->waitForElementVisible('#et-fb-form');
-		$I->click('#et-fb-form');
-		$I->click('li[data-value="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', '#et-fb-form');
+		// Select Product.
+		$I->waitForElementVisible('#et-fb-product');
+		$I->click('#et-fb-product');
+		$I->click('li[data-value="' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '"]', '#et-fb-product');
 
 		// Save module.
 		$I->click('button[data-tip="Save Changes"]');
@@ -189,22 +188,21 @@ class DiviFormCest
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that one ConvertKit Form is output in the DOM.
-		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		// Confirm that the module displays.
+		$I->seeProductOutput($I, $_ENV['CONVERTKIT_API_PRODUCT_URL'], 'Buy my product');
 	}
 
 	/**
-	 * Test the Form module displays the expected message when the Plugin has no credentials
+	 * Test the Product module displays the expected message when the Plugin has no credentials
 	 *
 	 * @since   2.5.7
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testFormModuleInFrontendEditorWhenNoCredentials(AcceptanceTester $I)
+	public function testProductModuleInFrontendEditorWhenNoCredentials(AcceptanceTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Divi: Frontend: No Credentials');
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Divi: Product: Frontend: No Credentials');
 
 		// Publish Page.
 		$url = $I->publishGutenbergPage($I);
@@ -226,33 +224,33 @@ class DiviFormCest
 
 		// Search for module.
 		$I->waitForElementVisible('input[name="filterByTitle"]');
-		$I->fillField('filterByTitle', 'ConvertKit Form');
+		$I->fillField('filterByTitle', 'ConvertKit Product');
 
 		// Insert module.
-		$I->waitForElementVisible('li.convertkit_form');
-		$I->click('li.convertkit_form');
+		$I->waitForElementVisible('li.convertkit_product');
+		$I->click('li.convertkit_product');
 
 		// Confirm the on screen message displays.
 		$I->seeInSource('Not connected to ConvertKit');
-		$I->seeInSource('Connect your ConvertKit account at Settings > ConvertKit, and then refresh this page to select a form.');
+		$I->seeInSource('Connect your ConvertKit account at Settings > ConvertKit, and then refresh this page to select a product.');
 	}
 
 	/**
-	 * Test the Form module displays the expected message when the ConvertKit account
-	 * has no forms.
+	 * Test the Product module displays the expected message when the ConvertKit account
+	 * has no products.
 	 *
 	 * @since   2.5.7
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testFormModuleInFrontendEditorWhenNoForms(AcceptanceTester $I)
+	public function testProductModuleInFrontendEditorWhenNoProduct(AcceptanceTester $I)
 	{
 		// Setup Plugin.
 		$I->setupConvertKitPluginCredentialsNoData($I);
 		$I->setupConvertKitPluginResourcesNoData($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Divi: Frontend: No Forms');
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Divi: Frontend: No Products');
 
 		// Publish Page.
 		$url = $I->publishGutenbergPage($I);
@@ -274,32 +272,32 @@ class DiviFormCest
 
 		// Search for module.
 		$I->waitForElementVisible('input[name="filterByTitle"]');
-		$I->fillField('filterByTitle', 'ConvertKit Form');
+		$I->fillField('filterByTitle', 'ConvertKit Product');
 
 		// Insert module.
-		$I->waitForElementVisible('li.convertkit_form');
-		$I->click('li.convertkit_form');
+		$I->waitForElementVisible('li.convertkit_product');
+		$I->click('li.convertkit_product');
 
 		// Confirm the on screen message displays.
-		$I->seeInSource('No forms exist in ConvertKit');
-		$I->seeInSource('Add a form to your ConvertKit account, and then refresh this page to select a form.');
+		$I->seeInSource('No products exist in ConvertKit');
+		$I->seeInSource('Add a product to your ConvertKit account, and then refresh this page to select a product.');
 	}
 
 	/**
-	 * Test the Form module works when a valid Legacy Form is selected.
+	 * Test the Product module works when no Product is selected.
 	 *
-	 * @since   2.5.6
+	 * @since   2.5.7
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testFormModuleWithValidLegacyFormParameter(AcceptanceTester $I)
+	public function testProductModuleWithNoProductParameter(AcceptanceTester $I)
 	{
 		// Setup Plugin, without defining default Forms.
 		$I->setupConvertKitPluginNoDefaultForms($I);
 		$I->setupConvertKitPluginResources($I);
 
-		// Create Page with Form module in Divi.
-		$pageID = $this->_createPageWithFormModule($I, 'ConvertKit: Legacy Form: Divi Module: Valid Form Param', $_ENV['CONVERTKIT_API_LEGACY_FORM_ID']);
+		// Create Page with Product module in Divi.
+		$pageID = $this->_createPageWithFormModule($I, 'ConvertKit: Page: Product: Divi Module: No Product Param', '');
 
 		// Load Page.
 		$I->amOnPage('?p=' . $pageID);
@@ -307,48 +305,22 @@ class DiviFormCest
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that the ConvertKit Form is displayed.
-		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
-	}
-
-	/**
-	 * Test the Form module works when no Form is selected.
-	 *
-	 * @since   2.5.6
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 */
-	public function testFormModuleWithNoFormParameter(AcceptanceTester $I)
-	{
-		// Setup Plugin, without defining default Forms.
-		$I->setupConvertKitPluginNoDefaultForms($I);
-		$I->setupConvertKitPluginResources($I);
-
-		// Create Page with Form module in Divi.
-		$pageID = $this->_createPageWithFormModule($I, 'ConvertKit: Page: Form: Divi Module: No Form Param', '');
-
-		// Load Page.
-		$I->amOnPage('?p=' . $pageID);
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm that no ConvertKit Form is displayed.
-		$I->dontSeeElementInDOM('form[data-sv-form]');
+		// Confirm that no ConvertKit Product is displayed.
+		$I->dontSeeProductOutput();
 	}
 
 	/**
 	 * Create a Page in the database comprising of Divi Page Builder data
-	 * containing a ConvertKit Form module.
+	 * containing a ConvertKit Product module.
 	 *
-	 * @since   2.5.6
+	 * @since   2.5.7
 	 *
 	 * @param   AcceptanceTester $I      Tester.
 	 * @param   string           $title  Page Title.
-	 * @param   int              $formID ConvertKit Form ID.
+	 * @param   int              $productID ConvertKit Product ID.
 	 * @return  int                         Page ID
 	 */
-	private function _createPageWithFormModule(AcceptanceTester $I, $title, $formID)
+	private function _createPageWithProductModule(AcceptanceTester $I, $title, $productID)
 	{
 		return $I->havePostInDatabase(
 			[
@@ -358,7 +330,7 @@ class DiviFormCest
 				'post_content' => '[et_pb_section fb_built="1" _builder_version="4.27.0" _module_preset="default" global_colors_info="{}"]
 					[et_pb_row _builder_version="4.27.0" _module_preset="default"]
 						[et_pb_column _builder_version="4.27.0" _module_preset="default" type="4_4"]
-							[convertkit_form _builder_version="4.27.0" _module_preset="default" form="' . $formID . '" hover_enabled="0" sticky_enabled="0"][/convertkit_form]
+							[convertkit_product _builder_version="4.27.0" _module_preset="default" product="' . $productID . '" hover_enabled="0" sticky_enabled="0"][/convertkit_product]
 						[/et_pb_column]
 					[/et_pb_row]
 				[/et_pb_section]',
@@ -384,7 +356,7 @@ class DiviFormCest
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
 	 *
-	 * @since   2.5.6
+	 * @since   2.5.7
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */

--- a/tests/acceptance/integrations/other/DiviProductCest.php
+++ b/tests/acceptance/integrations/other/DiviProductCest.php
@@ -68,9 +68,14 @@ class DiviProductCest
 		// Click Divi Builder button.
 		$I->click('#et_pb_toggle_builder');
 
-		// Dismiss modal.
-		$I->waitForElementVisible('.et-core-modal-action-dont-restore');
-		$I->click('.et-core-modal-action-dont-restore');
+		// Dismiss modal if displayed.
+		// May have been dismissed by other tests in the suite e.g. DiviFormCest.
+		try {
+			$I->waitForElementVisible('.et-core-modal-action-dont-restore');
+			$I->click('.et-core-modal-action-dont-restore');
+		} catch ( \Facebook\WebDriver\Exception\NoSuchElementException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// No modal exists, so nothing to dismiss.
+		}
 
 		// Click Build from scratch button.
 		$I->waitForElementVisible('.et-fb-page-creation-card-build_from_scratch');
@@ -306,7 +311,7 @@ class DiviProductCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that no ConvertKit Product is displayed.
-		$I->dontSeeProductOutput();
+		$I->dontSeeProductOutput($I);
 	}
 
 	/**

--- a/tests/acceptance/integrations/other/DiviProductCest.php
+++ b/tests/acceptance/integrations/other/DiviProductCest.php
@@ -105,6 +105,7 @@ class DiviProductCest
 		$I->click('Update');
 
 		// Load the Page on the frontend site.
+		$I->waitForElementNotVisible('.et-fb-preloader');
 		$I->waitForElementVisible('.notice-success');
 		$I->click('.notice-success a');
 


### PR DESCRIPTION
## Summary

Registers the ConvertKit Product block as a module in the Divi Builder, making it easier to add a ConvertKit Product button.

![Screenshot 2024-09-04 at 15 55 30](https://github.com/user-attachments/assets/ff363fb2-630e-45b1-867e-725b408f161a)

![Screenshot 2024-09-04 at 15 55 34](https://github.com/user-attachments/assets/7f318a6a-e4b6-4586-a090-b1d7bc629be2)

## Testing

- `DiviProductCest`: Test that adding the ConvertKit Product module to Divi works.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)