### PR TITLE
Classic Editor: Add closing tag to `color` input

### DIFF
--- a/views/backend/tinymce/modal-field-row.php
+++ b/views/backend/tinymce/modal-field-row.php
@@ -22,7 +22,7 @@ if ( isset( $field['condition'] ) ) {
 			<?php echo esc_attr( $field['label'] ); ?>
 		</label>
 	</div>
-	<div class="right <?php echo esc_attr( $condition ); ?>">
+	<div class="right<?php echo ! empty( $condition ) ? ' ' . esc_attr( $condition ) : ''; ?>">
 		<?php
 		require 'modal-field.php';
 		?>

--- a/views/backend/tinymce/modal-field.php
+++ b/views/backend/tinymce/modal-field.php
@@ -117,6 +117,7 @@ switch ( $field['type'] ) {
 				data-shortcode="<?php echo esc_attr( $field_name ); ?>"
 				placeholder="<?php echo esc_attr( isset( $field['placeholder'] ) ? $field['placeholder'] : '' ); ?>"
 				<?php echo ( array_key_exists( 'display_if', $field ) ? ' data-display-if="' . esc_attr( $field['display_if']['key'] ) . '" data-display-if-value="' . esc_attr( $field['display_if']['value'] ) . '"' : '' ); ?>
+				/>
 		<?php
 		break;
 }


### PR DESCRIPTION
## Summary

Adds a missing closing tag to the `color` input type.

Before:
<img width="668" height="559" alt="Screenshot 2026-02-24 at 15 24 16" src="https://github.com/user-attachments/assets/236d4c62-1ecc-4609-9c86-4f38bc118349" />

After:
<img width="668" height="560" alt="Screenshot 2026-02-24 at 15 24 06" src="https://github.com/user-attachments/assets/f3bb93b8-19c3-47e5-9df2-2647f953a19f" />

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)