### PR TITLE
Default Form Position: Fix errant HTML tags

### DIFF
--- a/tests/EndToEnd.suite.yml
+++ b/tests/EndToEnd.suite.yml
@@ -55,6 +55,7 @@ modules:
             capabilities:
               "goog:chromeOptions":
                 args:
+                  - "--headless"
                   - "--disable-gpu"
                   - "--disable-dev-shm-usage"
                   - "--disable-software-rasterizer"

--- a/tests/EndToEnd.suite.yml
+++ b/tests/EndToEnd.suite.yml
@@ -55,7 +55,6 @@ modules:
             capabilities:
               "goog:chromeOptions":
                 args:
-                  - "--headless"
                   - "--disable-gpu"
                   - "--disable-dev-shm-usage"
                   - "--disable-software-rasterizer"

--- a/tests/EndToEnd/forms/post-types/CPTFormCest.php
+++ b/tests/EndToEnd/forms/post-types/CPTFormCest.php
@@ -356,6 +356,9 @@ class CPTFormCest
 
 		// Confirm no meta tag exists within the content.
 		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
+
+		// Confirm no extra <html>, <head> or <body> tags are output i.e. injecting the form doesn't result in DOMDocument adding tags.
+		$I->seeNoExtraHtmlHeadBodyTagsOutput($I);
 	}
 
 	/**
@@ -403,6 +406,9 @@ class CPTFormCest
 
 		// Confirm no meta tag exists within the content.
 		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
+
+		// Confirm no extra <html>, <head> or <body> tags are output i.e. injecting the form doesn't result in DOMDocument adding tags.
+		$I->seeNoExtraHtmlHeadBodyTagsOutput($I);
 	}
 
 	/**
@@ -455,6 +461,9 @@ class CPTFormCest
 
 		// Confirm no meta tag exists within the content.
 		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
+
+		// Confirm no extra <html>, <head> or <body> tags are output i.e. injecting the form doesn't result in DOMDocument adding tags.
+		$I->seeNoExtraHtmlHeadBodyTagsOutput($I);
 	}
 
 	/**
@@ -507,6 +516,9 @@ class CPTFormCest
 
 		// Confirm no meta tag exists within the content.
 		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
+
+		// Confirm no extra <html>, <head> or <body> tags are output i.e. injecting the form doesn't result in DOMDocument adding tags.
+		$I->seeNoExtraHtmlHeadBodyTagsOutput($I);
 	}
 
 	/**
@@ -558,6 +570,9 @@ class CPTFormCest
 
 		// Confirm no meta tag exists within the content.
 		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
+
+		// Confirm no extra <html>, <head> or <body> tags are output i.e. injecting the form doesn't result in DOMDocument adding tags.
+		$I->seeNoExtraHtmlHeadBodyTagsOutput($I);
 	}
 
 	/**

--- a/tests/EndToEnd/forms/post-types/PageFormCest.php
+++ b/tests/EndToEnd/forms/post-types/PageFormCest.php
@@ -278,6 +278,9 @@ class PageFormCest
 
 		// Confirm no meta tag exists within the content.
 		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
+
+		// Confirm no extra <html>, <head> or <body> tags are output i.e. injecting the form doesn't result in DOMDocument adding tags.
+		$I->seeNoExtraHtmlHeadBodyTagsOutput($I);
 	}
 
 	/**
@@ -324,6 +327,9 @@ class PageFormCest
 
 		// Confirm no meta tag exists within the content.
 		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
+
+		// Confirm no extra <html>, <head> or <body> tags are output i.e. injecting the form doesn't result in DOMDocument adding tags.
+		$I->seeNoExtraHtmlHeadBodyTagsOutput($I);
 	}
 
 	/**
@@ -375,6 +381,9 @@ class PageFormCest
 
 		// Confirm no meta tag exists within the content.
 		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
+
+		// Confirm no extra <html>, <head> or <body> tags are output i.e. injecting the form doesn't result in DOMDocument adding tags.
+		$I->seeNoExtraHtmlHeadBodyTagsOutput($I);
 	}
 
 	/**
@@ -427,8 +436,8 @@ class PageFormCest
 		// Confirm no meta tag exists within the content.
 		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
 
-		// Confirm no meta tag exists within the content.
-		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
+		// Confirm no extra <html>, <head> or <body> tags are output i.e. injecting the form doesn't result in DOMDocument adding tags.
+		$I->seeNoExtraHtmlHeadBodyTagsOutput($I);
 	}
 
 	/**
@@ -479,6 +488,9 @@ class PageFormCest
 
 		// Confirm no meta tag exists within the content.
 		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
+
+		// Confirm no extra <html>, <head> or <body> tags are output i.e. injecting the form doesn't result in DOMDocument adding tags.
+		$I->seeNoExtraHtmlHeadBodyTagsOutput($I);
 	}
 
 	/**

--- a/tests/EndToEnd/forms/post-types/PostFormCest.php
+++ b/tests/EndToEnd/forms/post-types/PostFormCest.php
@@ -282,6 +282,9 @@ class PostFormCest
 
 		// Confirm no meta tag exists within the content.
 		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
+
+		// Confirm no extra <html>, <head> or <body> tags are output i.e. injecting the form doesn't result in DOMDocument adding tags.
+		$I->seeNoExtraHtmlHeadBodyTagsOutput($I);
 	}
 
 	/**
@@ -329,6 +332,9 @@ class PostFormCest
 
 		// Confirm no meta tag exists within the content.
 		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
+
+		// Confirm no extra <html>, <head> or <body> tags are output i.e. injecting the form doesn't result in DOMDocument adding tags.
+		$I->seeNoExtraHtmlHeadBodyTagsOutput($I);
 	}
 
 	/**
@@ -381,6 +387,9 @@ class PostFormCest
 
 		// Confirm no meta tag exists within the content.
 		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
+
+		// Confirm no extra <html>, <head> or <body> tags are output i.e. injecting the form doesn't result in DOMDocument adding tags.
+		$I->seeNoExtraHtmlHeadBodyTagsOutput($I);
 	}
 
 	/**
@@ -433,6 +442,9 @@ class PostFormCest
 
 		// Confirm no meta tag exists within the content.
 		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
+
+		// Confirm no extra <html>, <head> or <body> tags are output i.e. injecting the form doesn't result in DOMDocument adding tags.
+		$I->seeNoExtraHtmlHeadBodyTagsOutput($I);
 	}
 
 	/**
@@ -484,6 +496,9 @@ class PostFormCest
 
 		// Confirm no meta tag exists within the content.
 		$I->dontSeeInSource('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">');
+
+		// Confirm no extra <html>, <head> or <body> tags are output i.e. injecting the form doesn't result in DOMDocument adding tags.
+		$I->seeNoExtraHtmlHeadBodyTagsOutput($I);
 	}
 
 	/**

--- a/tests/Support/Helper/KitForms.php
+++ b/tests/Support/Helper/KitForms.php
@@ -236,4 +236,18 @@ class KitForms extends \Codeception\Module
 		$I->seeInSource('</body>');
 		$I->seeInSource('</html>');
 	}
+
+	/**
+	 * Confirm no extra <html>, <head> or <body> tags are output i.e. injecting the form doesn't result in DOMDocument adding tags.
+	 *
+	 * @since   3.2.1
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function seeNoExtraHtmlHeadBodyTagsOutput($I)
+	{
+		$I->seeNumberOfElementsInDOM('html', 1);
+		$I->seeNumberOfElementsInDOM('head', 1);
+		$I->seeNumberOfElementsInDOM('body', 1);
+	}
 }


### PR DESCRIPTION
## Summary

This PR fixes an issue introduced in [#723](https://github.com/Kit/convertkit-wordpress/pull/723), which allowed creators to choose where to display forms in Pages, Posts, and Custom Post Types (e.g., after the 3rd paragraph).

Previously, the implementation injected the entire `$form_node->documentElement` into the content using PHP's `DOMDocument`, which inadvertently included `<html>` and `<head>` tags.

This update instead extracts only the form’s actual node(s) (typically just a `<script>` or form fragment) and inserts them at the specified location in the Page/Post/CPT, avoiding any unintended root-level HTML tags.

## Testing

Updated tests to confirm no additional `<html>`, `<head>` or `<body>` tags are included in the DOM.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)