### PR TITLE
Blocks: Specify `apiVersion` in `registerBlockType`

### DIFF
--- a/includes/class-convertkit-gutenberg.php
+++ b/includes/class-convertkit-gutenberg.php
@@ -190,7 +190,7 @@ class ConvertKit_Gutenberg {
 	/**
 	 * Determines the block API version to use for registering blocks.
 	 *
-	 * @since   3.3.0
+	 * @since   3.2.0
 	 *
 	 * @return  int    Block API version.
 	 */

--- a/includes/class-convertkit-gutenberg.php
+++ b/includes/class-convertkit-gutenberg.php
@@ -149,19 +149,7 @@ class ConvertKit_Gutenberg {
 		}
 
 		// Determine the block API version to use for registering blocks.
-		// WordPress supports Version 3 from WordPress 6.3:
-		// https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/.
-		$block_api_version = ( version_compare( get_bloginfo( 'version' ), '6.3', '>=' ) ? 3 : 2 );
-
-		/**
-		 * Determine the block API version to use for registering blocks.
-		 *
-		 * @since   3.1.4
-		 *
-		 * @param   int  $block_api_version    Block API version.
-		 * @return  int                        Block API version.
-		 */
-		$block_api_version = apply_filters( 'convertkit_gutenberg_block_api_version', $block_api_version );
+		$block_api_version = $this->get_block_api_version();
 
 		// Get registered blocks.
 		$registered_blocks = array_keys( WP_Block_Type_Registry::get_instance()->get_all_registered() );
@@ -200,6 +188,33 @@ class ConvertKit_Gutenberg {
 	}
 
 	/**
+	 * Determines the block API version to use for registering blocks.
+	 *
+	 * @since   3.3.0
+	 *
+	 * @return  int    Block API version.
+	 */
+	public function get_block_api_version() {
+
+		// Determine the block API version to use for registering blocks.
+		// WordPress supports Version 3 from WordPress 6.3:
+		// https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/.
+		$block_api_version = ( version_compare( get_bloginfo( 'version' ), '6.3', '>=' ) ? 3 : 2 );
+
+		/**
+		 * Determine the block API version to use for registering blocks.
+		 *
+		 * @since   3.1.4
+		 *
+		 * @param   int  $block_api_version    Block API version.
+		 * @return  int                        Block API version.
+		 */
+		$block_api_version = apply_filters( 'convertkit_gutenberg_block_api_version', $block_api_version );
+
+		return absint( $block_api_version );
+
+	}
+	/**
 	 * Enqueues scripts for Gutenberg blocks in the editor view.
 	 *
 	 * @since   1.9.6
@@ -229,8 +244,9 @@ class ConvertKit_Gutenberg {
 			'convertkit-gutenberg',
 			'convertkit_gutenberg',
 			array(
-				'ajaxurl'          => rest_url( 'kit/v1/blocks' ),
-				'get_blocks_nonce' => wp_create_nonce( 'wp_rest' ),
+				'ajaxurl'           => rest_url( 'kit/v1/blocks' ),
+				'block_api_version' => $this->get_block_api_version(),
+				'get_blocks_nonce'  => wp_create_nonce( 'wp_rest' ),
 			)
 		);
 

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -885,6 +885,7 @@ function convertKitGutenbergRegisterBlock(block) {
 
 		// Register Block.
 		registerBlockType('convertkit/' + block.name, {
+			apiVersion: convertkit_gutenberg.block_api_version,
 			title: block.title,
 			description: block.description,
 			category: block.category,


### PR DESCRIPTION
## Summary

#982 and #985 upgraded the Plugin's blocks to the block `apiVersion` 2 and 3 respectively, depending on the WordPress version. However, this is insufficient, as `registerBlockType` must also specify the `apiVersion`, which this PR resolves.

<img width="754" height="94" alt="Screenshot 2026-02-24 at 14 36 56" src="https://github.com/user-attachments/assets/ba588f7c-0473-4944-b589-9b42fd7ef4df" />

`registerBlockType` does support [passing the metadata object](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#javascript) loaded from our block.json definitions, which will be addressed in a future PR when our JS build work extends to the backend scripts.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)