### PR TITLE
Member Content: Product: Display No Access Notice

### DIFF
--- a/tests/Support/Helper/KitRestrictContent.php
+++ b/tests/Support/Helper/KitRestrictContent.php
@@ -622,7 +622,7 @@ class KitRestrictContent extends \Codeception\Module
 	public function testRestrictContentByProductHidesContentWithCTA($I, $options = false)
 	{
 		// Merge options with defaults.
-		$options = $this->_getRestrictedContentOptionsWithDefaultsMerged($options);
+		$options = $this->getRestrictedContentOptionsWithDefaultsMerged($options);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -671,7 +671,7 @@ class KitRestrictContent extends \Codeception\Module
 	public function testRestrictContentByTagHidesContentWithCTA($I, $options = false, $testRecaptcha = false)
 	{
 		// Merge options with defaults.
-		$options = $this->_getRestrictedContentOptionsWithDefaultsMerged($options);
+		$options = $this->getRestrictedContentOptionsWithDefaultsMerged($options);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -710,7 +710,7 @@ class KitRestrictContent extends \Codeception\Module
 	public function testRestrictContentByFormHidesContentWithCTA($I, $formID, $options = false)
 	{
 		// Merge options with defaults.
-		$options = $this->_getRestrictedContentOptionsWithDefaultsMerged($options);
+		$options = $this->getRestrictedContentOptionsWithDefaultsMerged($options);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -754,7 +754,7 @@ class KitRestrictContent extends \Codeception\Module
 	public function testRestrictContentDisplaysContent($I, $options = false)
 	{
 		// Merge options with defaults.
-		$options = $this->_getRestrictedContentOptionsWithDefaultsMerged($options);
+		$options = $this->getRestrictedContentOptionsWithDefaultsMerged($options);
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -789,7 +789,7 @@ class KitRestrictContent extends \Codeception\Module
 	public function setupRestrictContentTest($I, $options, $urlOrPageID)
 	{
 		// Merge options with defaults.
-		$options = $this->_getRestrictedContentOptionsWithDefaultsMerged($options);
+		$options = $this->getRestrictedContentOptionsWithDefaultsMerged($options);
 
 		// Clear any existing cookie from a previous test and reload.
 		$I->clearRestrictContentCookie($I);
@@ -952,7 +952,7 @@ class KitRestrictContent extends \Codeception\Module
 	 *     @type array  $settings                 Restrict content settings. If not defined, uses expected defaults.
 	 * }
 	 */
-	private function _getRestrictedContentOptionsWithDefaultsMerged($options = false)
+	public function getRestrictedContentOptionsWithDefaultsMerged($options = false)
 	{
 		// Define default options for Restrict Content tests.
 		$defaults = [

--- a/views/frontend/restrict-content/product.php
+++ b/views/frontend/restrict-content/product.php
@@ -22,5 +22,8 @@
 
 	// Output a login link or form, if require login enabled.
 	require 'login.php';
+
+	// Output notices.
+	require 'notices.php';
 	?>
 </div>


### PR DESCRIPTION
## Summary

If a subscriber logs in to view content gated by e.g. a Kit Form, and then attempts to view content gated by a Kit Product that they have not purchased, the 'no access' message is only displayed when they click the login button:

<img width="752" height="358" alt="Screenshot 2025-11-03 at 16 08 41" src="https://github.com/user-attachments/assets/b08afb80-cef7-492f-ae6b-bc793fade182" />

This PR resolves by displaying the message sooner, on the gated section itself:

<img width="686" height="669" alt="Screenshot 2025-11-03 at 16 08 38" src="https://github.com/user-attachments/assets/4749e246-5f63-4fc3-9973-dffcb1e1ea8b" />

## Testing

- `testRestrictContentDisplaysNoticeWhenNoAccess`: Test that the no access notice is displayed before clicking login on content gated by Product, after the user has logged in to access content gated by a different resource e.g. a Form.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)