### PR TITLE
Support for Headings in `After Element` Form Positioning

### DIFF
--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -611,6 +611,11 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 			esc_attr( $this->settings->get_default_form_position_element( $args['post_type'] ) ),
 			array(
 				'p' => esc_html__( 'Paragraphs', 'convertkit' ),
+				'h2' => esc_html__( 'Headings <h2>', 'convertkit' ),
+				'h3' => esc_html__( 'Headings <h3>', 'convertkit' ),
+				'h4' => esc_html__( 'Headings <h4>', 'convertkit' ),
+				'h5' => esc_html__( 'Headings <h5>', 'convertkit' ),
+				'h6' => esc_html__( 'Headings <h6>', 'convertkit' ),
 			),
 			esc_html__( 'The number of elements before outputting the form.', 'convertkit' ),
 			array( 'after_element' )

--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -610,7 +610,7 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 			$args['post_type'] . '_form_position_element',
 			esc_attr( $this->settings->get_default_form_position_element( $args['post_type'] ) ),
 			array(
-				'p' => esc_html__( 'Paragraphs', 'convertkit' ),
+				'p'  => esc_html__( 'Paragraphs', 'convertkit' ),
 				'h2' => esc_html__( 'Headings <h2>', 'convertkit' ),
 				'h3' => esc_html__( 'Headings <h3>', 'convertkit' ),
 				'h4' => esc_html__( 'Headings <h4>', 'convertkit' ),

--- a/tests/_support/Helper/Acceptance/ConvertKitForms.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitForms.php
@@ -50,7 +50,17 @@ class ConvertKitForms extends \Codeception\Module
 				break;
 
 			case 'after_element':
-				$I->seeInSource('<' . $element . '>Item #' . $element_index . '</' . $element . '><form action="https://app.convertkit.com/forms/' . $formID . '/subscriptions" ');
+				// The block editor automatically adds CSS classes to some elements.
+				switch ( $element ) {
+					case 'p':
+						$I->seeInSource('<' . $element . '>Item #' . $element_index . '</' . $element . '><form action="https://app.convertkit.com/forms/' . $formID . '/subscriptions" ');
+						break;
+
+					// Headings.
+					default:
+						$I->seeInSource('<' . $element . ' class="wp-block-heading">Item #' . $element_index . '</' . $element . '><form action="https://app.convertkit.com/forms/' . $formID . '/subscriptions" ');
+						break;
+				}
 				break;
 		}
 	}

--- a/tests/_support/Helper/Acceptance/WPGutenberg.php
+++ b/tests/_support/Helper/Acceptance/WPGutenberg.php
@@ -368,4 +368,120 @@ class WPGutenberg extends \Codeception\Module
 		// Return URL from 'View page' button.
 		return $I->grabAttributeFrom('.post-publish-panel__postpublish-buttons a.components-button', 'href');
 	}
+
+	/**
+	 * Add a Page, Post or Custom Post Type directly to the WordPress database,
+	 * with dummy content used for testing.
+	 *
+	 * @since   2.6.2
+	 *
+	 * @param   AcceptanceTester $I                     Acceptance Tester.
+	 * @param   string           $postType              Post Type.
+	 * @param   string           $title                 Post Title.
+	 * @param   string           $formID                Meta Box `Form` value (-1: Default).
+	 */
+	public function addGutenbergPageToDatabase($I, $postType = 'page', $title = 'Gutenberg Title', $formID = '-1')
+	{
+		return $I->havePostInDatabase(
+			[
+				'post_title'   => $title,
+				'post_type'    => $postType,
+				'post_status'  => 'publish',
+				'meta_input'   => [
+					'_wp_convertkit_post_meta' => [
+						'form'         => $formID,
+						'landing_page' => '',
+						'tag'          => '',
+					],
+				],
+				'post_content' => '<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:paragraph -->
+<p>Item #1</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Item #1</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Item #2</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"id":4237,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="http://kit.local/wp-content/uploads/2022/05/iLRneK6yxY4WwQUdkkUMaq-122-683x1024.jpg" alt="Flowers" class="wp-image-4237"/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Item #2</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Item #3</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:image {"id":4240,"aspectRatio":"1","scale":"cover","sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full"><img src="http://kit.local/wp-content/uploads/2022/04/qM63x7vF3qN1whboGdEpuL-122.jpg" alt="MacBook Pro beside plant in vase" class="wp-image-4240" style="aspect-ratio:1;object-fit:cover"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">Item #1</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Item #4</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:heading {"level":4} -->
+<h4 class="wp-block-heading">Item #1</h4>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Item #5</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:heading {"level":5} -->
+<h5 class="wp-block-heading">Item #1</h5>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Item #6</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":6} -->
+<h6 class="wp-block-heading">Item #1</h6>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Item #7</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">Item #2</h3>
+<!-- /wp:heading -->
+
+<!-- wp:heading {"level":4} -->
+<h4 class="wp-block-heading">Item #2</h4>
+<!-- /wp:heading -->
+
+<!-- wp:heading {"level":5} -->
+<h5 class="wp-block-heading">Item #2</h5>
+<!-- /wp:heading -->
+
+<!-- wp:heading {"level":6} -->
+<h6 class="wp-block-heading">Item #2</h6>
+<!-- /wp:heading -->',
+			]
+		);
+	}
 }

--- a/tests/acceptance/forms/post-types/CPTFormCest.php
+++ b/tests/acceptance/forms/post-types/CPTFormCest.php
@@ -289,7 +289,7 @@ class CPTFormCest
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testAddNewCPTUsingDefaultFormAfterElement(AcceptanceTester $I)
+	public function testAddNewCPTUsingDefaultFormAfterParagraphElement(AcceptanceTester $I)
 	{
 		// Setup ConvertKit plugin with Default Form for CPTs set to be output after the 3rd paragraph of content.
 		$I->setupConvertKitPlugin(
@@ -303,30 +303,53 @@ class CPTFormCest
 		);
 		$I->setupConvertKitPluginResources($I);
 
-		// Add a CPT using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'article', 'Kit: CPT: Form: Default: After 3rd Paragraph Element');
+		// Setup Article with placeholder content.
+		$pageID = $I->addGutenbergPageToDatabase($I, 'article', 'Kit: CPT: Form: Default: After 3rd Paragraph Element');
 
-		// Add 5 paragraphs to CPT.
-		$I->addGutenbergParagraphBlock($I, 'Item #1');
-		$I->addGutenbergParagraphBlock($I, 'Item #2');
-		$I->addGutenbergParagraphBlock($I, 'Item #3');
-		$I->addGutenbergParagraphBlock($I, 'Item #4');
-		$I->addGutenbergParagraphBlock($I, 'Item #5');
+		// View the CPT on the frontend site.
+		$I->amOnPage('?p=' . $pageID);
 
-		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			[
-				'form' => [ 'select2', 'Default' ],
-			]
-		);
-
-		// Publish and view the CPT on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that one ConvertKit Form is output in the DOM after the third paragraph.
 		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_element', 'p', 3);
+	}
+
+	/**
+	 * Test that the Default Form specified in the Plugin Settings works when
+	 * creating and viewing a new WordPress CPT, and its position is set
+	 * to after the 2nd <h2> element.
+	 *
+	 * @since   2.6.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewCPTUsingDefaultFormAfterHeadingElement(AcceptanceTester $I)
+	{
+		// Setup ConvertKit plugin with Default Form for CPTs set to be output after the 2nd <h2> of content.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'article_form'                        => $_ENV['CONVERTKIT_API_FORM_ID'],
+				'article_form_position'               => 'after_element',
+				'article_form_position_element'       => 'h2',
+				'article_form_position_element_index' => 2,
+			]
+		);
+		$I->setupConvertKitPluginResources($I);
+
+		// Setup Article with placeholder content.
+		$pageID = $I->addGutenbergPageToDatabase($I, 'article', 'Kit: CPT: Form: Default: After 2nd H2 Element');
+
+		// View the CPT on the frontend site.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that one ConvertKit Form is output in the DOM after the second <h2> element.
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_element', 'h2', 2);
 	}
 
 	/**
@@ -347,30 +370,19 @@ class CPTFormCest
 				'article_form'                        => $_ENV['CONVERTKIT_API_FORM_ID'],
 				'article_form_position'               => 'after_element',
 				'article_form_position_element'       => 'p',
-				'article_form_position_element_index' => 7,
+				'article_form_position_element_index' => 9,
 			]
 		);
 		$I->setupConvertKitPluginResources($I);
 
-		// Add a CPT using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'article', 'Kit: CPT: Form: Default: After 7th Paragraph Element');
+		// Setup Article with placeholder content.
+		$pageID = $I->addGutenbergPageToDatabase($I, 'article', 'Kit: CPT: Form: Default: After 9th Paragraph Element');
 
-		// Add 5 paragraphs to CPT.
-		$I->addGutenbergParagraphBlock($I, 'Item #1');
-		$I->addGutenbergParagraphBlock($I, 'Item #2');
-		$I->addGutenbergParagraphBlock($I, 'Item #3');
+		// View the CPT on the frontend site.
+		$I->amOnPage('?p=' . $pageID);
 
-		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			[
-				'form' => [ 'select2', 'Default' ],
-			]
-		);
-
-		// Publish and view the CPT on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that one ConvertKit Form is output in the DOM after the content, as
 		// the number of paragraphs is less than the position.

--- a/tests/acceptance/forms/post-types/PageFormCest.php
+++ b/tests/acceptance/forms/post-types/PageFormCest.php
@@ -213,7 +213,7 @@ class PageFormCest
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testAddNewPageUsingDefaultFormAfterElement(AcceptanceTester $I)
+	public function testAddNewPageUsingDefaultFormAfterParagraphElement(AcceptanceTester $I)
 	{
 		// Setup ConvertKit plugin with Default Form for Pages set to be output after the 3rd paragraph of content.
 		$I->setupConvertKitPlugin(
@@ -227,30 +227,53 @@ class PageFormCest
 		);
 		$I->setupConvertKitPluginResources($I);
 
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Default: After 3rd Paragraph Element');
+		// Setup Page with placeholder content.
+		$pageID = $I->addGutenbergPageToDatabase($I, 'page', 'Kit: Page: Form: Default: After 3rd Paragraph Element');
 
-		// Add 5 paragraphs to Page.
-		$I->addGutenbergParagraphBlock($I, 'Item #1');
-		$I->addGutenbergParagraphBlock($I, 'Item #2');
-		$I->addGutenbergParagraphBlock($I, 'Item #3');
-		$I->addGutenbergParagraphBlock($I, 'Item #4');
-		$I->addGutenbergParagraphBlock($I, 'Item #5');
+		// View the Page on the frontend site.
+		$I->amOnPage('?p=' . $pageID);
 
-		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			[
-				'form' => [ 'select2', 'Default' ],
-			]
-		);
-
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that one ConvertKit Form is output in the DOM after the third paragraph.
 		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_element', 'p', 3);
+	}
+
+	/**
+	 * Test that the Default Form specified in the Plugin Settings works when
+	 * creating and viewing a new WordPress Page, and its position is set
+	 * to after the 2nd <h2> element.
+	 *
+	 * @since   2.6.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewPageUsingDefaultFormAfterHeadingElement(AcceptanceTester $I)
+	{
+		// Setup ConvertKit plugin with Default Form for Posts set to be output after the 2nd <h2> of content.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'page_form'                        => $_ENV['CONVERTKIT_API_FORM_ID'],
+				'page_form_position'               => 'after_element',
+				'page_form_position_element'       => 'h2',
+				'page_form_position_element_index' => 2,
+			]
+		);
+		$I->setupConvertKitPluginResources($I);
+
+		// Setup Page with placeholder content.
+		$pageID = $I->addGutenbergPageToDatabase($I, 'page', 'Kit: Page: Form: Default: After 2nd H2 Element');
+
+		// View the Post on the frontend site.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that one ConvertKit Form is output in the DOM after the second <h2> element.
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_element', 'h2', 2);
 	}
 
 	/**
@@ -271,30 +294,19 @@ class PageFormCest
 				'page_form'                        => $_ENV['CONVERTKIT_API_FORM_ID'],
 				'page_form_position'               => 'after_element',
 				'page_form_position_element'       => 'p',
-				'page_form_position_element_index' => 7,
+				'page_form_position_element_index' => 9,
 			]
 		);
 		$I->setupConvertKitPluginResources($I);
 
-		// Add a Page using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Default: After 7th Paragraph Element');
+		// Setup Page with placeholder content.
+		$pageID = $I->addGutenbergPageToDatabase($I, 'page', 'Kit: Page: Form: Default: After 9th Paragraph Element');
 
-		// Add 5 paragraphs to Page.
-		$I->addGutenbergParagraphBlock($I, 'Item #1');
-		$I->addGutenbergParagraphBlock($I, 'Item #2');
-		$I->addGutenbergParagraphBlock($I, 'Item #3');
+		// View the Page on the frontend site.
+		$I->amOnPage('?p=' . $pageID);
 
-		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			[
-				'form' => [ 'select2', 'Default' ],
-			]
-		);
-
-		// Publish and view the Page on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that one ConvertKit Form is output in the DOM after the content, as
 		// the number of paragraphs is less than the position.

--- a/tests/acceptance/forms/post-types/PostFormCest.php
+++ b/tests/acceptance/forms/post-types/PostFormCest.php
@@ -212,7 +212,7 @@ class PostFormCest
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testAddNewPostUsingDefaultFormAfterElement(AcceptanceTester $I)
+	public function testAddNewPostUsingDefaultFormAfterParagraphElement(AcceptanceTester $I)
 	{
 		// Setup ConvertKit plugin with Default Form for Posts set to be output after the 3rd paragraph of content.
 		$I->setupConvertKitPlugin(
@@ -226,30 +226,53 @@ class PostFormCest
 		);
 		$I->setupConvertKitPluginResources($I);
 
-		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Form: Default: After 3rd Paragraph Element');
+		// Setup Post with placeholder content.
+		$pageID = $I->addGutenbergPageToDatabase($I, 'post', 'Kit: Post: Form: Default: After 3rd Paragraph Element');
 
-		// Add 5 paragraphs to Post.
-		$I->addGutenbergParagraphBlock($I, 'Item #1');
-		$I->addGutenbergParagraphBlock($I, 'Item #2');
-		$I->addGutenbergParagraphBlock($I, 'Item #3');
-		$I->addGutenbergParagraphBlock($I, 'Item #4');
-		$I->addGutenbergParagraphBlock($I, 'Item #5');
+		// View the Post on the frontend site.
+		$I->amOnPage('?p=' . $pageID);
 
-		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			[
-				'form' => [ 'select2', 'Default' ],
-			]
-		);
-
-		// Publish and view the Post on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that one ConvertKit Form is output in the DOM after the third paragraph.
 		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_element', 'p', 3);
+	}
+
+	/**
+	 * Test that the Default Form specified in the Plugin Settings works when
+	 * creating and viewing a new WordPress Post, and its position is set
+	 * to after the 2nd <h2> element.
+	 *
+	 * @since   2.6.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddNewPostUsingDefaultFormAfterHeadingElement(AcceptanceTester $I)
+	{
+		// Setup ConvertKit plugin with Default Form for Posts set to be output after the 2nd <h2> of content.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'post_form'                        => $_ENV['CONVERTKIT_API_FORM_ID'],
+				'post_form_position'               => 'after_element',
+				'post_form_position_element'       => 'h2',
+				'post_form_position_element_index' => 2,
+			]
+		);
+		$I->setupConvertKitPluginResources($I);
+
+		// Setup Post with placeholder content.
+		$pageID = $I->addGutenbergPageToDatabase($I, 'post', 'Kit: Post: Form: Default: After 2nd H2 Element');
+
+		// View the Post on the frontend site.
+		$I->amOnPage('?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that one ConvertKit Form is output in the DOM after the second <h2> element.
+		$I->seeFormOutput($I, $_ENV['CONVERTKIT_API_FORM_ID'], 'after_element', 'h2', 2);
 	}
 
 	/**
@@ -270,30 +293,19 @@ class PostFormCest
 				'post_form'                        => $_ENV['CONVERTKIT_API_FORM_ID'],
 				'post_form_position'               => 'after_element',
 				'post_form_position_element'       => 'p',
-				'post_form_position_element_index' => 7,
+				'post_form_position_element_index' => 9,
 			]
 		);
 		$I->setupConvertKitPluginResources($I);
 
-		// Add a Post using the Gutenberg editor.
-		$I->addGutenbergPage($I, 'post', 'Kit: Post: Form: Default: After 7th Paragraph Element');
+		// Setup Post with placeholder content.
+		$pageID = $I->addGutenbergPageToDatabase($I, 'post', 'Kit: Post: Form: Default: After 9th Paragraph Element');
 
-		// Add 5 paragraphs to Post.
-		$I->addGutenbergParagraphBlock($I, 'Item #1');
-		$I->addGutenbergParagraphBlock($I, 'Item #2');
-		$I->addGutenbergParagraphBlock($I, 'Item #3');
+		// View the Post on the frontend site.
+		$I->amOnPage('?p=' . $pageID);
 
-		// Configure metabox's Form setting = Default.
-		$I->configureMetaboxSettings(
-			$I,
-			'wp-convertkit-meta-box',
-			[
-				'form' => [ 'select2', 'Default' ],
-			]
-		);
-
-		// Publish and view the Post on the frontend site.
-		$I->publishAndViewGutenbergPage($I);
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that one ConvertKit Form is output in the DOM after the content, as
 		// the number of paragraphs is less than the position.


### PR DESCRIPTION
## Summary

Extends https://github.com/ConvertKit/convertkit-wordpress/pull/723 to add support for `h2` through `h6` elements to position the default form after:

![Screenshot 2024-10-15 at 15 35 32](https://github.com/user-attachments/assets/6853e7fa-2676-460a-9e76-8a75021d3382)

The exclusion of `h1` is deliberate:
- For SEO, Pages should really only have a single `h1` element,
- Most Themes will output the Page / Post's title as a `h1` element. Including it as an option here may result in confusion as it will not be counted as the first element.

## Testing

Existing tests are renamed to identify what they test (i.e. paragraphs).

Added the `addGutenbergPageToDatabase` test helper, to create a WordPress Page / Post / CPT with placeholder content comprising of a number of different elements for the tests to ensure the form is appended to the correct element.

- `testAddNewPageUsingDefaultFormAfterHeadingElement`: Test that the Default Form specified in the Plugin Settings works when creating and viewing a new WordPress Page, and its position is set to after the 2nd `h2` element.
- `testAddNewPostUsingDefaultFormAfterHeadingElement`: Test that the Default Form specified in the Plugin Settings works when creating and viewing a new WordPress Post, and its position is set to after the 2nd `h2` element.
- `testAddNewCPTUsingDefaultFormAfterHeadingElement`: Test that the Default Form specified in the Plugin Settings works when creating and viewing a new WordPress Custom Post Type, and its position is set to after the 2nd `h2` element.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)