### PR TITLE
Update tags to include Plugin in Block Directory

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Kit (formerly ConvertKit) - Email Newsletter, Email Marketing, Subscribers and Landing Pages ===
 Contributors: nathanbarry, growdev, travisnorthcutt, ggwicz
 Donate link: https://kit.com
-Tags: email marketing, email newsletter, newsletter, subscribers, membership
+Tags: email marketing, email newsletter, subscribers, block, form
 Requires at least: 5.0
 Tested up to: 6.6.2
 Requires PHP: 5.6.20


### PR DESCRIPTION
## Summary

Updates the readme.txt tags to include `block`, which appears to be a requirement for the Plugin to be listed in the [block directory](https://wordpress.org/documentation/article/block-directory/):

![Screenshot 2024-10-21 at 13 32 37](https://github.com/user-attachments/assets/3d27cfd4-49df-4593-99a1-5f8a876b9f3f)

There's a limit of 5 tags in the WordPress Plugin directory, so this PR removes `newsletter` and `subscribers` in favor of `block` and `form`, to see if this increases visibility in the block directory.  This can always be reverted at a later date, similar to our periodic optimizations to the readme file.

## Testing

No changes to code, so no tests performed.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)