### PR TITLE
Broadcasts: Import: Exclude polls

### DIFF
--- a/includes/class-convertkit-broadcasts-importer.php
+++ b/includes/class-convertkit-broadcasts-importer.php
@@ -314,8 +314,13 @@ class ConvertKit_Broadcasts_Importer {
 		}
 
 		// Remove ck-hide-in-public-posts and their contents.
-		// This includesthe unsubscribe section.
+		// This includes the unsubscribe section.
 		foreach ( $xpath->query( '//div[contains(@class, "ck-hide-in-public-posts")]' ) as $node ) {
+			$node->parentNode->removeChild( $node ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		}
+
+		// Remove ck-poll, as interacting with these results in an error.
+		foreach ( $xpath->query( '//table[contains(@class, "ck-poll")]' ) as $node ) {
 			$node->parentNode->removeChild( $node ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		}
 

--- a/tests/acceptance/broadcasts/import-export/BroadcastsToPostsCest.php
+++ b/tests/acceptance/broadcasts/import-export/BroadcastsToPostsCest.php
@@ -155,6 +155,9 @@ class BroadcastsToPostsCest
 		// Confirm unsubscribe link section has been removed.
 		$I->dontSee('<div class="ck-section ck-hide-in-public-posts"');
 
+		// Confirm poll block has been removed.
+		$I->dontSee('<table roll="presentation" class="ck-poll');
+
 		// Confirm published date matches the Broadcast.
 		$date = date('Y-m-d', strtotime($_ENV['CONVERTKIT_API_BROADCAST_FIRST_DATE'])) . 'T' . date('H:i:s', strtotime($_ENV['CONVERTKIT_API_BROADCAST_FIRST_DATE']));
 		$I->seeInSource('<time datetime="' . $date);


### PR DESCRIPTION
## Summary

Attempting to vote on a poll that is included in a Broadcast imported to a WordPress Post results in an error:

<img width="840" alt="Screenshot 2024-10-21 at 16 08 57" src="https://github.com/user-attachments/assets/9a9e6c25-62c8-4d6f-9205-c8002a89f54e">

This PR excludes polls from import.

## Testing

- Updated tests to confirm the table with CSS class `ck-poll` isn't included in the created WordPress Post.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)