### PR TITLE
Tests: Landing Pages: Read ID from .env.dist.testing

### DIFF
--- a/tests/EndToEnd/landing-pages/PageLandingPageCest.php
+++ b/tests/EndToEnd/landing-pages/PageLandingPageCest.php
@@ -95,9 +95,6 @@ class PageLandingPageCest
 			]
 		);
 
-		// Get Landing Page ID.
-		$landingPageID = $I->grabValueFrom('#wp-convertkit-landing_page');
-
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
 
@@ -109,7 +106,7 @@ class PageLandingPageCest
 
 		// Confirm that the Kit Landing Page displays.
 		$I->dontSeeElementInDOM('body.page'); // WordPress didn't load its template, which is correct.
-		$I->seeElementInDOM('form[data-sv-form="' . $landingPageID . '"]'); // Kit injected its Landing Page Form, which is correct.
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_LANDING_PAGE_ID'] . '"]'); // Kit injected its Landing Page Form, which is correct.
 
 		// Subscribe.
 		$I->fillField('email_address', $I->generateEmailAddress());
@@ -145,9 +142,6 @@ class PageLandingPageCest
 			]
 		);
 
-		// Get Landing Page ID.
-		$landingPageID = $I->grabValueFrom('#wp-convertkit-landing_page');
-
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
 
@@ -163,7 +157,7 @@ class PageLandingPageCest
 
 		// Confirm that the Kit Landing Page displays.
 		$I->dontSeeElementInDOM('body.page'); // WordPress didn't load its template, which is correct.
-		$I->seeElementInDOM('form[data-sv-form="' . $landingPageID . '"]'); // Kit injected its Landing Page Form, which is correct.
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_LANDING_PAGE_ID'] . '"]'); // Kit injected its Landing Page Form, which is correct.
 	}
 
 	/**
@@ -189,9 +183,6 @@ class PageLandingPageCest
 				'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LANDING_PAGE_CHARACTER_ENCODING_NAME'] ],
 			]
 		);
-
-		// Get Landing Page ID.
-		$landingPageID = $I->grabValueFrom('#wp-convertkit-landing_page');
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -227,9 +218,6 @@ class PageLandingPageCest
 				'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME'] ],
 			]
 		);
-
-		// Get Landing Page ID.
-		$landingPageID = $I->grabValueFrom('#wp-convertkit-landing_page');
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -270,9 +258,6 @@ class PageLandingPageCest
 				'landing_page' => [ 'select2', $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_NAME'] ],
 			]
 		);
-
-		// Get Landing Page ID.
-		$landingPageID = $I->grabValueFrom('#wp-convertkit-landing_page');
 
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
@@ -376,9 +361,6 @@ class PageLandingPageCest
 			]
 		);
 
-		// Get Landing Page ID.
-		$landingPageID = $I->grabValueFrom('#wp-convertkit-landing_page');
-
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
 
@@ -390,7 +372,7 @@ class PageLandingPageCest
 
 		// Confirm that the Kit Landing Page displays.
 		$I->dontSeeElementInDOM('body.page'); // WordPress didn't load its template, which is correct.
-		$I->seeElementInDOM('form[data-sv-form="' . $landingPageID . '"]'); // Kit injected its Landing Page Form, which is correct.
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_LANDING_PAGE_ID'] . '"]'); // Kit injected its Landing Page Form, which is correct.
 
 		// Confirm that Autoptimize has not lazy loaded assets.
 		$I->dontSeeElementInDOM('img[data-bg]');
@@ -443,9 +425,6 @@ class PageLandingPageCest
 			]
 		);
 
-		// Get Landing Page ID.
-		$landingPageID = $I->grabValueFrom('#wp-convertkit-landing_page');
-
 		// Publish and view the Page on the frontend site.
 		$I->publishAndViewGutenbergPage($I);
 
@@ -457,7 +436,7 @@ class PageLandingPageCest
 
 		// Confirm that the Kit Landing Page displays.
 		$I->dontSeeElementInDOM('body.page'); // WordPress didn't load its template, which is correct.
-		$I->seeElementInDOM('form[data-sv-form="' . $landingPageID . '"]'); // Kit injected its Landing Page Form, which is correct.
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_LANDING_PAGE_ID'] . '"]'); // Kit injected its Landing Page Form, which is correct.
 
 		// Confirm that Perfmatters has not lazy loaded assets.
 		$I->dontSeeElementInDOM('.perfmatters-lazy');
@@ -501,9 +480,6 @@ class PageLandingPageCest
 			]
 		);
 
-		// Get Landing Page ID.
-		$landingPageID = $I->grabValueFrom('#wp-convertkit-landing_page');
-
 		// Publish and view the Page on the frontend site.
 		$url = $I->publishAndViewGutenbergPage($I);
 
@@ -521,7 +497,7 @@ class PageLandingPageCest
 
 		// Confirm that the Kit Landing Page displays.
 		$I->dontSeeElementInDOM('body.page'); // WordPress didn't load its template, which is correct.
-		$I->seeElementInDOM('form[data-sv-form="' . $landingPageID . '"]'); // Kit injected its Landing Page Form, which is correct.
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_LANDING_PAGE_ID'] . '"]'); // Kit injected its Landing Page Form, which is correct.
 
 		// Confirm that WP Rocket has not minified any CSS or JS assets.
 		// WP Rocket now always includes a minified file for its own Plugin, so we can't reliably check for data-minify="1"
@@ -578,9 +554,6 @@ class PageLandingPageCest
 			]
 		);
 
-		// Get Landing Page ID.
-		$landingPageID = $I->grabValueFrom('#wp-convertkit-landing_page');
-
 		// Publish and view the Page on the frontend site.
 		$url = $I->publishAndViewGutenbergPage($I);
 
@@ -598,7 +571,7 @@ class PageLandingPageCest
 
 		// Confirm that the Kit Landing Page displays.
 		$I->dontSeeElementInDOM('body.page'); // WordPress didn't load its template, which is correct.
-		$I->seeElementInDOM('form[data-sv-form="' . $landingPageID . '"]'); // Kit injected its Landing Page Form, which is correct.
+		$I->seeElementInDOM('form[data-sv-form="' . $_ENV['CONVERTKIT_API_LANDING_PAGE_ID'] . '"]'); // Kit injected its Landing Page Form, which is correct.
 
 		// Confirm that Rocket LazyLoad has not attempted to lazy load images.
 		$I->dontSeeElementInDOM('img[data-lazy-src]');


### PR DESCRIPTION
## Summary

Some Landing Page Tests fetch the Landing Page ID from the `select` element (and either use it or don't use it), whilst other tests use the ID from the `.env.dist.testing` file.

This PR resolves by cleaning up and consistently using the `.env.dist.testing` file to assert checks against the landing page ID.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)