### PR TITLE
Skip Actions on Dependabot PRs

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -22,7 +22,7 @@ jobs:
     # Don't run if the PR is from Dependabot, as it doesn't have access to the repository's secrets.
     # Dependabot also only checks for GitHub action dependencies, so it's not necessary to run
     # Plugin tests.
-    if: github.actor != 'dependabot[bot]
+    if: github.actor != 'dependabot[bot]'
 
     # Environment Variables.
     # Accessible by using ${{ env.NAME }}

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -18,6 +18,11 @@ jobs:
     # Virtual Environment to use.
     # @see: https://github.com/actions/virtual-environments
     runs-on: ubuntu-latest
+    
+    # Don't run if the PR is from Dependabot, as it doesn't have access to the repository's secrets.
+    # Dependabot also only checks for GitHub action dependencies, so it's not necessary to run
+    # Plugin tests.
+    if: github.actor != 'dependabot[bot]
 
     # Environment Variables.
     # Accessible by using ${{ env.NAME }}

--- a/.github/workflows/tests-backward-compat.yml
+++ b/.github/workflows/tests-backward-compat.yml
@@ -22,7 +22,7 @@ jobs:
     # Don't run if the PR is from Dependabot, as it doesn't have access to the repository's secrets.
     # Dependabot also only checks for GitHub action dependencies, so it's not necessary to run
     # Plugin tests.
-    if: github.actor != 'dependabot[bot]
+    if: github.actor != 'dependabot[bot]'
 
     # Environment Variables.
     # Accessible by using ${{ env.NAME }}

--- a/.github/workflows/tests-backward-compat.yml
+++ b/.github/workflows/tests-backward-compat.yml
@@ -19,6 +19,11 @@ jobs:
     # @see: https://github.com/actions/virtual-environments
     runs-on: ubuntu-latest
 
+    # Don't run if the PR is from Dependabot, as it doesn't have access to the repository's secrets.
+    # Dependabot also only checks for GitHub action dependencies, so it's not necessary to run
+    # Plugin tests.
+    if: github.actor != 'dependabot[bot]
+
     # Environment Variables.
     # Accessible by using ${{ env.NAME }}
     # Use ${{ secrets.NAME }} to include any GitHub Secrets in ${{ env.NAME }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     # Don't run if the PR is from Dependabot, as it doesn't have access to the repository's secrets.
     # Dependabot also only checks for GitHub action dependencies, so it's not necessary to run
     # Plugin tests.
-    if: github.actor != 'dependabot[bot]
+    if: github.actor != 'dependabot[bot]'
 
     # Environment Variables.
     # Accessible by using ${{ env.NAME }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,11 @@ jobs:
     # @see: https://github.com/actions/virtual-environments
     runs-on: ubuntu-latest
 
+    # Don't run if the PR is from Dependabot, as it doesn't have access to the repository's secrets.
+    # Dependabot also only checks for GitHub action dependencies, so it's not necessary to run
+    # Plugin tests.
+    if: github.actor != 'dependabot[bot]
+
     # Environment Variables.
     # Accessible by using ${{ env.NAME }}
     # Use ${{ secrets.NAME }} to include any GitHub Secrets in ${{ env.NAME }}
@@ -391,7 +396,7 @@ jobs:
     needs: tests
 
     # Only run on pull requests, not when merging to main branch
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
 
     # Virtual Environment to use.
     # @see: https://github.com/actions/virtual-environments


### PR DESCRIPTION
## Summary

Dependabot doesn't have access to a repository's secrets, resulting in errors on GitHub actions for tests:

<img width="1823" height="1464" alt="Screenshot 2026-03-20 at 17 12 46" src="https://github.com/user-attachments/assets/794dcd6f-bfed-45b7-a107-0d44c2ab55ef" />

Given Dependabot is only configured to update GitHub action dependencies, it's not necessary to run GitHub actions for Plugin tests.

This PR resolves by skipping tests if the PR is from Dependabot.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)