### PR TITLE
Fix `get_current_screen` PHP Warnings

### DIFF
--- a/admin/class-convertkit-admin-bulk-edit.php
+++ b/admin/class-convertkit-admin-bulk-edit.php
@@ -34,19 +34,11 @@ class ConvertKit_Admin_Bulk_Edit {
 	 */
 	public function enqueue_assets() {
 
-		// Bail if we cannot determine the screen.
-		if ( ! function_exists( 'get_current_screen' ) ) {
-			return;
-		}
-
 		// Bail if we're not on a Post Type Edit screen.
-		$screen = get_current_screen();
-		if ( $screen->base !== 'edit' ) {
-			return;
-		}
+		convertkit_get_current_screen( 'base' )
 
 		// Bail if the Post isn't a supported Post Type.
-		if ( ! in_array( $screen->post_type, convertkit_get_supported_post_types(), true ) ) {
+		if ( ! in_array( convertkit_get_current_screen( 'post_type' ), convertkit_get_supported_post_types(), true ) ) {
 			return;
 		}
 

--- a/admin/class-convertkit-admin-bulk-edit.php
+++ b/admin/class-convertkit-admin-bulk-edit.php
@@ -35,7 +35,9 @@ class ConvertKit_Admin_Bulk_Edit {
 	public function enqueue_assets() {
 
 		// Bail if we're not on a Post Type Edit screen.
-		convertkit_get_current_screen( 'base' )
+		if ( convertkit_get_current_screen( 'base' ) !== 'edit' ) {
+			return;
+		}
 
 		// Bail if the Post isn't a supported Post Type.
 		if ( ! in_array( convertkit_get_current_screen( 'post_type' ), convertkit_get_supported_post_types(), true ) ) {

--- a/admin/class-convertkit-admin-category.php
+++ b/admin/class-convertkit-admin-category.php
@@ -111,12 +111,7 @@ class ConvertKit_Admin_Category {
 		}
 
 		// Bail if we are not editing a Category.
-		if ( ! function_exists( 'get_current_screen' ) ) {
-			return false;
-		}
-		$screen = get_current_screen();
-
-		if ( $screen->id !== 'edit-category' ) {
+		if ( convertkit_get_current_screen( 'id' ) !== 'edit-category' ) {
 			return false;
 		}
 

--- a/admin/class-convertkit-admin-notices.php
+++ b/admin/class-convertkit-admin-notices.php
@@ -44,8 +44,7 @@ class ConvertKit_Admin_Notices {
 	public function output() {
 
 		// Don't output if we're on a settings screen.
-		$screen = get_current_screen();
-		if ( $screen->base === 'settings_page__wp_convertkit_settings' ) {
+		if ( convertkit_get_current_screen( 'base' ) === 'settings_page__wp_convertkit_settings' ) {
 			return;
 		}
 

--- a/admin/class-convertkit-admin-post.php
+++ b/admin/class-convertkit-admin-post.php
@@ -337,16 +337,7 @@ class ConvertKit_Admin_Post {
 	 */
 	private function get_current_post_type() {
 
-		// Bail if we cannot determine the screen.
-		if ( ! function_exists( 'get_current_screen' ) ) {
-			return false;
-		}
-
-		// Get screen.
-		$screen = get_current_screen();
-
-		// Return post type.
-		return $screen->post_type;
+		return convertkit_get_current_screen( 'post_type' );
 
 	}
 

--- a/admin/class-convertkit-admin-quick-edit.php
+++ b/admin/class-convertkit-admin-quick-edit.php
@@ -34,14 +34,8 @@ class ConvertKit_Admin_Quick_Edit {
 	 */
 	public function enqueue_assets() {
 
-		// Bail if we cannot determine the screen.
-		if ( ! function_exists( 'get_current_screen' ) ) {
-			return;
-		}
-
 		// Bail if we're not on a Post Type Edit screen.
-		$screen = get_current_screen();
-		if ( $screen->base !== 'edit' ) {
+		if ( convertkit_get_current_screen( 'base' ) !== 'edit' ) {
 			return;
 		}
 

--- a/admin/class-convertkit-admin-quick-edit.php
+++ b/admin/class-convertkit-admin-quick-edit.php
@@ -40,7 +40,7 @@ class ConvertKit_Admin_Quick_Edit {
 		}
 
 		// Bail if the Post isn't a supported Post Type.
-		if ( ! in_array( $screen->post_type, convertkit_get_supported_post_types(), true ) ) {
+		if ( ! in_array( convertkit_get_current_screen( 'post_type' ), convertkit_get_supported_post_types(), true ) ) {
 			return;
 		}
 

--- a/admin/class-convertkit-admin-restrict-content.php
+++ b/admin/class-convertkit-admin-restrict-content.php
@@ -248,26 +248,13 @@ class ConvertKit_Admin_Restrict_Content {
 	 */
 	private function is_wp_list_table_request_for_supported_post_type() {
 
-		// Bail if we cannot determine the screen.
-		if ( ! function_exists( 'get_current_screen' ) ) {
-			return false;
-		}
-
-		// Get screen.
-		$screen = get_current_screen();
-
-		// Bail if the screen couldn't be determined.
-		if ( is_null( $screen ) ) {
-			return false;
-		}
-
 		// Bail if we're not on an edit.php screen.
-		if ( $screen->base !== 'edit' ) {
+		if ( convertkit_get_current_screen( 'base' ) !== 'edit' ) {
 			return false;
 		}
 
 		// Return whether Post Type is supported for Restrict Content functionality.
-		return in_array( $screen->post_type, convertkit_get_supported_post_types(), true );
+		return in_array( convertkit_get_current_screen( 'post_type' ), convertkit_get_supported_post_types(), true );
 
 	}
 

--- a/admin/class-convertkit-admin-restrict-content.php
+++ b/admin/class-convertkit-admin-restrict-content.php
@@ -256,6 +256,11 @@ class ConvertKit_Admin_Restrict_Content {
 		// Get screen.
 		$screen = get_current_screen();
 
+		// Bail if the screen couldn't be determined.
+		if ( is_null( $screen ) ) {
+			return false;
+		}
+
 		// Bail if we're not on an edit.php screen.
 		if ( $screen->base !== 'edit' ) {
 			return false;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -614,6 +614,6 @@ function convertkit_get_current_screen( $property ) {
 	}
 
 	// Return property.
-	return $screen{ $property };
+	return $screen->$property;
 
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -586,3 +586,34 @@ function convertkit_get_subscription_dropdown_field( $name, $value, $id, $css_cl
 	return $output;
 
 }
+
+/**
+ * Helper method to safely call get_current_screen(), returning false
+ * if the function is not available or returns null.
+ *
+ * Otherwise returns the given WP_Screen property.
+ *
+ * @since   2.5.9
+ *
+ * @param   string $property   WP_Screen property to return.
+ * @return  bool|string
+ */
+function convertkit_get_current_screen( $property ) {
+
+	// Bail if we cannot determine the screen.
+	if ( ! function_exists( 'get_current_screen' ) ) {
+		return false;
+	}
+
+	// Get screen.
+	$screen = get_current_screen();
+
+	// Bail if the screen couldn't be determined.
+	if ( is_null( $screen ) ) {
+		return false;
+	}
+
+	// Return property.
+	return $screen{ $property };
+
+}

--- a/resources/frontend/js/convertkit.js
+++ b/resources/frontend/js/convertkit.js
@@ -199,7 +199,7 @@ document.addEventListener(
 			'click',
 			function (e) {
 				// Check if the form submit button was clicked, or the span element was clicked and its parent is the form submit button.
-				if ( e.target !== null && ! e.target.matches( '.formkit-submit' ) && ! e.target.parentElement !== null && e.target.parentElement.matches( '.formkit-submit' ) ) {
+				if ( ! e.target.matches( '.formkit-submit' ) && ( ! e.target.parentElement || ! e.target.parentElement.matches( '.formkit-submit' ) ) ) {
 					if ( convertkit.debug ) {
 						console.log( 'not a ck form' );
 					}

--- a/resources/frontend/js/convertkit.js
+++ b/resources/frontend/js/convertkit.js
@@ -199,7 +199,7 @@ document.addEventListener(
 			'click',
 			function (e) {
 				// Check if the form submit button was clicked, or the span element was clicked and its parent is the form submit button.
-				if ( ! e.target.matches( '.formkit-submit' ) && ! e.target.parentElement.matches( '.formkit-submit' ) ) {
+				if ( e.target !== null && ! e.target.matches( '.formkit-submit' ) && ! e.target.parentElement !== null && e.target.parentElement.matches( '.formkit-submit' ) ) {
 					if ( convertkit.debug ) {
 						console.log( 'not a ck form' );
 					}


### PR DESCRIPTION
## Summary

Fixes [these reported](https://wordpress.org/support/topic/some-error-log-registratios/#post-18030337) JS and PHP warnings.

Wraps `get_current_screen` in a helper method to return `false` if the function is unavailable or returns null.  Returns the requested `WP_Screen` property.  This should catch other instances where warnings may occur that we haven't yet caught.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)