### PR TITLE
Form Block: Fix “No Content” styling in Block Editor

### DIFF
--- a/resources/backend/js/gutenberg-block-form.js
+++ b/resources/backend/js/gutenberg-block-form.js
@@ -42,7 +42,7 @@ function convertKitGutenbergFormBlockRenderPreview( block, props ) {
 		switch ( format ) {
 			case 'modal':
 				html = block.i18n.gutenberg_form_modal.replace( '%s', form.name );
-				className.push( 'convertkit--no-content' );
+				className.push( 'convertkit-no-content' );
 				break;
 
 			case 'slide in':


### PR DESCRIPTION
## Summary

Fixes missing styles in the block editor when selecting a modal form in the Form Block.

Before:
<img width="651" height="186" alt="Screenshot 2025-07-22 at 18 41 54" src="https://github.com/user-attachments/assets/9b5c00f6-cd9d-45c9-b442-fced23659ccf" />

After:
<img width="660" height="315" alt="Screenshot 2025-07-22 at 18 41 44" src="https://github.com/user-attachments/assets/4120bd22-f51b-420f-850b-80ee1e4bb1d9" />

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)