### PR TITLE
Initialize `ConvertKit_Resource_Forms` correctly in Settings UI

### DIFF
--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -427,6 +427,44 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 	}
 
 	/**
+	 * Initialize resource classes and perform a and refresh of resources,
+	 * if initialization has not yet taken place.
+	 *
+	 * @since   2.5.9
+	 */
+	public function maybe_initialize_and_refresh_resources() {
+
+		// If the Forms resource class is initialized, this has already been done.
+		if ( $this->forms !== false ) {
+			return;
+		}
+
+		// Initialize and refresh resource classes, to ensure up to date resources are stored
+		// for when editing e.g. Pages.
+		$this->forms = new ConvertKit_Resource_Forms( 'settings' );
+		$this->forms->refresh();
+
+		// Also refresh Landing Pages, Tags and Posts. Whilst not displayed in the Plugin Settings, this ensures up to date
+		// lists are stored for when editing e.g. Pages.
+		$landing_pages = new ConvertKit_Resource_Landing_Pages( 'settings' );
+		$landing_pages->refresh();
+
+		remove_all_actions( 'convertkit_resource_refreshed_posts' );
+		$posts = new ConvertKit_Resource_Posts( 'settings' );
+		$posts->refresh();
+
+		$products = new ConvertKit_Resource_Products( 'settings' );
+		$products->refresh();
+
+		$sequences = new ConvertKit_Resource_Sequences( 'settings' );
+		$sequences->refresh();
+
+		$tags = new ConvertKit_Resource_Tags( 'settings' );
+		$tags->refresh();
+
+	}
+
+	/**
 	 * Renders the input for the Default Form setting for the given Post Type.
 	 *
 	 * @since  1.9.6
@@ -435,29 +473,8 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 	 */
 	public function default_form_callback( $args ) {
 
-		// Refresh Forms.
-		if ( ! $this->forms ) {
-			$this->forms = new ConvertKit_Resource_Forms( 'settings' );
-			$this->forms->refresh();
-
-			// Also refresh Landing Pages, Tags and Posts. Whilst not displayed in the Plugin Settings, this ensures up to date
-			// lists are stored for when editing e.g. Pages.
-			$landing_pages = new ConvertKit_Resource_Landing_Pages( 'settings' );
-			$landing_pages->refresh();
-
-			remove_all_actions( 'convertkit_resource_refreshed_posts' );
-			$posts = new ConvertKit_Resource_Posts( 'settings' );
-			$posts->refresh();
-
-			$products = new ConvertKit_Resource_Products( 'settings' );
-			$products->refresh();
-
-			$sequences = new ConvertKit_Resource_Sequences( 'settings' );
-			$sequences->refresh();
-
-			$tags = new ConvertKit_Resource_Tags( 'settings' );
-			$tags->refresh();
-		}
+		// Initialize resource classes and perform a refresh if this hasn't yet been done.
+		$this->maybe_initialize_and_refresh_resources();
 
 		// Bail if no Forms exist.
 		if ( ! $this->forms->exist() ) {
@@ -547,6 +564,9 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 	 * @param   array $args  Field arguments.
 	 */
 	public function non_inline_form_callback( $args ) {
+
+		// Initialize resource classes and perform a refresh if this hasn't yet been done.
+		$this->maybe_initialize_and_refresh_resources();
 
 		// Bail if no non-inline Forms exist.
 		if ( ! $this->forms->non_inline_exist() ) {


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/conversation/12263835120526?view=List), where the `ConvertKit_Resource_Forms` class is not initialized within the `non_inline_form_callback` method.

This class is initialized in the `default_form_callback` method, which is typically called earlier in the request when loading the settings UI.  However, if `convertkit_get_supported_post_types` are filtered to exclude all Post Types, then this initialization won't happen, resulting in the reported error.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)