### PR TITLE
Settings: Define Default Form Position

### DIFF
--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -279,15 +279,31 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 				continue;
 			}
 
-			// Add Settings Field.
+			// Add Settings Fields.
 			add_settings_field(
 				$supported_post_type . '_form',
 				sprintf(
-					/* translators: Post Type Name */
+					/* translators: Post Type Name, plural */
 					__( 'Default Form (%s)', 'convertkit' ),
 					$post_type->label
 				),
-				array( $this, 'custom_post_types_callback' ),
+				array( $this, 'default_form_callback' ),
+				$this->settings_key,
+				$this->name,
+				array(
+					'label_for'        => '_wp_convertkit_settings_' . $supported_post_type . '_form',
+					'post_type'        => $supported_post_type,
+					'post_type_object' => $post_type,
+				)
+			);
+			add_settings_field(
+				$supported_post_type . '_form_position',
+				sprintf(
+					/* translators: Post Type Name, plural */
+					__( 'Form Position (%s)', 'convertkit' ),
+					$post_type->label
+				),
+				array( $this, 'default_form_position_callback' ),
 				$this->settings_key,
 				$this->name,
 				array(
@@ -417,7 +433,7 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 	 *
 	 * @param   array $args  Field arguments.
 	 */
-	public function custom_post_types_callback( $args ) {
+	public function default_form_callback( $args ) {
 
 		// Refresh Forms.
 		if ( ! $this->forms ) {
@@ -498,6 +514,30 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 
 	}
 
+	/**
+	 * Renders the input for the Default Form Position setting for the given Post Type.
+	 *
+	 * @since  2.5.8
+	 *
+	 * @param   array $args  Field arguments.
+	 */
+	public function default_form_position_callback( $args ) {
+
+		echo $this->get_select_field(
+			$args['post_type'] . '_form_position',
+			$this->settings->get_default_form_position( $args['post_type'] ),
+			array(
+				'before_content' => esc_html__( 'Before Content', 'convertkit' ),
+				'after_content' => esc_html__( 'After Content', 'convertkit' ),
+			),
+			sprintf(
+				/* translators: Post Type name, plural */
+				esc_html__( 'Whether Forms should display before or after the %s content', 'convertkit' ),
+				$args['post_type_object']->label
+			)
+		);
+
+	}
 
 	/**
 	 * Renders the input for the Non-inline Form setting.

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -523,17 +523,17 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 	 */
 	public function default_form_position_callback( $args ) {
 
-		echo $this->get_select_field(
+		echo $this->get_select_field( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			$args['post_type'] . '_form_position',
-			$this->settings->get_default_form_position( $args['post_type'] ),
+			esc_attr( $this->settings->get_default_form_position( $args['post_type'] ) ),
 			array(
 				'before_content' => esc_html__( 'Before Content', 'convertkit' ),
-				'after_content' => esc_html__( 'After Content', 'convertkit' ),
+				'after_content'  => esc_html__( 'After Content', 'convertkit' ),
 			),
 			sprintf(
 				/* translators: Post Type name, plural */
 				esc_html__( 'Whether Forms should display before or after the %s content', 'convertkit' ),
-				$args['post_type_object']->label
+				esc_html( $args['post_type_object']->label )
 			)
 		);
 

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -249,7 +249,7 @@ class ConvertKit_Output {
 	}
 
 	/**
-	 * Appends a form to the singular Page, Post or Custom Post Type's Content.
+	 * Inserts a form to the singular Page, Post or Custom Post Type's Content.
 	 *
 	 * @param   string $content    Post Content.
 	 * @return  string              Post Content with Form Appended, if applicable
@@ -327,20 +327,32 @@ class ConvertKit_Output {
 		}
 
 		// If here, we have a ConvertKit Form.
-		// Append form to Post's Content.
-		$content = $content .= $form;
+		// Append form to Post's Content, based on the position setting.
+		$form_position = $this->settings->get_default_form_position( get_post_type( $post_id ) );
+		switch ( $form_position ) {
+			case 'before_content':
+				$content = $form . $content;
+				break;
 
+			case 'after_content':
+			default:
+				// Default behaviour < 2.5.8 was to append the Form after the content.
+				$content .= $form;
+				break;
+		}
+		
 		/**
 		 * Filter the Post's Content, which includes a ConvertKit Form, immediately before it is output.
 		 *
 		 * @since   1.9.6
 		 *
-		 * @param   string  $content    Post Content
-		 * @param   string  $form       ConvertKit Form HTML
-		 * @param   int     $post_id    Post ID
-		 * @param   int     $form_id    ConvertKit Form ID
+		 * @param   string  $content    	Post Content
+		 * @param   string  $form       	ConvertKit Form HTML
+		 * @param   int     $post_id    	Post ID
+		 * @param   int     $form_id    	ConvertKit Form ID
+		 * @param   string  $form_position 	Form Position setting for the Post's Type.
 		 */
-		$content = apply_filters( 'convertkit_frontend_append_form', $content, $form, $post_id, $form_id );
+		$content = apply_filters( 'convertkit_frontend_append_form', $content, $form, $post_id, $form_id, $form_position );
 
 		return $content;
 

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -340,17 +340,17 @@ class ConvertKit_Output {
 				$content .= $form;
 				break;
 		}
-		
+
 		/**
 		 * Filter the Post's Content, which includes a ConvertKit Form, immediately before it is output.
 		 *
 		 * @since   1.9.6
 		 *
-		 * @param   string  $content    	Post Content
-		 * @param   string  $form       	ConvertKit Form HTML
-		 * @param   int     $post_id    	Post ID
-		 * @param   int     $form_id    	ConvertKit Form ID
-		 * @param   string  $form_position 	Form Position setting for the Post's Type.
+		 * @param   string  $content        Post Content
+		 * @param   string  $form           ConvertKit Form HTML
+		 * @param   int     $post_id        Post ID
+		 * @param   int     $form_id        ConvertKit Form ID
+		 * @param   string  $form_position  Form Position setting for the Post's Type.
 		 */
 		$content = apply_filters( 'convertkit_frontend_append_form', $content, $form, $post_id, $form_id, $form_position );
 

--- a/includes/class-convertkit-settings.php
+++ b/includes/class-convertkit-settings.php
@@ -289,6 +289,25 @@ class ConvertKit_Settings {
 	}
 
 	/**
+	 * Returns the Default Form Position Plugin setting.
+	 *
+	 * @since   2.5.8
+	 *
+	 * @param   string $post_type  Post Type.
+	 * @return  string|int          Default Form (default|form id)
+	 */
+	public function get_default_form_position( $post_type ) {
+
+		// Return after_content if this Post Type's position doesn't exist as a setting.
+		if ( ! array_key_exists( $post_type . '_form_position', $this->settings ) ) {
+			return 'after_content';
+		}
+
+		return $this->settings[ $post_type . '_form_position' ];
+
+	}
+
+	/**
 	 * Returns the Global non-inline Form Plugin setting.
 	 *
 	 * @since   2.3.3
@@ -388,6 +407,7 @@ class ConvertKit_Settings {
 		// Add Post Type Default Forms.
 		foreach ( convertkit_get_supported_post_types() as $post_type ) {
 			$defaults[ $post_type . '_form' ] = 0; // -1, 0 or Form ID.
+			$defaults[ $post_type . '_form_position' ] = 'after_content'; // before_content,after_content.
 		}
 
 		/**

--- a/includes/class-convertkit-settings.php
+++ b/includes/class-convertkit-settings.php
@@ -406,7 +406,7 @@ class ConvertKit_Settings {
 
 		// Add Post Type Default Forms.
 		foreach ( convertkit_get_supported_post_types() as $post_type ) {
-			$defaults[ $post_type . '_form' ] = 0; // -1, 0 or Form ID.
+			$defaults[ $post_type . '_form' ]          = 0; // -1, 0 or Form ID.
 			$defaults[ $post_type . '_form_position' ] = 'after_content'; // before_content,after_content.
 		}
 

--- a/tests/_support/Helper/Acceptance/ConvertKitForms.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitForms.php
@@ -17,11 +17,24 @@ class ConvertKitForms extends \Codeception\Module
 	 *
 	 * @param   AcceptanceTester $I              Tester.
 	 * @param   int              $formID         Form ID.
+	 * @param   string           $position       Position of the form in the DOM relative to the content.
 	 */
-	public function seeFormOutput($I, $formID)
+	public function seeFormOutput($I, $formID, $position = 'after_content')
 	{
 		// Confirm the Form is in the DOM once.
 		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $formID . '"]', 1);
+
+		// Assert that the first or last child element is the Form ID, depending on the position.
+		switch ($position) {
+			case 'before_content':
+				$I->assertEquals($formID, $I->grabAttributeFrom('div.entry-content > *:first-child', 'data-sv-form'));
+				break;
+
+			case 'after_content':
+			default:
+				$I->assertEquals($formID, $I->grabAttributeFrom('div.entry-content > *:last-child', 'data-sv-form'));
+				break;
+		}
 	}
 
 	/**

--- a/tests/_support/Helper/Acceptance/ConvertKitForms.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitForms.php
@@ -11,6 +11,21 @@ class ConvertKitForms extends \Codeception\Module
 {
 	/**
 	 * Check that expected HTML exists in the DOM of the page we're viewing for
+	 * a Form block or shortcode.
+	 *
+	 * @since   2.5.8
+	 *
+	 * @param   AcceptanceTester $I              Tester.
+	 * @param   int              $formID         Form ID.
+	 */
+	public function seeFormOutput($I, $formID)
+	{
+		// Confirm the Form is in the DOM once.
+		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $formID . '"]', 1);
+	}
+
+	/**
+	 * Check that expected HTML exists in the DOM of the page we're viewing for
 	 * a Form Trigger block or shortcode, and that the button loads the expected
 	 * ConvertKit Form.
 	 *

--- a/tests/_support/Helper/Acceptance/ConvertKitForms.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitForms.php
@@ -25,7 +25,7 @@ class ConvertKitForms extends \Codeception\Module
 		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $formID . '"]', 1);
 
 		// Assert position of form, if required.
-		if (! $position) {
+		if ( ! $position) {
 			return;
 		}
 

--- a/tests/_support/Helper/Acceptance/ConvertKitForms.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitForms.php
@@ -19,10 +19,15 @@ class ConvertKitForms extends \Codeception\Module
 	 * @param   int              $formID         Form ID.
 	 * @param   bool|string      $position       Position of the form in the DOM relative to the content.
 	 */
-	public function seeFormOutput($I, $formID, $position = 'after_content')
+	public function seeFormOutput($I, $formID, $position = false)
 	{
 		// Confirm the Form is in the DOM once.
 		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $formID . '"]', 1);
+
+		// Assert position of form, if required.
+		if (! $position) {
+			return;
+		}
 
 		// Assert that the first or last child element is the Form ID, depending on the position.
 		switch ($position) {

--- a/tests/_support/Helper/Acceptance/ConvertKitForms.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitForms.php
@@ -17,7 +17,7 @@ class ConvertKitForms extends \Codeception\Module
 	 *
 	 * @param   AcceptanceTester $I              Tester.
 	 * @param   int              $formID         Form ID.
-	 * @param   string           $position       Position of the form in the DOM relative to the content.
+	 * @param   bool|string      $position       Position of the form in the DOM relative to the content.
 	 */
 	public function seeFormOutput($I, $formID, $position = 'after_content')
 	{
@@ -31,7 +31,6 @@ class ConvertKitForms extends \Codeception\Module
 				break;
 
 			case 'after_content':
-			default:
 				$I->assertEquals($formID, $I->grabAttributeFrom('div.entry-content > *:last-child', 'data-sv-form'));
 				break;
 		}

--- a/tests/acceptance/forms/blocks-shortcodes/PageBlockFormCest.php
+++ b/tests/acceptance/forms/blocks-shortcodes/PageBlockFormCest.php
@@ -58,7 +58,7 @@ class PageBlockFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**

--- a/tests/acceptance/forms/blocks-shortcodes/PageBlockFormCest.php
+++ b/tests/acceptance/forms/blocks-shortcodes/PageBlockFormCest.php
@@ -58,7 +58,7 @@ class PageBlockFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**

--- a/tests/acceptance/forms/blocks-shortcodes/PageShortcodeFormCest.php
+++ b/tests/acceptance/forms/blocks-shortcodes/PageShortcodeFormCest.php
@@ -59,7 +59,7 @@ class PageShortcodeFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -103,7 +103,7 @@ class PageShortcodeFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -166,7 +166,7 @@ class PageShortcodeFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -249,7 +249,7 @@ class PageShortcodeFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**

--- a/tests/acceptance/forms/blocks-shortcodes/PageShortcodeFormCest.php
+++ b/tests/acceptance/forms/blocks-shortcodes/PageShortcodeFormCest.php
@@ -59,7 +59,7 @@ class PageShortcodeFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -103,7 +103,7 @@ class PageShortcodeFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -166,7 +166,7 @@ class PageShortcodeFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -249,7 +249,7 @@ class PageShortcodeFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**

--- a/tests/acceptance/forms/general/CategoryFormCest.php
+++ b/tests/acceptance/forms/general/CategoryFormCest.php
@@ -79,7 +79,7 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -149,7 +149,7 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -207,7 +207,7 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -264,7 +264,7 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -343,7 +343,7 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -421,7 +421,7 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -480,7 +480,7 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -550,7 +550,7 @@ class CategoryFormCest
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form,
 		// and that the Category settings were correctly mapped.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**

--- a/tests/acceptance/forms/general/CategoryFormCest.php
+++ b/tests/acceptance/forms/general/CategoryFormCest.php
@@ -79,7 +79,7 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -149,7 +149,7 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -207,7 +207,7 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -264,7 +264,7 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -343,7 +343,7 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -421,7 +421,7 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -480,7 +480,7 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -550,7 +550,7 @@ class CategoryFormCest
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form,
 		// and that the Category settings were correctly mapped.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**

--- a/tests/acceptance/forms/general/CategoryFormCest.php
+++ b/tests/acceptance/forms/general/CategoryFormCest.php
@@ -79,7 +79,7 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -149,7 +149,7 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -207,7 +207,7 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -264,7 +264,7 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -343,7 +343,7 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -421,7 +421,7 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -480,7 +480,7 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -550,7 +550,7 @@ class CategoryFormCest
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form,
 		// and that the Category settings were correctly mapped.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**

--- a/tests/acceptance/forms/general/CategoryFormCest.php
+++ b/tests/acceptance/forms/general/CategoryFormCest.php
@@ -79,7 +79,7 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
 	}
 
 	/**
@@ -149,7 +149,7 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
 	}
 
 	/**
@@ -207,7 +207,7 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
 	}
 
 	/**
@@ -264,7 +264,7 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
 	}
 
 	/**
@@ -343,7 +343,7 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
 	}
 
 	/**
@@ -421,7 +421,7 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
 	}
 
 	/**
@@ -480,7 +480,7 @@ class CategoryFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
 	}
 
 	/**
@@ -550,7 +550,7 @@ class CategoryFormCest
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form,
 		// and that the Category settings were correctly mapped.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
 	}
 
 	/**

--- a/tests/acceptance/forms/post-types/CPTFormCest.php
+++ b/tests/acceptance/forms/post-types/CPTFormCest.php
@@ -190,7 +190,7 @@ class CPTFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -349,7 +349,7 @@ class CPTFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -441,7 +441,7 @@ class CPTFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -489,7 +489,7 @@ class CPTFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -537,7 +537,7 @@ class CPTFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -595,7 +595,7 @@ class CPTFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+			$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 		}
 	}
 
@@ -654,7 +654,7 @@ class CPTFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+			$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 		}
 	}
 
@@ -727,7 +727,7 @@ class CPTFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+			$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 		}
 	}
 

--- a/tests/acceptance/forms/post-types/CPTFormCest.php
+++ b/tests/acceptance/forms/post-types/CPTFormCest.php
@@ -190,7 +190,7 @@ class CPTFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -305,7 +305,7 @@ class CPTFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -397,7 +397,7 @@ class CPTFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -445,7 +445,7 @@ class CPTFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -493,7 +493,7 @@ class CPTFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -551,7 +551,7 @@ class CPTFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+			$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 		}
 	}
 
@@ -610,7 +610,7 @@ class CPTFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+			$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 		}
 	}
 
@@ -683,7 +683,7 @@ class CPTFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+			$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 		}
 	}
 

--- a/tests/acceptance/forms/post-types/CPTFormCest.php
+++ b/tests/acceptance/forms/post-types/CPTFormCest.php
@@ -194,6 +194,50 @@ class CPTFormCest
 	}
 
 	/**
+	 * Test that the Default Form specified in the Plugin Settings works when
+	 * creating and viewing a new WordPress CPT, and its position is set
+	 * to after the CPT content.
+	 *
+	 * @since   2.5.8
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewCPTUsingDefaultFormBeforeContent(AcceptanceTester $I)
+	{
+		// Setup ConvertKit plugin with Default Form for CPTs set to be output before the CPT content.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'article_form'          => $_ENV['CONVERTKIT_API_FORM_ID'],
+				'article_form_position' => 'before_content',
+			]
+		);
+		$I->setupConvertKitPluginResources($I);
+
+		// Add a CPT using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'article', 'ConvertKit: CPT: Form: Default: Before Content');
+
+		// Add paragraph to CPT.
+		$I->addGutenbergParagraphBlock($I, 'CPT content');
+
+		// Configure metabox's Form setting = Default.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'Default' ],
+			]
+		);
+
+		// Publish and view the CPT on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that one ConvertKit Form is output in the DOM after the CPT content.
+		// This confirms that there is only one script on the CPT for this form, which renders the form.
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'before_content');
+	}
+
+	/**
 	 * Test that the Default Legacy Form specified in the Plugin Settings works when
 	 * creating and viewing a new WordPress CPT.
 	 *

--- a/tests/acceptance/forms/post-types/PageFormCest.php
+++ b/tests/acceptance/forms/post-types/PageFormCest.php
@@ -116,7 +116,7 @@ class PageFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -269,7 +269,7 @@ class PageFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -634,7 +634,7 @@ class PageFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -677,7 +677,7 @@ class PageFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -720,7 +720,7 @@ class PageFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -773,7 +773,7 @@ class PageFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+			$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 		}
 	}
 
@@ -827,7 +827,7 @@ class PageFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+			$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 		}
 	}
 
@@ -895,7 +895,7 @@ class PageFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+			$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 		}
 	}
 

--- a/tests/acceptance/forms/post-types/PageFormCest.php
+++ b/tests/acceptance/forms/post-types/PageFormCest.php
@@ -120,6 +120,49 @@ class PageFormCest
 	}
 
 	/**
+	 * Test that the Default Form specified in the Plugin Settings works when
+	 * creating and viewing a new WordPress Page, and its position is set
+	 * to after the Page content.
+	 *
+	 * @since   2.5.8
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewPageUsingDefaultFormBeforeContent(AcceptanceTester $I)
+	{
+		// Setup ConvertKit plugin with Default Form for Pages set to be output before the Page content.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'page_form_position' => 'before_content',
+			]
+		);
+		$I->setupConvertKitPluginResources($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Default: Before Content');
+
+		// Add paragraph to Page.
+		$I->addGutenbergParagraphBlock($I, 'Page content');
+
+		// Configure metabox's Form setting = Default.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'Default' ],
+			]
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that one ConvertKit Form is output in the DOM after the Page content.
+		// This confirms that there is only one script on the page for this form, which renders the form.
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'before_content');
+	}
+
+	/**
 	 * Test that the Default Legacy Form specified in the Plugin Settings works when
 	 * creating and viewing a new WordPress Page.
 	 *

--- a/tests/acceptance/forms/post-types/PageFormCest.php
+++ b/tests/acceptance/forms/post-types/PageFormCest.php
@@ -116,7 +116,7 @@ class PageFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -226,7 +226,7 @@ class PageFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -591,7 +591,7 @@ class PageFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -634,7 +634,7 @@ class PageFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -677,7 +677,7 @@ class PageFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -730,7 +730,7 @@ class PageFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+			$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 		}
 	}
 
@@ -784,7 +784,7 @@ class PageFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+			$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 		}
 	}
 
@@ -852,7 +852,7 @@ class PageFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+			$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 		}
 	}
 

--- a/tests/acceptance/forms/post-types/PostFormCest.php
+++ b/tests/acceptance/forms/post-types/PostFormCest.php
@@ -115,7 +115,7 @@ class PostFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -265,7 +265,7 @@ class PostFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -347,7 +347,7 @@ class PostFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -390,7 +390,7 @@ class PostFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -433,7 +433,7 @@ class PostFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -486,7 +486,7 @@ class PostFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+			$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 		}
 	}
 
@@ -540,7 +540,7 @@ class PostFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+			$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 		}
 	}
 
@@ -608,7 +608,7 @@ class PostFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+			$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 		}
 	}
 

--- a/tests/acceptance/forms/post-types/PostFormCest.php
+++ b/tests/acceptance/forms/post-types/PostFormCest.php
@@ -119,6 +119,49 @@ class PostFormCest
 	}
 
 	/**
+	 * Test that the Default Form specified in the Plugin Settings works when
+	 * creating and viewing a new WordPress Post, and its position is set
+	 * to after the Post content.
+	 *
+	 * @since   2.5.8
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewPostUsingDefaultFormBeforeContent(AcceptanceTester $I)
+	{
+		// Setup ConvertKit plugin with Default Form for Posts set to be output before the Post content.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'post_form_position' => 'before_content',
+			]
+		);
+		$I->setupConvertKitPluginResources($I);
+
+		// Add a Post using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'post', 'ConvertKit: Page: Form: Default: Before Content');
+
+		// Add paragraph to Post.
+		$I->addGutenbergParagraphBlock($I, 'Post content');
+
+		// Configure metabox's Form setting = Default.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'Default' ],
+			]
+		);
+
+		// Publish and view the Post on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that one ConvertKit Form is output in the DOM after the Post content.
+		// This confirms that there is only one script on the post for this form, which renders the form.
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'before_content');
+	}
+
+	/**
 	 * Test that the Default Legacy Form specified in the Plugin Settings works when
 	 * creating and viewing a new WordPress Post.
 	 *

--- a/tests/acceptance/forms/post-types/PostFormCest.php
+++ b/tests/acceptance/forms/post-types/PostFormCest.php
@@ -115,7 +115,7 @@ class PostFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -222,7 +222,7 @@ class PostFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -304,7 +304,7 @@ class PostFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -347,7 +347,7 @@ class PostFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -390,7 +390,7 @@ class PostFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -443,7 +443,7 @@ class PostFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+			$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 		}
 	}
 
@@ -497,7 +497,7 @@ class PostFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+			$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 		}
 	}
 
@@ -565,7 +565,7 @@ class PostFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+			$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 		}
 	}
 

--- a/tests/acceptance/forms/post-types/PostFormCest.php
+++ b/tests/acceptance/forms/post-types/PostFormCest.php
@@ -139,7 +139,7 @@ class PostFormCest
 		$I->setupConvertKitPluginResources($I);
 
 		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'ConvertKit: Page: Form: Default: Before Content');
+		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: Default: Before Content');
 
 		// Add paragraph to Post.
 		$I->addGutenbergParagraphBlock($I, 'Post content');

--- a/tests/acceptance/general/PluginSettingsGeneralCest.php
+++ b/tests/acceptance/general/PluginSettingsGeneralCest.php
@@ -240,8 +240,9 @@ class PluginSettingsGeneralCest
 		// Go to the Plugin's Settings Screen.
 		$I->loadConvertKitSettingsGeneralScreen($I);
 
-		// Select Default Form for Pages.
+		// Select Default Form for Pages, and change the Position.
 		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->selectOption('_wp_convertkit_settings[page_form_position]', 'Before Content');
 
 		// Open preview.
 		$I->click('a#convertkit-preview-form-page');
@@ -255,7 +256,7 @@ class PluginSettingsGeneralCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 
 		// Close newly opened tab.
 		$I->closeTab();
@@ -275,7 +276,7 @@ class PluginSettingsGeneralCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 
 		// Close newly opened tab.
 		$I->closeTab();
@@ -305,7 +306,9 @@ class PluginSettingsGeneralCest
 
 		// Check the value of the fields match the inputs provided.
 		$I->seeInField('_wp_convertkit_settings[page_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->seeInField('_wp_convertkit_settings[page_form_position]', 'Before Content');
 		$I->seeInField('_wp_convertkit_settings[post_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->seeInField('_wp_convertkit_settings[post_form_position]', 'After Content');
 		$I->seeInField('_wp_convertkit_settings[non_inline_form]', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME']);
 	}
 

--- a/tests/acceptance/general/PluginSetupWizardCest.php
+++ b/tests/acceptance/general/PluginSetupWizardCest.php
@@ -232,7 +232,7 @@ class PluginSetupWizardCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 
 		// Close newly opened tab.
 		$I->closeTab();
@@ -252,7 +252,7 @@ class PluginSetupWizardCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 
 		// Close newly opened tab.
 		$I->closeTab();

--- a/tests/acceptance/general/PluginSetupWizardCest.php
+++ b/tests/acceptance/general/PluginSetupWizardCest.php
@@ -232,7 +232,7 @@ class PluginSetupWizardCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 
 		// Close newly opened tab.
 		$I->closeTab();
@@ -252,7 +252,7 @@ class PluginSetupWizardCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 
 		// Close newly opened tab.
 		$I->closeTab();

--- a/tests/acceptance/general/PostCest.php
+++ b/tests/acceptance/general/PostCest.php
@@ -102,7 +102,7 @@ class PostCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**

--- a/tests/acceptance/general/PostCest.php
+++ b/tests/acceptance/general/PostCest.php
@@ -102,7 +102,7 @@ class PostCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**

--- a/tests/acceptance/integrations/other/DiviFormCest.php
+++ b/tests/acceptance/integrations/other/DiviFormCest.php
@@ -50,7 +50,7 @@ class DiviFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 
 		// Deactivate Classic Editor.
 		$I->deactivateThirdPartyPlugin($I, 'classic-editor');
@@ -87,7 +87,7 @@ class DiviFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**

--- a/tests/acceptance/integrations/other/DiviFormCest.php
+++ b/tests/acceptance/integrations/other/DiviFormCest.php
@@ -50,7 +50,7 @@ class DiviFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 
 		// Deactivate Classic Editor.
 		$I->deactivateThirdPartyPlugin($I, 'classic-editor');
@@ -87,7 +87,7 @@ class DiviFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**

--- a/tests/acceptance/integrations/other/ElementorFormCest.php
+++ b/tests/acceptance/integrations/other/ElementorFormCest.php
@@ -66,7 +66,7 @@ class ElementorFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**

--- a/tests/acceptance/integrations/other/ElementorFormCest.php
+++ b/tests/acceptance/integrations/other/ElementorFormCest.php
@@ -66,7 +66,7 @@ class ElementorFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**

--- a/tests/acceptance/integrations/woocommerce/WooCommerceProductFormCest.php
+++ b/tests/acceptance/integrations/woocommerce/WooCommerceProductFormCest.php
@@ -72,7 +72,7 @@ class WooCommerceProductFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -139,7 +139,7 @@ class WooCommerceProductFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -182,7 +182,7 @@ class WooCommerceProductFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -225,7 +225,7 @@ class WooCommerceProductFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -268,7 +268,7 @@ class WooCommerceProductFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -311,7 +311,7 @@ class WooCommerceProductFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -364,7 +364,7 @@ class WooCommerceProductFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+			$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 		}
 	}
 
@@ -418,7 +418,7 @@ class WooCommerceProductFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+			$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 		}
 	}
 
@@ -486,7 +486,7 @@ class WooCommerceProductFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]', 1);
+			$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
 		}
 	}
 

--- a/tests/acceptance/integrations/woocommerce/WooCommerceProductFormCest.php
+++ b/tests/acceptance/integrations/woocommerce/WooCommerceProductFormCest.php
@@ -72,7 +72,7 @@ class WooCommerceProductFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
 	}
 
 	/**
@@ -139,7 +139,7 @@ class WooCommerceProductFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
 	}
 
 	/**
@@ -182,7 +182,7 @@ class WooCommerceProductFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
 	}
 
 	/**
@@ -225,7 +225,7 @@ class WooCommerceProductFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
 	}
 
 	/**
@@ -268,7 +268,7 @@ class WooCommerceProductFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
 	}
 
 	/**
@@ -311,7 +311,7 @@ class WooCommerceProductFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
 	}
 
 	/**
@@ -364,7 +364,7 @@ class WooCommerceProductFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
+			$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
 		}
 	}
 
@@ -418,7 +418,7 @@ class WooCommerceProductFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
+			$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
 		}
 	}
 
@@ -486,7 +486,7 @@ class WooCommerceProductFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
+			$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
 		}
 	}
 

--- a/tests/acceptance/integrations/woocommerce/WooCommerceProductFormCest.php
+++ b/tests/acceptance/integrations/woocommerce/WooCommerceProductFormCest.php
@@ -72,7 +72,7 @@ class WooCommerceProductFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -139,7 +139,7 @@ class WooCommerceProductFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -182,7 +182,7 @@ class WooCommerceProductFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -225,7 +225,7 @@ class WooCommerceProductFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -268,7 +268,7 @@ class WooCommerceProductFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -311,7 +311,7 @@ class WooCommerceProductFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -364,7 +364,7 @@ class WooCommerceProductFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+			$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 		}
 	}
 
@@ -418,7 +418,7 @@ class WooCommerceProductFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+			$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 		}
 	}
 
@@ -486,7 +486,7 @@ class WooCommerceProductFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeFormOutput($_ENV['CONVERTKIT_API_FORM_ID']);
+			$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 		}
 	}
 

--- a/tests/acceptance/integrations/woocommerce/WooCommerceProductFormCest.php
+++ b/tests/acceptance/integrations/woocommerce/WooCommerceProductFormCest.php
@@ -72,7 +72,7 @@ class WooCommerceProductFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -139,7 +139,7 @@ class WooCommerceProductFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -182,7 +182,7 @@ class WooCommerceProductFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -225,7 +225,7 @@ class WooCommerceProductFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -268,7 +268,7 @@ class WooCommerceProductFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -311,7 +311,7 @@ class WooCommerceProductFormCest
 
 		// Confirm that one ConvertKit Form is output in the DOM.
 		// This confirms that there is only one script on the page for this form, which renders the form.
-		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 	}
 
 	/**
@@ -364,7 +364,7 @@ class WooCommerceProductFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
+			$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 		}
 	}
 
@@ -418,7 +418,7 @@ class WooCommerceProductFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
+			$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 		}
 	}
 
@@ -486,7 +486,7 @@ class WooCommerceProductFormCest
 
 			// Confirm that one ConvertKit Form is output in the DOM.
 			// This confirms that there is only one script on the page for this form, which renders the form.
-			$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], false);
+			$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID']);
 		}
 	}
 


### PR DESCRIPTION
## Summary

Adds an option based on [these](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/12263831661911?view=List) [tickets](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/12263830004297?view=List) to specify whether the Default Form specified for a given Post Type should be added before or after the Page, Post or Custom Post Type's content:

![Screenshot 2024-09-16 at 14 24 41](https://github.com/user-attachments/assets/84120ba2-e456-4c4c-8f80-7d04f1c7d26b)

![Screenshot 2024-09-16 at 14 24 57](https://github.com/user-attachments/assets/bc4ed7c0-60dd-4b3a-b1e8-eb759f77bd9b)

![Screenshot 2024-09-16 at 14 25 42](https://github.com/user-attachments/assets/d38e43c4-4d47-444d-8bb7-f92a88d53d2c)

Further PR's to follow to add additional position options (such as after a given number of paragraphs).

## Testing

- `testAddNewPageUsingDefaultFormBeforeContent`: Test that adding a new WordPress Page using the default form set to display before the content works.
- `testAddNewPostUsingDefaultFormBeforeContent`: Test that adding a new WordPress Post using the default form set to display before the content works.
- `testAddNewCPTUsingDefaultFormBeforeContent`: Test that adding a new WordPress Custom Post Type using the default form set to display before the content works.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)