### PR TITLE
Remove `validate_and_store_subscriber_id` method

### DIFF
--- a/includes/class-convertkit-subscriber.php
+++ b/includes/class-convertkit-subscriber.php
@@ -35,68 +35,18 @@ class ConvertKit_Subscriber {
 
 		// If the subscriber ID is in the request URI, use it.
 		if ( filter_has_var( INPUT_GET, $this->key ) ) {
-			return $this->validate_and_store_subscriber_id( filter_input( INPUT_GET, $this->key, FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+			$subscriber_id = filter_input( INPUT_GET, $this->key, FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+			$this->set( $subscriber_id );
+			return $subscriber_id;
 		}
 
 		// If the subscriber ID is in a cookie, return it.
-		// For performance, we don't check that the subscriber ID exists every time, otherwise this would
-		// call the API on every page load.
 		if ( isset( $_COOKIE[ $this->key ] ) && ! empty( $_COOKIE[ $this->key ] ) ) {
 			return $this->get_subscriber_id_from_cookie();
 		}
 
 		// If here, no subscriber ID exists.
 		return false;
-
-	}
-
-	/**
-	 * Validates the given subscriber ID by querying the API to confirm
-	 * the subscriber exists before storing their ID in a cookie.
-	 *
-	 * @since   2.0.0
-	 *
-	 * @param   int|string $subscriber_id  Possible Subscriber ID or Signed Subscriber ID.
-	 * @return  WP_Error|int|string                 Error | Confirmed Subscriber ID or Signed Subscriber ID
-	 */
-	public function validate_and_store_subscriber_id( $subscriber_id ) {
-
-		// Bail if the API hasn't been configured.
-		$settings = new ConvertKit_Settings();
-		if ( ! $settings->has_access_and_refresh_token() ) {
-			return new WP_Error(
-				'convertkit_subscriber_get_subscriber_id_from_request_error',
-				__( 'Access Token not configured in Plugin Settings.', 'convertkit' )
-			);
-		}
-
-		// Initialize the API.
-		$api = new ConvertKit_API_V4(
-			CONVERTKIT_OAUTH_CLIENT_ID,
-			CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
-			$settings->get_access_token(),
-			$settings->get_refresh_token(),
-			$settings->debug_enabled(),
-			'subscriber'
-		);
-
-		// Get subscriber by ID, to ensure they exist.
-		$subscriber = $api->get_subscriber( absint( $subscriber_id ) );
-
-		// Bail if no subscriber exists with the given subscriber ID, or an error occured.
-		if ( is_wp_error( $subscriber ) ) {
-			// Delete the cookie.
-			$this->forget();
-
-			// Return error.
-			return $subscriber;
-		}
-
-		// Store the subscriber ID as a cookie.
-		$this->set( $subscriber['subscriber']['id'] );
-
-		// Return subscriber ID.
-		return $subscriber['subscriber']['id'];
 
 	}
 


### PR DESCRIPTION
## Summary

As a result of [this PR](https://github.com/Kit/convertkit-wordpress/pull/1050), storing the subscriber ID as a cookie only happens when:
- visiting a Page with the 'Add a Tag' setting defined and the `ck_subscriber_id` query parameter exists in the URL,
- visiting a Page with Member Content enabled

These methods each perform their own validation to see if the subscriber ID in the cookie has access to the form, tag or product:
- Custom Content Shortcode: Performs check if the subscriber ID has access to the tag: https://github.com/Kit/convertkit-wordpress/blob/main/includes/blocks/class-convertkit-block-content.php#L257
- Member Content / Gated Content: Uses `subscriber_has_access` method to check if the subscriber has access to the form, tag or product: https://github.com/Kit/convertkit-wordpress/blob/main/includes/class-convertkit-output-restrict-content.php#L1078

Therefore, there's no need for the `validate_and_store_subscriber_id` method to also query the API when detecting the `ck_subscriber_id` query parameter in the URL.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)