### PR TITLE
Use WordPress Libraries 2.0.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "2.0.2"
+        "convertkit/convertkit-wordpress-libraries": "2.0.3"
     },
     "require-dev": {
         "lucatume/wp-browser": "<3.5",

--- a/tests/_support/Helper/Acceptance/ConvertKitForms.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitForms.php
@@ -157,4 +157,27 @@ class ConvertKitForms extends \Codeception\Module
 		// Confirm that the link does not display.
 		$I->dontSeeElementInDOM('a.convertkit-form-link');
 	}
+
+	/**
+	 * Helper method to assert that the expected landing page HTML is output.
+	 *
+	 * @since   2.5.9
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 * @param   bool             $langTag   Assert if HTML tag includes lang attribute.
+	 */
+	public function seeLandingPageOutput($I, $langTag = false)
+	{
+		if ($langTag) {
+			$I->seeInSource('<html lang="en">');
+		} else {
+			$I->seeInSource('<html>');
+		}
+
+		$I->seeInSource('<head>');
+		$I->seeInSource('</head>');
+		$I->seeInSource('<body');
+		$I->seeInSource('</body>');
+		$I->seeInSource('</html>');
+	}
 }

--- a/tests/acceptance/landing-pages/PageLandingPageCest.php
+++ b/tests/acceptance/landing-pages/PageLandingPageCest.php
@@ -314,7 +314,7 @@ class PageLandingPageCest
 
 		// Confirm that the ConvertKit Landing Page displays.
 		$I->dontSeeElementInDOM('body.page'); // WordPress didn't load its template, which is correct.
-		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://app.kit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_ID'] . '/subscribe" data-remote="true">'); // ConvertKit injected its Landing Page Form, which is correct.
+		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://app.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_ID'] . '/subscribe" data-remote="true">'); // ConvertKit injected its Landing Page Form, which is correct.
 	}
 
 	/**

--- a/tests/acceptance/landing-pages/PageLandingPageCest.php
+++ b/tests/acceptance/landing-pages/PageLandingPageCest.php
@@ -91,7 +91,7 @@ class PageLandingPageCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the basic HTML structure is correct.
-		$this->_seeBasicHTMLStructure($I);
+		$this->_seeBasicHTMLStructure($I, true);
 
 		// Confirm the ConvertKit Site Icon displays.
 		$I->seeInSource('<link rel="shortcut icon" type="image/x-icon" href="https://pages.convertkit.com/templates/favicon.ico">');
@@ -142,7 +142,7 @@ class PageLandingPageCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the basic HTML structure is correct.
-		$this->_seeBasicHTMLStructure($I);
+		$this->_seeBasicHTMLStructure($I, true);
 
 		// Confirm the WordPress Site Icon displays.
 		$I->seeInSource('<link rel="icon" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/uploads/' . date( 'Y' ) . '/' . date( 'm' ) . '/icon-150x150.png" sizes="32x32">');
@@ -184,7 +184,7 @@ class PageLandingPageCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the basic HTML structure is correct.
-		$this->_seeBasicHTMLStructure($I);
+		$this->_seeBasicHTMLStructure($I, false);
 
 		// Confirm that the Landing Page title is the same as defined on ConvertKit i.e. that character encoding is correct.
 		$I->seeInSource('Vantar þinn ungling sjálfstraust í stærðfræði?');
@@ -363,7 +363,7 @@ class PageLandingPageCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the basic HTML structure is correct.
-		$this->_seeBasicHTMLStructure($I);
+		$this->_seeBasicHTMLStructure($I, true);
 
 		// Confirm the ConvertKit Site Icon displays.
 		$I->seeInSource('<link rel="shortcut icon" type="image/x-icon" href="https://pages.convertkit.com/templates/favicon.ico">');
@@ -442,7 +442,7 @@ class PageLandingPageCest
 		$I->amOnUrl($url);
 
 		// Confirm that the basic HTML structure is correct.
-		$this->_seeBasicHTMLStructure($I);
+		$this->_seeBasicHTMLStructure($I, true);
 
 		// Confirm the ConvertKit Site Icon displays.
 		$I->seeInSource('<link rel="shortcut icon" type="image/x-icon" href="https://pages.convertkit.com/templates/favicon.ico">');
@@ -467,10 +467,16 @@ class PageLandingPageCest
 	 * @since   1.9.7.5
 	 *
 	 * @param   AcceptanceTester $I  Tester.
+	 * @param 	bool 			 $langTag 	Assert if HTML tag includes lang attribute.
 	 */
-	private function _seeBasicHTMLStructure($I)
+	private function _seeBasicHTMLStructure($I, $langTag = false)
 	{
-		$I->seeInSource('<html>');
+		if($langTag) {
+			$I->seeInSource('<html lang="en">');
+		} else {
+			$I->seeInSource('<html>');
+		}
+
 		$I->seeInSource('<head>');
 		$I->seeInSource('</head>');
 		$I->seeInSource('<body');

--- a/tests/acceptance/landing-pages/PageLandingPageCest.php
+++ b/tests/acceptance/landing-pages/PageLandingPageCest.php
@@ -91,7 +91,7 @@ class PageLandingPageCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the basic HTML structure is correct.
-		$this->_seeBasicHTMLStructure($I, true);
+		$I->seeLandingPageOutput($I, true);
 
 		// Confirm the ConvertKit Site Icon displays.
 		$I->seeInSource('<link rel="shortcut icon" type="image/x-icon" href="https://pages.convertkit.com/templates/favicon.ico">');
@@ -142,7 +142,7 @@ class PageLandingPageCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the basic HTML structure is correct.
-		$this->_seeBasicHTMLStructure($I, true);
+		$I->seeLandingPageOutput($I, true);
 
 		// Confirm the WordPress Site Icon displays.
 		$I->seeInSource('<link rel="icon" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/uploads/' . date( 'Y' ) . '/' . date( 'm' ) . '/icon-150x150.png" sizes="32x32">');
@@ -184,7 +184,7 @@ class PageLandingPageCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the basic HTML structure is correct.
-		$this->_seeBasicHTMLStructure($I, false);
+		$I->seeLandingPageOutput($I);
 
 		// Confirm that the Landing Page title is the same as defined on ConvertKit i.e. that character encoding is correct.
 		$I->seeInSource('Vantar þinn ungling sjálfstraust í stærðfræði?');
@@ -219,7 +219,7 @@ class PageLandingPageCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the basic HTML structure is correct.
-		$this->_seeBasicHTMLStructure($I);
+		$I->seeLandingPageOutput($I);
 
 		// Confirm that the ConvertKit Landing Page displays.
 		$I->dontSeeElementInDOM('body.page'); // WordPress didn't load its template, which is correct.
@@ -259,7 +259,7 @@ class PageLandingPageCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the basic HTML structure is correct.
-		$this->_seeBasicHTMLStructure($I);
+		$I->seeLandingPageOutput($I);
 
 		// Confirm the WordPress Site Icon displays.
 		$I->seeInSource('<link rel="icon" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/uploads/' . date( 'Y' ) . '/' . date( 'm' ) . '/icon-150x150.png" sizes="32x32">');
@@ -310,11 +310,11 @@ class PageLandingPageCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that the basic HTML structure is correct.
-		$this->_seeBasicHTMLStructure($I);
+		$I->seeLandingPageOutput($I);
 
 		// Confirm that the ConvertKit Landing Page displays.
 		$I->dontSeeElementInDOM('body.page'); // WordPress didn't load its template, which is correct.
-		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://app.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_ID'] . '/subscribe" data-remote="true">'); // ConvertKit injected its Landing Page Form, which is correct.
+		$I->seeInSource('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://app.kit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_ID'] . '/subscribe" data-remote="true">'); // ConvertKit injected its Landing Page Form, which is correct.
 	}
 
 	/**
@@ -363,7 +363,7 @@ class PageLandingPageCest
 		$I->publishAndViewGutenbergPage($I);
 
 		// Confirm that the basic HTML structure is correct.
-		$this->_seeBasicHTMLStructure($I, true);
+		$I->seeLandingPageOutput($I, true);
 
 		// Confirm the ConvertKit Site Icon displays.
 		$I->seeInSource('<link rel="shortcut icon" type="image/x-icon" href="https://pages.convertkit.com/templates/favicon.ico">');
@@ -442,7 +442,7 @@ class PageLandingPageCest
 		$I->amOnUrl($url);
 
 		// Confirm that the basic HTML structure is correct.
-		$this->_seeBasicHTMLStructure($I, true);
+		$I->seeLandingPageOutput($I, true);
 
 		// Confirm the ConvertKit Site Icon displays.
 		$I->seeInSource('<link rel="shortcut icon" type="image/x-icon" href="https://pages.convertkit.com/templates/favicon.ico">');
@@ -459,29 +459,6 @@ class PageLandingPageCest
 
 		// Deactivate WP Rocket Plugin.
 		$I->deactivateThirdPartyPlugin($I, 'wp-rocket');
-	}
-
-	/**
-	 * Helper method to assert that the expected landing page HTML is output.
-	 *
-	 * @since   1.9.7.5
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 * @param 	bool 			 $langTag 	Assert if HTML tag includes lang attribute.
-	 */
-	private function _seeBasicHTMLStructure($I, $langTag = false)
-	{
-		if($langTag) {
-			$I->seeInSource('<html lang="en">');
-		} else {
-			$I->seeInSource('<html>');
-		}
-
-		$I->seeInSource('<head>');
-		$I->seeInSource('</head>');
-		$I->seeInSource('<body');
-		$I->seeInSource('</body>');
-		$I->seeInSource('</html>');
 	}
 
 	/**

--- a/tests/acceptance/landing-pages/PageLandingPageSetupWizardCest.php
+++ b/tests/acceptance/landing-pages/PageLandingPageSetupWizardCest.php
@@ -186,7 +186,7 @@ class PageLandingPageSetupWizardCest
 		$I->click('View landing page');
 
 		// Confirm that the basic HTML structure is correct.
-		$this->_seeBasicHTMLStructure($I);
+		$I->seeLandingPageOutput($I, true);
 
 		// Confirm the ConvertKit Site Icon displays.
 		$I->seeInSource('<link rel="shortcut icon" type="image/x-icon" href="https://pages.convertkit.com/templates/favicon.ico">');
@@ -223,7 +223,7 @@ class PageLandingPageSetupWizardCest
 		$I->click('View landing page');
 
 		// Confirm that the basic HTML structure is correct.
-		$this->_seeBasicHTMLStructure($I);
+		$I->seeLandingPageOutput($I);
 
 		// Confirm that the ConvertKit Landing Page displays.
 		$I->dontSeeElementInDOM('body.page'); // WordPress didn't load its template, which is correct.
@@ -252,23 +252,6 @@ class PageLandingPageSetupWizardCest
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
-	}
-
-	/**
-	 * Helper method to assert that the expected landing page HTML is output.
-	 *
-	 * @since   2.5.5
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 */
-	private function _seeBasicHTMLStructure($I)
-	{
-		$I->seeInSource('<html>');
-		$I->seeInSource('<head>');
-		$I->seeInSource('</head>');
-		$I->seeInSource('<body');
-		$I->seeInSource('</body>');
-		$I->seeInSource('</html>');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Uses 2.0.3 of the WordPress Libraries.

## Testing

Updates landing page tests to confirm the correct `<html>` tag exists, now that landing pages are parsed correctly.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)