### PR TITLE
Block Editor: Add `convertKitGutenbergEnabled` helper

### DIFF
--- a/resources/backend/js/gutenberg-block-formatters.js
+++ b/resources/backend/js/gutenberg-block-formatters.js
@@ -13,7 +13,7 @@
 // Register Gutenberg Block Toolbar formatters if the Gutenberg Editor is loaded on screen.
 // This prevents JS errors if this script is accidentally enqueued on a non-
 // Gutenberg editor screen, or the Classic Editor Plugin is active.
-if (typeof wp !== 'undefined' && typeof wp.blockEditor !== 'undefined') {
+if (convertKitGutenbergEnabled()) {
 	// Register each ConvertKit formatter in Gutenberg.
 	for (const formatter in convertkit_block_formatters) {
 		convertKitGutenbergRegisterBlockFormatter(

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -13,7 +13,7 @@
 // Register Gutenberg Blocks if the Gutenberg Editor is loaded on screen.
 // This prevents JS errors if this script is accidentally enqueued on a non-
 // Gutenberg editor screen, or the Classic Editor Plugin is active.
-if (typeof wp !== 'undefined' && typeof wp.blockEditor !== 'undefined') {
+if (convertKitGutenbergEnabled()) {
 	// Register each ConvertKit Block in Gutenberg.
 	for (const block in convertkit_blocks) {
 		convertKitGutenbergRegisterBlock(convertkit_blocks[block]);
@@ -941,4 +941,18 @@ function convertKitGutenbergDisplayBlockNotice(block_name, notice) {
 function convertKitEditingPostInGutenberg() {
 	// If the user is editing a post in the block editor, wp.editPost will be defined.
 	return typeof wp !== 'undefined' && typeof wp.editPost !== 'undefined';
+}
+
+/**
+ * Checks if the Gutenberg editor is loaded on screen.
+ *
+ * Returns true when editing a Post, Page or Custom Post Type in the block editor,
+ * or using the site editor.
+ *
+ * @since   3.0.8
+ *
+ * @return {boolean} Block editor is loaded
+ */
+function convertKitGutenbergEnabled() {
+	return typeof wp !== 'undefined' && typeof wp.blockEditor !== 'undefined';
 }


### PR DESCRIPTION
## Summary

Building on https://github.com/Kit/convertkit-wordpress/pull/938, adds a helper method to detect if the block editor is enabled.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)