### PR TITLE
Playground: Set OAuth Tokens + Networking

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -32,7 +32,11 @@ jobs:
       AWS_ROLE_SESSION_NAME: "kit-wordpress"
       AWS_BUCKET: "048876701201-kit-wp-plugin-builds" # The Amazon S3 bucket name
       AWS_REGION: "us-east-2" # The Amazon S3 region
-
+      CONVERTKIT_API_KEY: ${{ secrets.CONVERTKIT_API_KEY }} # ConvertKit API Key, stored in the repository's Settings > Secrets
+      CONVERTKIT_API_SECRET: ${{ secrets.CONVERTKIT_API_SECRET }} # ConvertKit API Secret, stored in the repository's Settings > Secrets
+      CONVERTKIT_OAUTH_CLIENT_ID: ${{ secrets.CONVERTKIT_OAUTH_CLIENT_ID }}
+      CONVERTKIT_OAUTH_REDIRECT_URI: ${{ secrets.CONVERTKIT_OAUTH_REDIRECT_URI }}
+      
     # Steps to build and provide the Playground URL
     steps:
       # Checkout (copy) this repository's Plugin to this VM.
@@ -57,12 +61,22 @@ jobs:
         run: |
           zip -r ${{ env.PLUGIN_SLUG }}.zip . -x ".git/*" ".github/*" ".scripts/*" ".wordpress-org/*" "log/*" "tests/*" "*.md" "*.yml" "*.json" "*.neon" "*.lock" "*.xml" "*.dist" "*.example"
 
+      # Exchange API Keys and Secrets for OAuth Tokens.
+      - name: Exchange API Key and Secret for OAuth Tokens
+        id: get-oauth-tokens
+        run: |
+          response=$(curl -s -X POST "${{ secrets.CONVERTKIT_EXCHANGE_API_KEYS_ENDPOINT }}?api_key=${{ env.CONVERTKIT_API_KEY }}&api_secret=${{ env.CONVERTKIT_API_SECRET }}&client_id=${{ env.CONVERTKIT_OAUTH_CLIENT_ID }}&redirect_uri=${{ env.CONVERTKIT_OAUTH_REDIRECT_URI }}&tenant_name=github-playground-${{ github.event.pull_request.number }}")
+          access_token=$(echo "$response" | jq -r '.oauth.access_token')
+          refresh_token=$(echo "$response" | jq -r '.oauth.refresh_token')
+          echo "CONVERTKIT_OAUTH_ACCESS_TOKEN=$access_token" >> $GITHUB_ENV
+          echo "CONVERTKIT_OAUTH_REFRESH_TOKEN=$refresh_token" >> $GITHUB_ENV
+          
       # Create base64 encoded version of blueprint JSON for Playground URL.
       # See: https://wordpress.github.io/wordpress-playground/blueprints/using-blueprints#base64-encoded-blueprints
       - name: Create Blueprint JSON, Base64 Encoded
         id: blueprint
         run: |
-          echo "blueprint_json_base64=$(echo -n '{"landingPage": "/wp-admin/index.php","login":true,"steps":[{"step":"installPlugin","pluginData":{"resource":"url","url":"https://${{ env.AWS_BUCKET }}.s3.${{ env.AWS_REGION }}.amazonaws.com/${{ env.PLUGIN_SLUG }}/${{ github.event.pull_request.number }}/${{ env.PLUGIN_SLUG }}.zip"}}]}' | base64 -w 0)" >> $GITHUB_OUTPUT
+          echo "blueprint_json_base64=$(echo -n '{"landingPage":"/wp-admin/index.php","login":true,"features":{"networking":true},"steps":[{"step":"installPlugin","pluginData":{"resource":"url","url":"https://${{ env.AWS_BUCKET }}.s3.${{ env.AWS_REGION }}.amazonaws.com/${{ env.PLUGIN_SLUG }}/${{ github.event.pull_request.number }}/${{ env.PLUGIN_SLUG }}.zip"}},{"step":"setSiteOptions","options":{"_wp_convertkit_settings":{"access_token":"${{ env.CONVERTKIT_OAUTH_ACCESS_TOKEN }}","refresh_token":"${{ env.CONVERTKIT_OAUTH_REFRESH_TOKEN }}"}}}]}' | base64 -w 0)" >> $GITHUB_OUTPUT
 
       # Upload to S3
       - name: Upload to S3


### PR DESCRIPTION
## Summary

WordPress Playground is served in an iframe, and therefore it's not possible to use the Kit OAuth flow due to the CORS policy:

<img width="1822" alt="Screenshot 2025-06-12 at 11 59 06" src="https://github.com/user-attachments/assets/cd57604d-f57d-4738-a0ff-af7f5236e7a0" />

This PR resolves by configuring the Plugin with an OAuth access + refresh tokens, obtained by using a v3 API Key and Secret.  The PR also enables networking, which is required for API calls.

<img width="1822" alt="Screenshot 2025-06-12 at 11 59 39" src="https://github.com/user-attachments/assets/0154f919-b43f-4f85-8699-c255a2e825ab" />

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)