### PR TITLE
Selectively Run `get_subscriber_id_from_request` method

### DIFF
--- a/includes/class-convertkit-output.php
+++ b/includes/class-convertkit-output.php
@@ -68,7 +68,6 @@ class ConvertKit_Output {
 	public function __construct() {
 
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
-		add_action( 'init', array( $this, 'get_subscriber_id_from_request' ) );
 		add_action( 'wp', array( $this, 'maybe_tag_subscriber' ) );
 		add_action( 'template_redirect', array( $this, 'output_form' ) );
 		add_action( 'template_redirect', array( $this, 'page_takeover' ) );
@@ -146,11 +145,6 @@ class ConvertKit_Output {
 	 */
 	public function maybe_tag_subscriber() {
 
-		// Bail if no subscriber ID detected.
-		if ( ! $this->subscriber_id ) {
-			return;
-		}
-
 		// Bail if not a singular Post Type supported by ConvertKit.
 		if ( ! is_singular( convertkit_get_supported_post_types() ) ) {
 			return;
@@ -181,6 +175,14 @@ class ConvertKit_Output {
 
 		// Bail if no "Add a Tag" setting specified for this Page.
 		if ( ! $this->post_settings->has_tag() ) {
+			return;
+		}
+
+		// Get subscriber ID from URL or cookie.
+		$this->get_subscriber_id_from_request();
+
+		// Bail if no subscriber ID detected.
+		if ( ! $this->subscriber_id ) {
 			return;
 		}
 

--- a/includes/class-convertkit-subscriber.php
+++ b/includes/class-convertkit-subscriber.php
@@ -35,68 +35,18 @@ class ConvertKit_Subscriber {
 
 		// If the subscriber ID is in the request URI, use it.
 		if ( filter_has_var( INPUT_GET, $this->key ) ) {
-			return $this->validate_and_store_subscriber_id( filter_input( INPUT_GET, $this->key, FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+			$subscriber_id = filter_input( INPUT_GET, $this->key, FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+			$this->set( $subscriber_id );
+			return $subscriber_id;
 		}
 
 		// If the subscriber ID is in a cookie, return it.
-		// For performance, we don't check that the subscriber ID exists every time, otherwise this would
-		// call the API on every page load.
 		if ( isset( $_COOKIE[ $this->key ] ) && ! empty( $_COOKIE[ $this->key ] ) ) {
 			return $this->get_subscriber_id_from_cookie();
 		}
 
 		// If here, no subscriber ID exists.
 		return false;
-
-	}
-
-	/**
-	 * Validates the given subscriber ID by querying the API to confirm
-	 * the subscriber exists before storing their ID in a cookie.
-	 *
-	 * @since   2.0.0
-	 *
-	 * @param   int|string $subscriber_id  Possible Subscriber ID or Signed Subscriber ID.
-	 * @return  WP_Error|int|string                 Error | Confirmed Subscriber ID or Signed Subscriber ID
-	 */
-	public function validate_and_store_subscriber_id( $subscriber_id ) {
-
-		// Bail if the API hasn't been configured.
-		$settings = new ConvertKit_Settings();
-		if ( ! $settings->has_access_and_refresh_token() ) {
-			return new WP_Error(
-				'convertkit_subscriber_get_subscriber_id_from_request_error',
-				__( 'Access Token not configured in Plugin Settings.', 'convertkit' )
-			);
-		}
-
-		// Initialize the API.
-		$api = new ConvertKit_API_V4(
-			CONVERTKIT_OAUTH_CLIENT_ID,
-			CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
-			$settings->get_access_token(),
-			$settings->get_refresh_token(),
-			$settings->debug_enabled(),
-			'subscriber'
-		);
-
-		// Get subscriber by ID, to ensure they exist.
-		$subscriber = $api->get_subscriber( absint( $subscriber_id ) );
-
-		// Bail if no subscriber exists with the given subscriber ID, or an error occured.
-		if ( is_wp_error( $subscriber ) ) {
-			// Delete the cookie.
-			$this->forget();
-
-			// Return error.
-			return $subscriber;
-		}
-
-		// Store the subscriber ID as a cookie.
-		$this->set( $subscriber['subscriber']['id'] );
-
-		// Return subscriber ID.
-		return $subscriber['subscriber']['id'];
 
 	}
 


### PR DESCRIPTION
## Summary

As a result of this ticket ([Linear](https://linear.app/kit/issue/WP-76/wordpress-p4-is-the-plugin-setting-cookies-based-on-subscriber-id), [Intercom](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/conversation/215473519630176)): moves the `get_subscriber_id_from_request()` call from the `init` hook (where it runs on every page load) into the `maybe_tag_subscriber()` method, so the subscriber ID lookup and cookie-setting logic only executes when the page actually has a tag configured. This follows the same conditional pattern used by `ConvertKit_Output_Restrict_Content`, where `get_subscriber_id_from_request()` is only called after verifying the post has relevant settings configured.

Previously, every request with a `ck_subscriber_id` URL parameter triggered a synchronous API call to validate the subscriber, storing their ID in a cookie, even on pages with no tag setting, where a check might not be necessary.

For high-traffic sites sending broadcasts to large lists (65K+ subscribers) with the `Add subscriber_id parameter in email links` setting enabled at https://app.kit.com/account_settings/advanced_settings results in subscribers clicking links to e.g. a WordPress Post that contain the `ck_subscriber_id` URL parameter, which would set a cookie to store said subscriber ID. This typically bypasses most caching configurations set (given the existence of a cookie typically means unique content must be served vs. cached content), which may resolve in performance issues for WordPress sites that heavily rely on caching strategies.

Whilst creators can disable the `Add subscriber_id parameter in email links` setting at https://app.kit.com/account_settings/advanced_settings, some believe doing so would result in a loss of functionality.  This isn't strictly true - for example, Member Content functionality doesn't rely on this setting at all, with the user entering their email to subscribe and/or receiving a OTP to login, at which point their subscriber ID is stored in a cookie.

Creators have also suggested this should be performed asynchronously using JS; however this approach was removed for both performance and security - see https://github.com/Kit/convertkit-wordpress/pull/749 and https://github.com/Kit/convertkit-wordpress/pull/675 for the full history.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)