### PR TITLE
Blocks: Fix unique `key` prop warning

### DIFF
--- a/resources/backend/css/gutenberg.css
+++ b/resources/backend/css/gutenberg.css
@@ -2,7 +2,7 @@
 .components-flex-item button.wp-convertkit-refresh-resources {
 	margin: 24px 0 0 0;
 	padding: 0;
-	height: 32px;
+	height: 40px;
 }
 
 .components-flex-item button.wp-convertkit-refresh-resources span.dashicons {

--- a/resources/backend/js/gutenberg-block-form.js
+++ b/resources/backend/js/gutenberg-block-form.js
@@ -77,7 +77,7 @@ function convertKitGutenbergFormBlockRenderPreview(block, props) {
 			{
 				className: className.join(' '),
 			},
-			wp.components.SandBox({
+			wp.element.createElement(wp.components.SandBox, {
 				html,
 				title: block.name,
 				styles: [

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -144,6 +144,13 @@ function convertKitGutenbergRegisterBlock(block) {
 				label: field.label,
 				help: field.description,
 				value: props.attributes[attribute],
+
+				// Add __next40pxDefaultSize and __nextHasNoMarginBottom properties,
+				// preventing deprecation notices in the block editor and opt in to the new styles
+				// from 7.0.
+				__next40pxDefaultSize: true,
+				__nextHasNoMarginBottom: true,
+
 				onChange(value) {
 					if (field.type === 'number') {
 						// If value is a blank string i.e. no attribute value was provided,


### PR DESCRIPTION
## Summary

Fixes a React warning in the browser console that all items require a unique `key` property.

<img width="516" height="154" alt="Screenshot 2025-12-09 at 13 44 11" src="https://github.com/user-attachments/assets/c64f3058-85b1-473f-a975-10e0b3242f68" />

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)