### PR TITLE
Broadcasts: `DISABLE_WP_CRON` notice

### DIFF
--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -326,6 +326,27 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 		<p class="description"><?php esc_html_e( 'Defines whether public broadcasts ("Enabled on public feeds") in Kit should automatically be published on this site as WordPress Posts, and whether to enable options to create draft Kit Broadcasts from WordPress Posts.', 'convertkit' ); ?></p>
 		<?php
 
+		// If the DISABLE_WP_CRON constant exists and is true, display a warning that this functionality
+		// may not work.
+		if ( defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON === true ) {
+			?>
+			<div class="notice notice-warning">
+				<p>
+					<?php
+					printf(
+						'%s %s %s %s %s',
+						esc_html__( 'We\'ve detected that the', 'convertkit' ),
+						'<code>DISABLE_WP_CRON</code>',
+						esc_html__( 'constant is enabled. If broadcasts do not import automatically or when using the import button below, either remove this constant from your', 'convertkit' ),
+						'<code>wp-config.php</code>',
+						esc_html__( 'file, or check with your web host if they have disabled your WordPress Cron. If importing broadcasts work, no changes to your WordPress configuration file are required.', 'convertkit' )
+					);
+					?>
+				</p>
+			</div>
+			<?php
+		}
+
 	}
 
 

--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -330,7 +330,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 		// may not work.
 		if ( defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON === true ) {
 			?>
-			<div class="notice notice-warning">
+			<div class="notice notice-info">
 				<p>
 					<?php
 					printf(
@@ -339,7 +339,7 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 						'<code>DISABLE_WP_CRON</code>',
 						esc_html__( 'constant is enabled. If broadcasts do not import automatically or when using the import button below, either remove this constant from your', 'convertkit' ),
 						'<code>wp-config.php</code>',
-						esc_html__( 'file, or check with your web host if they have disabled your WordPress Cron. If importing broadcasts work, no changes to your WordPress configuration file are required.', 'convertkit' )
+						esc_html__( 'file, or check that your web host is triggering the WordPress Cron via an alternate method. If importing broadcasts work, no changes to your WordPress configuration file are required.', 'convertkit' )
 					);
 					?>
 				</p>


### PR DESCRIPTION
## Summary

Adds a notice in the Broadcasts settings of the Plugin if the `DISABLE_WP_CRON` constant is detected. This was the reason for [this issue](https://linear.app/kit/issue/BCDC-3262/bcdc-latest-2-broadcast-posts-not-appearing-on-creators-wordpress-page), where broadcasts were not importing for the creator.

![Screenshot 2024-10-17 at 15 57 45](https://github.com/user-attachments/assets/6f5ac82b-f4c0-467b-8f17-2b9d667fabc7)

The WordPress Cron system is essential for importing broadcasts. Normally, it's triggered by site activity, such as visitors or user logins. However, some web hosts disable this default behavior by specifying the `DISABLE_WP_CRON` constant, opting instead to trigger it via crontab or similar methods (see more: https://help.dreamhost.com/hc/en-us/articles/360048323291-Disabling-WP-CRON-to-Improve-Overall-Site-Performance).

The notice prompts creators to either ensure that their host is handling WordPress Cron manually or to remove the `DISABLE_WP_CRON` constant if Cron is not being triggered.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)