### PR TITLE
Fix `Add Tag` Functionality

### DIFF
--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -112,8 +112,8 @@ class ConvertKit_Output {
 			$this->settings = new ConvertKit_Settings();
 		}
 
-		// Bail if the API if an API Key and Secret is not defined.
-		if ( ! $this->settings->has_api_key_and_secret() ) {
+		// Bail if the API hasn't been configured.
+		if ( ! $this->settings->has_access_and_refresh_token() ) {
 			return;
 		}
 

--- a/includes/class-convertkit-settings.php
+++ b/includes/class-convertkit-settings.php
@@ -162,7 +162,8 @@ class ConvertKit_Settings {
 	 */
 	public function has_api_key_and_secret() {
 
-		return $this->has_api_key() && $this->has_api_secret();
+		// Use check for access and refresh token.
+		return $this->has_access_and_refresh_token();
 
 	}
 

--- a/includes/class-convertkit-settings.php
+++ b/includes/class-convertkit-settings.php
@@ -162,6 +162,8 @@ class ConvertKit_Settings {
 	 */
 	public function has_api_key_and_secret() {
 
+		_deprecated_function( __FUNCTION__, '2.6.3', 'has_access_and_refresh_token()' );
+
 		// Use check for access and refresh token.
 		return $this->has_access_and_refresh_token();
 

--- a/tests/_support/Helper/Acceptance/ConvertKitPlugin.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitPlugin.php
@@ -60,9 +60,6 @@ class ConvertKitPlugin extends \Codeception\Module
 	{
 		// Define default options.
 		$defaults = [
-			// API Key and Secret retained for testing Legacy Forms and Landing Pages.
-			'api_key'         => $_ENV['CONVERTKIT_API_KEY'],
-			'api_secret'      => $_ENV['CONVERTKIT_API_SECRET'],
 			'access_token'    => $_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
 			'refresh_token'   => $_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN'],
 			'debug'           => 'on',
@@ -99,8 +96,6 @@ class ConvertKitPlugin extends \Codeception\Module
 		$I->setupConvertKitPlugin(
 			$I,
 			[
-				'api_key'       => $_ENV['CONVERTKIT_API_KEY_NO_DATA'],
-				'api_secret'    => $_ENV['CONVERTKIT_API_SECRET_NO_DATA'],
 				'access_token'  => $_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN_NO_DATA'],
 				'refresh_token' => $_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN_NO_DATA'],
 				'post_form'     => '',

--- a/tests/acceptance/forms/blocks-shortcodes/PageBlockFormCest.php
+++ b/tests/acceptance/forms/blocks-shortcodes/PageBlockFormCest.php
@@ -70,8 +70,17 @@ class PageBlockFormCest
 	 */
 	public function testFormBlockWithValidLegacyFormParameter(AcceptanceTester $I)
 	{
-		// Setup Plugin and Resources.
-		$I->setupConvertKitPlugin($I);
+		// Setup Plugin with API Key and Secret, which is required for Legacy Forms to work.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'api_key'      => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret'   => $_ENV['CONVERTKIT_API_SECRET'],
+				'post_form'    => '',
+				'page_form'    => '',
+				'product_form' => '',
+			]
+		);
 		$I->setupConvertKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.

--- a/tests/acceptance/forms/blocks-shortcodes/PageShortcodeFormCest.php
+++ b/tests/acceptance/forms/blocks-shortcodes/PageShortcodeFormCest.php
@@ -261,8 +261,17 @@ class PageShortcodeFormCest
 	 */
 	public function testFormShortcodeWithValidLegacyFormParameter(AcceptanceTester $I)
 	{
-		// Setup Plugin.
-		$I->setupConvertKitPluginNoDefaultForms($I); // Don't specify default forms.
+		// Setup Plugin with API Key and Secret, which is required for Legacy Forms to work.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'api_key'      => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret'   => $_ENV['CONVERTKIT_API_SECRET'],
+				'post_form'    => '',
+				'page_form'    => '',
+				'product_form' => '',
+			]
+		);
 		$I->setupConvertKitPluginResources($I);
 
 		// Create Page with Shortcode.
@@ -325,8 +334,17 @@ class PageShortcodeFormCest
 	 */
 	public function testFormShortcodeWithValidLegacyFormShortcodeFromConvertKitApp(AcceptanceTester $I)
 	{
-		// Setup Plugin.
-		$I->setupConvertKitPluginNoDefaultForms($I); // Don't specify default forms.
+		// Setup Plugin with API Key and Secret, which is required for Legacy Forms to work.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'api_key'      => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret'   => $_ENV['CONVERTKIT_API_SECRET'],
+				'post_form'    => '',
+				'page_form'    => '',
+				'product_form' => '',
+			]
+		);
 		$I->setupConvertKitPluginResources($I);
 
 		// Create Page with Shortcode.

--- a/tests/acceptance/forms/general/EditFormLinkCest.php
+++ b/tests/acceptance/forms/general/EditFormLinkCest.php
@@ -159,6 +159,15 @@ class EditFormLinkCest
 	 */
 	public function testEditFormLinkOnPageWithLegacyForm(AcceptanceTester $I)
 	{
+		// Setup Plugin with API Key and Secret, which is required for Legacy Forms to work.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+			]
+		);
+
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage($I, 'page', 'Kit: Page: Form: Legacy: Edit Link');
 

--- a/tests/acceptance/forms/general/WidgetFormCest.php
+++ b/tests/acceptance/forms/general/WidgetFormCest.php
@@ -42,6 +42,17 @@ class WidgetFormCest
 	 */
 	public function testLegacyFormWidgetWithValidFormParameter(AcceptanceTester $I)
 	{
+		// Setup Plugin with API Key and Secret, which is required for Legacy Forms to work.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+				'page_form'  => '',
+				'post_form'  => '',
+			]
+		);
+
 		// Add legacy widget, setting the Form setting to the value specified in the .env file.
 		$I->addLegacyWidget(
 			$I,
@@ -69,6 +80,17 @@ class WidgetFormCest
 	 */
 	public function testLegacyFormWidgetWithValidLegacyFormParameter(AcceptanceTester $I)
 	{
+		// Setup Plugin with API Key and Secret, which is required for Legacy Forms to work.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+				'page_form'  => '',
+				'post_form'  => '',
+			]
+		);
+
 		// Add legacy widget, setting the Form setting to the value specified in the .env file.
 		$I->addLegacyWidget(
 			$I,
@@ -118,6 +140,17 @@ class WidgetFormCest
 	 */
 	public function testBlockFormBlockWithValidLegacyFormParameter(AcceptanceTester $I)
 	{
+		// Setup Plugin with API Key and Secret, which is required for Legacy Forms to work.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+				'page_form'  => '',
+				'post_form'  => '',
+			]
+		);
+
 		// Add block widget, setting the Form setting to the value specified in the .env file.
 		$I->addBlockWidget(
 			$I,

--- a/tests/acceptance/forms/post-types/CPTFormCest.php
+++ b/tests/acceptance/forms/post-types/CPTFormCest.php
@@ -435,7 +435,7 @@ class CPTFormCest
 	 */
 	public function testAddNewCPTUsingDefaultLegacyForm(AcceptanceTester $I)
 	{
-		// Setup Plugin, without defining default Forms.
+		// Setup Plugin with API Key and Secret, which is required for Legacy Forms to work.
 		$I->setupConvertKitPlugin(
 			$I,
 			[
@@ -552,7 +552,7 @@ class CPTFormCest
 	 */
 	public function testAddNewCPTUsingDefinedLegacyForm(AcceptanceTester $I)
 	{
-		// Setup ConvertKit Plugin.
+		// Setup Plugin with API Key and Secret, which is required for Legacy Forms to work.
 		$I->setupConvertKitPlugin(
 			$I,
 			[

--- a/tests/acceptance/forms/post-types/CPTFormCest.php
+++ b/tests/acceptance/forms/post-types/CPTFormCest.php
@@ -439,6 +439,8 @@ class CPTFormCest
 		$I->setupConvertKitPlugin(
 			$I,
 			[
+				'api_key'      => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret'   => $_ENV['CONVERTKIT_API_SECRET'],
 				'article_form' => $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
 			]
 		);
@@ -554,7 +556,9 @@ class CPTFormCest
 		$I->setupConvertKitPlugin(
 			$I,
 			[
-				'article_form' => $_ENV['CONVERTKIT_API_FORM_ID'],
+				'api_key'      => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret'   => $_ENV['CONVERTKIT_API_SECRET'],
+				'article_form' => '',
 			]
 		);
 		$I->setupConvertKitPluginResources($I);

--- a/tests/acceptance/forms/post-types/PageFormCest.php
+++ b/tests/acceptance/forms/post-types/PageFormCest.php
@@ -327,9 +327,9 @@ class PageFormCest
 		$I->setupConvertKitPlugin(
 			$I,
 			[
-				'page_form'    => $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
-				'post_form'    => '',
-				'product_form' => '',
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+				'page_form'  => $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
 			]
 		);
 		$I->setupConvertKitPluginResources($I);
@@ -714,7 +714,14 @@ class PageFormCest
 	public function testAddNewPageUsingDefinedLegacyForm(AcceptanceTester $I)
 	{
 		// Setup ConvertKit plugin.
-		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+				'page_form'  => '',
+			]
+		);
 		$I->setupConvertKitPluginResources($I);
 
 		// Add a Page using the Gutenberg editor.

--- a/tests/acceptance/forms/post-types/PageFormCest.php
+++ b/tests/acceptance/forms/post-types/PageFormCest.php
@@ -323,7 +323,7 @@ class PageFormCest
 	 */
 	public function testAddNewPageUsingDefaultLegacyForm(AcceptanceTester $I)
 	{
-		// Setup ConvertKit plugin to use legacy Form as default for Pages.
+		// Setup Plugin with API Key and Secret, which is required for Legacy Forms to work.
 		$I->setupConvertKitPlugin(
 			$I,
 			[
@@ -713,7 +713,7 @@ class PageFormCest
 	 */
 	public function testAddNewPageUsingDefinedLegacyForm(AcceptanceTester $I)
 	{
-		// Setup ConvertKit plugin.
+		// Setup Plugin with API Key and Secret, which is required for Legacy Forms to work.
 		$I->setupConvertKitPlugin(
 			$I,
 			[

--- a/tests/acceptance/forms/post-types/PostFormCest.php
+++ b/tests/acceptance/forms/post-types/PostFormCest.php
@@ -362,9 +362,9 @@ class PostFormCest
 		$I->setupConvertKitPlugin(
 			$I,
 			[
-				'page_form'    => '',
-				'post_form'    => $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
-				'product_form' => '',
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+				'post_form'  => $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
 			]
 		);
 		$I->setupConvertKitPluginResources($I);
@@ -466,7 +466,14 @@ class PostFormCest
 	public function testAddNewPostUsingDefinedLegacyForm(AcceptanceTester $I)
 	{
 		// Setup ConvertKit Plugin.
-		$I->setupConvertKitPlugin($I);
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+				'post_form'  => '',
+			]
+		);
 		$I->setupConvertKitPluginResources($I);
 
 		// Add a Post using the Gutenberg editor.

--- a/tests/acceptance/forms/post-types/PostFormCest.php
+++ b/tests/acceptance/forms/post-types/PostFormCest.php
@@ -358,7 +358,7 @@ class PostFormCest
 	 */
 	public function testAddNewPostUsingDefaultLegacyForm(AcceptanceTester $I)
 	{
-		// Setup Plugin, without defining default Forms.
+		// Setup Plugin with API Key and Secret, which is required for Legacy Forms to work.
 		$I->setupConvertKitPlugin(
 			$I,
 			[
@@ -465,7 +465,7 @@ class PostFormCest
 	 */
 	public function testAddNewPostUsingDefinedLegacyForm(AcceptanceTester $I)
 	{
-		// Setup ConvertKit Plugin.
+		// Setup Plugin with API Key and Secret, which is required for Legacy Forms to work.
 		$I->setupConvertKitPlugin(
 			$I,
 			[

--- a/tests/acceptance/integrations/other/DiviFormCest.php
+++ b/tests/acceptance/integrations/other/DiviFormCest.php
@@ -152,8 +152,17 @@ class DiviFormCest
 	 */
 	public function testFormModuleWithValidLegacyFormParameter(AcceptanceTester $I)
 	{
-		// Setup Plugin, without defining default Forms.
-		$I->setupConvertKitPluginNoDefaultForms($I);
+		// Setup Plugin with API Key and Secret, which is required for Legacy Forms to work.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'api_key'      => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret'   => $_ENV['CONVERTKIT_API_SECRET'],
+				'post_form'    => '',
+				'page_form'    => '',
+				'product_form' => '',
+			]
+		);
 		$I->setupConvertKitPluginResources($I);
 
 		// Create Page with Form module in Divi.

--- a/tests/acceptance/integrations/other/ElementorFormCest.php
+++ b/tests/acceptance/integrations/other/ElementorFormCest.php
@@ -78,6 +78,18 @@ class ElementorFormCest
 	 */
 	public function testFormWidgetWithValidLegacyFormParameter(AcceptanceTester $I)
 	{
+		// Setup Plugin with API Key and Secret, which is required for Legacy Forms to work.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'api_key'      => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret'   => $_ENV['CONVERTKIT_API_SECRET'],
+				'post_form'    => '',
+				'page_form'    => '',
+				'product_form' => '',
+			]
+		);
+
 		// Create Page with Form widget in Elementor.
 		$pageID = $this->_createPageWithFormWidget($I, 'Kit: Legacy Form: Elementor Widget: Valid Form Param', $_ENV['CONVERTKIT_API_LEGACY_FORM_ID']);
 


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://linear.app/kit/issue/BCDC-3064/tag-not-being-applies-when-subscribers-click-to-wp-site), due to the `maybe_tag_subscriber` method checking for an API Key and Secret, instead of an Access and Refresh Token.

There are no other calls to `has_api_key_and_secret`, and this PR sets the `has_api_key_and_secret` method to deprecated, with it calling `has_access_and_refresh_token` and logging/displaying (depending on WordPress configuration) a notice for developers who might still be relying on this method:

![Screenshot 2024-10-28 at 11 35 21](https://github.com/user-attachments/assets/65690c1a-af95-4e19-8c79-0b9752d3e53b)

In the future, it's best to remove the `has_api_key_and_secret` method entirely, now it's no longer used. 

## Testing

Tests failed to pick this up, as all tests would pre-populate the Plugin settings data in the database with an API Key and Secret, therefore ensuring that the `has_api_key_and_secret` condition passes.

Removed pre-populating the Plugin settings data in the database with an API Key and Secret.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)