### PR TITLE
Broadcasts: Import Images

### DIFF
--- a/admin/class-convertkit-admin-settings.php
+++ b/admin/class-convertkit-admin-settings.php
@@ -108,6 +108,13 @@ class ConvertKit_Admin_Settings {
 	 */
 	public function add_settings_page() {
 
+		// Refresh Posts Resource.
+		/*
+		$posts  = new ConvertKit_Resource_Posts( 'cron' );
+		$result = $posts->refresh();
+		die('Finished');
+		*/
+
 		add_options_page(
 			__( 'Kit', 'convertkit' ),
 			__( 'Kit', 'convertkit' ),

--- a/admin/class-convertkit-admin-settings.php
+++ b/admin/class-convertkit-admin-settings.php
@@ -108,13 +108,6 @@ class ConvertKit_Admin_Settings {
 	 */
 	public function add_settings_page() {
 
-		// Refresh Posts Resource.
-		/*
-		$posts  = new ConvertKit_Resource_Posts( 'cron' );
-		$result = $posts->refresh();
-		die('Finished');
-		*/
-
 		add_options_page(
 			__( 'Kit', 'convertkit' ),
 			__( 'Kit', 'convertkit' ),

--- a/admin/section/class-convertkit-admin-settings-broadcasts.php
+++ b/admin/section/class-convertkit-admin-settings-broadcasts.php
@@ -274,6 +274,20 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 		);
 
 		add_settings_field(
+			'import_images',
+			__( 'Import Images', 'convertkit' ),
+			array( $this, 'import_images_callback' ),
+			$this->settings_key,
+			$this->name,
+			array(
+				'name'        => 'import_images',
+				'label_for'   => 'import_images',
+				'label'       => __( 'If enabled, the imported Broadcast\'s inline images will be stored in the Media Library, instead of served by Kit.', 'convertkit' ),
+				'description' => '',
+			)
+		);
+
+		add_settings_field(
 			'published_at_min_date',
 			__( 'Earliest Date', 'convertkit' ),
 			array( $this, 'date_callback' ),
@@ -510,6 +524,29 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 	}
 
 	/**
+	 * Renders the input for the Import Images setting.
+	 *
+	 * @since   2.6.3
+	 *
+	 * @param   array $args   Setting field arguments (name,description).
+	 */
+	public function import_images_callback( $args ) {
+
+		// Output field.
+		echo $this->get_checkbox_field( // phpcs:ignore WordPress.Security.EscapeOutput
+			$args['name'],
+			'on',
+			$this->settings->import_images(), // phpcs:ignore WordPress.Security.EscapeOutput
+			$args['label'],  // phpcs:ignore WordPress.Security.EscapeOutput
+			$args['description'], // phpcs:ignore WordPress.Security.EscapeOutput
+			array(
+				'enabled',
+			)
+		);
+
+	}
+
+	/**
 	 * Renders the input for the date setting.
 	 *
 	 * @since   2.2.9
@@ -583,6 +620,13 @@ class ConvertKit_Admin_Settings_Broadcasts extends ConvertKit_Settings_Base {
 		// Therefore, if the setting doesn't exist, set it to blank.
 		if ( ! array_key_exists( 'import_thumbnail', $settings ) ) {
 			$settings['import_thumbnail'] = '';
+		}
+
+		// If the 'Include Images' setting isn't checked, it won't be included
+		// in the array of settings, and the defaults will enable this.
+		// Therefore, if the setting doesn't exist, set it to blank.
+		if ( ! array_key_exists( 'import_images', $settings ) ) {
+			$settings['import_images'] = '';
 		}
 
 		// Merge settings with defaults.

--- a/includes/class-convertkit-broadcasts-importer.php
+++ b/includes/class-convertkit-broadcasts-importer.php
@@ -59,7 +59,7 @@ class ConvertKit_Broadcasts_Importer {
 
 		// Initialize required classes.
 		$this->broadcasts_settings = new ConvertKit_Settings_Broadcasts();
-		$this->media_library 	   = new ConvertKit_Media_Library();
+		$this->media_library       = new ConvertKit_Media_Library();
 		$settings                  = new ConvertKit_Settings();
 		$log                       = new ConvertKit_Log( CONVERTKIT_PLUGIN_PATH );
 
@@ -299,7 +299,7 @@ class ConvertKit_Broadcasts_Importer {
 
 	/**
 	 * Parses the given Broadcast's content, removing unnecessary HTML tags and styles.
-	 * 
+	 *
 	 * If 'Import Images' is enabled in the Plugin settings, imports images to the
 	 * Media Library, replacing the <img> `src` with the WordPress Media Library
 	 * Image URL.
@@ -307,7 +307,7 @@ class ConvertKit_Broadcasts_Importer {
 	 * @since   2.2.9
 	 *
 	 * @param   string $broadcast_content  Broadcast Content.
-	 * @param   int    $post_id 		   WordPress Post ID.
+	 * @param   int    $post_id            WordPress Post ID.
 	 * @return  string                     Parsed Content.
 	 */
 	private function parse_broadcast_content( $broadcast_content, $post_id ) {
@@ -355,7 +355,6 @@ class ConvertKit_Broadcasts_Importer {
 		// If the Import Images setting is enabled, iterate through all images within the Broadcast, importing them and changing their
 		// URLs to the WordPress Media Library hosted versions.
 		if ( $this->broadcasts_settings->import_images() ) {
-			
 
 			foreach ( $xpath->query( '//img' ) as $node ) {
 				$image = array(
@@ -382,9 +381,14 @@ class ConvertKit_Broadcasts_Importer {
 				}
 
 				// Get image URL from Media Library.
-				$image_url = wp_get_attachment_image( $image_id, 'full', false, array(
-					'alt' => $image['alt'],
-				) );
+				$image_url = wp_get_attachment_image(
+					$image_id,
+					'full',
+					false,
+					array(
+						'alt' => $image['alt'],
+					)
+				);
 
 				// Replace this image's `src` attribute with the Media Library Image URL.
 				$node->setAttribute( 'src', $image_url );

--- a/includes/class-convertkit-broadcasts-importer.php
+++ b/includes/class-convertkit-broadcasts-importer.php
@@ -347,7 +347,7 @@ class ConvertKit_Broadcasts_Importer {
 		}
 
 		// Remove ck-hide-in-public-posts and their contents.
-		// This includesthe unsubscribe section.
+		// This includes the unsubscribe section.
 		foreach ( $xpath->query( '//div[contains(@class, "ck-hide-in-public-posts")]' ) as $node ) {
 			$node->parentNode->removeChild( $node ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		}

--- a/includes/class-convertkit-broadcasts-importer.php
+++ b/includes/class-convertkit-broadcasts-importer.php
@@ -363,8 +363,8 @@ class ConvertKit_Broadcasts_Importer {
 
 			foreach ( $xpath->query( '//img' ) as $node ) {
 				$image = array(
-					'src' => $node->getAttribute( 'src' ),
-					'alt' => $node->getAttribute( 'alt' ),
+					'src' => $node->getAttribute( 'src' ), // @phpstan-ignore-line
+					'alt' => $node->getAttribute( 'alt' ), // @phpstan-ignore-line
 				);
 
 				// Skip if this image isn't served from https://embed.filekitcdn.com, as it isn't
@@ -392,7 +392,7 @@ class ConvertKit_Broadcasts_Importer {
 				);
 
 				// Replace this image's `src` attribute with the Media Library Image URL.
-				$node->setAttribute( 'src', $image_url[0] );
+				$node->setAttribute( 'src', $image_url[0] ); // @phpstan-ignore-line
 			}
 		}
 

--- a/includes/class-convertkit-broadcasts-importer.php
+++ b/includes/class-convertkit-broadcasts-importer.php
@@ -381,17 +381,13 @@ class ConvertKit_Broadcasts_Importer {
 				}
 
 				// Get image URL from Media Library.
-				$image_url = wp_get_attachment_image(
+				$image_url = wp_get_attachment_image_src(
 					$image_id,
-					'full',
-					false,
-					array(
-						'alt' => $image['alt'],
-					)
+					'full'
 				);
 
 				// Replace this image's `src` attribute with the Media Library Image URL.
-				$node->setAttribute( 'src', $image_url );
+				$node->setAttribute( 'src', $image_url[0] );
 			}
 		}
 

--- a/includes/class-convertkit-settings-broadcasts.php
+++ b/includes/class-convertkit-settings-broadcasts.php
@@ -138,6 +138,19 @@ class ConvertKit_Settings_Broadcasts {
 	}
 
 	/**
+	 * Returns whether to import the thumbnail to the Featured Image.
+	 *
+	 * @since   2.6.3
+	 *
+	 * @return  bool
+	 */
+	public function import_images() {
+
+		return ( $this->settings['import_images'] === 'on' ? true : false );
+
+	}
+
+	/**
 	 * Returns the earliest date that Broadcasts should be imported,
 	 * based on their published_at date.
 	 *
@@ -220,6 +233,7 @@ class ConvertKit_Settings_Broadcasts {
 			'post_status'           => 'publish',
 			'category_id'           => '',
 			'import_thumbnail'      => 'on',
+			'import_images'         => '',
 
 			// By default, only import Broadcasts as Posts for the last 30 days.
 			'published_at_min_date' => gmdate( 'Y-m-d', strtotime( '-30 days' ) ),

--- a/tests/_support/Helper/Acceptance/ConvertKitBroadcasts.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitBroadcasts.php
@@ -28,6 +28,7 @@ class ConvertKitBroadcasts extends \Codeception\Module
 				switch ( $key ) {
 					case 'enabled':
 					case 'import_thumbnail':
+					case 'import_images':
 					case 'enabled_export':
 					case 'no_styles':
 						if ( $value ) {

--- a/tests/acceptance/broadcasts/import-export/BroadcastsToPostsCest.php
+++ b/tests/acceptance/broadcasts/import-export/BroadcastsToPostsCest.php
@@ -472,6 +472,66 @@ class BroadcastsToPostsCest
 	}
 
 	/**
+	 * Tests that Broadcasts import with inline images copied to WordPress when the Import Images
+	 * option is enabled.
+	 *
+	 * @since   2.6.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testBroadcastsImportWithImportImagesEnabled(AcceptanceTester $I)
+	{
+		// Enable Broadcasts to Posts.
+		$I->setupConvertKitPluginBroadcasts(
+			$I,
+			[
+				'enabled'               => true,
+				'import_thumbnail'      => false,
+				'import_images'         => true,
+				'published_at_min_date' => '01/01/2020',
+			]
+		);
+
+		// Run the WordPress Cron event to import Broadcasts to WordPress Posts.
+		$I->runCronEvent($I, $this->cronEventName);
+
+		// Wait a few seconds for the Cron event to complete importing Broadcasts.
+		$I->wait(7);
+
+		// Load the Posts screen.
+		$I->amOnAdminPage('edit.php');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm expected Broadcasts exist as Posts.
+		$I->see($_ENV['CONVERTKIT_API_BROADCAST_FIRST_TITLE']);
+		$I->see($_ENV['CONVERTKIT_API_BROADCAST_SECOND_TITLE']);
+		$I->see($_ENV['CONVERTKIT_API_BROADCAST_THIRD_TITLE']);
+
+		// Get created Post IDs.
+		$postIDs = [
+			(int) str_replace('post-', '', $I->grabAttributeFrom('tbody#the-list > tr:nth-child(2)', 'id')),
+			(int) str_replace('post-', '', $I->grabAttributeFrom('tbody#the-list > tr:nth-child(3)', 'id')),
+			(int) str_replace('post-', '', $I->grabAttributeFrom('tbody#the-list > tr:nth-child(4)', 'id')),
+		];
+
+		// Set cookie with signed subscriber ID, so Member Content broadcasts can be viewed.
+		$I->setCookie('ck_subscriber_id', $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID']);
+
+		// View the first post.
+		$I->amOnPage('?p=' . $postIDs[0]);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm no images are served from Kit's CDN, and they are served from the WordPress Media Library
+		// (uploads folder).
+		$I->dontSeeInSource('embed.filekitcdn.com');
+		$I->seeInSource($_ENV['TEST_SITE_WP_URL'] . '/wp-content/uploads/2023/08');
+	}
+
+	/**
 	 * Tests that Broadcasts do not import when enabled in the Plugin's settings
 	 * and an Earliest Date is specified that is newer than any Broadcasts sent
 	 * on the ConvertKit account.

--- a/tests/acceptance/broadcasts/import-export/BroadcastsToPostsSettingsCest.php
+++ b/tests/acceptance/broadcasts/import-export/BroadcastsToPostsSettingsCest.php
@@ -41,6 +41,7 @@ class BroadcastsToPostsSettingsCest
 		$I->seeInSource('<label for="author_id">');
 		$I->seeInSource('<label for="category_id">');
 		$I->seeInSource('<label for="import_thumbnail">');
+		$I->seeInSource('<label for="import_images">');
 		$I->seeInSource('<label for="published_at_min_date">');
 		$I->seeInSource('<label for="no_styles">');
 	}
@@ -80,6 +81,7 @@ class BroadcastsToPostsSettingsCest
 		$I->seeElement('span[aria-labelledby="select2-_wp_convertkit_settings_broadcasts_author_id-container"]');
 		$I->seeElement('span[aria-labelledby="select2-_wp_convertkit_settings_broadcasts_category_id-container"]');
 		$I->seeElement('input#import_thumbnail');
+		$I->seeElement('input#import_images');
 		$I->seeElement('div.convertkit-select2-container');
 		$I->seeElement('input#published_at_min_date');
 
@@ -105,6 +107,7 @@ class BroadcastsToPostsSettingsCest
 		$I->dontSeeElement('span[aria-labelledby="select2-_wp_convertkit_settings_broadcasts_author_id-container"]');
 		$I->dontSeeElement('span[aria-labelledby="select2-_wp_convertkit_settings_broadcasts_category_id-container"]');
 		$I->dontSeeElement('input#import_thumbnail');
+		$I->dontSeeElement('input#import_images');
 		$I->dontSeeElement('input#published_at_min_date');
 
 		// Check the next import date and time is not displayed.
@@ -129,6 +132,7 @@ class BroadcastsToPostsSettingsCest
 		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_broadcasts_author_id-container', 'admin');
 		$I->fillSelect2Field($I, '#select2-_wp_convertkit_settings_broadcasts_category_id-container', 'Kit Broadcasts to Posts');
 		$I->checkOption('#import_thumbnail');
+		$I->checkOption('#import_images');
 		$I->fillField('_wp_convertkit_settings_broadcasts[published_at_min_date]', '01/01/2023');
 		$I->checkOption('#enabled_export');
 		$I->checkOption('#no_styles');
@@ -145,6 +149,7 @@ class BroadcastsToPostsSettingsCest
 		$I->seeInField('_wp_convertkit_settings_broadcasts[author_id]', 'admin');
 		$I->seeInField('_wp_convertkit_settings_broadcasts[category_id]', 'Kit Broadcasts to Posts');
 		$I->seeCheckboxIsChecked('#import_thumbnail');
+		$I->seeCheckboxIsChecked('#import_images');
 		$I->seeInField('_wp_convertkit_settings_broadcasts[published_at_min_date]', '2023-01-01');
 		$I->seeCheckboxIsChecked('#enabled_export');
 		$I->seeCheckboxIsChecked('#no_styles');


### PR DESCRIPTION
## Summary

Adds [this requested feature](https://linear.app/kit/issue/BCDC-3262/bcdc-latest-2-broadcast-posts-not-appearing-on-creators-wordpress-page#comment-35d197dc) by including an option to save a Broadcast's images to WordPress when importing the Broadcast to a WordPress Post.

![Screenshot 2024-10-28 at 15 27 48](https://github.com/user-attachments/assets/0b0e9fe0-dbbe-4519-904e-471eb029672b)

This won't import non-creator uploaded images, such as icons for links and social links.

## Testing

- `testBroadcastsImportWithImportImagesEnabled`: Tests that Broadcasts import with inline images copied to WordPress when the Import Images option is enabled. 

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)