### PR TITLE
JS: Fix Uncaught ReferenceError `convertkit`

### DIFF
--- a/resources/frontend/js/convertkit.js
+++ b/resources/frontend/js/convertkit.js
@@ -162,67 +162,71 @@ window.convertKitRecaptchaFormSubmit = convertKitRecaptchaFormSubmit;
 /* eslint-enable no-unused-vars */
 
 /**
- * Register events
+ * Register events on frontend.
+ *
+ * @since   3.2.0
  */
-document.addEventListener('DOMContentLoaded', function () {
-	// Removes `ck_subscriber_id` from the URI.
-	convertKitRemoveSubscriberIDFromURL(window.location.href);
+if (typeof convertkit !== 'undefined') {
+	document.addEventListener('DOMContentLoaded', function () {
+		// Removes `ck_subscriber_id` from the URI.
+		convertKitRemoveSubscriberIDFromURL(window.location.href);
 
-	// Store subscriber ID as a cookie from the email address used when a ConvertKit Form is submitted.
-	document.addEventListener('click', function (e) {
-		// Check if the form submit button was clicked, or the span element was clicked and its parent is the form submit button.
+		// Store subscriber ID as a cookie from the email address used when a ConvertKit Form is submitted.
+		document.addEventListener('click', function (e) {
+			// Check if the form submit button was clicked, or the span element was clicked and its parent is the form submit button.
+			if (
+				!e.target.matches('.formkit-submit') &&
+				(!e.target.parentElement ||
+					!e.target.parentElement.matches('.formkit-submit'))
+			) {
+				if (convertkit.debug) {
+					console.log('not a ck form');
+				}
+
+				return;
+			}
+
+			// Get email address.
+			const emailAddress = document.querySelector(
+				'input[name="email_address"]'
+			).value;
+
+			// If the email address is empty, don't attempt to get the subscriber ID by email.
+			if (!emailAddress.length) {
+				if (convertkit.debug) {
+					console.log('email empty');
+				}
+
+				return;
+			}
+
+			// If the email address is invalid, don't attempt to get the subscriber ID by email.
+			const validator =
+				/^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+			if (!validator.test(emailAddress.toLowerCase())) {
+				if (convertkit.debug) {
+					console.log('email not an email address');
+				}
+
+				return;
+			}
+
+			// Wait a moment before sending the AJAX request.
+			convertKitSleep(2000);
+			convertStoreSubscriberEmailAsIDInCookie(emailAddress);
+		});
+
+		// Set a cookie if any scripts with data-kit-limit-per-session attribute exist.
 		if (
-			!e.target.matches('.formkit-submit') &&
-			(!e.target.parentElement ||
-				!e.target.parentElement.matches('.formkit-submit'))
+			document.querySelectorAll('script[data-kit-limit-per-session="1"]')
+				.length > 0
 		) {
+			document.cookie = 'ck_non_inline_form_displayed=1; path=/';
 			if (convertkit.debug) {
-				console.log('not a ck form');
+				console.log(
+					'Set `ck_non_inline_form_displayed` cookie for non-inline form limit'
+				);
 			}
-
-			return;
 		}
-
-		// Get email address.
-		const emailAddress = document.querySelector(
-			'input[name="email_address"]'
-		).value;
-
-		// If the email address is empty, don't attempt to get the subscriber ID by email.
-		if (!emailAddress.length) {
-			if (convertkit.debug) {
-				console.log('email empty');
-			}
-
-			return;
-		}
-
-		// If the email address is invalid, don't attempt to get the subscriber ID by email.
-		const validator =
-			/^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-		if (!validator.test(emailAddress.toLowerCase())) {
-			if (convertkit.debug) {
-				console.log('email not an email address');
-			}
-
-			return;
-		}
-
-		// Wait a moment before sending the AJAX request.
-		convertKitSleep(2000);
-		convertStoreSubscriberEmailAsIDInCookie(emailAddress);
 	});
-
-	// Set a cookie if any scripts with data-kit-limit-per-session attribute exist.
-	if (
-		document.querySelectorAll('script[data-kit-limit-per-session="1"]')
-			.length > 0
-	) {
-		document.cookie = 'ck_non_inline_form_displayed=1; path=/';
-		if (convertkit.debug) {
-			console.log(
-				'Set `ck_non_inline_form_displayed` cookie for non-inline form limit'
-			);
-		}
-	}
-});
+}


### PR DESCRIPTION
## Summary

Fixes an uncaught ReferenceError due to bundling frontend JS into a single file, and the `convertkit` object not always being available i.e. when the user is in the WordPress Administration interface.

<img width="489" height="48" alt="Screenshot 2026-02-24 at 13 43 14" src="https://github.com/user-attachments/assets/07f0149a-b932-4ce2-93fe-693e27c4bfc3" />

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)