### PR TITLE
Query separator incorrectly appended to URLs when `ck_subscriber_id` cookie set

### DIFF
--- a/resources/frontend/js/convertkit.js
+++ b/resources/frontend/js/convertkit.js
@@ -150,16 +150,16 @@ function convertKitRemoveSubscriberIDFromURL( url ) {
 	url_object.searchParams.delete( 'ck_subscriber_id' );
 
 	// Get title and string of parameters.
-	const title   = document.getElementsByTagName( 'title' )[0].innerHTML;
-	let clean_url = url_object.searchParams.toString();
+	const title = document.getElementsByTagName( 'title' )[0].innerHTML;
+	let params  = url_object.searchParams.toString();
 
-	// If leading question mark missing, prepend it.
-	if ( clean_url.charAt( 0 ) !== '?' ) {
-		clean_url = '?' + clean_url;
+	// Only add '?' if there are parameters.
+	if ( params.length > 0 ) {
+		params = '?' + params;
 	}
 
 	// Update history.
-	window.history.pushState( null, title, clean_url );
+	window.history.pushState( null, title, url_object.pathname + params );
 
 }
 

--- a/tests/acceptance/general/SubscriberIDURLCest.php
+++ b/tests/acceptance/general/SubscriberIDURLCest.php
@@ -67,6 +67,33 @@ class SubscriberIDURLCest
 	}
 
 	/**
+	 * Test that no query separator is appended to the URL when a valid ck_subscriber_id exists.
+	 *
+	 * @since   2.5.9
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testQuerySeparatorNotAppendedToURLWhenCookieExists(AcceptanceTester $I)
+	{
+		// Create Page.
+		$I->havePageInDatabase(
+			[
+				'post_name'    => 'convertkit-subscriber-id-cookie',
+				'post_content' => 'Test',
+			]
+		);
+
+		// Set the ck_subscriber_id cookie.
+		$I->setCookie('ck_subscriber_id', $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']);
+
+		// Confirm that no query parameters does not append a separator/question mark.
+		$I->amOnPage('/convertkit-subscriber-id-url');
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+		$I->wait(2);
+		$I->assertStringNotContainsString('?', $I->grabFromCurrentUrl());
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
@@ -77,6 +104,7 @@ class SubscriberIDURLCest
 	 */
 	public function _passed(AcceptanceTester $I)
 	{
+		$I->resetCookie('ck_subscriber_id');
 		$I->deactivateConvertKitPlugin($I);
 		$I->resetConvertKitPlugin($I);
 	}


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/12263835123906?view=List), where the query separator would be appended to any URL when the `ck_subscriber_id` cookie is set, caused by using `charAt` in [this PR](https://github.com/ConvertKit/convertkit-wordpress/pull/709).

Updates variable names to make clearer what the JS function does.

## Testing

- `testQuerySeparatorNotAppendedToURLWhenCookieExists`: Confirm no query separator is appended to a URL when a `ck_subscriber_id` cookie is set.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)