### PR TITLE
Settings: Disable "Add New" Button

### DIFF
--- a/admin/class-convertkit-admin-landing-page.php
+++ b/admin/class-convertkit-admin-landing-page.php
@@ -44,6 +44,11 @@ class ConvertKit_Admin_Landing_Page {
 			return $buttons;
 		}
 
+		// If the Add New Landing Page / Member Content button is disabled, don't output the button.
+		if ( $settings->add_new_disabled() ) {
+			return $buttons;
+		}
+
 		// Bail if the Post Type isn't supported.
 		if ( $post_type !== 'page' ) {
 			return $buttons;

--- a/admin/class-convertkit-admin-landing-page.php
+++ b/admin/class-convertkit-admin-landing-page.php
@@ -45,7 +45,7 @@ class ConvertKit_Admin_Landing_Page {
 		}
 
 		// If the Add New Landing Page / Member Content button is disabled, don't output the button.
-		if ( $settings->add_new_disabled() ) {
+		if ( $settings->add_new_button_disabled() ) {
 			return $buttons;
 		}
 

--- a/admin/class-convertkit-admin-restrict-content.php
+++ b/admin/class-convertkit-admin-restrict-content.php
@@ -241,6 +241,11 @@ class ConvertKit_Admin_Restrict_Content {
 			return $buttons;
 		}
 
+		// If the Add New Landing Page / Member Content button is disabled, don't output the button.
+		if ( $settings->add_new_disabled() ) {
+			return $buttons;
+		}
+
 		// Bail if the Post Type isn't supported.
 		if ( ! in_array( $post_type, convertkit_get_supported_post_types(), true ) ) {
 			return $buttons;

--- a/admin/class-convertkit-admin-restrict-content.php
+++ b/admin/class-convertkit-admin-restrict-content.php
@@ -242,7 +242,7 @@ class ConvertKit_Admin_Restrict_Content {
 		}
 
 		// If the Add New Landing Page / Member Content button is disabled, don't output the button.
-		if ( $settings->add_new_disabled() ) {
+		if ( $settings->add_new_button_disabled() ) {
 			return $buttons;
 		}
 

--- a/admin/section/class-convertkit-admin-section-general.php
+++ b/admin/section/class-convertkit-admin-section-general.php
@@ -462,6 +462,17 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 		);
 
 		add_settings_field(
+			'no_css',
+			__( 'Disable Add New Landing Page / Member Content Button', 'convertkit' ),
+			array( $this, 'no_add_new_callback' ),
+			$this->settings_key,
+			$this->name . '-advanced',
+			array(
+				'label_for' => 'no_add_new',
+			)
+		);
+
+		add_settings_field(
 			'usage_tracking',
 			__( 'Usage Tracking', 'convertkit' ),
 			array( $this, 'usage_tracking_callback' ),
@@ -1011,6 +1022,23 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 					esc_html__( 'integrations.', 'convertkit' )
 				),
 			)
+		);
+
+	}
+
+	/**
+	 * Renders the input for the Disable Add New Landing Page / Member Content setting.
+	 *
+	 * @since   3.2.0
+	 */
+	public function no_add_new_callback() {
+
+		// Output field.
+		$this->output_checkbox_field(
+			'no_add_new',
+			'on',
+			$this->settings->add_new_disabled(),
+			esc_html__( 'Hide the "Add New" button on Pages for creating Landing Pages and Member Content.', 'convertkit' )
 		);
 
 	}

--- a/admin/section/class-convertkit-admin-section-general.php
+++ b/admin/section/class-convertkit-admin-section-general.php
@@ -464,11 +464,11 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 		add_settings_field(
 			'no_css',
 			__( 'Disable Add New Landing Page / Member Content Button', 'convertkit' ),
-			array( $this, 'no_add_new_callback' ),
+			array( $this, 'no_add_new_button_callback' ),
 			$this->settings_key,
 			$this->name . '-advanced',
 			array(
-				'label_for' => 'no_add_new',
+				'label_for' => 'no_add_new_button',
 			)
 		);
 
@@ -1031,13 +1031,13 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 	 *
 	 * @since   3.2.0
 	 */
-	public function no_add_new_callback() {
+	public function no_add_new_button_callback() {
 
 		// Output field.
 		$this->output_checkbox_field(
-			'no_add_new',
+			'no_add_new_button',
 			'on',
-			$this->settings->add_new_disabled(),
+			$this->settings->add_new_button_disabled(),
 			esc_html__( 'Hide the "Add New" button on Pages for creating Landing Pages and Member Content.', 'convertkit' )
 		);
 

--- a/admin/section/class-convertkit-admin-section-general.php
+++ b/admin/section/class-convertkit-admin-section-general.php
@@ -462,7 +462,7 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 		);
 
 		add_settings_field(
-			'no_css',
+			'no_add_new_button',
 			__( 'Disable Add New Landing Page / Member Content Button', 'convertkit' ),
 			array( $this, 'no_add_new_button_callback' ),
 			$this->settings_key,

--- a/includes/class-convertkit-settings.php
+++ b/includes/class-convertkit-settings.php
@@ -543,15 +543,15 @@ class ConvertKit_Settings {
 	}
 
 	/**
-	 * Returns whether the Add New Landing Page / Member Content option is disabled in the Plugin settings.
+	 * Returns whether the Add New Landing Page / Member Content button is disabled in the Plugin settings.
 	 *
 	 * @since   3.2.0
 	 *
 	 * @return  bool
 	 */
-	public function add_new_disabled() {
+	public function add_new_button_disabled() {
 
-		return ( $this->settings['no_add_new'] === 'on' ? true : false );
+		return ( $this->settings['no_add_new_button'] === 'on' ? true : false );
 
 	}
 
@@ -602,7 +602,7 @@ class ConvertKit_Settings {
 			'debug'                              => '', // blank|on.
 			'no_scripts'                         => '', // blank|on.
 			'no_css'                             => '', // blank|on.
-			'no_add_new'                         => '', // blank|on.
+			'no_add_new_button'                  => '', // blank|on.
 			'usage_tracking'                     => '', // blank|on.
 		);
 

--- a/includes/class-convertkit-settings.php
+++ b/includes/class-convertkit-settings.php
@@ -543,6 +543,19 @@ class ConvertKit_Settings {
 	}
 
 	/**
+	 * Returns whether the Add New Landing Page / Member Content option is disabled in the Plugin settings.
+	 *
+	 * @since   3.2.0
+	 *
+	 * @return  bool
+	 */
+	public function add_new_disabled() {
+
+		return ( $this->settings['no_add_new'] === 'on' ? true : false );
+
+	}
+
+	/**
 	 * Returns whether usage tracking is enabled in the Plugin settings.
 	 *
 	 * @since   3.0.4
@@ -589,6 +602,7 @@ class ConvertKit_Settings {
 			'debug'                              => '', // blank|on.
 			'no_scripts'                         => '', // blank|on.
 			'no_css'                             => '', // blank|on.
+			'no_add_new'                         => '', // blank|on.
 			'usage_tracking'                     => '', // blank|on.
 		);
 

--- a/tests/EndToEnd.suite.yml
+++ b/tests/EndToEnd.suite.yml
@@ -55,6 +55,7 @@ modules:
             capabilities:
               "goog:chromeOptions":
                 args:
+                  - "--headless"
                   - "--disable-gpu"
                   - "--disable-dev-shm-usage"
                   - "--disable-software-rasterizer"

--- a/tests/EndToEnd.suite.yml
+++ b/tests/EndToEnd.suite.yml
@@ -55,7 +55,6 @@ modules:
             capabilities:
               "goog:chromeOptions":
                 args:
-                  - "--headless"
                   - "--disable-gpu"
                   - "--disable-dev-shm-usage"
                   - "--disable-software-rasterizer"

--- a/tests/EndToEnd/general/plugin-screens/PluginSettingsGeneralCest.php
+++ b/tests/EndToEnd/general/plugin-screens/PluginSettingsGeneralCest.php
@@ -45,6 +45,7 @@ class PluginSettingsGeneralCest
 		$I->seeInSource('<label for="debug">');
 		$I->seeInSource('<label for="no_scripts">');
 		$I->seeInSource('<label for="no_css">');
+		$I->seeInSource('<label for="no_add_new_button">');
 		$I->seeInSource('<label for="usage_tracking">');
 
 		// Confirm that the UTM parameters exist for the documentation links.
@@ -776,6 +777,48 @@ class PluginSettingsGeneralCest
 
 		// Confirm CSS is output by the Plugin.
 		$I->seeInSource('<link rel="stylesheet" id="convertkit-frontend-css" href="' . $_ENV['WORDPRESS_URL'] . '/wp-content/plugins/convertkit/resources/frontend/css/frontend.css');
+	}
+
+	/**
+	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen
+	 * when the Disable Add New Landing Page / Member Content button settings is unchecked, and that CSS is output
+	 * on the frontend web site.
+	 *
+	 * @since   3.2.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testEnableAndDisableAddNewLandingPageMemberContentButtonSetting(EndToEndTester $I)
+	{
+		// Setup Plugin.
+		$I->setupKitPlugin($I);
+
+		// Go to the Plugin's Settings Screen.
+		$I->loadKitSettingsGeneralScreen($I);
+
+		// Tick field.
+		$I->checkOption('#no_add_new_button');
+
+		// Click the Save Changes button.
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check the field remains ticked.
+		$I->seeCheckboxIsChecked('#no_add_new_button');
+
+		// Untick field.
+		$I->uncheckOption('#no_add_new_button');
+
+		// Click the Save Changes button.
+		$I->click('Save Changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Check the field remains unticked.
+		$I->dontSeeCheckboxIsChecked('#no_add_new_button');
 	}
 
 	/**

--- a/tests/EndToEnd/landing-pages/PageLandingPageSetupWizardCest.php
+++ b/tests/EndToEnd/landing-pages/PageLandingPageSetupWizardCest.php
@@ -61,6 +61,30 @@ class PageLandingPageSetupWizardCest
 	}
 
 	/**
+	 * Test that the Add New Landing Page button does not display on the Pages screen when the Add New Landing Page / Member Content button is disabled.
+	 *
+	 * @since   3.2.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testAddNewLandingPageButtonNotDisplayedWhenDisabled(EndToEndTester $I)
+	{
+		// Setup Plugin, disabling the Add New Landing Page / Member Content button.
+		$I->setupKitPlugin(
+			$I,
+			[
+				'no_add_new_button' => 'on',
+			]
+		);
+
+		// Navigate to Pages.
+		$I->amOnAdminPage('edit.php?post_type=page');
+
+		// Check the buttons are not displayed.
+		$I->dontSeeElementInDOM('span.convertkit-action.page-title-action');
+	}
+
+	/**
 	 * Test that the Dashboard submenu item for this wizard does not display when a
 	 * third party Admin Menu editor type Plugin is installed and active.
 	 *

--- a/tests/EndToEnd/restrict-content/general/RestrictContentSetupCest.php
+++ b/tests/EndToEnd/restrict-content/general/RestrictContentSetupCest.php
@@ -61,6 +61,30 @@ class RestrictContentSetupCest
 	}
 
 	/**
+	 * Test that the Add New Member Content button does not display on the Pages screen when the Add New Member Content button is disabled.
+	 *
+	 * @since   3.2.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testAddNewMemberContentButtonNotDisplayedWhenDisabled(EndToEndTester $I)
+	{
+		// Setup Plugin, disabling the Add New Landing Page / Member Content button.
+		$I->setupKitPlugin(
+			$I,
+			[
+				'no_add_new_button' => 'on',
+			]
+		);
+
+		// Navigate to Pages.
+		$I->amOnAdminPage('edit.php?post_type=page');
+
+		// Check the buttons are not displayed.
+		$I->dontSeeElementInDOM('span.convertkit-action.page-title-action');
+	}
+
+	/**
 	 * Test that the Dashboard submenu item for this wizard does not display when a
 	 * third party Admin Menu editor type Plugin is installed and active.
 	 *

--- a/tests/Support/Helper/KitPlugin.php
+++ b/tests/Support/Helper/KitPlugin.php
@@ -72,6 +72,7 @@ class KitPlugin extends \Codeception\Module
 			'debug'                              => 'on',
 			'no_scripts'                         => '',
 			'no_css'                             => '',
+			'no_add_new_button'                  => '',
 			'usage_tracking'                     => '',
 			'post_form'                          => $_ENV['CONVERTKIT_API_FORM_ID'],
 			'page_form'                          => $_ENV['CONVERTKIT_API_FORM_ID'],


### PR DESCRIPTION
## Summary

Adds an option to disable the "Add New" Landing Page/Member Content dropdown button on Pages, [as requested here](https://wordpress.org/support/topic/possible-to-disable-kit-add-new-on-backend-pages-page/).

<img width="1348" height="1118" alt="Screenshot 2026-02-24 at 08 59 15" src="https://github.com/user-attachments/assets/9064da8b-1a90-4e38-b240-2da57916c2c2" />

## Testing

- `PluginSettingsGeneralCest:testAccessibilityAndUTMParameters`: Test the `Disable Add New Landing Page / Member Content Button` option has the correct label for accessibility
- `PluginSettingsGeneralCest:testEnableAndDisableAddNewLandingPageMemberContentButtonSetting`: Test the `Disable Add New Landing Page / Member Content Button` option saves correctly when changed
- `PageLandingPageSetupWizard:testAddNewLandingPageButtonNotDisplayedWhenDisabled`: Test the Add New button is not displayed when disabled in the Plugin's settings.
- `RestrictContentSetupCest:testAddNewMemberContentButtonNotDisplayedWhenDisabled`: Test the Add New button is not displayed when disabled in the Plugin's settings.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)