### PR TITLE
Move `maybe_disconnect` call

### DIFF
--- a/admin/section/class-convertkit-admin-section-general.php
+++ b/admin/section/class-convertkit-admin-section-general.php
@@ -81,6 +81,8 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 			),
 		);
 
+		$this->maybe_disconnect();
+
 		// Register and maybe output notices for this settings screen, and the Intercom messenger.
 		if ( $this->on_settings_screen( $this->name ) ) {
 			add_filter( 'convertkit_settings_base_register_notices', array( $this, 'register_notices' ) );
@@ -94,7 +96,6 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 		parent::__construct();
 
 		$this->check_credentials();
-		$this->maybe_disconnect();
 
 	}
 


### PR DESCRIPTION
## Summary

Moves the `maybe_disconnect` call earlier in the request, to avoid fetching resources from the API before then honoring the user's disconnect request.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)