### PR TITLE
Define Default Form Position: Add `Before and after content` option

### DIFF
--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -527,12 +527,13 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 			$args['post_type'] . '_form_position',
 			esc_attr( $this->settings->get_default_form_position( $args['post_type'] ) ),
 			array(
-				'before_content' => esc_html__( 'Before Content', 'convertkit' ),
-				'after_content'  => esc_html__( 'After Content', 'convertkit' ),
+				'before_content'       => esc_html__( 'Before content', 'convertkit' ),
+				'after_content'        => esc_html__( 'After content', 'convertkit' ),
+				'before_after_content' => esc_html__( 'Before and after content', 'convertkit' ),
 			),
 			sprintf(
 				/* translators: Post Type name, plural */
-				esc_html__( 'Whether Forms should display before or after the %s content', 'convertkit' ),
+				esc_html__( 'Where forms should display relative to the %s content', 'convertkit' ),
 				esc_html( $args['post_type_object']->label )
 			)
 		);

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -330,6 +330,10 @@ class ConvertKit_Output {
 		// Append form to Post's Content, based on the position setting.
 		$form_position = $this->settings->get_default_form_position( get_post_type( $post_id ) );
 		switch ( $form_position ) {
+			case 'before_after_content':
+				$content = $form . $content . $form;
+				break;
+
 			case 'before_content':
 				$content = $form . $content;
 				break;

--- a/tests/_support/Helper/Acceptance/ConvertKitForms.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitForms.php
@@ -21,16 +21,24 @@ class ConvertKitForms extends \Codeception\Module
 	 */
 	public function seeFormOutput($I, $formID, $position = false)
 	{
-		// Confirm the Form is in the DOM once.
-		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $formID . '"]', 1);
+		// Calculate how many times the Form should be in the DOM.
+		$count = ( ( $position === 'before_after_content' ) ? 2 : 1 );
+
+		// Confirm the Form is in the DOM the expected number of times.
+		$I->seeNumberOfElementsInDOM('form[data-sv-form="' . $formID . '"]', $count);
 
 		// Assert position of form, if required.
 		if ( ! $position) {
 			return;
 		}
 
-		// Assert that the first or last child element is the Form ID, depending on the position.
+		// Assert that the first and/or last child element is the Form ID, depending on the position.
 		switch ($position) {
+			case 'before_after_content':
+				$I->assertEquals($formID, $I->grabAttributeFrom('div.entry-content > *:first-child', 'data-sv-form'));
+				$I->assertEquals($formID, $I->grabAttributeFrom('div.entry-content > *:last-child', 'data-sv-form'));
+				break;
+
 			case 'before_content':
 				$I->assertEquals($formID, $I->grabAttributeFrom('div.entry-content > *:first-child', 'data-sv-form'));
 				break;

--- a/tests/acceptance/forms/post-types/CPTFormCest.php
+++ b/tests/acceptance/forms/post-types/CPTFormCest.php
@@ -238,6 +238,49 @@ class CPTFormCest
 	}
 
 	/**
+	 * Test that the Default Form specified in the Plugin Settings works when
+	 * creating and viewing a new WordPress CPT, and its position is set
+	 * to before and after the CPT content.
+	 *
+	 * @since   2.5.9
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewCPTUsingDefaultFormBeforeAndAfterContent(AcceptanceTester $I)
+	{
+		// Setup ConvertKit plugin with Default Form for CPTs set to be output before and after the CPT content.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'article_form'          => $_ENV['CONVERTKIT_API_FORM_ID'],
+				'article_form_position' => 'before_after_content',
+			]
+		);
+		$I->setupConvertKitPluginResources($I);
+
+		// Add a CPT using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'article', 'ConvertKit: CPT: Form: Default: Before and After Content');
+
+		// Add paragraph to CPT.
+		$I->addGutenbergParagraphBlock($I, 'CPT content');
+
+		// Configure metabox's Form setting = Default.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'Default' ],
+			]
+		);
+
+		// Publish and view the CPT on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that two ConvertKit Forms are output in the DOM before and after the CPT content.
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'before_after_content');
+	}
+
+	/**
 	 * Test that the Default Legacy Form specified in the Plugin Settings works when
 	 * creating and viewing a new WordPress CPT.
 	 *

--- a/tests/acceptance/forms/post-types/PageFormCest.php
+++ b/tests/acceptance/forms/post-types/PageFormCest.php
@@ -163,6 +163,48 @@ class PageFormCest
 	}
 
 	/**
+	 * Test that the Default Form specified in the Plugin Settings works when
+	 * creating and viewing a new WordPress Page, and its position is set
+	 * to before and after the Page content.
+	 *
+	 * @since   2.5.9
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewPageUsingDefaultFormBeforeAndAfterContent(AcceptanceTester $I)
+	{
+		// Setup ConvertKit plugin with Default Form for Pages set to be output before and after the Page content.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'page_form_position' => 'before_after_content',
+			]
+		);
+		$I->setupConvertKitPluginResources($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'ConvertKit: Page: Form: Default: Before and After Content');
+
+		// Add paragraph to Page.
+		$I->addGutenbergParagraphBlock($I, 'Page content');
+
+		// Configure metabox's Form setting = Default.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'Default' ],
+			]
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that two ConvertKit Forms are output in the DOM before and after the Page content.
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'before_after_content');
+	}
+
+	/**
 	 * Test that the Default Legacy Form specified in the Plugin Settings works when
 	 * creating and viewing a new WordPress Page.
 	 *

--- a/tests/acceptance/forms/post-types/PostFormCest.php
+++ b/tests/acceptance/forms/post-types/PostFormCest.php
@@ -162,6 +162,48 @@ class PostFormCest
 	}
 
 	/**
+	 * Test that the Default Form specified in the Plugin Settings works when
+	 * creating and viewing a new WordPress Post, and its position is set
+	 * to before and after the Post content.
+	 *
+	 * @since   2.5.9
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewPostUsingDefaultFormBeforeAndAfterContent(AcceptanceTester $I)
+	{
+		// Setup ConvertKit plugin with Default Form for Pages set to be output before and after the Post content.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'post_form_position' => 'before_after_content',
+			]
+		);
+		$I->setupConvertKitPluginResources($I);
+
+		// Add a Post using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'post', 'ConvertKit: Post: Form: Default: Before and After Content');
+
+		// Add paragraph to Post.
+		$I->addGutenbergParagraphBlock($I, 'Post content');
+
+		// Configure metabox's Form setting = Default.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'Default' ],
+			]
+		);
+
+		// Publish and view the Post on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that two ConvertKit Forms are output in the DOM before and after the Post content.
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'before_after_content');
+	}
+
+	/**
 	 * Test that the Default Legacy Form specified in the Plugin Settings works when
 	 * creating and viewing a new WordPress Post.
 	 *

--- a/tests/acceptance/general/PluginSettingsGeneralCest.php
+++ b/tests/acceptance/general/PluginSettingsGeneralCest.php
@@ -242,7 +242,7 @@ class PluginSettingsGeneralCest
 
 		// Select Default Form for Pages, and change the Position.
 		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
-		$I->selectOption('_wp_convertkit_settings[page_form_position]', 'Before Content');
+		$I->selectOption('_wp_convertkit_settings[page_form_position]', 'Before content');
 
 		// Open preview.
 		$I->click('a#convertkit-preview-form-page');
@@ -306,9 +306,9 @@ class PluginSettingsGeneralCest
 
 		// Check the value of the fields match the inputs provided.
 		$I->seeInField('_wp_convertkit_settings[page_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
-		$I->seeInField('_wp_convertkit_settings[page_form_position]', 'Before Content');
+		$I->seeInField('_wp_convertkit_settings[page_form_position]', 'Before content');
 		$I->seeInField('_wp_convertkit_settings[post_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
-		$I->seeInField('_wp_convertkit_settings[post_form_position]', 'After Content');
+		$I->seeInField('_wp_convertkit_settings[post_form_position]', 'After content');
 		$I->seeInField('_wp_convertkit_settings[non_inline_form]', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME']);
 	}
 


### PR DESCRIPTION
## Summary

Adds a `Before and after content` option when defining default form positions in the Plugin's settings:

![Screenshot 2024-09-24 at 15 10 56](https://github.com/user-attachments/assets/c9ff3867-ae70-492b-9c96-5e8712952425)

## Testing

- `testAddNewCPTUsingDefaultFormBeforeAndAfterContent`: Test that the form displays before and after the content on a Custom Post Type
- `testAddNewPageUsingDefaultFormBeforeAndAfterContent`: Test that the form displays before and after the content on a Page
- `testAddNewPostUsingDefaultFormBeforeAndAfterContent`: Test that the form displays before and after the content on a Post

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)