### PR TITLE
Define Default Form Position: Add `After element` option

### DIFF
--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -206,7 +206,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 				'label_for'   => 'enabled',
 				'label'       => __( 'Enables automatic publication of public Kit Broadcasts as WordPress Posts.', 'convertkit' ),
 				'description' => $enabled_description,
-			),
+			)
 		);
 
 		// Render import button if the feature is enabled.

--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -206,7 +206,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 				'label_for'   => 'enabled',
 				'label'       => __( 'Enables automatic publication of public Kit Broadcasts as WordPress Posts.', 'convertkit' ),
 				'description' => $enabled_description,
-			)
+			),
 		);
 
 		// Render import button if the feature is enabled.
@@ -357,7 +357,8 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 			'on',
 			$this->settings->enabled(), // phpcs:ignore WordPress.Security.EscapeOutput
 			$args['label'],  // phpcs:ignore WordPress.Security.EscapeOutput
-			$args['description'] // phpcs:ignore WordPress.Security.EscapeOutput
+			$args['description'], // phpcs:ignore WordPress.Security.EscapeOutput
+			array( 'convertkit-conditional-display' )
 		);
 
 	}

--- a/admin/section/class-convertkit-settings-base.php
+++ b/admin/section/class-convertkit-settings-base.php
@@ -437,6 +437,35 @@ abstract class ConvertKit_Settings_Base {
 	}
 
 	/**
+	 * Returns a number field.
+	 *
+	 * @since   2.6.1
+	 *
+	 * @param   string            $name           Name.
+	 * @param   string            $value          Value.
+	 * @param   bool|string|array $description    Description (false|string|array).
+	 * @param   bool|array        $css_classes    CSS Classes (false|array).
+	 * @return  string                              HTML Field
+	 */
+	public function get_number_field( $name, $value = '', $min = 0, $max = 9999, $step = 1, $description = false, $css_classes = false ) {
+
+		$html = sprintf(
+			'<input type="number" class="%s" id="%s" name="%s[%s]" value="%s" min="%s" max="%s" step="%s" />',
+			( is_array( $css_classes ) ? implode( ' ', $css_classes ) : 'regular-text' ),
+			$name,
+			$this->settings_key,
+			$name,
+			$value,
+			$min,
+			$max,
+			$step
+		);
+
+		return $html . $this->get_description( $description );
+
+	}
+
+	/**
 	 * Returns a textarea field.
 	 *
 	 * @since   2.3.5

--- a/admin/section/class-convertkit-settings-base.php
+++ b/admin/section/class-convertkit-settings-base.php
@@ -443,15 +443,18 @@ abstract class ConvertKit_Settings_Base {
 	 *
 	 * @param   string            $name           Name.
 	 * @param   string            $value          Value.
+	 * @param   int               $min            `min` attribute value.
+	 * @param   int               $max            `max` attribute value.
+	 * @param   int               $step           `step` attribute value.
 	 * @param   bool|string|array $description    Description (false|string|array).
 	 * @param   bool|array        $css_classes    CSS Classes (false|array).
-	 * @return  string                              HTML Field
+	 * @return  string                            HTML Field
 	 */
 	public function get_number_field( $name, $value = '', $min = 0, $max = 9999, $step = 1, $description = false, $css_classes = false ) {
 
 		$html = sprintf(
 			'<input type="number" class="%s" id="%s" name="%s[%s]" value="%s" min="%s" max="%s" step="%s" />',
-			( is_array( $css_classes ) ? implode( ' ', $css_classes ) : 'regular-text' ),
+			( is_array( $css_classes ) ? implode( ' ', $css_classes ) : 'small-text' ),
 			$name,
 			$this->settings_key,
 			$name,

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -598,7 +598,7 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 
 		echo $this->get_number_field( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			$args['post_type'] . '_form_position_element_index',
-			esc_attr( $this->settings->get_default_form_position_element_index( $args['post_type'] ) ),
+			esc_attr( (string) $this->settings->get_default_form_position_element_index( $args['post_type'] ) ),
 			1,
 			999,
 			1,

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -233,8 +233,9 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 		// Enqueue Select2 JS.
 		convertkit_select2_enqueue_scripts();
 
-		// Enqueue Preview Output JS.
+		// Enqueue JS.
 		wp_enqueue_script( 'convertkit-admin-preview-output', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/preview-output.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
+		wp_enqueue_script( 'convertkit-admin-settings-conditional-display', CONVERTKIT_PLUGIN_URL . 'resources/backend/js/settings-conditional-display.js', array( 'jquery' ), CONVERTKIT_PLUGIN_VERSION, true );
 
 	}
 
@@ -313,13 +314,13 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 				)
 			);
 			add_settings_field(
-				$supported_post_type . '_form_position_index',
+				$supported_post_type . '_form_position_element',
 				'',
-				array( $this, 'default_form_position_index_callback' ),
+				array( $this, 'default_form_position_element_callback' ),
 				$this->settings_key,
 				$this->name,
 				array(
-					'label_for'        => '_wp_convertkit_settings_' . $supported_post_type . '_form_position_index',
+					'label_for'        => '_wp_convertkit_settings_' . $supported_post_type . '_form_position_element',
 					'post_type'        => $supported_post_type,
 					'post_type_object' => $post_type,
 				)
@@ -473,7 +474,6 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 
 		$tags = new ConvertKit_Resource_Tags( 'settings' );
 		$tags->refresh();
-
 	}
 
 	/**
@@ -557,24 +557,31 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 			esc_attr( $this->settings->get_default_form_position( $args['post_type'] ) ),
 			array(
 				'before_content'       => sprintf(
-					esc_html__( 'Before %s content', 'convertkit' ),
-					$args['post_type_object']->labels->singular_name
+					/* translators: Post type singular name */
+					esc_attr__( 'Before %s content', 'convertkit' ),
+					esc_attr( $args['post_type_object']->labels->singular_name )
 				),
 				'after_content'        => sprintf(
-					esc_html__( 'After %s content', 'convertkit' ),
-					$args['post_type_object']->labels->singular_name
+					/* translators: Post type singular name */
+					esc_attr__( 'After %s content', 'convertkit' ),
+					esc_attr( $args['post_type_object']->labels->singular_name )
 				),
 				'before_after_content' => sprintf(
-					esc_html__( 'Before and after %s content', 'convertkit' ),
-					$args['post_type_object']->labels->singular_name
+					/* translators: Post type singular name */
+					esc_attr__( 'Before and after %s content', 'convertkit' ),
+					esc_attr( $args['post_type_object']->labels->singular_name )
 				),
-				'before_paragraph'     => esc_html__( 'Before paragraph', 'convertkit' ),
-				'after_paragraph'      => esc_html__( 'After paragraph', 'convertkit' ),
+				'after_element'        => esc_html__( 'After element', 'convertkit' ),
 			),
 			sprintf(
 				/* translators: Post Type name, plural */
 				esc_html__( 'Where forms should display relative to the %s content', 'convertkit' ),
 				esc_html( $args['post_type_object']->labels->singular_name )
+			),
+			array( 'convertkit-conditional-display' ),
+			array(
+				'data-conditional-value'   => 'after_element',
+				'data-conditional-element' => esc_attr( $args['post_type'] ) . '_form_position_element_index',
 			)
 		);
 
@@ -587,12 +594,26 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 	 *
 	 * @param   array $args  Field arguments.
 	 */
-	public function default_form_position_index_callback( $args ) {
+	public function default_form_position_element_callback( $args ) {
 
-		echo $this->get_text_field( // phpcs:ignore WordPress.Security.EscapeOutput
-			$args['post_type'] . '_form_position',
-			esc_attr( $this->settings->get_default_form_position_index( $args['post_type'] ) ),
-			esc_html__( 'The number of paragraphs before or after to display the form.', 'convertkit' )
+		echo $this->get_number_field( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			$args['post_type'] . '_form_position_element_index',
+			esc_attr( $this->settings->get_default_form_position_element_index( $args['post_type'] ) ),
+			1,
+			999,
+			1,
+			false,
+			array( 'after_element' )
+		);
+
+		echo $this->get_select_field( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			$args['post_type'] . '_form_position_element',
+			esc_attr( $this->settings->get_default_form_position_element( $args['post_type'] ) ),
+			array(
+				'p' => esc_html__( 'Paragraphs', 'convertkit' ),
+			),
+			esc_html__( 'The number of elements before outputting the form.', 'convertkit' ),
+			array( 'after_element' )
 		);
 
 	}

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -307,7 +307,19 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 				$this->settings_key,
 				$this->name,
 				array(
-					'label_for'        => '_wp_convertkit_settings_' . $supported_post_type . '_form',
+					'label_for'        => '_wp_convertkit_settings_' . $supported_post_type . '_form_position',
+					'post_type'        => $supported_post_type,
+					'post_type_object' => $post_type,
+				)
+			);
+			add_settings_field(
+				$supported_post_type . '_form_position_index',
+				'',
+				array( $this, 'default_form_position_index_callback' ),
+				$this->settings_key,
+				$this->name,
+				array(
+					'label_for'        => '_wp_convertkit_settings_' . $supported_post_type . '_form_position_index',
 					'post_type'        => $supported_post_type,
 					'post_type_object' => $post_type,
 				)
@@ -544,15 +556,43 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 			$args['post_type'] . '_form_position',
 			esc_attr( $this->settings->get_default_form_position( $args['post_type'] ) ),
 			array(
-				'before_content'       => esc_html__( 'Before content', 'convertkit' ),
-				'after_content'        => esc_html__( 'After content', 'convertkit' ),
-				'before_after_content' => esc_html__( 'Before and after content', 'convertkit' ),
+				'before_content'       => sprintf(
+					esc_html__( 'Before %s content', 'convertkit' ),
+					$args['post_type_object']->labels->singular_name
+				),
+				'after_content'        => sprintf(
+					esc_html__( 'After %s content', 'convertkit' ),
+					$args['post_type_object']->labels->singular_name
+				),
+				'before_after_content' => sprintf(
+					esc_html__( 'Before and after %s content', 'convertkit' ),
+					$args['post_type_object']->labels->singular_name
+				),
+				'before_paragraph'     => esc_html__( 'Before paragraph', 'convertkit' ),
+				'after_paragraph'      => esc_html__( 'After paragraph', 'convertkit' ),
 			),
 			sprintf(
 				/* translators: Post Type name, plural */
 				esc_html__( 'Where forms should display relative to the %s content', 'convertkit' ),
-				esc_html( $args['post_type_object']->label )
+				esc_html( $args['post_type_object']->labels->singular_name )
 			)
+		);
+
+	}
+
+	/**
+	 * Renders the input for the Default Form Position Index setting for the given Post Type.
+	 *
+	 * @since  2.6.1
+	 *
+	 * @param   array $args  Field arguments.
+	 */
+	public function default_form_position_index_callback( $args ) {
+
+		echo $this->get_text_field( // phpcs:ignore WordPress.Security.EscapeOutput
+			$args['post_type'] . '_form_position',
+			esc_attr( $this->settings->get_default_form_position_index( $args['post_type'] ) ),
+			esc_html__( 'The number of paragraphs before or after to display the form.', 'convertkit' )
 		);
 
 	}

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -338,6 +338,35 @@ class ConvertKit_Output {
 				$content = $form . $content;
 				break;
 
+			case 'after_element':
+				$form_position_element            = $this->settings->get_default_form_position_element( get_post_type( $post_id ) );
+				$form_position_element_index      = $this->settings->get_default_form_position_element_index( get_post_type( $post_id ) );
+				$form_position_element_tag_length = ( strlen( $form_position_element ) + 3 );
+
+				// Find all closing elements.
+				preg_match_all( '/<\/' . $form_position_element . '>/', $content, $matches );
+
+				// If the number of elements is less than the index, we don't have enough elements to add the form to.
+				// Just add the form after the content.
+				if ( count( $matches[0] ) <= $form_position_element_index ) {
+					$content = $content . $form;
+					break;
+				}
+
+				// Iterate through the content to find the element at the configured index e.g. find the 4th closing paragraph.
+				$offset = 0;
+				foreach ( $matches[0] as $element_index => $element ) {
+					$position = strpos( $content, $element, $offset );
+					if ( $element_index === $form_position_element_index ) {
+						$content = substr( $content, 0, $position + 4 ) . $form . substr( $content, $position + 4 );
+						break;
+					}
+
+					// Increment offset.
+					$offset = $position + 1;
+				}
+				break;
+
 			case 'after_content':
 			default:
 				// Default behaviour < 2.5.8 was to append the Form after the content.

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -357,7 +357,7 @@ class ConvertKit_Output {
 				$offset = 0;
 				foreach ( $matches[0] as $element_index => $element ) {
 					$position = strpos( $content, $element, $offset );
-					if ( $element_index === $form_position_element_index ) {
+					if ( ( $element_index + 1 ) === $form_position_element_index ) {
 						$content = substr( $content, 0, $position + 4 ) . $form . substr( $content, $position + 4 );
 						break;
 					}

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -400,13 +400,18 @@ class ConvertKit_Output {
 		// item() is a zero based index.
 		$element_node = $html->getElementsByTagName( $tag )->item( $index - 1 );
 
+		// If the element could not be found, either the number of elements by tag name is less
+		// than the requested position the form be inserted in, or no element exists.
+		// Append the form to the content and return.
+		if ( is_null( $element_node ) ) {
+			return $content . $form;
+		}
+
 		// Create new element for the Form.
 		$form_node = new DOMDocument();
 		$form_node->loadHTML( $form, LIBXML_HTML_NODEFDTD );
 
 		// Append the form to the specific element.
-		// If the index is greater than the number of elements that exist in the content, this will append the form
-		// to the end of the content.
 		$element_node->parentNode->insertBefore( $html->importNode( $form_node->documentElement, true ), $element_node->nextSibling ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 		// Fetch HTML string.

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -385,7 +385,7 @@ class ConvertKit_Output {
 	 *
 	 * @param   string $content        Page / Post Content.
 	 * @param   string $tag            HTML tag to insert form after.
-	 * @param   string $index          Number of $tag elements to find before inserting form.
+	 * @param   int    $index          Number of $tag elements to find before inserting form.
 	 * @param   string $form           Form HTML to inject.
 	 * @return  string
 	 */
@@ -440,7 +440,7 @@ class ConvertKit_Output {
 	 *
 	 * @param   string $content        Page / Post Content.
 	 * @param   string $tag            HTML tag to insert form after.
-	 * @param   string $index          Number of $tag elements to find before inserting form.
+	 * @param   int   $index           Number of $tag elements to find before inserting form.
 	 * @param   string $form           Form HTML to inject.
 	 * @return  string
 	 */

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -339,32 +339,19 @@ class ConvertKit_Output {
 				break;
 
 			case 'after_element':
-				$form_position_element            = $this->settings->get_default_form_position_element( get_post_type( $post_id ) );
-				$form_position_element_index      = $this->settings->get_default_form_position_element_index( get_post_type( $post_id ) );
-				$form_position_element_tag_length = ( strlen( $form_position_element ) + 3 );
+				$element = $this->settings->get_default_form_position_element( get_post_type( $post_id ) );
+				$index   = $this->settings->get_default_form_position_element_index( get_post_type( $post_id ) );
 
-				// Find all closing elements.
-				preg_match_all( '/<\/' . $form_position_element . '>/', $content, $matches );
-
-				// If the number of elements is less than the index, we don't have enough elements to add the form to.
-				// Just add the form after the content.
-				if ( count( $matches[0] ) <= $form_position_element_index ) {
-					$content = $content . $form;
+				// Check if DOMDocument is installed.
+				// It should be installed as mosts hosts include php-dom and php-xml modules.
+				// If not, fallback to using preg_match_all(), which is less reliable.
+				if ( ! class_exists( 'DOMDocument' ) ) {
+					$content = $this->inject_form_after_element_fallback( $content, $element, $index, $form );
 					break;
 				}
 
-				// Iterate through the content to find the element at the configured index e.g. find the 4th closing paragraph.
-				$offset = 0;
-				foreach ( $matches[0] as $element_index => $element ) {
-					$position = strpos( $content, $element, $offset );
-					if ( ( $element_index + 1 ) === $form_position_element_index ) {
-						$content = substr( $content, 0, $position + 4 ) . $form . substr( $content, $position + 4 );
-						break;
-					}
-
-					// Increment offset.
-					$offset = $position + 1;
-				}
+				// Use DOMDocument.
+				$content = $this->inject_form_after_element( $content, $element, $index, $form );
 				break;
 
 			case 'after_content':
@@ -387,6 +374,107 @@ class ConvertKit_Output {
 		 */
 		$content = apply_filters( 'convertkit_frontend_append_form', $content, $form, $post_id, $form_id, $form_position );
 
+		return $content;
+
+	}
+
+	/**
+	 * Injects the form after the given element and index, using DOMDocument.
+	 *
+	 * @since   2.6.2
+	 *
+	 * @param   string $content        Page / Post Content.
+	 * @param   string $tag            HTML tag to insert form after.
+	 * @param   string $index          Number of $tag elements to find before inserting form.
+	 * @param   string $form           Form HTML to inject.
+	 * @return  string
+	 */
+	private function inject_form_after_element( $content, $tag, $index, $form ) {
+
+		// Load Page / Post content into DOMDocument.
+		libxml_use_internal_errors( true );
+		$html = new DOMDocument();
+		$html->loadHTML( $content, LIBXML_HTML_NODEFDTD );
+
+		// Find the element to append the form to.
+		// item() is a zero based index.
+		$element_node = $html->getElementsByTagName( $tag )->item( $index - 1 );
+
+		// Create new element for the Form.
+		$form_node = new DOMDocument();
+		$form_node->loadHTML( $form, LIBXML_HTML_NODEFDTD );
+
+		// Append the form to the specific element.
+		// If the index is greater than the number of elements that exist in the content, this will append the form
+		// to the end of the content.
+		$element_node->parentNode->insertBefore( $html->importNode( $form_node->documentElement, true ), $element_node->nextSibling ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+		// Fetch HTML string.
+		$content = $html->saveHTML();
+
+		// Remove some HTML tags that DOMDocument adds, returning the output.
+		// We do this instead of using LIBXML_HTML_NOIMPLIED in loadHTML(), because Legacy Forms are not always contained in
+		// a single root / outer element, which is required for LIBXML_HTML_NOIMPLIED to correctly work.
+		$content = str_replace( '<html>', '', $content );
+		$content = str_replace( '</html>', '', $content );
+		$content = str_replace( '<head>', '', $content );
+		$content = str_replace( '</head>', '', $content );
+		$content = str_replace( '<body>', '', $content );
+		$content = str_replace( '</body>', '', $content );
+
+		return $content;
+
+	}
+
+	/**
+	 * Injects the form after the given element and index, using preg_match_all().
+	 * This is less reliable than DOMDocument, and is called if DOMDocument is
+	 * not installed on the server.
+	 *
+	 * @since   2.6.2
+	 *
+	 * @param   string $content        Page / Post Content.
+	 * @param   string $tag            HTML tag to insert form after.
+	 * @param   string $index          Number of $tag elements to find before inserting form.
+	 * @param   string $form           Form HTML to inject.
+	 * @return  string
+	 */
+	private function inject_form_after_element_fallback( $content, $tag, $index, $form ) {
+
+		// Calculate tag length.
+		$tag_length = ( strlen( $tag ) + 3 );
+
+		// Find all closing elements.
+		preg_match_all( '/<\/' . $tag . '>/', $content, $matches );
+
+		// If no elements exist, just append the form.
+		if ( count( $matches[0] ) === 0 ) {
+			$content = $content . $form;
+			return $content;
+		}
+
+		// If the number of elements is less than the index, we don't have enough elements to add the form to.
+		// Just add the form after the content.
+		if ( count( $matches[0] ) <= $index ) {
+			$content = $content . $form;
+			return $content;
+		}
+
+		// Iterate through the content to find the element at the configured index e.g. find the 4th closing paragraph.
+		$offset = 0;
+		foreach ( $matches[0] as $element_index => $element ) {
+			$position = strpos( $content, $element, $offset );
+			if ( ( $element_index + 1 ) === $index ) {
+				return substr( $content, 0, $position + 4 ) . $form . substr( $content, $position + 4 );
+			}
+
+			// Increment offset.
+			$offset = $position + 1;
+		}
+
+		// If here, something went wrong.
+		// Just add the form after the content.
+		$content = $content . $form;
 		return $content;
 
 	}

--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -440,7 +440,7 @@ class ConvertKit_Output {
 	 *
 	 * @param   string $content        Page / Post Content.
 	 * @param   string $tag            HTML tag to insert form after.
-	 * @param   int   $index           Number of $tag elements to find before inserting form.
+	 * @param   int    $index           Number of $tag elements to find before inserting form.
 	 * @param   string $form           Form HTML to inject.
 	 * @return  string
 	 */

--- a/includes/class-convertkit-settings.php
+++ b/includes/class-convertkit-settings.php
@@ -308,21 +308,40 @@ class ConvertKit_Settings {
 	}
 
 	/**
+	 * Returns the Default Form Position Element Plugin setting.
+	 *
+	 * @since   2.6.1
+	 *
+	 * @param   string $post_type  Post Type.
+	 * @return  string             Element to insert form after
+	 */
+	public function get_default_form_position_element( $post_type ) {
+
+		// Return after_content if this Post Type's position doesn't exist as a setting.
+		if ( ! array_key_exists( $post_type . '_form_position_element', $this->settings ) ) {
+			return 'p';
+		}
+
+		return $this->settings[ $post_type . '_form_position_element' ];
+
+	}
+
+	/**
 	 * Returns the Default Form Position Index Plugin setting.
 	 *
 	 * @since   2.6.1
 	 *
 	 * @param   string $post_type  Post Type.
-	 * @return  int 			   Position Index
+	 * @return  int                Number of elements before inserting form
 	 */
-	public function get_default_form_position_index( $post_type ) {
+	public function get_default_form_position_element_index( $post_type ) {
 
 		// Return 1 if this Post Type's position index doesn't exist as a setting.
-		if ( ! array_key_exists( $post_type . '_form_position_index', $this->settings ) ) {
+		if ( ! array_key_exists( $post_type . '_form_position_element_index', $this->settings ) ) {
 			return 1;
 		}
 
-		return (int) $this->settings[ $post_type . '_form_position_index' ];
+		return (int) $this->settings[ $post_type . '_form_position_element_index' ];
 
 	}
 
@@ -425,9 +444,10 @@ class ConvertKit_Settings {
 
 		// Add Post Type Default Forms.
 		foreach ( convertkit_get_supported_post_types() as $post_type ) {
-			$defaults[ $post_type . '_form' ]          		 = 0; // -1, 0 or Form ID.
-			$defaults[ $post_type . '_form_position' ] 		 = 'after_content'; // before_content,after_content.
-			$defaults[ $post_type . '_form_position_index' ] = 1;
+			$defaults[ $post_type . '_form' ]                        = 0; // -1, 0 or Form ID.
+			$defaults[ $post_type . '_form_position' ]               = 'after_content'; // before_content,after_content,before_after_content,element.
+			$defaults[ $post_type . '_form_position_element' ]       = 'p';
+			$defaults[ $post_type . '_form_position_element_index' ] = 1;
 		}
 
 		/**

--- a/includes/class-convertkit-settings.php
+++ b/includes/class-convertkit-settings.php
@@ -308,6 +308,25 @@ class ConvertKit_Settings {
 	}
 
 	/**
+	 * Returns the Default Form Position Index Plugin setting.
+	 *
+	 * @since   2.6.1
+	 *
+	 * @param   string $post_type  Post Type.
+	 * @return  int 			   Position Index
+	 */
+	public function get_default_form_position_index( $post_type ) {
+
+		// Return 1 if this Post Type's position index doesn't exist as a setting.
+		if ( ! array_key_exists( $post_type . '_form_position_index', $this->settings ) ) {
+			return 1;
+		}
+
+		return (int) $this->settings[ $post_type . '_form_position_index' ];
+
+	}
+
+	/**
 	 * Returns the Global non-inline Form Plugin setting.
 	 *
 	 * @since   2.3.3
@@ -406,8 +425,9 @@ class ConvertKit_Settings {
 
 		// Add Post Type Default Forms.
 		foreach ( convertkit_get_supported_post_types() as $post_type ) {
-			$defaults[ $post_type . '_form' ]          = 0; // -1, 0 or Form ID.
-			$defaults[ $post_type . '_form_position' ] = 'after_content'; // before_content,after_content.
+			$defaults[ $post_type . '_form' ]          		 = 0; // -1, 0 or Form ID.
+			$defaults[ $post_type . '_form_position' ] 		 = 'after_content'; // before_content,after_content.
+			$defaults[ $post_type . '_form_position_index' ] = 1;
 		}
 
 		/**

--- a/resources/backend/js/settings-conditional-display.js
+++ b/resources/backend/js/settings-conditional-display.js
@@ -18,17 +18,18 @@ document.addEventListener(
 
 		// Update settings and refresh UI when a setting is changed.
 		const sourceInputs = document.querySelectorAll( '.convertkit-conditional-display' );
-		console.log( sourceInputs );
-		sourceInputs.forEach( function( input ) {
-			input.addEventListener(
-				'change',
-				function () {
-					convertKitConditionallyDisplaySettings( this );
-				}
-			);
+		sourceInputs.forEach(
+			function ( input ) {
+				input.addEventListener(
+					'change',
+					function () {
+						convertKitConditionallyDisplaySettings( this );
+					}
+				);
 
-			convertKitConditionallyDisplaySettings( input );
-		} );
+				convertKitConditionallyDisplaySettings( input );
+			}
+		);
 
 	}
 );
@@ -38,17 +39,18 @@ document.addEventListener(
  * table rows related to a setting, if that setting is disabled.
  *
  * @since 	2.2.4
- * 
+ *
  * @param 	object  input 	Element interacted with
  */
 function convertKitConditionallyDisplaySettings( input ) {
 
-	// Show all rows.
 	const rows = document.querySelectorAll( 'table.form-table tr' );
-	rows.forEach( row => row.style.display = '' );
 
 	switch ( input.type ) {
 		case 'checkbox':
+			// Show all rows.
+			rows.forEach( row => row.style.display = '' );
+
 			// Don't do anything else if the checkbox is checked.
 			if ( input.checked ) {
 				return;
@@ -70,7 +72,24 @@ function convertKitConditionallyDisplaySettings( input ) {
 			);
 			break;
 
-		case 'select':
+		case 'select-one':
+			// Iterate through the table rows, hiding any settings.
+			rows.forEach(
+				function ( row ) {
+					// Skip if this table row is for the setting we've just changed.
+					if ( row.querySelector( `[id = "${input.id}"]` ) ) {
+						return;
+					}
+
+					if ( row.querySelector( `input#${input.dataset.conditionalElement}` ) ) {
+						if ( input.value !== input.dataset.conditionalValue ) {
+							row.style.display = 'none';
+						} else {
+							row.style.display = '';
+						}
+					}
+				}
+			);
 			break;
 	}
 

--- a/resources/backend/js/settings-conditional-display.js
+++ b/resources/backend/js/settings-conditional-display.js
@@ -72,7 +72,7 @@ function convertKitConditionallyDisplaySettings( input ) {
 			);
 			break;
 
-		case 'select-one':
+		default:
 			// Iterate through the table rows, hiding any settings.
 			rows.forEach(
 				function ( row ) {

--- a/resources/backend/js/settings-conditional-display.js
+++ b/resources/backend/js/settings-conditional-display.js
@@ -17,15 +17,18 @@ document.addEventListener(
 	function () {
 
 		// Update settings and refresh UI when a setting is changed.
-		const enabledInput = document.querySelector( 'input#enabled' );
-		enabledInput.addEventListener(
-			'change',
-			function () {
-				convertKitConditionallyDisplaySettings( this.id, this.checked );
-			}
-		);
+		const sourceInputs = document.querySelectorAll( '.convertkit-conditional-display' );
+		console.log( sourceInputs );
+		sourceInputs.forEach( function( input ) {
+			input.addEventListener(
+				'change',
+				function () {
+					convertKitConditionallyDisplaySettings( this );
+				}
+			);
 
-		convertKitConditionallyDisplaySettings( 'enabled', enabledInput.checked );
+			convertKitConditionallyDisplaySettings( input );
+		} );
 
 	}
 );
@@ -35,31 +38,40 @@ document.addEventListener(
  * table rows related to a setting, if that setting is disabled.
  *
  * @since 	2.2.4
+ * 
+ * @param 	object  input 	Element interacted with
  */
-function convertKitConditionallyDisplaySettings( name, display ) {
+function convertKitConditionallyDisplaySettings( input ) {
 
 	// Show all rows.
 	const rows = document.querySelectorAll( 'table.form-table tr' );
 	rows.forEach( row => row.style.display = '' );
 
-	// Don't do anything else if display is true.
-	if ( display ) {
-		return;
+	switch ( input.type ) {
+		case 'checkbox':
+			// Don't do anything else if the checkbox is checked.
+			if ( input.checked ) {
+				return;
+			}
+
+			// Iterate through the table rows, hiding any settings.
+			rows.forEach(
+				function ( row ) {
+					// Skip if this table row is for the setting we've just checked/unchecked.
+					if ( row.querySelector( `[id = "${input.id}"]` ) ) {
+						return;
+					}
+
+					// Hide this row if the input, select, link or span element within the row has the CSS class of the setting ID.
+					if ( row.querySelector( `input.${input.id}, select.${input.id}, a.${input.id}, span.${input.id}` ) ) {
+						row.style.display = 'none';
+					}
+				}
+			);
+			break;
+
+		case 'select':
+			break;
 	}
-
-	// Iterate through the table rows, hiding any settings.
-	rows.forEach(
-		function ( row ) {
-			// Skip if this table row is for the setting we've just checked/unchecked.
-			if ( row.querySelector( `[id = "${name}"]` ) ) {
-					return;
-			}
-
-			// Hide this row if the input, select, link or span element within the row has the CSS class of the setting name.
-			if ( row.querySelector( `input.${name}, select.${name}, a.${name}, span.${name}` ) ) {
-				row.style.display = 'none';
-			}
-		}
-	);
 
 }

--- a/tests/_support/Helper/Acceptance/ConvertKitForms.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitForms.php
@@ -18,8 +18,10 @@ class ConvertKitForms extends \Codeception\Module
 	 * @param   AcceptanceTester $I              Tester.
 	 * @param   int              $formID         Form ID.
 	 * @param   bool|string      $position       Position of the form in the DOM relative to the content.
+	 * @param   bool|string      $element        Element the form should display after.
+	 * @param   bool|string      $element_index  Number of elements before the form should display.
 	 */
-	public function seeFormOutput($I, $formID, $position = false)
+	public function seeFormOutput($I, $formID, $position = false, $element = false, $element_index = 0)
 	{
 		// Calculate how many times the Form should be in the DOM.
 		$count = ( ( $position === 'before_after_content' ) ? 2 : 1 );
@@ -45,6 +47,10 @@ class ConvertKitForms extends \Codeception\Module
 
 			case 'after_content':
 				$I->assertEquals($formID, $I->grabAttributeFrom('div.entry-content > *:last-child', 'data-sv-form'));
+				break;
+
+			case 'after_element':
+				$I->seeInSource('<' . $element . '>Item #' . $element_index . '</' . $element . '><form action="https://app.convertkit.com/forms/' . $formID . '/subscriptions" ');
 				break;
 		}
 	}

--- a/tests/acceptance/forms/post-types/CPTFormCest.php
+++ b/tests/acceptance/forms/post-types/CPTFormCest.php
@@ -281,6 +281,55 @@ class CPTFormCest
 	}
 
 	/**
+	 * Test that the Default Form specified in the Plugin Settings works when
+	 * creating and viewing a new WordPress CPT, and its position is set
+	 * to after the 3rd paragraph.
+	 *
+	 * @since   2.6.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewCPTUsingDefaultFormAfterElement(AcceptanceTester $I)
+	{
+		// Setup ConvertKit plugin with Default Form for CPTs set to be output after the 3rd paragraph of content.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'article_form'                        => $_ENV['CONVERTKIT_API_FORM_ID'],
+				'article_form_position'               => 'after_element',
+				'article_form_position_element'       => 'p',
+				'article_form_position_element_index' => 3,
+			]
+		);
+		$I->setupConvertKitPluginResources($I);
+
+		// Add a CPT using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'article', 'Kit: CPT: Form: Default: After 3rd Paragraph Element');
+
+		// Add 5 paragraphs to CPT.
+		$I->addGutenbergParagraphBlock($I, 'Item #1');
+		$I->addGutenbergParagraphBlock($I, 'Item #2');
+		$I->addGutenbergParagraphBlock($I, 'Item #3');
+		$I->addGutenbergParagraphBlock($I, 'Item #4');
+		$I->addGutenbergParagraphBlock($I, 'Item #5');
+
+		// Configure metabox's Form setting = Default.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'Default' ],
+			]
+		);
+
+		// Publish and view the CPT on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that one ConvertKit Form is output in the DOM after the third paragraph.
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_element', 'p', 3);
+	}
+
+	/**
 	 * Test that the Default Legacy Form specified in the Plugin Settings works when
 	 * creating and viewing a new WordPress CPT.
 	 *

--- a/tests/acceptance/forms/post-types/CPTFormCest.php
+++ b/tests/acceptance/forms/post-types/CPTFormCest.php
@@ -330,6 +330,54 @@ class CPTFormCest
 	}
 
 	/**
+	 * Test that the Default Form specified in the Plugin Settings works when
+	 * creating and viewing a new WordPress CPT, and its position is set
+	 * to a number greater than the number of elements in the content.
+	 *
+	 * @since   2.6.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewCPTUsingDefaultFormAfterOutOfBoundsElement(AcceptanceTester $I)
+	{
+		// Setup ConvertKit plugin with Default Form for CPTs set to be output after the 7th paragraph of content.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'article_form'                        => $_ENV['CONVERTKIT_API_FORM_ID'],
+				'article_form_position'               => 'after_element',
+				'article_form_position_element'       => 'p',
+				'article_form_position_element_index' => 7,
+			]
+		);
+		$I->setupConvertKitPluginResources($I);
+
+		// Add a CPT using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'article', 'Kit: CPT: Form: Default: After 7th Paragraph Element');
+
+		// Add 5 paragraphs to CPT.
+		$I->addGutenbergParagraphBlock($I, 'Item #1');
+		$I->addGutenbergParagraphBlock($I, 'Item #2');
+		$I->addGutenbergParagraphBlock($I, 'Item #3');
+
+		// Configure metabox's Form setting = Default.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'Default' ],
+			]
+		);
+
+		// Publish and view the CPT on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that one ConvertKit Form is output in the DOM after the content, as
+		// the number of paragraphs is less than the position.
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_content');
+	}
+
+	/**
 	 * Test that the Default Legacy Form specified in the Plugin Settings works when
 	 * creating and viewing a new WordPress CPT.
 	 *

--- a/tests/acceptance/forms/post-types/PageFormCest.php
+++ b/tests/acceptance/forms/post-types/PageFormCest.php
@@ -254,6 +254,54 @@ class PageFormCest
 	}
 
 	/**
+	 * Test that the Default Form specified in the Plugin Settings works when
+	 * creating and viewing a new WordPress Page, and its position is set
+	 * to a number greater than the number of elements in the content.
+	 *
+	 * @since   2.6.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewPageUsingDefaultFormAfterOutOfBoundsElement(AcceptanceTester $I)
+	{
+		// Setup ConvertKit plugin with Default Form for Pages set to be output after the 7rd paragraph of content.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'page_form'                        => $_ENV['CONVERTKIT_API_FORM_ID'],
+				'page_form_position'               => 'after_element',
+				'page_form_position_element'       => 'p',
+				'page_form_position_element_index' => 7,
+			]
+		);
+		$I->setupConvertKitPluginResources($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Default: After 7th Paragraph Element');
+
+		// Add 5 paragraphs to Page.
+		$I->addGutenbergParagraphBlock($I, 'Item #1');
+		$I->addGutenbergParagraphBlock($I, 'Item #2');
+		$I->addGutenbergParagraphBlock($I, 'Item #3');
+
+		// Configure metabox's Form setting = Default.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'Default' ],
+			]
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that one ConvertKit Form is output in the DOM after the content, as
+		// the number of paragraphs is less than the position.
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_content');
+	}
+
+	/**
 	 * Test that the Default Legacy Form specified in the Plugin Settings works when
 	 * creating and viewing a new WordPress Page.
 	 *

--- a/tests/acceptance/forms/post-types/PageFormCest.php
+++ b/tests/acceptance/forms/post-types/PageFormCest.php
@@ -205,6 +205,55 @@ class PageFormCest
 	}
 
 	/**
+	 * Test that the Default Form specified in the Plugin Settings works when
+	 * creating and viewing a new WordPress Page, and its position is set
+	 * to after the 3rd paragraph.
+	 *
+	 * @since   2.6.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewPageUsingDefaultFormAfterElement(AcceptanceTester $I)
+	{
+		// Setup ConvertKit plugin with Default Form for Pages set to be output after the 3rd paragraph of content.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'page_form'                        => $_ENV['CONVERTKIT_API_FORM_ID'],
+				'page_form_position'               => 'after_element',
+				'page_form_position_element'       => 'p',
+				'page_form_position_element_index' => 3,
+			]
+		);
+		$I->setupConvertKitPluginResources($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Default: After 3rd Paragraph Element');
+
+		// Add 5 paragraphs to Page.
+		$I->addGutenbergParagraphBlock($I, 'Item #1');
+		$I->addGutenbergParagraphBlock($I, 'Item #2');
+		$I->addGutenbergParagraphBlock($I, 'Item #3');
+		$I->addGutenbergParagraphBlock($I, 'Item #4');
+		$I->addGutenbergParagraphBlock($I, 'Item #5');
+
+		// Configure metabox's Form setting = Default.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'Default' ],
+			]
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that one ConvertKit Form is output in the DOM after the third paragraph.
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_element', 'p', 3);
+	}
+
+	/**
 	 * Test that the Default Legacy Form specified in the Plugin Settings works when
 	 * creating and viewing a new WordPress Page.
 	 *

--- a/tests/acceptance/forms/post-types/PostFormCest.php
+++ b/tests/acceptance/forms/post-types/PostFormCest.php
@@ -253,6 +253,54 @@ class PostFormCest
 	}
 
 	/**
+	 * Test that the Default Form specified in the Plugin Settings works when
+	 * creating and viewing a new WordPress Post, and its position is set
+	 * to a number greater than the number of elements in the content.
+	 *
+	 * @since   2.6.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewPostUsingDefaultFormAfterOutOfBoundsElement(AcceptanceTester $I)
+	{
+		// Setup ConvertKit plugin with Default Form for Posts set to be output after the 7rd paragraph of content.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'post_form'                        => $_ENV['CONVERTKIT_API_FORM_ID'],
+				'post_form_position'               => 'after_element',
+				'post_form_position_element'       => 'p',
+				'post_form_position_element_index' => 7,
+			]
+		);
+		$I->setupConvertKitPluginResources($I);
+
+		// Add a Post using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'post', 'Kit: Post: Form: Default: After 7th Paragraph Element');
+
+		// Add 5 paragraphs to Post.
+		$I->addGutenbergParagraphBlock($I, 'Item #1');
+		$I->addGutenbergParagraphBlock($I, 'Item #2');
+		$I->addGutenbergParagraphBlock($I, 'Item #3');
+
+		// Configure metabox's Form setting = Default.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'Default' ],
+			]
+		);
+
+		// Publish and view the Post on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that one ConvertKit Form is output in the DOM after the content, as
+		// the number of paragraphs is less than the position.
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_content');
+	}
+
+	/**
 	 * Test that the Default Legacy Form specified in the Plugin Settings works when
 	 * creating and viewing a new WordPress Post.
 	 *

--- a/tests/acceptance/forms/post-types/PostFormCest.php
+++ b/tests/acceptance/forms/post-types/PostFormCest.php
@@ -204,6 +204,55 @@ class PostFormCest
 	}
 
 	/**
+	 * Test that the Default Form specified in the Plugin Settings works when
+	 * creating and viewing a new WordPress Post, and its position is set
+	 * to after the 3rd paragraph.
+	 *
+	 * @since   2.6.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewPostUsingDefaultFormAfterElement(AcceptanceTester $I)
+	{
+		// Setup ConvertKit plugin with Default Form for Posts set to be output after the 3rd paragraph of content.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'post_form'                        => $_ENV['CONVERTKIT_API_FORM_ID'],
+				'post_form_position'               => 'after_element',
+				'post_form_position_element'       => 'p',
+				'post_form_position_element_index' => 3,
+			]
+		);
+		$I->setupConvertKitPluginResources($I);
+
+		// Add a Post using the Gutenberg editor.
+		$I->addGutenbergPage($I, 'post', 'Kit: Post: Form: Default: After 3rd Paragraph Element');
+
+		// Add 5 paragraphs to Post.
+		$I->addGutenbergParagraphBlock($I, 'Item #1');
+		$I->addGutenbergParagraphBlock($I, 'Item #2');
+		$I->addGutenbergParagraphBlock($I, 'Item #3');
+		$I->addGutenbergParagraphBlock($I, 'Item #4');
+		$I->addGutenbergParagraphBlock($I, 'Item #5');
+
+		// Configure metabox's Form setting = Default.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'Default' ],
+			]
+		);
+
+		// Publish and view the Post on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that one ConvertKit Form is output in the DOM after the third paragraph.
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_element', 'p', 3);
+	}
+
+	/**
 	 * Test that the Default Legacy Form specified in the Plugin Settings works when
 	 * creating and viewing a new WordPress Post.
 	 *

--- a/tests/acceptance/general/PluginSettingsGeneralCest.php
+++ b/tests/acceptance/general/PluginSettingsGeneralCest.php
@@ -313,6 +313,73 @@ class PluginSettingsGeneralCest
 	}
 
 	/**
+	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
+	 * when the Default Form Position setting for Pages and Posts are changed.
+	 *
+	 * @since   2.6.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testChangeDefaultFormPositionAfterElementSetting(AcceptanceTester $I)
+	{
+		// Setup Plugin, without defining default Forms.
+		$I->setupConvertKitPluginNoDefaultForms($I);
+
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsGeneralScreen($I);
+
+		// Confirm the conditional fields do not display for Pages, as the 'After element' is not selected.
+		$I->dontSeeElement('_wp_convertkit_settings[page_form_position_element_index]');
+		$I->dontSeeElement('_wp_convertkit_settings[page_form_position_element]');
+		
+		// Select Default Form for Pages, and change the Position.
+		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->selectOption('_wp_convertkit_settings[page_form_position]', 'After element');
+
+		// Confirm the conditional fields display for Pages, now that 'After element' is selected.
+		$I->waitForElementVisible('input[name="_wp_convertkit_settings[page_form_position_element_index]"]');
+		$I->waitForElementVisible('select[name="_wp_convertkit_settings[page_form_position_element]"]');
+
+		// Change a setting.
+		$I->fillField('_wp_convertkit_settings[page_form_position_element_index]', '3');
+
+		// Confirm the conditional fields do not display for Posts, as the 'After element' is not selected.
+		$I->dontSeeElement('input[name="_wp_convertkit_settings[post_form_position_element_index]"]');
+		$I->dontSeeElement('select[name="_wp_convertkit_settings[post_form_position_element]"]');
+		
+		// Select Default Form for Posts, and change the Position.
+		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_post_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->selectOption('_wp_convertkit_settings[post_form_position]', 'After element');
+
+		// Confirm the conditional fields display for Posts, now that 'After element' is selected.
+		$I->waitForElementVisible('input[name="_wp_convertkit_settings[post_form_position_element_index]"]');
+		$I->waitForElementVisible('select[name="_wp_convertkit_settings[post_form_position_element]"]');
+
+		// Change a setting.
+		$I->fillField('_wp_convertkit_settings[post_form_position_element_index]', '2');
+
+		// Click the Save Changes button.
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check the value of the fields match the inputs provided.
+		$I->seeInField('_wp_convertkit_settings[page_form_position]', 'After element');
+		$I->seeInField('_wp_convertkit_settings[page_form_position_element]', 'Paragraphs');
+		$I->seeInField('_wp_convertkit_settings[page_form_position_element_index]', '3');
+		$I->seeInField('_wp_convertkit_settings[post_form_position]', 'After element');
+		$I->seeInField('_wp_convertkit_settings[post_form_position_element]', 'Paragraphs');
+		$I->seeInField('_wp_convertkit_settings[post_form_position_element_index]', '2');
+
+		// Check that the conditional fields display, as 'After element' is selected for Pages and Posts.
+		$I->seeElement('input[name="_wp_convertkit_settings[page_form_position_element_index]"]');
+		$I->seeElement('select[name="_wp_convertkit_settings[page_form_position_element]"]');
+		$I->seeElement('input[name="_wp_convertkit_settings[post_form_position_element_index]"]');
+		$I->seeElement('select[name="_wp_convertkit_settings[post_form_position_element]"]');
+	}
+
+	/**
 	 * Test that the settings screen does not display preview links
 	 * when no Pages and Posts exist in WordPress.
 	 *

--- a/tests/acceptance/general/PluginSettingsGeneralCest.php
+++ b/tests/acceptance/general/PluginSettingsGeneralCest.php
@@ -331,7 +331,7 @@ class PluginSettingsGeneralCest
 		// Confirm the conditional fields do not display for Pages, as the 'After element' is not selected.
 		$I->dontSeeElement('_wp_convertkit_settings[page_form_position_element_index]');
 		$I->dontSeeElement('_wp_convertkit_settings[page_form_position_element]');
-		
+
 		// Select Default Form for Pages, and change the Position.
 		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
 		$I->selectOption('_wp_convertkit_settings[page_form_position]', 'After element');
@@ -346,7 +346,7 @@ class PluginSettingsGeneralCest
 		// Confirm the conditional fields do not display for Posts, as the 'After element' is not selected.
 		$I->dontSeeElement('input[name="_wp_convertkit_settings[post_form_position_element_index]"]');
 		$I->dontSeeElement('select[name="_wp_convertkit_settings[post_form_position_element]"]');
-		
+
 		// Select Default Form for Posts, and change the Position.
 		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_post_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
 		$I->selectOption('_wp_convertkit_settings[post_form_position]', 'After element');

--- a/tests/acceptance/general/PluginSettingsGeneralCest.php
+++ b/tests/acceptance/general/PluginSettingsGeneralCest.php
@@ -242,7 +242,7 @@ class PluginSettingsGeneralCest
 
 		// Select Default Form for Pages, and change the Position.
 		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_page_form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
-		$I->selectOption('_wp_convertkit_settings[page_form_position]', 'Before content');
+		$I->selectOption('_wp_convertkit_settings[page_form_position]', 'Before Page content');
 
 		// Open preview.
 		$I->click('a#convertkit-preview-form-page');
@@ -306,9 +306,9 @@ class PluginSettingsGeneralCest
 
 		// Check the value of the fields match the inputs provided.
 		$I->seeInField('_wp_convertkit_settings[page_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
-		$I->seeInField('_wp_convertkit_settings[page_form_position]', 'Before content');
+		$I->seeInField('_wp_convertkit_settings[page_form_position]', 'Before Page content');
 		$I->seeInField('_wp_convertkit_settings[post_form]', $_ENV['CONVERTKIT_API_FORM_NAME']);
-		$I->seeInField('_wp_convertkit_settings[post_form_position]', 'After content');
+		$I->seeInField('_wp_convertkit_settings[post_form_position]', 'After Post content');
 		$I->seeInField('_wp_convertkit_settings[non_inline_form]', $_ENV['CONVERTKIT_API_FORM_FORMAT_STICKY_BAR_NAME']);
 	}
 


### PR DESCRIPTION
## Summary

Adds an `After element` option when defining default form positions in the Plugin's settings, with an option to choose the element and the number of elements after which to insert the form.

Support for elements other than paragraphs to follow in future PR's.

Settings screen:

![Screenshot 2024-10-11 at 20 48 05](https://github.com/user-attachments/assets/ca02ea62-6bc4-4856-802d-fcade1fcbe77)

If the setting is not `After element`, the conditional options will not be displayed:

![Screenshot 2024-10-11 at 20 48 12](https://github.com/user-attachments/assets/d9e4946a-4769-4c16-9ddd-47d42fabe15a)

Example output of the form after a paragraph:

![Screenshot 2024-10-11 at 20 48 41](https://github.com/user-attachments/assets/d2c0c51c-6ac7-4b06-a400-968de7ac9f01)

## Testing

- `testChangeDefaultFormPositionAfterElementSetting `: Test that no PHP errors or notices are displayed on the Plugin's Setting screen, when the Default Form Position setting for Pages and Posts are changed to `After element`
- `testAddNewCPTUsingDefaultFormAfterElement `: Test that the Default Form specified in the Plugin Settings works when creating and viewing a new WordPress CPT, and its position is set to after the 3rd paragraph.
- `testAddNewPageUsingDefaultFormAfterElement `: Test that the Default Form specified in the Plugin Settings works when creating and viewing a new WordPress Page, and its position is set to after the 3rd paragraph.
- `testAddNewPostUsingDefaultFormAfterElement `: Test that the Default Form specified in the Plugin Settings works when creating and viewing a new WordPress Post, and its position is set to after the 3rd paragraph.
- `testAddNewCPTUsingDefaultFormAfterOutOfBoundsElement`: Test that the Default Form specified in the Plugin Settings works when creating and viewing a new WordPress CPT, appended to the end of the content, when the position is set to a number greater than the number of paragraph elements.
- `testAddNewPageUsingDefaultFormAfterOutOfBoundsElement`: Test that the Default Form specified in the Plugin Settings works when creating and viewing a new WordPress Page, appended to the end of the content, when the position is set to a number greater than the number of paragraph elements.
- `testAddNewPostUsingDefaultFormAfterOutOfBoundsElement`: Test that the Default Form specified in the Plugin Settings works when creating and viewing a new WordPress Post, appended to the end of the content, when the position is set to a number greater than the number of paragraph elements.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)