### PR TITLE
Revoke and Remove Tokens on Disconnect

### DIFF
--- a/admin/section/class-convertkit-admin-section-general.php
+++ b/admin/section/class-convertkit-admin-section-general.php
@@ -193,7 +193,22 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 			return;
 		}
 
-		// Delete Access Token.
+		// Revoke Access Token.
+		$api    = new ConvertKit_API_V4(
+			CONVERTKIT_OAUTH_CLIENT_ID,
+			CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
+			$this->settings->get_access_token(),
+			$this->settings->get_refresh_token(),
+			$this->settings->debug_enabled(),
+			'settings'
+		);
+		$result = $api->revoke_token();
+		if ( is_wp_error( $result ) ) {
+			$this->output_error( $result->get_error_message() );
+			return;
+		}
+
+		// Delete Access and Refresh Tokens.
 		$settings = new ConvertKit_Settings();
 		$settings->delete_credentials();
 

--- a/admin/section/class-convertkit-admin-section-general.php
+++ b/admin/section/class-convertkit-admin-section-general.php
@@ -193,13 +193,16 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 			return;
 		}
 
+		// Get Settings class.
+		$settings = new ConvertKit_Settings();
+
 		// Revoke Access Token.
 		$api    = new ConvertKit_API_V4(
 			CONVERTKIT_OAUTH_CLIENT_ID,
 			CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
-			$this->settings->get_access_token(),
-			$this->settings->get_refresh_token(),
-			$this->settings->debug_enabled(),
+			$settings->get_access_token(),
+			$settings->get_refresh_token(),
+			$settings->debug_enabled(),
 			'settings'
 		);
 		$result = $api->revoke_token();
@@ -207,10 +210,6 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 			$this->output_error( $result->get_error_message() );
 			return;
 		}
-
-		// Delete Access and Refresh Tokens.
-		$settings = new ConvertKit_Settings();
-		$settings->delete_credentials();
 
 		// Delete cached resources.
 		$creator_network = new ConvertKit_Resource_Creator_Network_Recommendations();

--- a/admin/section/class-convertkit-admin-section-general.php
+++ b/admin/section/class-convertkit-admin-section-general.php
@@ -215,7 +215,7 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 		}
 
 		// Revoke Access and Refresh Tokens.
-		// See convertkit_revoke_credentials() method in functions.php, which is called
+		// See convertkit_delete_credentials() method in functions.php, which is called
 		// by the `convertkit_api_revoke_tokens` action and deletes credentials from the Plugin's settings.
 		$result = $api->revoke_tokens();
 		if ( is_wp_error( $result ) ) {

--- a/admin/section/class-convertkit-admin-section-general.php
+++ b/admin/section/class-convertkit-admin-section-general.php
@@ -196,8 +196,8 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 		// Get Settings class.
 		$settings = new ConvertKit_Settings();
 
-		// Revoke Access Token.
-		$api    = new ConvertKit_API_V4(
+		// Setup API.
+		$api = new ConvertKit_API_V4(
 			CONVERTKIT_OAUTH_CLIENT_ID,
 			CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI,
 			$settings->get_access_token(),
@@ -205,7 +205,19 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 			$settings->debug_enabled(),
 			'settings'
 		);
-		$result = $api->revoke_token();
+
+		// Check that we're using the Kit WordPress Libraries 2.1.4 or higher.
+		// If another Kit Plugin is active and out of date, its libraries might
+		// be loaded that don't have this method.
+		if ( ! method_exists( $api, 'revoke_tokens' ) ) { // @phpstan-ignore-line Older WordPress Libraries won't have this function.
+			$this->output_error( __( 'The Kit WordPress Libraries is missing the `revoke_tokens` method. Please update all Kit WordPress Plugins to their latest versions, and click Disconnect again.', 'convertkit' ) );
+			return;
+		}
+
+		// Revoke Access and Refresh Tokens.
+		// See convertkit_revoke_credentials() method in functions.php, which is called
+		// by the `convertkit_api_revoke_tokens` action and deletes credentials from the Plugin's settings.
+		$result = $api->revoke_tokens();
 		if ( is_wp_error( $result ) ) {
 			$this->output_error( $result->get_error_message() );
 			return;

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "2.1.3"
+        "convertkit/convertkit-wordpress-libraries": "dev-add-revoke-token-method"
     },
     "require-dev": {
         "php-webdriver/webdriver": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "dev-add-revoke-token-method"
+        "convertkit/convertkit-wordpress-libraries": "2.1.4"
     },
     "require-dev": {
         "php-webdriver/webdriver": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "2.1.4"
+        "convertkit/convertkit-wordpress-libraries": "2.1.5"
     },
     "require-dev": {
         "php-webdriver/webdriver": "^1.0",

--- a/includes/class-convertkit-settings.php
+++ b/includes/class-convertkit-settings.php
@@ -667,9 +667,14 @@ class ConvertKit_Settings {
 
 		$this->save(
 			array(
+				// OAuth.
 				'access_token'  => '',
 				'refresh_token' => '',
 				'token_expires' => '',
+
+				// API Key.
+				'api_key'       => '',
+				'api_secret'    => '',
 			)
 		);
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -801,7 +801,7 @@ function convertkit_maybe_update_credentials( $result, $client_id ) {
  *
  * @param   string $client_id   OAuth Client ID used for the Access and Refresh Tokens.
  */
-function convertkit_revoke_credentials( $client_id ) {
+function convertkit_delete_credentials( $client_id ) {
 
 	// Don't delete these credentials if they're not for this Client ID.
 	// They're for another Kit Plugin that uses OAuth.
@@ -854,7 +854,7 @@ add_action( 'convertkit_api_get_access_token', 'convertkit_maybe_update_credenti
 add_action( 'convertkit_api_refresh_token', 'convertkit_maybe_update_credentials', 10, 2 );
 
 // Delete credentials when the user revokes the access and refresh tokens.
-add_action( 'convertkit_api_revoke_tokens', 'convertkit_revoke_credentials', 10, 1 );
+add_action( 'convertkit_api_revoke_tokens', 'convertkit_delete_credentials', 10, 1 );
 
 // Delete credentials if the API class uses a invalid access token.
 // This prevents the Plugin making repetitive API requests that will 401.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -853,8 +853,8 @@ function convertkit_maybe_delete_credentials( $result, $client_id ) {
 add_action( 'convertkit_api_get_access_token', 'convertkit_maybe_update_credentials', 10, 2 );
 add_action( 'convertkit_api_refresh_token', 'convertkit_maybe_update_credentials', 10, 2 );
 
-// Delete credentials when the user revokes the access token.
-add_action( 'convertkit_api_revoke_token', 'convertkit_revoke_credentials', 10, 1 );
+// Delete credentials when the user revokes the access and refresh tokens.
+add_action( 'convertkit_api_revoke_tokens', 'convertkit_revoke_credentials', 10, 1 );
 
 // Delete credentials if the API class uses a invalid access token.
 // This prevents the Plugin making repetitive API requests that will 401.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -795,6 +795,29 @@ function convertkit_maybe_update_credentials( $result, $client_id ) {
 /**
  * Deletes the stored access token, refresh token and its expiry from the Plugin settings,
  * and clears any existing scheduled WordPress Cron event to refresh the token on expiry,
+ * when the user revokes the access token.
+ *
+ * @since   3.2.4
+ *
+ * @param   string $client_id   OAuth Client ID used for the Access and Refresh Tokens.
+ */
+function convertkit_revoke_credentials( $client_id ) {
+
+	// Don't delete these credentials if they're not for this Client ID.
+	// They're for another Kit Plugin that uses OAuth.
+	if ( $client_id !== CONVERTKIT_OAUTH_CLIENT_ID ) {
+		return;
+	}
+
+	// Delete Access and Refresh Tokens.
+	$settings = new ConvertKit_Settings();
+	$settings->delete_credentials();
+
+}
+
+/**
+ * Deletes the stored access token, refresh token and its expiry from the Plugin settings,
+ * and clears any existing scheduled WordPress Cron event to refresh the token on expiry,
  * when either:
  * - The access token is invalid
  * - The access token expired, and refreshing failed
@@ -829,6 +852,9 @@ function convertkit_maybe_delete_credentials( $result, $client_id ) {
 // Update Access Token when refreshed by the API class.
 add_action( 'convertkit_api_get_access_token', 'convertkit_maybe_update_credentials', 10, 2 );
 add_action( 'convertkit_api_refresh_token', 'convertkit_maybe_update_credentials', 10, 2 );
+
+// Delete credentials when the user revokes the access token.
+add_action( 'convertkit_api_revoke_token', 'convertkit_revoke_credentials', 10, 1 );
 
 // Delete credentials if the API class uses a invalid access token.
 // This prevents the Plugin making repetitive API requests that will 401.

--- a/tests/EndToEnd/general/plugin-screens/PluginSettingsGeneralCest.php
+++ b/tests/EndToEnd/general/plugin-screens/PluginSettingsGeneralCest.php
@@ -161,12 +161,46 @@ class PluginSettingsGeneralCest
 
 		// Check that no notice is displayed that the API credentials are invalid.
 		$I->dontSeeErrorNotice($I, 'Kit: Authorization failed. Please connect your Kit account.');
+	}
+
+	/**
+	 * Test that the credentials and resources are deleted on disconnect.
+	 *
+	 * @since   3.2.4
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testCredentialsAndResourcesAreDeletedOnDisconnect(EndToEndTester $I)
+	{
+		// Setup Plugin.
+		$I->setupKitPlugin($I);
+		$I->setupKitPluginResources($I);
 
 		// Go to the Plugin's Settings Screen.
 		$I->loadKitSettingsGeneralScreen($I);
 
+		// Fake the API Key, API Secret, Access and Refresh Tokens; if we revoke the tokens used for tests, future tests will fail.
+		$I->setupKitPlugin(
+			$I,
+			[
+				'access_token'  => 'fakeAccessToken',
+				'refresh_token' => 'fakeRefreshToken',
+				'token_expires' => time() + 3600,
+				'api_key'       => 'fakeAPIKey',
+				'api_secret'    => 'fakeAPISecret',
+			]
+		);
+
 		// Disconnect the Plugin connection to Kit.
 		$I->click('Disconnect');
+
+		// Check credentials are removed from the settings.
+		$settings = $I->grabOptionFromDatabase('_wp_convertkit_settings');
+		$I->assertEmpty($settings['access_token']);
+		$I->assertEmpty($settings['refresh_token']);
+		$I->assertEmpty($settings['token_expires']);
+		$I->assertEmpty($settings['api_key']);
+		$I->assertEmpty($settings['api_secret']);
 
 		// Check cached resources are removed from the database on disconnection.
 		$I->dontSeeOptionInDatabase('convertkit_creator_network_recommendations');
@@ -182,14 +216,6 @@ class PluginSettingsGeneralCest
 		$I->see('Connect');
 		$I->dontSee('Disconnect');
 		$I->dontSeeElementInDOM('input#submit');
-
-		// Check that the option table no longer contains cached resources.
-		$I->dontSeeOptionInDatabase('convertkit_creator_network_recommendations');
-		$I->dontSeeOptionInDatabase('convertkit_forms');
-		$I->dontSeeOptionInDatabase('convertkit_landing_pages');
-		$I->dontSeeOptionInDatabase('convertkit_posts');
-		$I->dontSeeOptionInDatabase('convertkit_products');
-		$I->dontSeeOptionInDatabase('convertkit_tags');
 	}
 
 	/**

--- a/tests/Integration/APITest.php
+++ b/tests/Integration/APITest.php
@@ -218,16 +218,29 @@ class APITest extends WPTestCase
 		// Confirm the token works when making an authenticated request.
 		$this->assertNotInstanceOf( 'WP_Error', $api->get_account() );
 
-		// Revoke the access token.
-		$api->revoke_token();
+		// Revoke the access and refresh tokens.
+		$api->revoke_tokens();
 
 		// Confirm the access token and refresh token are deleted from the Plugin's settings.
 		$this->assertEmpty( $settings->get_access_token() );
 		$this->assertEmpty( $settings->get_refresh_token() );
 		$this->assertEmpty( $settings->get_token_expiry() );
 
-		// Confirm the token no longer works when making an authenticated request.
+		// Initialize the API with the (now revoked) access token and refresh token.
+		// revoke_tokens() will have removed the access token and refresh token from the API class, so we need to provide them again
+		// to test they're revoked.
+		$api = new \ConvertKit_API_V4(
+			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
+			$_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
+			$result['oauth']['access_token'],
+			$result['oauth']['refresh_token']
+		);
+
+		// Confirm attempting to use the revoked access token no longer works.
 		$this->assertInstanceOf( 'WP_Error', $api->get_account() );
+
+		// Confirm attempting to use the revoked refresh token no longer works.
+		$this->assertInstanceOf( 'WP_Error', $api->refresh_token() );
 	}
 
 	/**

--- a/tests/Integration/APITest.php
+++ b/tests/Integration/APITest.php
@@ -177,6 +177,60 @@ class APITest extends WPTestCase
 	}
 
 	/**
+	 * Test that the access token and refresh token are deleted from the Plugin's settings
+	 * when the access token is revoked.
+	 *
+	 * @since   3.2.4
+	 */
+	public function testCredentialsDeletedAndInvalidWhenRevoked()
+	{
+		// Initialize the API without an access token or refresh token.
+		$api = new \ConvertKit_API_V4(
+			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
+			$_ENV['KIT_OAUTH_REDIRECT_URI']
+		);
+
+		// Generate an access token by API key and secret.
+		$result = $api->get_access_token_by_api_key_and_secret(
+			$_ENV['CONVERTKIT_API_KEY'],
+			$_ENV['CONVERTKIT_API_SECRET'],
+			wp_generate_password( 10, false ) // Random tenant name to produce a token for this request only.
+		);
+
+		// Store the access token in the Plugin's settings.
+		$settings = new \ConvertKit_Settings();
+		$settings->save(
+			array(
+				'access_token'  => $result['oauth']['access_token'],
+				'refresh_token' => $result['oauth']['refresh_token'],
+				'token_expires' => $result['oauth']['expires_at'],
+			)
+		);
+
+		// Initialize the API with the access token and refresh token.
+		$api = new \ConvertKit_API_V4(
+			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
+			$_ENV['KIT_OAUTH_REDIRECT_URI'],
+			$settings->get_access_token(),
+			$settings->get_refresh_token()
+		);
+
+		// Confirm the token works when making an authenticated request.
+		$this->assertNotInstanceOf( 'WP_Error', $api->get_account() );
+
+		// Revoke the access token.
+		$api->revoke_token();
+
+		// Confirm the access token and refresh token are deleted from the Plugin's settings.
+		$this->assertEmpty( $settings->get_access_token() );
+		$this->assertEmpty( $settings->get_refresh_token() );
+		$this->assertEmpty( $settings->get_token_expiry() );
+
+		// Confirm the token no longer works when making an authenticated request.
+		$this->assertInstanceOf( 'WP_Error', $api->get_account() );
+	}
+
+	/**
 	 * Mocks an API response as if the Access Token expired.
 	 *
 	 * @since   2.5.0


### PR DESCRIPTION
## Summary

When the user clicks the `Disconnect` button at Settings > Kit:
- Revokes the access and refresh tokens by calling the `oauth/revoke` endpoint
- Removes the v3 API Key, v3 API Secret, v4 Access Token, v4 Refresh Token and v4 Token Expires settings from the database

## Testing

- `testCredentialsAndResourcesAreDeletedOnDisconnect`: end to end test confirming that the API Key, Secret, Access Token and Refresh Token are deleted from the Plugin.
- `testCredentialsDeletedAndInvalidWhenRevoked`: integration test confirming that the credentials are deleted from the Plugin and no longer work i.e. are revoked, when the API's `revoke_tokens` method is called.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)