### PR TITLE
Remove Custom Fields and Sequences on Disconnect

### DIFF
--- a/admin/section/class-convertkit-admin-section-general.php
+++ b/admin/section/class-convertkit-admin-section-general.php
@@ -198,16 +198,20 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 
 		// Delete cached resources.
 		$creator_network = new ConvertKit_Resource_Creator_Network_Recommendations();
+		$custom_fields   = new ConvertKit_Resource_Custom_Fields();
 		$forms           = new ConvertKit_Resource_Forms();
 		$landing_pages   = new ConvertKit_Resource_Landing_Pages();
 		$posts           = new ConvertKit_Resource_Posts();
 		$products        = new ConvertKit_Resource_Products();
+		$sequences       = new ConvertKit_Resource_Sequences();
 		$tags            = new ConvertKit_Resource_Tags();
 		$creator_network->delete();
+		$custom_fields->delete();
 		$forms->delete();
 		$landing_pages->delete();
 		$posts->delete();
 		$products->delete();
+		$sequences->delete();
 		$tags->delete();
 
 		// Redirect to General screen, which will now show the ConvertKit_Settings_OAuth screen, because

--- a/tests/EndToEnd/general/plugin-screens/PluginSettingsGeneralCest.php
+++ b/tests/EndToEnd/general/plugin-screens/PluginSettingsGeneralCest.php
@@ -176,6 +176,16 @@ class PluginSettingsGeneralCest
 		// Disconnect the Plugin connection to Kit.
 		$I->click('Disconnect');
 
+		// Check cached resources are removed from the database on disconnection.
+		$I->dontSeeOptionInDatabase('convertkit_creator_network_recommendations');
+		$I->dontSeeOptionInDatabase('convertkit_custom_fields');
+		$I->dontSeeOptionInDatabase('convertkit_forms');
+		$I->dontSeeOptionInDatabase('convertkit_landing_pages');
+		$I->dontSeeOptionInDatabase('convertkit_posts');
+		$I->dontSeeOptionInDatabase('convertkit_products');
+		$I->dontSeeOptionInDatabase('convertkit_sequences');
+		$I->dontSeeOptionInDatabase('convertkit_tags');
+
 		// Confirm the Connect button displays.
 		$I->see('Connect');
 		$I->dontSee('Disconnect');


### PR DESCRIPTION
## Summary

Removes Custom Fields and Sequences from cached resources when the user disconnects the Kit Plugin via Settings > Kit > Disconnect.

## Testing

- `testValidCredentials`: Updated test to confirm resources are deleted on disconnection.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)