### PR TITLE
Update Secondary Button Colors

### DIFF
--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -403,13 +403,13 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 
 		// Output Account Name.
 		$html = sprintf(
-			'<code>%s</code>',
+			'<p>%s</p>',
 			isset( $this->account['account']['name'] ) ? esc_attr( $this->account['account']['name'] ) : esc_html__( '(Not specified)', 'convertkit' )
 		);
 
 		// Display an option to disconnect.
 		$html .= sprintf(
-			'<p><a href="%1$s" class="button button-primary">%2$s</a></p>',
+			'<p><a href="%1$s" class="button button-secondary">%2$s</a></p>',
 			esc_url(
 				add_query_arg(
 					array(

--- a/views/backend/settings/tools.php
+++ b/views/backend/settings/tools.php
@@ -28,14 +28,8 @@
 					'convertkit-download-debug-log',
 					false
 				);
-
-				submit_button(
-					__( 'Clear log', 'convertkit' ),
-					'secondary',
-					'convertkit-clear-debug-log',
-					false
-				);
 				?>
+				<input type="submit" name="convertkit-clear-debug-log" id="convertkit-clear-debug-log" class="button button-secondary" value="<?php esc_attr_e( 'Clear log', 'convertkit' ); ?>" />
 			</p>
 			<p><?php esc_html_e( 'Log file', 'convertkit' ); ?>: <code><?php echo esc_attr( $log->get_filename() ); ?></code></p>
 			<?php


### PR DESCRIPTION
## Summary

Changes button colors for `Disconnect` and `Clear log` to match Kit's secondary button styles.
Removes the `code` tag for the account name.
This matches the Kit for WooCommerce Plugin styling.

Before:
![Screenshot 2024-10-07 at 11 31 16](https://github.com/user-attachments/assets/38cf8895-9214-475b-9fd3-15778db2ab20)

![Screenshot 2024-10-07 at 11 30 53](https://github.com/user-attachments/assets/f835fe11-29cc-45ff-a504-6782d0488fd9)

After:
![Screenshot 2024-10-07 at 11 25 09](https://github.com/user-attachments/assets/c922a6c3-8649-4d24-a65d-2ef1cfd39521)

![Screenshot 2024-10-07 at 11 30 44](https://github.com/user-attachments/assets/4f4e4971-cd28-4d7d-b79b-c71a7602cc6e)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)