### PR TITLE
Tests: Elementor: Dismiss Notice

### DIFF
--- a/tests/Support/Data/dump-6.2.8.sql
+++ b/tests/Support/Data/dump-6.2.8.sql
@@ -334,7 +334,8 @@ INSERT INTO `wp_usermeta` (`umeta_id`, `user_id`, `meta_key`, `meta_value`) VALU
 (19,  1,  'wp_dashboard_quick_press_last_post_id',  '1'),
 (20,  1,  'edit_page_per_page',  '100'),
 (21,  1,  'edit_post_per_page',  '100'),
-(22,  1,  'wp_persisted_preferences', 'a:4:{s:4:"core";a:2:{s:26:"isComplementaryAreaVisible";b:1;s:24:"enableChoosePatternModal";b:0;}s:14:"core/edit-post";a:4:{s:12:"welcomeGuide";b:0;s:23:"metaBoxesMainOpenHeight";i:540;s:20:"welcomeGuideTemplate";b:0;s:19:"metaBoxesMainIsOpen";b:1;}s:9:"_modified";s:24:"2024-07-18T02:45:41.491Z";s:17:"core/edit-widgets";a:2:{s:26:"isComplementaryAreaVisible";b:1;s:12:"welcomeGuide";b:0;}}');
+(22,  1,  'wp_persisted_preferences', 'a:4:{s:4:"core";a:2:{s:26:"isComplementaryAreaVisible";b:1;s:24:"enableChoosePatternModal";b:0;}s:14:"core/edit-post";a:4:{s:12:"welcomeGuide";b:0;s:23:"metaBoxesMainOpenHeight";i:540;s:20:"welcomeGuideTemplate";b:0;s:19:"metaBoxesMainIsOpen";b:1;}s:9:"_modified";s:24:"2024-07-18T02:45:41.491Z";s:17:"core/edit-widgets";a:2:{s:26:"isComplementaryAreaVisible";b:1;s:12:"welcomeGuide";b:0;}}'),
+(23,  1,  'elementor_introduction', 'a:5:{s:7:"exit_to";b:1;s:27:"ai-get-started-announcement";b:1;s:20:"globals_introduction";b:1;s:6:"e-apps";b:1;s:27:"e-editor-one-notice-pointer";b:1;}');
 
 DROP TABLE IF EXISTS `wp_users`;
 CREATE TABLE `wp_users` (

--- a/tests/Support/Data/dump.sql
+++ b/tests/Support/Data/dump.sql
@@ -372,7 +372,8 @@ INSERT INTO `wp_usermeta` (`umeta_id`, `user_id`, `meta_key`, `meta_value`) VALU
 (19,  1,  'wp_dashboard_quick_press_last_post_id',  '1'),
 (20,  1,  'edit_page_per_page',  '100'),
 (21,  1,  'edit_post_per_page',  '100'),
-(22,  1,  'wp_persisted_preferences', 'a:4:{s:4:"core";a:1:{s:26:"isComplementaryAreaVisible";b:1;}s:14:"core/edit-post";a:1:{s:12:"welcomeGuide";b:0;}s:9:"_modified";s:24:"2024-07-18T02:45:41.491Z";s:17:"core/edit-widgets";a:2:{s:26:"isComplementaryAreaVisible";b:1;s:12:"welcomeGuide";b:0;}}');
+(22,  1,  'wp_persisted_preferences', 'a:4:{s:4:"core";a:1:{s:26:"isComplementaryAreaVisible";b:1;}s:14:"core/edit-post";a:1:{s:12:"welcomeGuide";b:0;}s:9:"_modified";s:24:"2024-07-18T02:45:41.491Z";s:17:"core/edit-widgets";a:2:{s:26:"isComplementaryAreaVisible";b:1;s:12:"welcomeGuide";b:0;}}'),
+(23,  1,  'elementor_introduction', 'a:5:{s:7:"exit_to";b:1;s:27:"ai-get-started-announcement";b:1;s:20:"globals_introduction";b:1;s:6:"e-apps";b:1;s:27:"e-editor-one-notice-pointer";b:1;}');
 
 DROP TABLE IF EXISTS `wp_users`;
 CREATE TABLE `wp_users` (


### PR DESCRIPTION
## Summary

Updates the database dump file to prevent Elementor displaying a notice in 3.34.2 and higher, which breaks tests:

<img width="1920" height="941" alt="Tests EndToEnd ElementorBroadcastsCest testBroadcastsWidgetIsRegistered fail" src="https://github.com/user-attachments/assets/99a8dd46-aa8d-456d-9239-5167fd34508c" />

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)