### PR TITLE
Broadcasts Importer: Remove Duplicate Title in Content

### DIFF
--- a/includes/class-convertkit-broadcasts-importer.php
+++ b/includes/class-convertkit-broadcasts-importer.php
@@ -410,37 +410,48 @@ class ConvertKit_Broadcasts_Importer {
 		$xpath = new DOMXPath( $html );
 
 		// Remove certain elements and their contents, as we never want these to be included in the WordPress Post.
+		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 		// Remove open tracking.
 		foreach ( $xpath->query( '//img[@src="https://preview.convertkit-mail2.com/open"]' ) as $node ) {
-			$node->parentNode->removeChild( $node ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$node->parentNode->removeChild( $node );
 		}
 
 		// Remove blank contenteditable table cells.
 		foreach ( $xpath->query( '//td[@contenteditable="false"]' ) as $node ) {
-			$node->parentNode->removeChild( $node ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$node->parentNode->removeChild( $node );
 		}
 
 		// Remove <style> elements and their contents.
 		foreach ( $xpath->query( '//style' ) as $node ) {
-			$node->parentNode->removeChild( $node ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$node->parentNode->removeChild( $node );
 		}
 
 		// Remove ck-hide-in-public-posts and their contents.
 		// This includes the unsubscribe section.
 		foreach ( $xpath->query( '//div[contains(@class, "ck-hide-in-public-posts")]' ) as $node ) {
-			$node->parentNode->removeChild( $node ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$node->parentNode->removeChild( $node );
 		}
 
 		// Remove ck-poll, as interacting with these results in an error.
 		foreach ( $xpath->query( '//table[contains(@class, "ck-poll")]' ) as $node ) {
-			$node->parentNode->removeChild( $node ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$node->parentNode->removeChild( $node );
 		}
+
+		// If a H1 through H6 heading matches the Broadcast's title, remove it from the content.
+		// The Broadcast's title will always display as the WordPress Post title.
+		for ( $i = 1; $i <= 6; $i++ ) {
+			foreach ( $xpath->query( '//h' . $i ) as $node ) {
+				if ( $node->textContent === $broadcast_title ) {
+					$node->parentNode->removeChild( $node );
+				}
+			}
+		}
+		// phpcs:enable
 
 		// If the Import Images setting is enabled, iterate through all images within the Broadcast, importing them and changing their
 		// URLs to the WordPress Media Library hosted versions.
 		if ( $import_images ) {
-
 			foreach ( $xpath->query( '//img' ) as $node ) {
 				$image = array(
 					'src' => $node->getAttribute( 'src' ), // @phpstan-ignore-line

--- a/tests/acceptance/broadcasts/import-export/BroadcastsToPostsCest.php
+++ b/tests/acceptance/broadcasts/import-export/BroadcastsToPostsCest.php
@@ -147,7 +147,7 @@ class BroadcastsToPostsCest
 
 		// Confirm inline styles exist in the imported Broadcast.
 		$I->seeElementInDOM('div.ck-inner-section');
-		$I->assertNotNull($I->grabAttributeFrom('div.wp-block-post-content h1', 'style'));
+		$I->assertNotNull($I->grabAttributeFrom('div.ck-section', 'style'));
 
 		// Confirm tracking image has been removed.
 		$I->dontSee('<img src="https://preview.convertkit-mail2.com/open" alt="">');
@@ -226,7 +226,7 @@ class BroadcastsToPostsCest
 
 		// Confirm inline styles exist in the imported Broadcast.
 		$I->seeElementInDOM('div.ck-inner-section');
-		$I->assertNotNull($I->grabAttributeFrom('div.wp-block-post-content h1', 'style'));
+		$I->assertNotNull($I->grabAttributeFrom('div.ck-section', 'style'));
 
 		// Confirm published date matches the Broadcast.
 		$date = date('Y-m-d', strtotime($_ENV['CONVERTKIT_API_BROADCAST_FIRST_DATE'])) . 'T' . date('H:i:s', strtotime($_ENV['CONVERTKIT_API_BROADCAST_FIRST_DATE']));
@@ -677,7 +677,7 @@ class BroadcastsToPostsCest
 
 		// Confirm no inline styles exist in the imported Broadcast.
 		$I->dontSeeElementInDOM('div.ck-inner-section');
-		$I->assertNull($I->grabAttributeFrom('div.wp-block-post-content h1', 'style'));
+		$I->assertNull($I->grabAttributeFrom('div.ck-section', 'style'));
 	}
 
 	/**

--- a/tests/acceptance/broadcasts/import-export/BroadcastsToPostsCest.php
+++ b/tests/acceptance/broadcasts/import-export/BroadcastsToPostsCest.php
@@ -677,7 +677,7 @@ class BroadcastsToPostsCest
 
 		// Confirm no inline styles exist in the imported Broadcast.
 		$I->dontSeeElementInDOM('div.ck-inner-section');
-		$I->assertNull($I->grabAttributeFrom('div.ck-section', 'style'));
+		$I->dontSeeInSource('<h2 style="');
 	}
 
 	/**

--- a/tests/wpunit/BroadcastsImportTest.php
+++ b/tests/wpunit/BroadcastsImportTest.php
@@ -313,6 +313,9 @@ class BroadcastsImportTest extends \Codeception\TestCase\WPTestCase
 		// Confirm title correct.
 		$this->assertEquals($_ENV['CONVERTKIT_API_BROADCAST_FIRST_TITLE'], $post->post_title);
 
+		// Confirm the title is not included in the content as a heading.
+		$this->assertStringNotContainsString($_ENV['CONVERTKIT_API_BROADCAST_FIRST_TITLE'] . '</h1>', $post->post_content);
+
 		// Confirm tracking image has been removed.
 		$this->assertStringNotContainsString('<img src="https://preview.convertkit-mail2.com/open" alt="">', $post->post_content);
 


### PR DESCRIPTION
## Summary

[As requested](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/conversation/12263835305931), if the Broadcast's title matches a H1 through H6 in the Broadcast's content, removes the heading in the content, because the Broadcast's title is always stored as the WordPress Post title, and a Post title is required.

Kit:
![Screenshot 2024-10-30 at 12 09 29](https://github.com/user-attachments/assets/1c445db0-93a3-4184-8da5-fc249c6abe9c)

WordPress:
![Screenshot 2024-10-30 at 12 13 27](https://github.com/user-attachments/assets/c66dbd9b-1704-4b10-a9b5-110710f27ce3)

## Testing

- `BroadcastsImportTest`: Updated assertion to confirm no H1 is included in the `HTML Template Test` broadcast, which contains the same title in both the Broadcast's title and H1.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)