### PR TITLE
Divi: Add Form Trigger Module

### DIFF
--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -147,14 +147,16 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 
 			// Help descriptions, displayed when no Access Token / resources exist and this block/shortcode is added.
 			'no_access_token'                   => array(
-				'notice'    => __( 'Not connected to ConvertKit.', 'convertkit' ),
-				'link'      => convertkit_get_setup_wizard_plugin_link(),
-				'link_text' => __( 'Click here to connect your ConvertKit account.', 'convertkit' ),
+				'notice'           => __( 'Not connected to ConvertKit.', 'convertkit' ),
+				'link'             => convertkit_get_setup_wizard_plugin_link(),
+				'link_text'        => __( 'Click here to connect your ConvertKit account.', 'convertkit' ),
+				'instruction_text' => __( 'Connect your ConvertKit account at Settings > ConvertKit, and then refresh this page to configure broadcasts to display.', 'convertkit' ),
 			),
 			'no_resources'                      => array(
-				'notice'    => __( 'No broadcasts exist in ConvertKit.', 'convertkit' ),
-				'link'      => convertkit_get_new_broadcast_url(),
-				'link_text' => __( 'Click here to send your first broadcast.', 'convertkit' ),
+				'notice'           => __( 'No broadcasts exist in ConvertKit.', 'convertkit' ),
+				'link'             => convertkit_get_new_broadcast_url(),
+				'link_text'        => __( 'Click here to send your first broadcast.', 'convertkit' ),
+				'instruction_text' => __( 'Add a broadcast to your ConvertKit account, and then refresh this page to configure broadcasts to display.', 'convertkit' ),
 			),
 
 			// Gutenberg: JS function to call when rendering the block preview in the Gutenberg editor.

--- a/includes/blocks/class-convertkit-block-form-trigger.php
+++ b/includes/blocks/class-convertkit-block-form-trigger.php
@@ -113,14 +113,16 @@ class ConvertKit_Block_Form_Trigger extends ConvertKit_Block {
 
 			// Help descriptions, displayed when no API key / resources exist and this block/shortcode is added.
 			'no_access_token'                   => array(
-				'notice'    => __( 'Not connected to ConvertKit.', 'convertkit' ),
-				'link'      => convertkit_get_setup_wizard_plugin_link(),
-				'link_text' => __( 'Click here to connect your ConvertKit account.', 'convertkit' ),
+				'notice'           => __( 'Not connected to ConvertKit.', 'convertkit' ),
+				'link'             => convertkit_get_setup_wizard_plugin_link(),
+				'link_text'        => __( 'Click here to connect your ConvertKit account.', 'convertkit' ),
+				'instruction_text' => __( 'Connect your ConvertKit account at Settings > ConvertKit, and then refresh this page to select a form.', 'convertkit' ),
 			),
 			'no_resources'                      => array(
-				'notice'    => __( 'No modal, sticky bar or slide in forms exist in ConvertKit.', 'convertkit' ),
-				'link'      => convertkit_get_new_form_url(),
-				'link_text' => __( 'Click here to create a form.', 'convertkit' ),
+				'notice'           => __( 'No modal, sticky bar or slide in forms exist in ConvertKit.', 'convertkit' ),
+				'link'             => convertkit_get_new_form_url(),
+				'link_text'        => __( 'Click here to create a form.', 'convertkit' ),
+				'instruction_text' => __( 'Add a non-inline form to your ConvertKit account, and then refresh this page to select a form.', 'convertkit' ),
 			),
 			'gutenberg_help_description'        => __( 'Select a Form using the Form option in the Gutenberg sidebar.', 'convertkit' ),
 

--- a/includes/integrations/divi/class-convertkit-divi-module-broadcasts.php
+++ b/includes/integrations/divi/class-convertkit-divi-module-broadcasts.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Divi Module: ConvertKit Broadcasts.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Registers the ConvertKit Broadcasts Block as a Divi Module.
+ *
+ * @package ConvertKit
+ * @author  ConvertKit
+ */
+class ConvertKit_Divi_Module_Broadcasts extends ConvertKit_Divi_Module {
+
+	/**
+	 * The ConvertKit block name.
+	 *
+	 * @since   2.5.7
+	 *
+	 * @var     string
+	 */
+	public $block_name = 'broadcasts';
+
+	/**
+	 * The ConvertKit Divi module name.
+	 *
+	 * @since   2.5.7
+	 *
+	 * @var     string
+	 */
+	public $slug = 'convertkit_broadcasts';
+
+}
+
+new ConvertKit_Divi_Module_Broadcasts();

--- a/includes/integrations/divi/class-convertkit-divi-module-form-trigger.php
+++ b/includes/integrations/divi/class-convertkit-divi-module-form-trigger.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Divi Module: ConvertKit Form Trigger.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Registers the ConvertKit Form Trigger Block as a Divi Module.
+ *
+ * @package ConvertKit
+ * @author  ConvertKit
+ */
+class ConvertKit_Divi_Module_Form_Trigger extends ConvertKit_Divi_Module {
+
+	/**
+	 * The ConvertKit block name.
+	 *
+	 * @since   2.5.7
+	 *
+	 * @var     string
+	 */
+	public $block_name = 'formtrigger';
+
+	/**
+	 * The ConvertKit Divi module name.
+	 *
+	 * @since   2.5.7
+	 *
+	 * @var     string
+	 */
+	public $slug = 'convertkit_formtrigger';
+
+}
+
+new ConvertKit_Divi_Module_Form_Trigger();

--- a/includes/integrations/divi/class-convertkit-divi-module.php
+++ b/includes/integrations/divi/class-convertkit-divi-module.php
@@ -139,14 +139,11 @@ class ConvertKit_Divi_Module extends ET_Builder_Module {
 				 * Select
 				 */
 				case 'select':
-					$fields[ $field_name ]['options'] = $field['values'];
-
-					// For select dropdowns, if no default value exists, we have to force the first
-					// value as the default, otherwise Divi will show that the first value is selected,
-					// but its underlying value won't be saved unless the user changes the chosen selection.
-					if ( ! $this->get_default_value( $field ) ) {
-						$fields[ $field_name ]['default'] = array_key_first( $field['values'] );
-					}
+					// For select dropdowns, Divi treats the first <option> as the default. If it's selected,
+					// Divi won't pass the underlying value, resulting in no output.
+					// Forcing a 'None' option as the first ensures the user must select an <option>, therefore
+					// ensuring output is correct.
+					$fields[ $field_name ]['options'] = array( 0 => __( '(None)', 'convertkit' ) ) + $field['values'];
 					break;
 
 				/**

--- a/includes/integrations/divi/loader.php
+++ b/includes/integrations/divi/loader.php
@@ -18,4 +18,5 @@ if ( ! class_exists( 'ET_Builder_Element' ) ) {
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/divi/class-convertkit-divi-module.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/divi/class-convertkit-divi-module-broadcasts.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/divi/class-convertkit-divi-module-form.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/divi/class-convertkit-divi-module-form-trigger.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/divi/class-convertkit-divi-module-product.php';

--- a/includes/integrations/divi/loader.php
+++ b/includes/integrations/divi/loader.php
@@ -16,5 +16,6 @@ if ( ! class_exists( 'ET_Builder_Element' ) ) {
 
 // Load Divi modules.
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/divi/class-convertkit-divi-module.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/divi/class-convertkit-divi-module-broadcasts.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/divi/class-convertkit-divi-module-form.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/integrations/divi/class-convertkit-divi-module-product.php';

--- a/includes/integrations/divi/scripts/builder-bundle.min.js
+++ b/includes/integrations/divi/scripts/builder-bundle.min.js
@@ -1,4 +1,39 @@
 /**
+ * ConvertKit Broadcasts Divi Module.
+ */
+class ConvertKitDiviBroadcasts extends React.Component {
+
+	/**
+	 * The Divi module name. Must match the slug defined in
+	 * the PHP class ConvertKit_Divi_Module_Broadcasts.
+	 * 
+	 * @since 	2.5.7
+	 */
+	static slug = 'convertkit_broadcasts';
+
+	/**
+	 * Renders the frontend output for this module.
+	 * 
+	 * @since 	2.5.7
+	 */
+	render() {
+
+		// Fetch element if no access token or resources exist.
+		const warning = ConvertKitDiviMaybeRenderWarning( window.ConvertkitDiviBuilderData.broadcasts );
+		if ( warning !== true ) {
+			return warning;
+		}
+
+		// Return module with text.
+		return React.createElement( 'div', {
+			className: 'convertkit-divi-module'
+		}, 'Configure this broadcasts module by clicking the settings cog.' );
+
+	}
+
+}
+
+/**
  * ConvertKit Form Divi Module.
  */
 class ConvertKitDiviForm extends React.Component {
@@ -20,7 +55,7 @@ class ConvertKitDiviForm extends React.Component {
 
 		const form = ( typeof this.props.form !== 'undefined' ? this.props.form : '' );
 
-		return ConvertKitDiviRenderModule(
+		return ConvertKitDiviRenderResourceModule(
 			window.ConvertkitDiviBuilderData.form,
 			form,
 			( form ? window.ConvertkitDiviBuilderData.form.fields.form.data.forms[ form ].name : '' ),
@@ -53,7 +88,7 @@ class ConvertKitDiviProduct extends React.Component {
 
 		const product = ( typeof this.props.product !== 'undefined' ? this.props.product : '' );
 
-		return ConvertKitDiviRenderModule(
+		return ConvertKitDiviRenderResourceModule(
 			window.ConvertkitDiviBuilderData.product,
 			product,
 			( product ? window.ConvertkitDiviBuilderData.product.fields.product.values[ product ] : '' ),
@@ -75,7 +110,41 @@ class ConvertKitDiviProduct extends React.Component {
  * @param 	string 	valueLabel 		Selected value's label.
  * @param 	string 	resourceName 	Resource name (form,product).
  */
-function ConvertKitDiviRenderModule( block, value, valueLabel, resourceName ) {
+function ConvertKitDiviRenderResourceModule( block, value, valueLabel, resourceName ) {
+
+	// Fetch element if no access token or resources exist.
+	const warning = ConvertKitDiviMaybeRenderWarning( block );
+	if ( warning !== true ) {
+		return warning;
+	}
+
+	// Show instructions if no resource selected.
+	if ( value.length === 0 ) {
+		// Return module with text.
+		return React.createElement( 'div', {
+			className: 'convertkit-divi-module'
+		}, 'Configure this module by clicking the settings cog.' );
+	}
+
+	// Return module with text.
+	return React.createElement( 'div', {
+		className: 'convertkit-divi-module'
+	}, 'ConvertKit ' + resourceName + ' "' + valueLabel + '" selected. View on the frontend site to see the ' + resourceName + '.' ); 
+
+}
+
+/**
+ * Returns the Divi module for the given ConvertKit block (form, product, broadcast etc).
+ * if there is no access token or resources.
+ * 
+ * @since 	2.5.7
+ * 
+ * @param 	object 	block 			Block.
+ * @param 	string  value   		Selected value.
+ * @param 	string 	valueLabel 		Selected value's label.
+ * @param 	string 	resourceName 	Resource name (form,product).
+ */
+function ConvertKitDiviMaybeRenderWarning( block ) {
 
 	// If no Access Token has been defined in the Plugin, show a message in the module to tell the user what to do.
 	if ( ! block.has_access_token ) {
@@ -97,21 +166,9 @@ function ConvertKitDiviRenderModule( block, value, valueLabel, resourceName ) {
 		]  );
 	}
 
-	// Show instructions if no resource selected.
-	if ( value.length === 0 ) {
-		// Return module with text.
-		return React.createElement( 'div', {
-			className: 'convertkit-divi-module'
-		}, 'Configure this module by clicking the settings cog.' );
-	}
-
-	// Return module with text.
-	return React.createElement( 'div', {
-		className: 'convertkit-divi-module'
-	}, 'ConvertKit ' + resourceName + ' "' + valueLabel + '" selected. View on the frontend site to see the product.' ); 
+	return true;
 
 }
-
 
 /**
  * Register Divi modules when the Divi Builder API is ready.
@@ -125,6 +182,7 @@ jQuery( window ).on( 'et_builder_api_ready', function ( event, API ) {
 
 	// Register Divi modules.
   	API.registerModules( [
+  		ConvertKitDiviBroadcasts,
   		ConvertKitDiviForm,
   		ConvertKitDiviProduct
   	] );

--- a/includes/integrations/divi/scripts/builder-bundle.min.js
+++ b/includes/integrations/divi/scripts/builder-bundle.min.js
@@ -53,13 +53,46 @@ class ConvertKitDiviForm extends React.Component {
 	 */
 	render() {
 
-		const form = ( typeof this.props.form !== 'undefined' ? this.props.form : '' );
+		const form = Number( typeof this.props.form !== 'undefined' ? this.props.form : 0 );
 
 		return ConvertKitDiviRenderResourceModule(
 			window.ConvertkitDiviBuilderData.form,
 			form,
-			( form ? window.ConvertkitDiviBuilderData.form.fields.form.data.forms[ form ].name : '' ),
+			( form > 0 ? window.ConvertkitDiviBuilderData.form.fields.form.data.forms[ form ].name : '' ),
 			window.ConvertkitDiviBuilderData.form.fields.form.label
+		);
+
+	}
+
+}
+
+/**
+ * ConvertKit Form Trigger Divi Module.
+ */
+class ConvertKitDiviFormTrigger extends React.Component {
+
+	/**
+	 * The Divi module name. Must match the slug defined in
+	 * the PHP class ConvertKit_Divi_Module_Form.
+	 * 
+	 * @since 	2.5.7
+	 */
+	static slug = 'convertkit_formtrigger';
+
+	/**
+	 * Renders the frontend output for this module.
+	 * 
+	 * @since 	2.5.7
+	 */
+	render() {
+
+		const form = Number( typeof this.props.form !== 'undefined' ? this.props.form : 0 );
+
+		return ConvertKitDiviRenderResourceModule(
+			window.ConvertkitDiviBuilderData.formtrigger,
+			form,
+			( form > 0 ? window.ConvertkitDiviBuilderData.formtrigger.fields.form.values[ form ] : '' ),
+			window.ConvertkitDiviBuilderData.formtrigger.fields.form.label
 		);
 
 	}
@@ -86,12 +119,12 @@ class ConvertKitDiviProduct extends React.Component {
 	 */
 	render() {
 
-		const product = ( typeof this.props.product !== 'undefined' ? this.props.product : '' );
+		const product = Number( typeof this.props.product !== 'undefined' ? this.props.product : 0 );
 
 		return ConvertKitDiviRenderResourceModule(
 			window.ConvertkitDiviBuilderData.product,
 			product,
-			( product ? window.ConvertkitDiviBuilderData.product.fields.product.values[ product ] : '' ),
+			( product > 0 ? window.ConvertkitDiviBuilderData.product.fields.product.values[ product ] : '' ),
 			window.ConvertkitDiviBuilderData.product.fields.product.label
 		);
 
@@ -119,7 +152,7 @@ function ConvertKitDiviRenderResourceModule( block, value, valueLabel, resourceN
 	}
 
 	// Show instructions if no resource selected.
-	if ( value.length === 0 ) {
+	if ( value.length === 0 || value === 0 ) {
 		// Return module with text.
 		return React.createElement( 'div', {
 			className: 'convertkit-divi-module'
@@ -184,6 +217,7 @@ jQuery( window ).on( 'et_builder_api_ready', function ( event, API ) {
   	API.registerModules( [
   		ConvertKitDiviBroadcasts,
   		ConvertKitDiviForm,
+  		ConvertKitDiviFormTrigger,
   		ConvertKitDiviProduct
   	] );
 

--- a/tests/acceptance/integrations/other/DiviBroadcastsCest.php
+++ b/tests/acceptance/integrations/other/DiviBroadcastsCest.php
@@ -1,15 +1,15 @@
 <?php
 /**
- * Tests for the ConvertKit Form's Divi Module.
+ * Tests for the ConvertKit Broadcasts Divi Module.
  *
- * @since   2.5.6
+ * @since   2.5.7
  */
-class DiviFormCest
+class DiviBroadcastsCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
 	 *
-	 * @since   2.5.6
+	 * @since   2.5.7
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
@@ -20,14 +20,14 @@ class DiviFormCest
 	}
 
 	/**
-	 * Test the Form module works when a valid Form is selected
+	 * Test the Broadcasts module works when added
 	 * using Divi's backend editor.
 	 *
-	 * @since   2.5.6
+	 * @since   2.5.7
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testFormModuleInBackendEditor(AcceptanceTester $I)
+	public function testBroadcastsModuleInBackendEditor(AcceptanceTester $I)
 	{
 		// Setup Plugin, without defining default Forms.
 		$I->setupConvertKitPluginNoDefaultForms($I);
@@ -37,7 +37,7 @@ class DiviFormCest
 		$I->activateThirdPartyPlugin($I, 'classic-editor');
 
 		// Add a Page using the Classic Editor.
-		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Form: Divi: Backend Editor');
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Broadcasts: Divi: Backend Editor');
 
 		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
 		$I->configureMetaboxSettings(
@@ -87,16 +87,11 @@ class DiviFormCest
 
 		// Search for module.
 		$I->waitForElementVisible('input[name="filterByTitle"]');
-		$I->fillField('filterByTitle', 'ConvertKit Form');
+		$I->fillField('filterByTitle', 'ConvertKit Broadcasts');
 
 		// Insert module.
-		$I->waitForElementVisible('li.convertkit_form');
-		$I->click('li.convertkit_form');
-
-		// Select Form.
-		$I->waitForElementVisible('#et-fb-form');
-		$I->click('#et-fb-form');
-		$I->click('li[data-value="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', '#et-fb-form');
+		$I->waitForElementVisible('li.convertkit_broadcasts');
+		$I->click('li.convertkit_broadcasts');
 
 		// Save module.
 		$I->click('button[data-tip="Save Changes"]');
@@ -105,6 +100,7 @@ class DiviFormCest
 		$I->click('Update');
 
 		// Load the Page on the frontend site.
+		$I->waitForElementNotVisible('.et-fb-preloader');
 		$I->waitForElementVisible('.notice-success');
 		$I->click('.notice-success a');
 
@@ -114,23 +110,34 @@ class DiviFormCest
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that one ConvertKit Form is output in the DOM.
-		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		// Confirm that the block displays.
+		$I->seeBroadcastsOutput($I);
+
+		// Confirm that the default date format is as expected.
+		$I->seeInSource('<time datetime="' . date( 'Y-m-d', strtotime( $_ENV['CONVERTKIT_API_BROADCAST_FIRST_DATE'] ) ) . '">' . date( 'F j, Y', strtotime( $_ENV['CONVERTKIT_API_BROADCAST_FIRST_DATE'] ) ) . '</time>');
+
+		// Confirm that the default expected number of Broadcasts are displayed.
+		$I->seeNumberOfElements('li.convertkit-broadcast', [ 1, 10 ]);
+
+		// Confirm that the expected Broadcast name is displayed first links to the expected URL, with UTM parameters.
+		$I->assertEquals(
+			$I->grabAttributeFrom('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast:nth-child(2) a', 'href'),
+			$_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&utm_term=en_US&utm_content=convertkit'
+		);
 
 		// Deactivate Classic Editor.
 		$I->deactivateThirdPartyPlugin($I, 'classic-editor');
 	}
 
 	/**
-	 * Test the Form module works when a valid Form is selected
-	 * using Divi's backend editor.
+	 * Test the Broadcasts module works when added
+	 * using Divi's frontend editor.
 	 *
-	 * @since   2.5.6
+	 * @since   2.5.7
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testFormModuleInFrontendEditor(AcceptanceTester $I)
+	public function testBroadcastsModuleInFrontendEditor(AcceptanceTester $I)
 	{
 		// Setup Plugin, without defining default Forms.
 		$I->setupConvertKitPluginNoDefaultForms($I);
@@ -168,16 +175,11 @@ class DiviFormCest
 
 		// Search for module.
 		$I->waitForElementVisible('input[name="filterByTitle"]');
-		$I->fillField('filterByTitle', 'ConvertKit Form');
+		$I->fillField('filterByTitle', 'ConvertKit Broadcasts');
 
 		// Insert module.
-		$I->waitForElementVisible('li.convertkit_form');
-		$I->click('li.convertkit_form');
-
-		// Select Form.
-		$I->waitForElementVisible('#et-fb-form');
-		$I->click('#et-fb-form');
-		$I->click('li[data-value="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', '#et-fb-form');
+		$I->waitForElementVisible('li.convertkit_broadcasts');
+		$I->click('li.convertkit_broadcasts');
 
 		// Save module.
 		$I->click('button[data-tip="Save Changes"]');
@@ -194,22 +196,33 @@ class DiviFormCest
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Confirm that one ConvertKit Form is output in the DOM.
-		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		// Confirm that the block displays.
+		$I->seeBroadcastsOutput($I);
+
+		// Confirm that the default date format is as expected.
+		$I->seeInSource('<time datetime="' . date( 'Y-m-d', strtotime( $_ENV['CONVERTKIT_API_BROADCAST_FIRST_DATE'] ) ) . '">' . date( 'F j, Y', strtotime( $_ENV['CONVERTKIT_API_BROADCAST_FIRST_DATE'] ) ) . '</time>');
+
+		// Confirm that the default expected number of Broadcasts are displayed.
+		$I->seeNumberOfElements('li.convertkit-broadcast', [ 1, 10 ]);
+
+		// Confirm that the expected Broadcast name is displayed first links to the expected URL, with UTM parameters.
+		$I->assertEquals(
+			$I->grabAttributeFrom('div.convertkit-broadcasts ul.convertkit-broadcasts-list li.convertkit-broadcast:nth-child(2) a', 'href'),
+			$_ENV['CONVERTKIT_API_BROADCAST_FIRST_URL'] . '?utm_source=wordpress&utm_term=en_US&utm_content=convertkit'
+		);
 	}
 
 	/**
-	 * Test the Form module displays the expected message when the Plugin has no credentials
+	 * Test the Broadcasts module displays the expected message when the Plugin has no credentials
 	 *
 	 * @since   2.5.7
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testFormModuleInFrontendEditorWhenNoCredentials(AcceptanceTester $I)
+	public function testBroadcastsModuleInFrontendEditorWhenNoCredentials(AcceptanceTester $I)
 	{
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Divi: Frontend: No Credentials');
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Divi: Broadcasts: Frontend: No Credentials');
 
 		// Publish Page.
 		$url = $I->publishGutenbergPage($I);
@@ -231,33 +244,33 @@ class DiviFormCest
 
 		// Search for module.
 		$I->waitForElementVisible('input[name="filterByTitle"]');
-		$I->fillField('filterByTitle', 'ConvertKit Form');
+		$I->fillField('filterByTitle', 'ConvertKit Broadcasts');
 
 		// Insert module.
-		$I->waitForElementVisible('li.convertkit_form');
-		$I->click('li.convertkit_form');
+		$I->waitForElementVisible('li.convertkit_broadcasts');
+		$I->click('li.convertkit_broadcasts');
 
 		// Confirm the on screen message displays.
 		$I->seeInSource('Not connected to ConvertKit');
-		$I->seeInSource('Connect your ConvertKit account at Settings > ConvertKit, and then refresh this page to select a form.');
+		$I->seeInSource('Connect your ConvertKit account at Settings > ConvertKit, and then refresh this page to configure broadcasts to display.');
 	}
 
 	/**
-	 * Test the Form module displays the expected message when the ConvertKit account
-	 * has no forms.
+	 * Test the Broadcasts module displays the expected message when the ConvertKit account
+	 * has no broadcasts.
 	 *
 	 * @since   2.5.7
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testFormModuleInFrontendEditorWhenNoForms(AcceptanceTester $I)
+	public function testBroadcastsModuleInFrontendEditorWhenNoBroadcasts(AcceptanceTester $I)
 	{
 		// Setup Plugin.
 		$I->setupConvertKitPluginCredentialsNoData($I);
 		$I->setupConvertKitPluginResourcesNoData($I);
 
 		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Divi: Frontend: No Forms');
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Divi: Frontend: No Broadcasts');
 
 		// Publish Page.
 		$url = $I->publishGutenbergPage($I);
@@ -279,109 +292,15 @@ class DiviFormCest
 
 		// Search for module.
 		$I->waitForElementVisible('input[name="filterByTitle"]');
-		$I->fillField('filterByTitle', 'ConvertKit Form');
+		$I->fillField('filterByTitle', 'ConvertKit Broadcasts');
 
 		// Insert module.
-		$I->waitForElementVisible('li.convertkit_form');
-		$I->click('li.convertkit_form');
+		$I->waitForElementVisible('li.convertkit_broadcasts');
+		$I->click('li.convertkit_broadcasts');
 
 		// Confirm the on screen message displays.
-		$I->seeInSource('No forms exist in ConvertKit');
-		$I->seeInSource('Add a form to your ConvertKit account, and then refresh this page to select a form.');
-	}
-
-	/**
-	 * Test the Form module works when a valid Legacy Form is selected.
-	 *
-	 * @since   2.5.6
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 */
-	public function testFormModuleWithValidLegacyFormParameter(AcceptanceTester $I)
-	{
-		// Setup Plugin, without defining default Forms.
-		$I->setupConvertKitPluginNoDefaultForms($I);
-		$I->setupConvertKitPluginResources($I);
-
-		// Create Page with Form module in Divi.
-		$pageID = $this->_createPageWithFormModule($I, 'ConvertKit: Legacy Form: Divi Module: Valid Form Param', $_ENV['CONVERTKIT_API_LEGACY_FORM_ID']);
-
-		// Load Page.
-		$I->amOnPage('?p=' . $pageID);
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm that the ConvertKit Form is displayed.
-		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">');
-	}
-
-	/**
-	 * Test the Form module works when no Form is selected.
-	 *
-	 * @since   2.5.6
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 */
-	public function testFormModuleWithNoFormParameter(AcceptanceTester $I)
-	{
-		// Setup Plugin, without defining default Forms.
-		$I->setupConvertKitPluginNoDefaultForms($I);
-		$I->setupConvertKitPluginResources($I);
-
-		// Create Page with Form module in Divi.
-		$pageID = $this->_createPageWithFormModule($I, 'ConvertKit: Page: Form: Divi Module: No Form Param', '');
-
-		// Load Page.
-		$I->amOnPage('?p=' . $pageID);
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm that no ConvertKit Form is displayed.
-		$I->dontSeeElementInDOM('form[data-sv-form]');
-	}
-
-	/**
-	 * Create a Page in the database comprising of Divi Page Builder data
-	 * containing a ConvertKit Form module.
-	 *
-	 * @since   2.5.6
-	 *
-	 * @param   AcceptanceTester $I      Tester.
-	 * @param   string           $title  Page Title.
-	 * @param   int              $formID ConvertKit Form ID.
-	 * @return  int                         Page ID
-	 */
-	private function _createPageWithFormModule(AcceptanceTester $I, $title, $formID)
-	{
-		return $I->havePostInDatabase(
-			[
-				'post_title'   => $title,
-				'post_type'    => 'page',
-				'post_status'  => 'publish',
-				'post_content' => '[et_pb_section fb_built="1" _builder_version="4.27.0" _module_preset="default" global_colors_info="{}"]
-					[et_pb_row _builder_version="4.27.0" _module_preset="default"]
-						[et_pb_column _builder_version="4.27.0" _module_preset="default" type="4_4"]
-							[convertkit_form _builder_version="4.27.0" _module_preset="default" form="' . $formID . '" hover_enabled="0" sticky_enabled="0"][/convertkit_form]
-						[/et_pb_column]
-					[/et_pb_row]
-				[/et_pb_section]',
-				'meta_input'   => [
-					// Enable Divi Builder.
-					'_et_pb_use_builder'         => 'on',
-					'_et_pb_built_for_post_type' => 'page',
-
-					// Configure ConvertKit Plugin to not display a default Form,
-					// as we are testing for the Form in Elementor.
-					'_wp_convertkit_post_meta'   => [
-						'form'         => '0',
-						'landing_page' => '',
-						'tag'          => '',
-					],
-				],
-			]
-		);
+		$I->seeInSource('No broadcasts exist in ConvertKit');
+		$I->seeInSource('Add a broadcast to your ConvertKit account, and then refresh this page to configure broadcasts to display.');
 	}
 
 	/**
@@ -389,7 +308,7 @@ class DiviFormCest
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
 	 *
-	 * @since   2.5.6
+	 * @since   2.5.7
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */

--- a/tests/acceptance/integrations/other/DiviBroadcastsCest.php
+++ b/tests/acceptance/integrations/other/DiviBroadcastsCest.php
@@ -60,6 +60,7 @@ class DiviBroadcastsCest
 		$I->click('input#publish');
 
 		// Wait for notice to display.
+		$I->waitForElementNotVisible('.et-fb-preloader');
 		$I->waitForElementVisible('.notice-success');
 
 		// Remove transient set by Divi that would show the welcome modal.

--- a/tests/acceptance/integrations/other/DiviFormCest.php
+++ b/tests/acceptance/integrations/other/DiviFormCest.php
@@ -60,6 +60,7 @@ class DiviFormCest
 		$I->click('input#publish');
 
 		// Wait for notice to display.
+		$I->waitForElementNotVisible('.et-fb-preloader');
 		$I->waitForElementVisible('.notice-success');
 
 		// Remove transient set by Divi that would show the welcome modal.
@@ -105,6 +106,7 @@ class DiviFormCest
 		$I->click('Update');
 
 		// Load the Page on the frontend site.
+		$I->waitForElementNotVisible('.et-fb-preloader');
 		$I->waitForElementVisible('.notice-success');
 		$I->click('.notice-success a');
 

--- a/tests/acceptance/integrations/other/DiviFormTriggerCest.php
+++ b/tests/acceptance/integrations/other/DiviFormTriggerCest.php
@@ -1,0 +1,384 @@
+<?php
+/**
+ * Tests for the ConvertKit Form's Divi Module.
+ *
+ * @since   2.5.7
+ */
+class DiviFormTriggerCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   2.5.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'divi-builder');
+	}
+
+	/**
+	 * Test the Form module works when a valid Form is selected
+	 * using Divi's backend editor.
+	 *
+	 * @since   2.5.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFormTriggerModuleInBackendEditor(AcceptanceTester $I)
+	{
+		// Setup Plugin, without defining default Forms.
+		$I->setupConvertKitPluginNoDefaultForms($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Activate Classic Editor Plugin.
+		$I->activateThirdPartyPlugin($I, 'classic-editor');
+
+		// Add a Page using the Classic Editor.
+		$I->addClassicEditorPage($I, 'page', 'ConvertKit: Page: Form Trigger: Divi: Backend Editor');
+
+		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
+
+		// Scroll to Publish meta box, so its buttons are not hidden.
+		$I->scrollTo('#submitdiv');
+
+		// Wait for the Publish button to change its state from disabled (WordPress disables it for a moment when auto-saving).
+		$I->waitForElementVisible('input#publish:not(:disabled)');
+
+		// Click the Publish button twice, because Divi is flaky at best.
+		$I->click('input#publish');
+		$I->wait(2);
+		$I->click('input#publish');
+
+		// Wait for notice to display.
+		$I->waitForElementNotVisible('.et-fb-preloader');
+		$I->waitForElementVisible('.notice-success');
+
+		// Remove transient set by Divi that would show the welcome modal.
+		$I->dontHaveTransientInDatabase('et_builder_show_bfb_welcome_modal');
+
+		// Click Divi Builder button.
+		$I->click('#et_pb_toggle_builder');
+
+		// Dismiss modal if displayed.
+		// May have been dismissed by other tests in the suite e.g. DiviFormCest.
+		try {
+			$I->waitForElementVisible('.et-core-modal-action-dont-restore');
+			$I->click('.et-core-modal-action-dont-restore');
+		} catch ( \Facebook\WebDriver\Exception\NoSuchElementException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// No modal exists, so nothing to dismiss.
+		}
+
+		// Click Build from scratch button.
+		$I->waitForElementVisible('.et-fb-page-creation-card-build_from_scratch');
+		$I->click('Start Building', '.et-fb-page-creation-card-build_from_scratch');
+
+		// Insert row.
+		$I->waitForElementVisible('li[data-layout="4_4"]');
+		$I->click('li[data-layout="4_4"]');
+
+		// Search for module.
+		$I->waitForElementVisible('input[name="filterByTitle"]');
+		$I->fillField('filterByTitle', 'ConvertKit Form');
+
+		// Insert module.
+		$I->waitForElementVisible('li.convertkit_formtrigger');
+		$I->click('li.convertkit_formtrigger');
+
+		// Select Form.
+		$I->waitForElementVisible('#et-fb-form');
+		$I->click('#et-fb-form');
+		$I->click('li[data-value="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '"]', '#et-fb-form');
+
+		// Save module.
+		$I->click('button[data-tip="Save Changes"]');
+
+		// Update page.
+		$I->click('Update');
+
+		// Load the Page on the frontend site.
+		$I->waitForElementNotVisible('.et-fb-preloader');
+		$I->waitForElementVisible('.notice-success');
+		$I->click('.notice-success a');
+
+		// Wait for frontend web site to load.
+		$I->waitForElementVisible('body');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the block displays.
+		$I->seeFormTriggerOutput($I, $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_URL'], 'Subscribe');
+
+		// Confirm that one ConvertKit Form is output in the DOM.
+		// This confirms that there is only one script on the page for this form, which renders the form.
+		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '"]', 1);
+
+		// Deactivate Classic Editor.
+		$I->deactivateThirdPartyPlugin($I, 'classic-editor');
+	}
+
+	/**
+	 * Test the Form module works when a valid Form is selected
+	 * using Divi's backend editor.
+	 *
+	 * @since   2.5.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFormTriggerModuleInFrontendEditor(AcceptanceTester $I)
+	{
+		// Setup Plugin, without defining default Forms.
+		$I->setupConvertKitPluginNoDefaultForms($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form Trigger: Divi: Frontend');
+
+		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
+
+		// Publish Page.
+		$url = $I->publishGutenbergPage($I);
+
+		// Click Divi Builder button.
+		$I->click('Use Divi Builder');
+
+		// Reload page to dismiss modal.
+		$I->wait(5);
+		$I->amOnUrl($url . '?et_fb=1&PageSpeed=off');
+
+		// Click Build from scratch button.
+		$I->waitForElementVisible('.et-fb-page-creation-card-build_from_scratch', 30);
+		$I->click('Start Building', '.et-fb-page-creation-card-build_from_scratch');
+
+		// Insert row.
+		$I->waitForElementVisible('li[data-layout="4_4"]');
+		$I->click('li[data-layout="4_4"]');
+
+		// Search for module.
+		$I->waitForElementVisible('input[name="filterByTitle"]');
+		$I->fillField('filterByTitle', 'ConvertKit Form Trigger');
+
+		// Insert module.
+		$I->waitForElementVisible('li.convertkit_formtrigger');
+		$I->click('li.convertkit_formtrigger');
+
+		// Select Form.
+		$I->waitForElementVisible('#et-fb-form');
+		$I->click('#et-fb-form');
+		$I->click('li[data-value="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '"]', '#et-fb-form');
+
+		// Save module.
+		$I->click('button[data-tip="Save Changes"]');
+
+		// Save page.
+		$I->click('.et-fb-page-settings-bar__toggle-button');
+		$I->waitForElementVisible('button.et-fb-button--publish');
+		$I->click('button.et-fb-button--publish');
+		$I->wait(3);
+
+		// Load page without Divi frontend builder.
+		$I->amOnUrl($url);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the block displays.
+		$I->seeFormTriggerOutput($I, $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_URL'], 'Subscribe');
+
+		// Confirm that one ConvertKit Form is output in the DOM.
+		// This confirms that there is only one script on the page for this form, which renders the form.
+		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '"]', 1);
+	}
+
+	/**
+	 * Test the Form module displays the expected message when the Plugin has no credentials
+	 *
+	 * @since   2.5.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFormTriggerModuleInFrontendEditorWhenNoCredentials(AcceptanceTester $I)
+	{
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form Trigger: Divi: Frontend: No Credentials');
+
+		// Publish Page.
+		$url = $I->publishGutenbergPage($I);
+
+		// Click Divi Builder button.
+		$I->click('Use Divi Builder');
+
+		// Reload page to dismiss modal.
+		$I->wait(5);
+		$I->amOnUrl($url . '?et_fb=1&PageSpeed=off');
+
+		// Click Build from scratch button.
+		$I->waitForElementVisible('.et-fb-page-creation-card-build_from_scratch', 30);
+		$I->click('Start Building', '.et-fb-page-creation-card-build_from_scratch');
+
+		// Insert row.
+		$I->waitForElementVisible('li[data-layout="4_4"]');
+		$I->click('li[data-layout="4_4"]');
+
+		// Search for module.
+		$I->waitForElementVisible('input[name="filterByTitle"]');
+		$I->fillField('filterByTitle', 'ConvertKit Form Trigger');
+
+		// Insert module.
+		$I->waitForElementVisible('li.convertkit_formtrigger');
+		$I->click('li.convertkit_formtrigger');
+
+		// Confirm the on screen message displays.
+		$I->seeInSource('Not connected to ConvertKit');
+		$I->seeInSource('Connect your ConvertKit account at Settings > ConvertKit, and then refresh this page to select a form.');
+	}
+
+	/**
+	 * Test the Form module displays the expected message when the ConvertKit account
+	 * has no forms.
+	 *
+	 * @since   2.5.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFormTriggerModuleInFrontendEditorWhenNoForms(AcceptanceTester $I)
+	{
+		// Setup Plugin.
+		$I->setupConvertKitPluginCredentialsNoData($I);
+		$I->setupConvertKitPluginResourcesNoData($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form Trigger: Divi: Frontend: No Forms');
+
+		// Publish Page.
+		$url = $I->publishGutenbergPage($I);
+
+		// Click Divi Builder button.
+		$I->click('Use Divi Builder');
+
+		// Reload page to dismiss modal.
+		$I->wait(5);
+		$I->amOnUrl($url . '?et_fb=1&PageSpeed=off');
+
+		// Click Build from scratch button.
+		$I->waitForElementVisible('.et-fb-page-creation-card-build_from_scratch', 30);
+		$I->click('Start Building', '.et-fb-page-creation-card-build_from_scratch');
+
+		// Insert row.
+		$I->waitForElementVisible('li[data-layout="4_4"]');
+		$I->click('li[data-layout="4_4"]');
+
+		// Search for module.
+		$I->waitForElementVisible('input[name="filterByTitle"]');
+		$I->fillField('filterByTitle', 'ConvertKit Form Trigger');
+
+		// Insert module.
+		$I->waitForElementVisible('li.convertkit_formtrigger');
+		$I->click('li.convertkit_formtrigger');
+
+		// Confirm the on screen message displays.
+		$I->seeInSource('No modal, sticky bar or slide in forms exist in ConvertKit');
+		$I->seeInSource('Add a non-inline form to your ConvertKit account, and then refresh this page to select a form.');
+	}
+
+	/**
+	 * Test the Form module works when no Form is selected.
+	 *
+	 * @since   2.5.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testFormTriggerModuleWithNoFormParameter(AcceptanceTester $I)
+	{
+		// Setup Plugin, without defining default Forms.
+		$I->setupConvertKitPluginNoDefaultForms($I);
+		$I->setupConvertKitPluginResources($I);
+
+		// Create Page with Form module in Divi.
+		$pageID = $this->_createPageWithFormTriggerModule($I, 'ConvertKit: Page: Form Trigger: Divi Module: No Form Param', '');
+
+		// Load Page.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that no ConvertKit Form trigger button is displayed.
+		$I->dontSeeFormTriggerOutput($I);
+	}
+
+	/**
+	 * Create a Page in the database comprising of Divi Page Builder data
+	 * containing a ConvertKit Form module.
+	 *
+	 * @since   2.5.7
+	 *
+	 * @param   AcceptanceTester $I      Tester.
+	 * @param   string           $title  Page Title.
+	 * @param   int              $formID ConvertKit Form ID.
+	 * @return  int                         Page ID
+	 */
+	private function _createPageWithFormTriggerModule(AcceptanceTester $I, $title, $formID)
+	{
+		return $I->havePostInDatabase(
+			[
+				'post_title'   => $title,
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_content' => '[et_pb_section fb_built="1" _builder_version="4.27.0" _module_preset="default" global_colors_info="{}"]
+					[et_pb_row _builder_version="4.27.0" _module_preset="default"]
+						[et_pb_column _builder_version="4.27.0" _module_preset="default" type="4_4"]
+							[convertkit_formtrigger _builder_version="4.27.0" _module_preset="default" form="' . $formID . '" hover_enabled="0" sticky_enabled="0"][/convertkit_formtrigger]
+						[/et_pb_column]
+					[/et_pb_row]
+				[/et_pb_section]',
+				'meta_input'   => [
+					// Enable Divi Builder.
+					'_et_pb_use_builder'         => 'on',
+					'_et_pb_built_for_post_type' => 'page',
+
+					// Configure ConvertKit Plugin to not display a default Form,
+					// as we are testing for the Form in Elementor.
+					'_wp_convertkit_post_meta'   => [
+						'form'         => '0',
+						'landing_page' => '',
+						'tag'          => '',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   2.5.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateThirdPartyPlugin($I, 'divi-builder');
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
+	}
+}

--- a/tests/acceptance/integrations/other/DiviProductCest.php
+++ b/tests/acceptance/integrations/other/DiviProductCest.php
@@ -60,6 +60,7 @@ class DiviProductCest
 		$I->click('input#publish');
 
 		// Wait for notice to display.
+		$I->waitForElementNotVisible('.et-fb-preloader');
 		$I->waitForElementVisible('.notice-success');
 
 		// Remove transient set by Divi that would show the welcome modal.

--- a/tests/acceptance/integrations/other/DiviProductCest.php
+++ b/tests/acceptance/integrations/other/DiviProductCest.php
@@ -105,6 +105,7 @@ class DiviProductCest
 		$I->click('Update');
 
 		// Load the Page on the frontend site.
+		$I->waitForElementNotVisible('.et-fb-preloader');
 		$I->waitForElementVisible('.notice-success');
 		$I->click('.notice-success a');
 


### PR DESCRIPTION
## Summary

Registers the ConvertKit Form Trigger block as a module in the Divi Builder, making it easier to add ConvertKit Form Trigger buttons for modal, sticky bar and slide in forms.

![Screenshot 2024-09-05 at 17 45 45](https://github.com/user-attachments/assets/9debf772-6287-419e-b7bd-5990d68ebefd)

![Screenshot 2024-09-05 at 17 45 49](https://github.com/user-attachments/assets/825ae85e-c882-40de-82c6-810cc4c371b9)

## Testing

- `DiviFormTriggerCest`: Test that adding the ConvertKit Form Trigger module to Divi works.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)