### PR TITLE
Correctly remove `ck_subscriber_id` from URL

### DIFF
--- a/resources/frontend/js/convertkit.js
+++ b/resources/frontend/js/convertkit.js
@@ -145,11 +145,21 @@ function convertStoreSubscriberEmailAsIDInCookie( emailAddress ) {
  */
 function convertKitRemoveSubscriberIDFromURL( url ) {
 
-	var clean_url = url.substring( 0, url.indexOf( "?ck_subscriber_id" ) );
-	var title     = document.getElementsByTagName( "title" )[0].innerHTML;
-	if ( clean_url ) {
-		window.history.pushState( null, title, clean_url );
+	// Remove ck_subscriber_id, retaining other params.
+	const url_object = new URL( url );
+	url_object.searchParams.delete( 'ck_subscriber_id' );
+
+	// Get title and string of parameters.
+	const title   = document.getElementsByTagName( 'title' )[0].innerHTML;
+	let clean_url = url_object.searchParams.toString();
+
+	// If leading question mark missing, prepend it.
+	if ( clean_url.charAt( 0 ) !== '?' ) {
+		clean_url = '?' + clean_url;
 	}
+
+	// Update history.
+	window.history.pushState( null, title, clean_url );
 
 }
 

--- a/tests/acceptance/general/SubscriberIDURLCest.php
+++ b/tests/acceptance/general/SubscriberIDURLCest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Tests that the ck_subscriber_id is removed from the URL by the Plugin's JS.
+ *
+ * @since   2.5.7
+ */
+class SubscriberIDURLCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   2.5.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPluginResources($I);
+	}
+
+	/**
+	 * Test that the ck_subscriber_id parameter is removed from the URL.
+	 *
+	 * @since   2.5.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSubscriberIDRemovedFromURL(AcceptanceTester $I)
+	{
+		// Create Page.
+		$I->havePageInDatabase(
+			[
+				'post_name'    => 'convertkit-subscriber-id-url',
+				'post_content' => 'Test',
+			]
+		);
+
+		// Confirm that the ck_subscriber_id was removed.
+		$I->amOnPage('/convertkit-subscriber-id-url?ck_subscriber_id=' . $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']);
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+		$I->wait(2);
+		$I->assertStringNotContainsString('ck_subscriber_id=' . $_ENV['CONVERTKIT_API_SUBSCRIBER_ID'], $I->grabFromCurrentUrl());
+
+		// Load the Page with UTM parameters at the end.
+		$I->amOnPage('/convertkit-subscriber-id-url?ck_subscriber_id=' . $_ENV['CONVERTKIT_API_SUBSCRIBER_ID'] . '&utm_source=email&utm_medium=email');
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+		$I->wait(2);
+		$I->assertStringNotContainsString('ck_subscriber_id=' . $_ENV['CONVERTKIT_API_SUBSCRIBER_ID'], $I->grabFromCurrentUrl());
+		$I->assertStringContainsString('?utm_source=email&utm_medium=email', $I->grabFromCurrentUrl());
+
+		// Load the Page with UTM parameters at the start.
+		$I->amOnPage('/convertkit-subscriber-id-url?utm_source=email&utm_medium=email&ck_subscriber_id=' . $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']);
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+		$I->wait(2);
+		$I->assertStringNotContainsString('ck_subscriber_id=' . $_ENV['CONVERTKIT_API_SUBSCRIBER_ID'], $I->grabFromCurrentUrl());
+		$I->assertStringContainsString('?utm_source=email&utm_medium=email', $I->grabFromCurrentUrl());
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   2.5.7
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
+	}
+}


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://n7studios-workspace.slack.com/archives/C02KFR6N1GF/p1725892885330669) where additional URL parameters (such as UTM params) would be incorrectly stripped from the URL by the Plugin's JS.

## Testing

- `SubscriberIDURLCest`: Test that the `ck_subscriber_id` parameter and its value are correctly removed, retaining other parameters before and after it.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)