### PR TITLE
Broadcasts Importer: Retain `figure` and `figcaption`

### DIFF
--- a/includes/class-convertkit-broadcasts-importer.php
+++ b/includes/class-convertkit-broadcasts-importer.php
@@ -566,6 +566,8 @@ class ConvertKit_Broadcasts_Importer {
 			's',
 			'a',
 			'img',
+			'figure',
+			'figcaption',
 			'br',
 			'style', // Deliberate; we'll use DOMDocument to remove inline styles and their contents.
 		);

--- a/tests/wpunit/BroadcastsImportTest.php
+++ b/tests/wpunit/BroadcastsImportTest.php
@@ -316,6 +316,12 @@ class BroadcastsImportTest extends \Codeception\TestCase\WPTestCase
 		// Confirm tracking image has been removed.
 		$this->assertStringNotContainsString('<img src="https://preview.convertkit-mail2.com/open" alt="">', $post->post_content);
 
+		// Confirm images included retain their <figure> and <figcaption> elements.
+		$this->assertStringContainsString('<figure', $post->post_content);
+		$this->assertStringContainsString('<figcaption', $post->post_content);
+		$this->assertStringContainsString('A Sample Caption</figcaption>', $post->post_content);
+		$this->assertStringContainsString('</figure>', $post->post_content);
+		
 		// Confirm unsubscribe link section has been removed.
 		$this->assertStringNotContainsString('<div class="ck-section ck-hide-in-public-posts"', $post->post_content);
 

--- a/tests/wpunit/BroadcastsImportTest.php
+++ b/tests/wpunit/BroadcastsImportTest.php
@@ -321,7 +321,7 @@ class BroadcastsImportTest extends \Codeception\TestCase\WPTestCase
 		$this->assertStringContainsString('<figcaption', $post->post_content);
 		$this->assertStringContainsString('A Sample Caption</figcaption>', $post->post_content);
 		$this->assertStringContainsString('</figure>', $post->post_content);
-		
+
 		// Confirm unsubscribe link section has been removed.
 		$this->assertStringNotContainsString('<div class="ck-section ck-hide-in-public-posts"', $post->post_content);
 


### PR DESCRIPTION
## Summary

As requested here, don't strip the `figure` and `figcaption` elements when importing a Broadcast, to ensure the caption isn't detached from the image.

## Testing

- `BroadcastsImportTest`: Assert that the `figure` and `figcaption` elements are retained on import.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)