### PR TITLE
Form Builder: Lock Email Field

### DIFF
--- a/includes/blocks/class-convertkit-block-form-builder.php
+++ b/includes/blocks/class-convertkit-block-form-builder.php
@@ -348,6 +348,10 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 				),
 				'convertkit/form-builder-field-email' => array(
 					'label' => 'Email address',
+					'lock'  => array(
+						'move'   => false,
+						'remove' => true,
+					),
 				),
 				'core/button'                         => array(
 					'label'     => 'Submit button',


### PR DESCRIPTION
## Summary

Locks the Form Builder's email field when adding the Form Builder block in the editor, so it cannot be deleted.

<img width="753" height="312" alt="Screenshot 2025-10-19 at 13 34 33" src="https://github.com/user-attachments/assets/7b8da71d-7664-402e-ac2c-3bf00b676bbd" />

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)