### PR TITLE
Reinstate backend JS linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "fix:css": "prettier --write 'resources/frontend/scss/**/*.scss' && wp-scripts lint-style 'resources/frontend/scss/**/*.scss' 'resources/backend/css/**/*.css' --fix",
     "build:js": "wp-scripts build resources/frontend/js/frontend.js --output-path=resources/frontend/js/dist --output-filename=frontend.min.js",
     "watch:js": "wp-scripts start resources/frontend/js/frontend.js --output-path=resources/frontend/js/dist --output-filename=frontend.min.js",
-    "lint:js": "wp-scripts lint-js 'resources/frontend/js/*.js' --max-warnings=0",
-    "fix:js": "wp-scripts lint-js 'resources/frontend/js/*.js' --fix",
+    "lint:js": "wp-scripts lint-js 'resources/frontend/js/*.js' 'resources/backend/js/*.js' --max-warnings=0",
+    "fix:js": "wp-scripts lint-js 'resources/frontend/js/*.js' 'resources/backend/js/*.js' --fix",
     "build": "npm run fix:css && npm run lint:css && npm run fix:js && npm run lint:js && npm run build:css && npm run build:js"
   },
   "prettier": "@wordpress/prettier-config",


### PR DESCRIPTION
## Summary

This was accidentally dropped in #1024

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)