### PR TITLE
Tests: Coding Standards: Use `contains` for PHP version check

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -120,7 +120,7 @@ jobs:
       # Installs WordPress scripts for CSS and JS Coding Standards.
       - name: Run npm install
         working-directory: ${{ env.PLUGIN_DIR }}
-        run: npm installtes
+        run: npm install
 
       # Run PHP Coding Standards on Tests.
       - name: Run WordPress PHP Coding Standards on Tests


### PR DESCRIPTION
## Summary

Uses `contains` instead of a lengthly if statement in the GitHub action, when conditionally running step(s) based on the PHP version.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)