### PR TITLE
Add JS Coding Standards: Block Editor Formatters

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,6 @@ module.exports = {
 		convertkit_quicktags: 'readonly',
 		convertkit_shortcodes: 'readonly',
 	},
-	ignorePatterns: ['resources/backend/js/gutenberg-block-formatters.js'],
 	rules: {
 		// Turn off specific rules
 		camelcase: 'off',

--- a/resources/backend/js/gutenberg-block-formatters.js
+++ b/resources/backend/js/gutenberg-block-formatters.js
@@ -3,21 +3,23 @@
  *
  * @since   2.2.0
  *
- * @package ConvertKit
  * @author ConvertKit
+ */
+
+/**
+ * @typedef {import('@wordpress/element').WPElement} WPElement
  */
 
 // Register Gutenberg Block Toolbar formatters if the Gutenberg Editor is loaded on screen.
 // This prevents JS errors if this script is accidentally enqueued on a non-
 // Gutenberg editor screen, or the Classic Editor Plugin is active.
-if ( typeof wp !== 'undefined' &&
-	typeof wp.blockEditor !== 'undefined' ) {
-
+if (typeof wp !== 'undefined' && typeof wp.blockEditor !== 'undefined') {
 	// Register each ConvertKit formatter in Gutenberg.
-	for ( const formatter in convertkit_block_formatters ) {
-		convertKitGutenbergRegisterBlockFormatter( convertkit_block_formatters[ formatter ] );
+	for (const formatter in convertkit_block_formatters) {
+		convertKitGutenbergRegisterBlockFormatter(
+			convertkit_block_formatters[formatter]
+		);
 	}
-
 }
 
 /**
@@ -25,34 +27,21 @@ if ( typeof wp !== 'undefined' &&
  *
  * @since   2.2.0
  *
- * @param   object  formatter   Block formatter.
+ * @param {Object} formatter Block formatter.
  */
-function convertKitGutenbergRegisterBlockFormatter( formatter ) {
-
-	( function ( editor, richText, element, components ) {
-
+function convertKitGutenbergRegisterBlockFormatter(formatter) {
+	(function (editor, richText, element, components) {
 		// Define the Gutenberg/React components to use.
-		const {
-			Fragment,
-			useState,
-			createElement
-		} = element;
+		const { Fragment, useState, createElement } = element;
 		const {
 			registerFormatType,
 			toggleFormat,
 			applyFormat,
 			useAnchorRef,
-			useAnchor
+			useAnchor,
 		} = richText;
-		const {
-			BlockControls,
-			RichTextToolbarButton,
-		} = editor;
-		const {
-			Button,
-			Popover,
-			SelectControl
-		} = components;
+		const { RichTextToolbarButton } = editor;
+		const { Popover, SelectControl } = components;
 
 		/**
 		 * Returns the icon to display in the block toolbar for this formatter, depending
@@ -60,28 +49,24 @@ function convertKitGutenbergRegisterBlockFormatter( formatter ) {
 		 *
 		 * @since   2.2.0
 		 *
-		 * @return  element|string
+		 * @return  {WPElement|string} Either a WordPress element (RawHTML) or a dashicon string.
 		 */
 		const getIcon = function () {
-
 			// Return a fallback default icon if none is specified for this block formatter.
-			if ( typeof formatter.gutenberg_icon === 'undefined' ) {
+			if (typeof formatter.gutenberg_icon === 'undefined') {
 				return 'dashicons-tablet';
 			}
 
 			// Return HTML element if the icon is an SVG string.
-			if ( formatter.gutenberg_icon.search( 'svg' ) >= 0 ) {
-				return element.RawHTML(
-					{
-						children: formatter.gutenberg_icon
-					}
-				);
+			if (formatter.gutenberg_icon.search('svg') >= 0) {
+				return element.RawHTML({
+					children: formatter.gutenberg_icon,
+				});
 			}
 
 			// Just return the string, as it's a dashicon CSS class.
 			return formatter.gutenberg_icon;
-
-		}
+		};
 
 		/**
 		 * Returns an object of this formatter's attributes if this formatter
@@ -92,41 +77,42 @@ function convertKitGutenbergRegisterBlockFormatter( formatter ) {
 		 *
 		 * @since   2.2.0
 		 *
-		 * @param   object  activeFormats   All active formatters applied to the selected text.
-		 * @return  object
+		 * @param {Object} activeFormats All active formatters applied to the selected text.
+		 * @return {Object} Attributes.
 		 */
-		const getAttributes = function ( activeFormats ) {
-
+		const getAttributes = function (activeFormats) {
 			// Define the attribute object.
-			let attributes = {};
-			for ( let attribute in formatter.attributes ) {
-				attributes[ attribute ] = '';
+			const attributes = {};
+			for (const attribute in formatter.attributes) {
+				attributes[attribute] = '';
 			}
 
 			// Return if no active formats have been applied to the selected text.
-			if ( typeof activeFormats === 'undefined' ) {
+			if (typeof activeFormats === 'undefined') {
 				return attributes;
 			}
 
 			// Return if this formatter has not been used on the selected text.
-			const formats = activeFormats.filter( format => 'convertkit/' + formatter.name === format['type'] );
-			if ( formats.length === 0 ) {
+			const formats = activeFormats.filter(
+				(format) => 'convertkit/' + formatter.name === format.type
+			);
+			if (formats.length === 0) {
 				return attributes;
 			}
 
 			// This formatter has been applied to the selected text.
 			// Build the object of attributes and return.
-			for ( let attribute in formatter.attributes ) {
-				if ( typeof formats[0].unregisteredAttributes !== 'undefined' ) {
-					attributes[ attribute ] = formats[0].unregisteredAttributes[ attribute ];
-				} else if ( typeof formats[0].attributes !== 'undefined' ) {
-					attributes[ attribute ] = formats[0].attributes[ attribute ];
+			for (const attribute in formatter.attributes) {
+				if (typeof formats[0].unregisteredAttributes !== 'undefined') {
+					attributes[attribute] =
+						formats[0].unregisteredAttributes[attribute];
+				} else if (typeof formats[0].attributes !== 'undefined') {
+					attributes[attribute] = formats[0].attributes[attribute];
 				}
 			}
 
 			return attributes;
-
-		}
+		};
 
 		/**
 		 * Updates the block formatter's attributes when a field in the
@@ -134,50 +120,42 @@ function convertKitGutenbergRegisterBlockFormatter( formatter ) {
 		 *
 		 * @since   2.2.0
 		 *
-		 * @param   object  props         Block formatter properties.
-		 * @param   array   field         Field definition.
-		 * @param   string  newValue      New value
+		 * @param {Object} props    Block formatter properties.
+		 * @param {Object} field    Field definition.
+		 * @param {string} newValue New value.
 		 */
-		const setAttributes = function ( props, field, newValue ) {
-
+		const setAttributes = function (props, field, newValue) {
 			// Define properties and functions to use.
 			const { onChange, value } = props;
 
 			// If no value exists, remove the formatter.
-			if ( newValue === '' ) {
+			if (newValue === '') {
 				return onChange(
-					toggleFormat(
-						value,
-						{
-							type: 'convertkit/' + formatter.name
-						}
-					)
+					toggleFormat(value, {
+						type: 'convertkit/' + formatter.name,
+					})
 				);
 			}
 
 			// Build object of new attributes.
-			let attributes = {};
-			for ( let attribute in formatter.attributes ) {
+			const attributes = {};
+			for (const attribute in formatter.attributes) {
 				// If 'None' selected, blank the attribute's value.
-				if ( newValue === '' ) {
-					attributes[ attribute ] = '';
+				if (newValue === '') {
+					attributes[attribute] = '';
 				} else {
-					attributes[ attribute ] = field.data[ newValue ][ attribute ];
+					attributes[attribute] = field.data[newValue][attribute];
 				}
 			}
 
 			// Apply formatter with new attributes.
 			return onChange(
-				applyFormat(
-					value,
-					{
-						type: 'convertkit/' + formatter.name,
-						attributes: attributes
-					}
-				)
+				applyFormat(value, {
+					type: 'convertkit/' + formatter.name,
+					attributes,
+				})
 			);
-
-		}
+		};
 
 		/**
 		 * Return an array of field elements to display in the popover modal when
@@ -185,81 +163,68 @@ function convertKitGutenbergRegisterBlockFormatter( formatter ) {
 		 *
 		 * @since   2.2.0
 		 *
-		 * @param   object  props           Block formatter properties.
-		 * @param   object  setShowPopover  Function to toggle showing/hiding the popover.
-		 * @param   object  attributes      Field attributes.
-		 * @return  array                   Field elements
+		 * @param {Object}   props          Block formatter properties.
+		 * @param {Function} setShowPopover Function to toggle showing/hiding the popover.
+		 * @param {Object}   attributes     Field attributes.
+		 * @return  {Array}                   Field elements
 		 */
-		const getFields = function ( props, setShowPopover, attributes ) {
-
+		const getFields = function (props, setShowPopover, attributes) {
 			// Define array of field elements.
-			let elements = [];
+			const elements = [];
 
 			// Return if no fields exist.
-			if ( formatter.fields.length === 0 ) {
+			if (formatter.fields.length === 0) {
 				return elements;
 			}
 
 			// Iterate through the formatter's fields, adding a field element for each.
-			for ( let fieldName in formatter.fields ) {
-				const field = formatter.fields[ fieldName ];
+			for (const fieldName in formatter.fields) {
+				const field = formatter.fields[fieldName];
 
 				// Build options for <select> input.
-				let fieldOptions = [
+				const fieldOptions = [
 					{
 						label: '(None)',
-						value: ''
-				}
+						value: '',
+					},
 				];
-				for ( let fieldValue in field.values ) {
-					fieldOptions.push(
-						{
-							label: field.values[ fieldValue ],
-							value: fieldValue
-						}
-					);
+				for (const fieldValue in field.values) {
+					fieldOptions.push({
+						label: field.values[fieldValue],
+						value: fieldValue,
+					});
 				}
 
 				// Sort field's options alphabetically by label.
-				fieldOptions.sort(
-					function ( x, y ) {
-
-						let a = x.label.toUpperCase(),
-						b     = y.label.toUpperCase();
-						return a.localeCompare( b );
-
-					}
-				);
+				fieldOptions.sort(function (x, y) {
+					const a = x.label.toUpperCase(),
+						b = y.label.toUpperCase();
+					return a.localeCompare(b);
+				});
 
 				// Add field to array.
 				elements.push(
-					createElement(
-						SelectControl,
-						{
-							key:        'convertkit_' + formatter.name + '_' + fieldName,
-							id:         'convertkit-' + formatter.name + '-' + fieldName,
-							label:      field.label,
-							value:      attributes[ fieldName ],
-							help:       field.description,
-							options:    fieldOptions,
-							onChange:   function ( newValue ) {
+					createElement(SelectControl, {
+						key: 'convertkit_' + formatter.name + '_' + fieldName,
+						id: 'convertkit-' + formatter.name + '-' + fieldName,
+						label: field.label,
+						value: attributes[fieldName],
+						help: field.description,
+						options: fieldOptions,
+						onChange(newValue) {
+							// Hide popover.
+							setShowPopover(false);
 
-								// Hide popover.
-								setShowPopover( false );
-
-								// Update and apply attributes to the selected text.
-								setAttributes( props, field, newValue );
-
-							}
-						}
-					)
+							// Update and apply attributes to the selected text.
+							setAttributes(props, field, newValue);
+						},
+					})
 				);
 			}
 
 			// Return elements.
 			return elements;
-
-		}
+		};
 
 		/**
 		 * Display modal when the formatter's button is clicked, and save
@@ -267,92 +232,95 @@ function convertKitGutenbergRegisterBlockFormatter( formatter ) {
 		 *
 		 * @since   2.2.0
 		 *
-		 * @param   object  props   Block formatter properties.
-		 * @return  object          Block formatter button and modal elements
+		 * @param {Object} props Block formatter properties.
+		 * @return  {Object}          Block formatter button and modal elements
 		 */
-		const editFormatType = function ( props ) {
-
+		const EditFormatType = function (props) {
 			// Get props.
 			const { contentRef, isActive, value } = props;
-			const { activeFormats }               = value;
+			const { activeFormats } = value;
 			let anchorRef;
 
 			// Get anchor reference to the text.
-			if ( typeof useAnchor === 'undefined' ) {
+			if (typeof useAnchor === 'undefined') {
 				// Use WordPress 6.0 and lower useAnchorRef(), as useAnchor() isn't available.
-				anchorRef = useAnchorRef( { ref: contentRef, value } );
+				anchorRef = useAnchorRef({ ref: contentRef, value }); // eslint-disable-line react-hooks/rules-of-hooks
 			} else {
 				// Use WordPress 6.1+ useAnchor(), as useAnchorRef() is deprecated in 6.2+.
-				anchorRef = useAnchor( { editableContentElement: contentRef.current, value } );
+				// eslint-disable-next-line react-hooks/rules-of-hooks
+				anchorRef = useAnchor({
+					editableContentElement: contentRef.current,
+					value,
+				});
 			}
 
 			// State to show popover.
-			const [ showPopover, setShowPopover ] = useState( false );
+			const [showPopover, setShowPopover] = useState(false);
 
 			// Get attributes.
-			let attributes = getAttributes( activeFormats );
+			const attributes = getAttributes(activeFormats);
 
 			// Define fields to display in the popover modal.
-			let popoverModalElements = getFields( props, setShowPopover, attributes );
-
-			// Return block toolbar button and its modal.
-			return (
-				createElement(
-					Fragment,
-					{
-						key:  'convertkit_' + formatter.name + '_rich_text_toolbar_fragment'
-					},
-					// Register the button in the rich text toolbar.
-					createElement(
-						RichTextToolbarButton,
-						{
-							key:      'convertkit_' + formatter.name + '_rich_text_toolbar_button',
-							icon:     getIcon( formatter ),
-							title:    formatter.title,
-							isActive: isActive,
-							onClick:  function () {
-								setShowPopover( true );
-							}
-						},
-					),
-					// Popover which displays fields when the button is active.
-					showPopover && ( createElement(
-						Popover,
-						{
-							key:        'convertkit_' + formatter.name + '_popover',
-							className:  'convertkit-popover',
-							anchor:     anchorRef,
-							onClose:    function () {
-								setShowPopover( false );
-							}
-						},
-						popoverModalElements
-					) )
-				)
+			const popoverModalElements = getFields(
+				props,
+				setShowPopover,
+				attributes
 			);
 
-		}
+			// Return block toolbar button and its modal.
+			return createElement(
+				Fragment,
+				{
+					key:
+						'convertkit_' +
+						formatter.name +
+						'_rich_text_toolbar_fragment',
+				},
+				// Register the button in the rich text toolbar.
+				createElement(RichTextToolbarButton, {
+					key:
+						'convertkit_' +
+						formatter.name +
+						'_rich_text_toolbar_button',
+					icon: getIcon(formatter),
+					title: formatter.title,
+					isActive,
+					onClick() {
+						setShowPopover(true);
+					},
+				}),
+				// Popover which displays fields when the button is active.
+				showPopover &&
+					createElement(
+						Popover,
+						{
+							key: 'convertkit_' + formatter.name + '_popover',
+							className: 'convertkit-popover',
+							anchor: anchorRef,
+							onClose() {
+								setShowPopover(false);
+							},
+						},
+						popoverModalElements
+					)
+			);
+		};
 
 		// Register Format Type.
-		registerFormatType(
-			'convertkit/' + formatter.name,
-			{
-				title:      formatter.title,
+		registerFormatType('convertkit/' + formatter.name, {
+			title: formatter.title,
 
-				// The tagName and className combination allow Gutenberg to uniquely identify
-				// whether this formatter has been used on the selected text.
-				tagName:    formatter.tag,
-				className:  'convertkit-' + formatter.name,
-				attributes: formatter.attributes,
-				edit:       editFormatType,
-			}
-		);
-
-	} (
+			// The tagName and className combination allow Gutenberg to uniquely identify
+			// whether this formatter has been used on the selected text.
+			tagName: formatter.tag,
+			className: 'convertkit-' + formatter.name,
+			attributes: formatter.attributes,
+			edit: EditFormatType,
+		});
+	})(
 		window.wp.blockEditor,
 		window.wp.richText,
 		window.wp.element,
 		window.wp.components
-	) );
-
+	);
 }


### PR DESCRIPTION
## Summary

Implement WordPress' recommended configuration for JS coding standards / linting on backend block editor formatters JS code:
https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/#installation
https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/#lint-js

## Testing

The GitHub action's coding-standards includes a new step to check JS coding standards.

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)