### PR TITLE
Block Editor: Form Builder: Sequence Option

### DIFF
--- a/includes/blocks/class-convertkit-block-form-builder.php
+++ b/includes/blocks/class-convertkit-block-form-builder.php
@@ -126,6 +126,11 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 			$api->tag_subscriber( absint( $form_data['tag_id'] ), $result['subscriber']['id'] );
 		}
 
+		// If a sequence was specified, add the subscriber to the sequence.
+		if ( array_key_exists( 'sequence_id', $form_data ) && $form_data['sequence_id'] > 0 ) {
+			$api->add_subscriber_to_sequence( absint( $form_data['sequence_id'] ), $result['subscriber']['id'] );
+		}
+
 		// Get the redirect URL, based on whether the form is configured to redirect
 		// or not.
 		if ( array_key_exists( 'redirect', $form_data ) && wp_http_validate_url( sanitize_url( $form_data['redirect'] ) ) ) {
@@ -266,6 +271,10 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 				'type'    => 'string',
 				'default' => $this->get_default_value( 'tag_id' ),
 			),
+			'sequence_id'                => array(
+				'type'    => 'string',
+				'default' => $this->get_default_value( 'sequence_id' ),
+			),
 
 			// get_supports() style, color and typography attributes.
 			'align'                      => array(
@@ -337,11 +346,20 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 		}
 
 		// Get Kit Tags.
-		$tags   = new ConvertKit_Resource_Tags( 'block_form_builder' );
-		$values = array();
+		$tags         = new ConvertKit_Resource_Tags( 'block_form_builder' );
+		$tags_options = array();
 		if ( $tags->exist() ) {
 			foreach ( $tags->get() as $tag ) {
-				$values[ $tag['id'] ] = sanitize_text_field( $tag['name'] );
+				$tags_options[ $tag['id'] ] = sanitize_text_field( $tag['name'] );
+			}
+		}
+
+		// Get Kit Sequences.
+		$sequences         = new ConvertKit_Resource_Sequences( 'block_form_builder' );
+		$sequences_options = array();
+		if ( $sequences->exist() ) {
+			foreach ( $sequences->get() as $sequence ) {
+				$sequences_options[ $sequence['id'] ] = sanitize_text_field( $sequence['name'] );
 			}
 		}
 
@@ -365,7 +383,13 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 				'label'       => __( 'Tag', 'convertkit' ),
 				'type'        => 'select',
 				'description' => __( 'The Kit tag to add the subscriber to.', 'convertkit' ),
-				'values'      => $values,
+				'values'      => $tags_options,
+			),
+			'sequence_id'                => array(
+				'label'       => __( 'Sequence', 'convertkit' ),
+				'type'        => 'select',
+				'description' => __( 'The Kit sequence to add the subscriber to.', 'convertkit' ),
+				'values'      => $sequences_options,
 			),
 		);
 
@@ -390,6 +414,7 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 				'label'  => __( 'General', 'convertkit' ),
 				'fields' => array(
 					'tag_id',
+					'sequence_id',
 					'redirect',
 					'display_form_if_subscribed',
 					'text_if_subscribed',
@@ -410,6 +435,7 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 
 		return array(
 			'tag_id'                     => '',
+			'sequence_id'                => '',
 			'redirect'                   => '',
 			'display_form_if_subscribed' => true,
 			'text_if_subscribed'         => 'Thanks for subscribing!',
@@ -550,10 +576,11 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 
 		// Add hidden fields.
 		$fields = array(
-			'convertkit[post_id]'  => absint( $post_id ),
-			'convertkit[redirect]' => esc_url( $atts['redirect'] ),
-			'convertkit[tag_id]'   => absint( $atts['tag_id'] ),
-			'_wpnonce'             => wp_create_nonce( 'convertkit_block_form_builder' ),
+			'convertkit[post_id]'     => absint( $post_id ),
+			'convertkit[redirect]'    => esc_url( $atts['redirect'] ),
+			'convertkit[tag_id]'      => absint( $atts['tag_id'] ),
+			'convertkit[sequence_id]' => absint( $atts['sequence_id'] ),
+			'_wpnonce'                => wp_create_nonce( 'convertkit_block_form_builder' ),
 		);
 		foreach ( $fields as $name => $value ) {
 			$hidden = $html->createElement( 'input' );

--- a/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormBuilderCest.php
+++ b/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormBuilderCest.php
@@ -328,6 +328,108 @@ class PageBlockFormBuilderCest
 	}
 
 	/**
+	 * Test the Form Builder block works when added and a Sequence is specified
+	 * to subscribe the subscriber to.
+	 *
+	 * @since   3.0.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFormBuilderBlockWithSequenceEnabled(EndToEndTester $I)
+	{
+		// Setup Plugin and Resources.
+		$I->setupKitPlugin($I);
+		$I->setupKitPluginResources($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Builder: Block: Sequence Enabled'
+		);
+
+		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+		$I->configureMetaboxSettings(
+			$I,
+			'wp-convertkit-meta-box',
+			[
+				'form' => [ 'select2', 'None' ],
+			]
+		);
+
+		// Add block to Page, setting the Form setting to the value specified in the .env file.
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Form Builder',
+			blockProgrammaticName: 'convertkit-form-builder',
+			blockConfiguration: [
+				'sequence_id' => [ 'select', $_ENV['CONVERTKIT_API_SEQUENCE_NAME'] ],
+			]
+		);
+
+		// Confirm the block template was used as the default.
+		$this->seeFormBuilderBlock($I);
+		$this->seeFormBuilderButtonBlock($I);
+		$this->seeFormBuilderField(
+			$I,
+			fieldName: 'first_name',
+			fieldID: 'first_name',
+			label: 'First name',
+			container: 'div[data-type="convertkit/form-builder"]'
+		);
+		$this->seeFormBuilderField(
+			$I,
+			fieldName: 'email',
+			fieldID: 'email',
+			label: 'Email address',
+			container: 'div[data-type="convertkit/form-builder"]'
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that the Form is output in the DOM.
+		$this->seeFormBuilderField(
+			$I,
+			fieldName: 'first_name',
+			fieldID: 'first_name',
+			label: 'First name',
+			container: 'div.wp-block-convertkit-form-builder'
+		);
+		$this->seeFormBuilderField(
+			$I,
+			fieldName: 'email',
+			fieldID: 'email',
+			label: 'Email address',
+			container: 'div.wp-block-convertkit-form-builder'
+		);
+
+		// Generate email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Submit form.
+		$I->fillField('input[name="convertkit[first_name]"]', 'First');
+		$I->fillField('input[name="convertkit[email]"]', $emailAddress);
+		$I->click('div.wp-block-convertkit-form-builder button[type="submit"]');
+		$I->waitForElementVisible('body.page');
+
+		// Confirm that the email address was added to Kit.
+		$I->waitForElementVisible('body.page');
+		$I->wait(3);
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $emailAddress,
+			firstName: 'First'
+		);
+
+		// Confirm that the subscriber has the sequence.
+		$I->apiCheckSubscriberHasSequence(
+			$I,
+			subscriberID: $subscriber['id'],
+			sequenceID: $_ENV['CONVERTKIT_API_SEQUENCE_ID']
+		);
+	}
+
+	/**
 	 * Test the Form Builder block works when a custom field is added.
 	 *
 	 * @since   3.0.0


### PR DESCRIPTION
## Summary

Adds an optional setting to assign subscribers to a sequence when they subscribe using the Form Builder's subscription form:

<img width="1038" height="460" alt="Screenshot 2025-08-12 at 10 43 33" src="https://github.com/user-attachments/assets/d9d1aedf-07ab-4556-8914-f10c2d979a63" />

## Testing

- `testFormBuilderBlockWithSequenceEnabled `: Test that the subscriber is added to the selected sequence when configured on the Form Builder

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)