### PR TITLE
Autoptimize: Automatically Disable Image Lazy Loading

### DIFF
--- a/includes/class-convertkit-cache-plugins.php
+++ b/includes/class-convertkit-cache-plugins.php
@@ -51,6 +51,7 @@ class ConvertKit_Cache_Plugins {
 		// Autoptimize: Exclude Forms from JS defer.
 		add_filter( 'convertkit_output_script_footer', array( $this, 'autoptimize_exclude_js_defer' ) );
 		add_filter( 'convertkit_resource_forms_output_script', array( $this, 'autoptimize_exclude_js_defer' ) );
+		add_filter( 'autoptimize_filter_imgopt_should_lazyload', array( $this, 'disable_image_lazy_loading_on_landing_pages' ) );
 
 		// Debloat: Exclude Forms from Delay Load JS.
 		add_filter( 'debloat/defer_js_excludes', array( $this, 'exclude_hosts_from_minification' ) );
@@ -67,7 +68,7 @@ class ConvertKit_Cache_Plugins {
 		// Perfmatters: Exclude Forms from Delay JavaScript.
 		add_filter( 'convertkit_output_script_footer', array( $this, 'perfmatters_exclude_delay_js' ) );
 		add_filter( 'convertkit_resource_forms_output_script', array( $this, 'perfmatters_exclude_delay_js' ) );
-		add_filter( 'perfmatters_lazyload', array( $this, 'perfmatters_disable_lazy_loading_on_landing_pages' ) );
+		add_filter( 'perfmatters_lazyload', array( $this, 'disable_image_lazy_loading_on_landing_pages' ) );
 
 		// Siteground Speed Optimizer: Exclude Forms from JS combine.
 		add_filter( 'convertkit_output_script_footer', array( $this, 'siteground_speed_optimizer_exclude_js_combine' ) );
@@ -176,7 +177,7 @@ class ConvertKit_Cache_Plugins {
 	}
 
 	/**
-	 * Disable lazy loading in Perfmatters when a WordPress Page configured to display a
+	 * Disable image lazy loading when a WordPress Page configured to display a
 	 * ConvertKit Landing Page is viewed.
 	 *
 	 * @since   2.5.1
@@ -184,7 +185,7 @@ class ConvertKit_Cache_Plugins {
 	 * @param   bool $enabled    Lazy loading enabled.
 	 * @return  bool
 	 */
-	public function perfmatters_disable_lazy_loading_on_landing_pages( $enabled ) {
+	public function disable_image_lazy_loading_on_landing_pages( $enabled ) {
 
 		// If the request isn't for a Page, don't change lazy loading settings.
 		if ( ! is_page( get_the_ID() ) ) {
@@ -198,7 +199,7 @@ class ConvertKit_Cache_Plugins {
 		}
 
 		// ConvertKit Landing Page is going to be displayed.
-		// Disable Perfmatters Lazy Loading so that the Landing Page images display.
+		// Disable image lazy loading so that the Landing Page images display.
 		return false;
 
 	}


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/215470695297842?view=List
) by using the `autoptimize_filter_imgopt_should_lazyload` filter to disable image lazyloading on embedded landing pages, which would result in images not displaying, rather than users having to manually configure exclusions in the Autoptimize plugin.

Before:
<img width="1823" height="1465" alt="Screenshot 2025-09-08 at 17 56 54" src="https://github.com/user-attachments/assets/20dfc8da-ec86-41e1-9309-26d84c15d276" />

After:
<img width="1823" height="1465" alt="Screenshot 2025-09-08 at 17 56 57" src="https://github.com/user-attachments/assets/ab6fd0b3-8f11-4f00-b3e3-3bf051f667ef" />

## Testing

- `testAddNewPageUsingDefinedLandingPageWithAutoptimizePlugin`: Test that the Landing Page specified in the Page Settings works when creating and viewing a new WordPress Page, with Autoptimize's Lazy-load images active.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)