### PR TITLE
Remove `convertKitRemoveSubscriberIDFromURL` function

### DIFF
--- a/resources/frontend/js/convertkit.js
+++ b/resources/frontend/js/convertkit.js
@@ -57,8 +57,6 @@ function convertStoreSubscriberIDInCookie( subscriber_id ) {
 			if ( convertkit.debug ) {
 				console.log( result );
 			}
-
-			convertKitRemoveSubscriberIDFromURL( window.location.href );
 		}
 	)
 	.catch(
@@ -66,8 +64,6 @@ function convertStoreSubscriberIDInCookie( subscriber_id ) {
 			if ( convertkit.debug ) {
 				console.error( error );
 			}
-
-			convertKitRemoveSubscriberIDFromURL( window.location.href );
 		}
 	);
 
@@ -130,26 +126,6 @@ function convertStoreSubscriberEmailAsIDInCookie( emailAddress ) {
 			}
 		}
 	);
-
-}
-
-/**
- * Remove the url subscriber_id url param
- *
- * The 'ck_subscriber_id' should only be set on URLs included on
- * links from a ConvertKit email with no other URL parameters.
- * This function removes the parameters so a customer won't share
- * a URL with their subscriber ID in it.
- *
- * @param url
- */
-function convertKitRemoveSubscriberIDFromURL( url ) {
-
-	var clean_url = url.substring( 0, url.indexOf( "?ck_subscriber_id" ) );
-	var title     = document.getElementsByTagName( "title" )[0].innerHTML;
-	if ( clean_url ) {
-		window.history.pushState( null, title, clean_url );
-	}
 
 }
 


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://n7studios-workspace.slack.com/archives/C02KFR6N1GF/p1725892885330669) where additional URL parameters (such as UTM params) would be incorrectly stripped from the URL by the Plugin's JS, by removing the `convertKitRemoveSubscriberIDFromURL` JS function entirely, given [this PR's approach](https://github.com/ConvertKit/convertkit-wordpress/pull/709) reportedly doesn't work.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)