### PR TITLE
Fix Landing Page Redirect

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "2.0.1"
+        "convertkit/convertkit-wordpress-libraries": "dev-remove-rocket-loader"
     },
     "require-dev": {
         "lucatume/wp-browser": "<3.5",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "dev-remove-rocket-loader"
+        "convertkit/convertkit-wordpress-libraries": "2.0.2"
     },
     "require-dev": {
         "lucatume/wp-browser": "<3.5",

--- a/tests/acceptance/landing-pages/PageLandingPageCest.php
+++ b/tests/acceptance/landing-pages/PageLandingPageCest.php
@@ -63,7 +63,8 @@ class PageLandingPageCest
 
 	/**
 	 * Test that the Landing Page specified in the Page Settings works when
-	 * creating and viewing a new WordPress Page.
+	 * creating and viewing a new WordPress Page, and that the Landing Page's
+	 * "Redirect to an external page" setting in ConvertKit is honored.
 	 *
 	 * @since   1.9.6
 	 *
@@ -98,6 +99,14 @@ class PageLandingPageCest
 		// Confirm that the ConvertKit Landing Page displays.
 		$I->dontSeeElementInDOM('body.page'); // WordPress didn't load its template, which is correct.
 		$I->seeElementInDOM('form[data-sv-form="' . $landingPageID . '"]'); // ConvertKit injected its Landing Page Form, which is correct.
+
+		// Subscribe.
+		$I->fillField('email_address', $I->generateEmailAddress());
+		$I->click('button.formkit-submit');
+
+		// Confirm the Landing Page's redirect worked i.e. rocket-loader.min.js was not included and blocking, and the Landing Page
+		// redirected to its external URL, https://cheerful-architect-3237.ck.page/.
+		$I->waitForElementVisible('.creator-avatar');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://linear.app/kit/issue/BCDC-3182/bcdc-embedded-landing-pages-on-wordpress-do-not-redirect-when-someone), where a Landing Page setup to redirect, and embedded in WordPress, won't redirect to the thank you page URL.

Uses [this PR](https://github.com/ConvertKit/convertkit-wordpress-libraries/pull/77) to exclude rocket-loader.min.js, which was the cause of this.

## Testing

- `testAddNewPageUsingDefinedLandingPage`: Updated test to complete subscription form, submit and observe that the redirect configured in ConvertKit is honored.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)