### PR TITLE
Settings Screens: Improve request checks

### DIFF
--- a/admin/section/class-convertkit-admin-section-base.php
+++ b/admin/section/class-convertkit-admin-section-base.php
@@ -109,6 +109,11 @@ abstract class ConvertKit_Admin_Section_Base {
 	 */
 	public function on_settings_screen( $tab ) {
 
+		// Bail if this is an AJAX or Cron request.
+		if ( wp_doing_ajax() || wp_doing_cron() ) {
+			return false;
+		}
+
 		// Bail if we're not on the settings screen.
 		if ( ! filter_has_var( INPUT_GET, 'page' ) ) {
 			return false;


### PR DESCRIPTION
## Summary

[This ticket's](https://linear.app/kit/issue/WP-62/wordpress-med-api-calls-from-kit-plugin-reducing-back-end-site) log ([view log](https://pastebin.com/QUy0JQ1k)) shows that some WordPress admin AJAX requests trigger refreshing resources, which is an API-intensive query only performed when viewing the Plugin's settings screen, because the Plugin's `on_settings_screen` method returns true, despite conditions to check if the user is truly on the `_wp_convertkit_settings` settings screen.

This PR aims to resolve - or at least rule out - AJAX requests by ensuring the `on_settings_screen` method returns false if the request is an AJAX or WP-Cron event. Neither are used for the Plugin's settings screens, so requests made via AJAX or WP-Cron should not be considered as a request for the settings screen.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)