### PR TITLE
Tests: Classic Editor: Fix Publish Button click

### DIFF
--- a/tests/Support/Helper/WPClassicEditor.php
+++ b/tests/Support/Helper/WPClassicEditor.php
@@ -257,6 +257,9 @@ class WPClassicEditor extends \Codeception\Module
 		// Wait for the Publish button to change its state from disabled (WordPress disables it for a moment when auto-saving).
 		$I->waitForElementVisible('input#publish:not(:disabled)');
 
+		// Some tests are flaky and fail if we click the Publish button too soon.
+		$I->wait(1);
+
 		// Click the Publish button.
 		$I->click('input#publish');
 


### PR DESCRIPTION
## Summary

https://github.com/Kit/convertkit-wordpress/pull/1027 (WordPress 7.0 RC2) and https://github.com/Kit/convertkit-wordpress/pull/1053 (greater test coverage using the Classic Editor with the Form setting) result in some tests being flaky and failing due to the Publish button in the Classic Editor not always being clicked.

Other methods have been tried, however still result in flaky, failing tests:
- Using JS to click the button
- Moving focus to a non-select2 field before clicking the publish button
- Using Codeception's `retryClick` method

`wait()` isn't ideal, but results in tests that reliably, consistently work.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)