### PR TITLE
Fix Fatal Error when `ck_subscriber_id` in query param is non-numeric

### DIFF
--- a/includes/class-convertkit-subscriber.php
+++ b/includes/class-convertkit-subscriber.php
@@ -34,14 +34,14 @@ class ConvertKit_Subscriber {
 	public function get_subscriber_id() {
 
 		// If the subscriber ID is in the request URI, use it.
-		if ( isset( $_REQUEST[ $this->key ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		if ( isset( $_REQUEST[ $this->key ] ) && is_numeric( $_REQUEST[ $this->key ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return $this->validate_and_store_subscriber_id( sanitize_text_field( $_REQUEST[ $this->key ] ) ); // phpcs:ignore WordPress.Security.NonceVerification
 		}
 
 		// If the subscriber ID is in a cookie, return it.
 		// For performance, we don't check that the subscriber ID exists every time, otherwise this would
 		// call the API on every page load.
-		if ( isset( $_COOKIE[ $this->key ] ) ) {
+		if ( isset( $_COOKIE[ $this->key ] ) && ! empty( $_COOKIE[ $this->key ] ) ) {
 			return $this->get_subscriber_id_from_cookie();
 		}
 
@@ -81,7 +81,7 @@ class ConvertKit_Subscriber {
 		);
 
 		// Get subscriber by ID, to ensure they exist.
-		$subscriber = $api->get_subscriber( $subscriber_id );
+		$subscriber = $api->get_subscriber( absint( $subscriber_id ) );
 
 		// Bail if no subscriber exists with the given subscriber ID, or an error occured.
 		if ( is_wp_error( $subscriber ) ) {

--- a/tests/acceptance/general/SubscriberIDURLCest.php
+++ b/tests/acceptance/general/SubscriberIDURLCest.php
@@ -37,6 +37,14 @@ class SubscriberIDURLCest
 			]
 		);
 
+		// Confirm that a blank ck_subscriber_id does not cause a fatal error.
+		$I->amOnPage('/convertkit-subscriber-id-url?ck_subscriber_id=');
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that a non-numeric ck_subscriber_id does not cause a fatal error.
+		$I->amOnPage('/convertkit-subscriber-id-url?ck_subscriber_id=abcde');
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
 		// Confirm that the ck_subscriber_id was removed.
 		$I->amOnPage('/convertkit-subscriber-id-url?ck_subscriber_id=' . $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']);
 		$I->checkNoWarningsAndNoticesOnScreen($I);


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://linear.app/kit/issue/BCDC-3228/bcdc-wordpress-php-error-when-ck-subscriber-id-is-missing), where a non-numeric or blank `ck_subscriber_id` query parameter results in an uncaught TypeError:

![Screenshot 2024-09-17 at 08 52 47](https://github.com/user-attachments/assets/39abb44f-5efb-48be-92e9-9725e6034f97)

## Testing

- `testSubscriberIDRemovedFromURL`: Added tests to confirm no errors on screen when a non-numeric or blank `ck_subscriber_id` is passed.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)