### PR TITLE
Composer: Alias commands

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -16,17 +16,19 @@ If you haven't yet set up your local development environment with the Kit Plugin
 
 If you haven't yet created a branch and made any code changes to the Plugin, refer to the [Development Guide](DEVELOPMENT.md)
 
-> **Familiar with wp-browser, Codeception, PHP Coding Standards and PHPStan?**  
+> **Familiar with wp-browser, Codeception, PHP Coding Standards and PHPStan?**
+> 
 > Write your tests 
+> 
 > Run tests using `composer test [folder]/[cest]` or `composer test-integration [test]`
-> Run PHP Coding Standards using `composer phpcs` and `composer phpcs-tests`
-> Run static analysis using `composer phpstan`
+> 
+> Run PHP Coding Standards using `composer coding-standards` and `composer coding-standards-tests`
+> 
+> Fix PHP Coding Standards using `composer fix-coding-standards` and `composer fix-coding-standards-tests`
+> 
+> Run static analysis using `composer static-analysis`
+> 
 > [Submit a Pull Request](https://github.com/ConvertKit/convertkit-wordpress/compare).
-
-## 
-
-- Write your tests
-- `composer test
 
 ## Write (or modify) a test
 
@@ -389,11 +391,16 @@ To register your own helper function, add it to the `tests/Support/Helper/Wpunit
 
 ## Run Tests
 
-> **Quick Commands**  
+> **Quick Commands**
+>  
 > `composer test`: Run all End to End tests
+>
 > `composer test general`: Run all tests in the EndToEnd/general folder
+>
 > `composer test general/ActivateDeactivatePluginCest`: Run all tests in the EndToEnd/general/ActivateDeactivatePluginCest file
+>
 > `composer test-integration`: Run all Integration tests
+>
 > `composer test-integration APITest`: Run the Integration/APITest tests
 
 Once you have written your code and test(s), run the tests to make sure there are no errors.
@@ -418,7 +425,7 @@ Any errors should be corrected by making applicable code or test changes.
 ## Run PHP CodeSniffer
 
 > **Quick Command**  
-> `composer phpcs`: Run PHP Coding Standards on Plugin files
+> `composer coding-standards`: Run PHP Coding Standards on Plugin files
 
 [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) checks that all Plugin code meets the 
 [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/).
@@ -450,7 +457,7 @@ Need to change the PHP or WordPress coding standard rules applied?  Either:
 ## Run PHPStan
 
 > **Quick Command**  
-> `composer phpstan`: Run PHPStan static analysis on Plugin files
+> `composer static-analysis`: Run PHPStan static analysis on Plugin files
 
 [PHPStan](https://phpstan.org) performs static analysis on the Plugin's PHP code.  This ensures:
 
@@ -474,7 +481,7 @@ False positives [can be excluded by configuring](https://phpstan.org/user-guide/
 ## Run PHP CodeSniffer for Tests
 
 > **Quick Command**  
-> `composer phpcs-tests`: Run PHP Coding Standards on test files
+> `composer coding-standards-tests`: Run PHP Coding Standards on test files
 
 In the Plugin's directory, run the following command to run PHP_CodeSniffer, which will check the code meets Coding Standards
 as defined in the `phpcs.tests.xml` configuration:

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,11 @@
         "phpcs-tests": "vendor/bin/phpcs ./tests --standard=phpcs.tests.xml -s -v",
         "phpcbf-tests": "vendor/bin/phpcbf ./tests --standard=phpcs.tests.xml -s -v",
         "phpstan": "vendor/bin/phpstan analyse --memory-limit=1250M",
+        "coding-standards": "vendor/bin/phpcs ./ -s -v",
+        "fix-coding-standards": "vendor/bin/phpcbf ./ -s -v",
+        "coding-standards-on-tests": "vendor/bin/phpcs ./tests --standard=phpcs.tests.xml -s -v",
+        "fix-coding-standards-on-tests": "vendor/bin/phpcbf ./tests --standard=phpcs.tests.xml -s -v",
+        "static-analysis": "vendor/bin/phpstan analyse --memory-limit=1250M",
         "test": [
             "vendor/bin/codecept build @no_additional_args",
             "vendor/bin/codecept run EndToEnd @additional_args --fail-fast"


### PR DESCRIPTION
## Summary

Adds alias commands:

| Command | Description |
|---------|-------------|
| `coding-standards` | Runs PHP CodeSniffer on the entire plugin codebase |
| `fix-coding-standards` | Runs PHP CodeSniffer specifically on the tests directory using test-specific standards |
| `coding-standards-on-tests` | Runs PHPStan static analysis with increased memory limit |
| `fix-coding-standards-on-tests` | Builds and runs end-to-end tests with fail-fast enabled |
| `static-analysis` | Builds and runs integration tests with fail-fast enabled |

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)