### PR TITLE
Settings: Only display Form Settings if Forms exist

### DIFF
--- a/admin/section/class-convertkit-settings-general.php
+++ b/admin/section/class-convertkit-settings-general.php
@@ -271,6 +271,9 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 			$this->name
 		);
 
+		// Initialize resource classes and perform a refresh if this hasn't yet been done.
+		$this->maybe_initialize_and_refresh_resources();
+
 		foreach ( convertkit_get_supported_post_types() as $supported_post_type ) {
 			// Get Post Type's Label.
 			$post_type = get_post_type_object( $supported_post_type );
@@ -297,34 +300,39 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 					'post_type_object' => $post_type,
 				)
 			);
-			add_settings_field(
-				$supported_post_type . '_form_position',
-				sprintf(
-					/* translators: Post Type Name, plural */
-					__( 'Form Position (%s)', 'convertkit' ),
-					$post_type->label
-				),
-				array( $this, 'default_form_position_callback' ),
-				$this->settings_key,
-				$this->name,
-				array(
-					'label_for'        => '_wp_convertkit_settings_' . $supported_post_type . '_form_position',
-					'post_type'        => $supported_post_type,
-					'post_type_object' => $post_type,
-				)
-			);
-			add_settings_field(
-				$supported_post_type . '_form_position_element',
-				'',
-				array( $this, 'default_form_position_element_callback' ),
-				$this->settings_key,
-				$this->name,
-				array(
-					'label_for'        => '_wp_convertkit_settings_' . $supported_post_type . '_form_position_element',
-					'post_type'        => $supported_post_type,
-					'post_type_object' => $post_type,
-				)
-			);
+			
+			// Show Form settings only if Forms exist.
+			if ( $this->forms->exist() ) {
+				add_settings_field(
+					$supported_post_type . '_form_position',
+					sprintf(
+						/* translators: Post Type Name, plural */
+						__( 'Form Position (%s)', 'convertkit' ),
+						$post_type->label
+					),
+					array( $this, 'default_form_position_callback' ),
+					$this->settings_key,
+					$this->name,
+					array(
+						'label_for'        => '_wp_convertkit_settings_' . $supported_post_type . '_form_position',
+						'post_type'        => $supported_post_type,
+						'post_type_object' => $post_type,
+					)
+				);
+
+				add_settings_field(
+					$supported_post_type . '_form_position_element',
+					'',
+					array( $this, 'default_form_position_element_callback' ),
+					$this->settings_key,
+					$this->name,
+					array(
+						'label_for'        => '_wp_convertkit_settings_' . $supported_post_type . '_form_position_element',
+						'post_type'        => $supported_post_type,
+						'post_type_object' => $post_type,
+					)
+				);
+			}
 		}
 
 		add_settings_field(
@@ -485,9 +493,6 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 	 */
 	public function default_form_callback( $args ) {
 
-		// Initialize resource classes and perform a refresh if this hasn't yet been done.
-		$this->maybe_initialize_and_refresh_resources();
-
 		// Bail if no Forms exist.
 		if ( ! $this->forms->exist() ) {
 			esc_html_e( 'No Forms exist in Kit.', 'convertkit' );
@@ -632,9 +637,6 @@ class ConvertKit_Settings_General extends ConvertKit_Settings_Base {
 	 * @param   array $args  Field arguments.
 	 */
 	public function non_inline_form_callback( $args ) {
-
-		// Initialize resource classes and perform a refresh if this hasn't yet been done.
-		$this->maybe_initialize_and_refresh_resources();
 
 		// Bail if no non-inline Forms exist.
 		if ( ! $this->forms->non_inline_exist() ) {

--- a/tests/acceptance/general/PluginSettingsGeneralCest.php
+++ b/tests/acceptance/general/PluginSettingsGeneralCest.php
@@ -584,6 +584,42 @@ class PluginSettingsGeneralCest
 	}
 
 	/**
+	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
+	 * when using a Kit account with no resources, and that the applicable Form settings
+	 * fields do not display.
+	 *
+	 * @since   2.6.
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSettingsScreenWhenNoResources(AcceptanceTester $I)
+	{
+		// Setup Plugin using account that has no resources or data.
+		$I->setupConvertKitPluginCredentialsNoData($I);
+
+		// Go to the Plugin's Settings Screen.
+		$I->loadConvertKitSettingsGeneralScreen($I);
+
+		// Confirm 'No Forms exist in Kit' message displays.
+		$I->see('No Forms exist in Kit.');
+		$I->see('Click here to create your first form');
+		$I->seeInSource('<a href="https://app.kit.com/forms/new/?utm_source=wordpress&amp;utm_term=en_US&amp;utm_content=convertkit" target="_blank">');
+
+		// Confirm no Form settings are displayed for Pages or Posts.
+		$I->dontSeeElementInDOM('#_wp_convertkit_settings_page_form');
+		$I->dontSeeElementInDOM('#_wp_convertkit_settings_page_form_position');
+		$I->dontSeeElementInDOM('#_wp_convertkit_settings_page_form_position_element');
+		$I->dontSeeElementInDOM('#_wp_convertkit_settings_page_form_position_element_index');
+		$I->dontSeeElementInDOM('#_wp_convertkit_settings_post_form');
+		$I->dontSeeElementInDOM('#_wp_convertkit_settings_post_form_position');
+		$I->dontSeeElementInDOM('#_wp_convertkit_settings_post_form_position_element');
+		$I->dontSeeElementInDOM('#_wp_convertkit_settings_post_form_position_element_index');
+
+		// Confirm no Form settings are displayed for non-inline Forms.
+		$I->dontSeeElementInDOM('#_wp_convertkit_settings_non_inline_form');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/acceptance/general/PluginSettingsGeneralCest.php
+++ b/tests/acceptance/general/PluginSettingsGeneralCest.php
@@ -588,7 +588,7 @@ class PluginSettingsGeneralCest
 	 * when using a Kit account with no resources, and that the applicable Form settings
 	 * fields do not display.
 	 *
-	 * @since   2.6.
+	 * @since   2.6.3
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */


### PR DESCRIPTION
## Summary

Only displays the `Form Position` setting if Forms exist on the Kit account.

Before:
![Screenshot 2024-10-25 at 16 58 29](https://github.com/user-attachments/assets/c8a62a2e-9653-4f79-9165-cd0b5ff100a7)

After:
![Screenshot 2024-10-25 at 16 58 10](https://github.com/user-attachments/assets/e6818206-78c7-4103-a1b8-ce3a3e3e76a1)

## Testing

- `testSettingsScreenWhenNoResources`: Test that Form setting options are not displayed when no Forms exist.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)