### PR TITLE
Gutenberg: Pre-Publish Actions: Display Kit name

### DIFF
--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -972,7 +972,7 @@ function convertKitGutenbergRegisterPrePublishActions(actions) {
 				PluginPrePublishPanel,
 				{
 					className: 'convertkit-pre-publish-actions',
-					title: 'ConvertKit',
+					title: 'Kit',
 					initialOpen: true,
 				},
 				rows


### PR DESCRIPTION
## Summary

Sets the name to `Kit` on the pre-publish panel in the block editor, replacing the old `ConvertKit` name

Before:
<img width="294" height="495" alt="Screenshot 2026-03-03 at 19 07 49" src="https://github.com/user-attachments/assets/78d33c52-3d34-43e8-9f4f-c4d90ae9b0d3" />

After:
<img width="296" height="491" alt="Screenshot 2026-03-03 at 19 07 56" src="https://github.com/user-attachments/assets/2fdcebfc-b8a4-43a8-a250-45645b65b819" />


## Testing

Existing tests pass

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)