### PR TITLE
Remove v3 API Secret on Plugin Update

### DIFF
--- a/includes/class-convertkit-setup.php
+++ b/includes/class-convertkit-setup.php
@@ -60,10 +60,6 @@ class ConvertKit_Setup {
 			return;
 		}
 
-		// Actions that should run regardless of the version number
-		// whenever the Plugin is updated.
-		$this->remove_v3_api_secret_from_settings();
-
 		/**
 		 * 3.0.4: Add form_id to entries database table.
 		 */
@@ -154,6 +150,10 @@ class ConvertKit_Setup {
 			$posts = new ConvertKit_Resource_Posts( 'cron' );
 			$posts->schedule_cron_event();
 		}
+
+		// Actions that should run regardless of the version number
+		// whenever the Plugin is updated.
+		$this->remove_v3_api_secret_from_settings();
 
 		// Update the installed version number in the options table.
 		update_option( 'convertkit_version', CONVERTKIT_PLUGIN_VERSION );

--- a/includes/class-convertkit-setup.php
+++ b/includes/class-convertkit-setup.php
@@ -60,6 +60,10 @@ class ConvertKit_Setup {
 			return;
 		}
 
+		// Actions that should run regardless of the version number
+		// whenever the Plugin is updated.
+		$this->remove_v3_api_secret_from_settings();
+
 		/**
 		 * 3.0.4: Add form_id to entries database table.
 		 */
@@ -153,6 +157,22 @@ class ConvertKit_Setup {
 
 		// Update the installed version number in the options table.
 		update_option( 'convertkit_version', CONVERTKIT_PLUGIN_VERSION );
+
+	}
+
+	/**
+	 * Remove v3 API Secret from settings.
+	 *
+	 * @since   3.2.4
+	 */
+	private function remove_v3_api_secret_from_settings() {
+
+		$settings = new ConvertKit_Settings();
+		$settings->save(
+			array(
+				'api_secret' => '',
+			)
+		);
 
 	}
 

--- a/tests/EndToEnd/general/other/UpgradePathsCest.php
+++ b/tests/EndToEnd/general/other/UpgradePathsCest.php
@@ -259,6 +259,39 @@ class UpgradePathsCest
 	}
 
 	/**
+	 * Tests that the v3 API Secret is removed from settings when upgrading to 3.2.4 or later.
+	 *
+	 * @since   3.2.4
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testV3APISecretRemovedFromSettings(EndToEndTester $I)
+	{
+		// Setup Plugin with v3 API Key and Secret.
+		$I->setupKitPlugin(
+			$I,
+			[
+				'api_key'      => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret'   => $_ENV['CONVERTKIT_API_SECRET'],
+				'post_form'    => '',
+				'page_form'    => '',
+				'product_form' => '',
+			]
+		);
+
+		// Define an installation version older than 3.2.4.
+		$I->haveOptionInDatabase('convertkit_version', '3.2.0');
+
+		// Activate the Plugin.
+		$I->activateKitPlugin($I, false);
+
+		// Confirm the settings no longer have a value for the v3 API Secret.
+		$settings = $I->grabOptionFromDatabase('_wp_convertkit_settings');
+		$I->assertEquals($settings['api_key'], $_ENV['CONVERTKIT_API_KEY']);
+		$I->assertEquals($settings['api_secret'], '');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/EndToEnd/general/other/UpgradePathsCest.php
+++ b/tests/EndToEnd/general/other/UpgradePathsCest.php
@@ -127,11 +127,9 @@ class UpgradePathsCest
 		$I->assertArrayHasKey('refresh_token', $settings);
 		$I->assertArrayHasKey('token_expires', $settings);
 
-		// Confirm the API Key and Secret are retained, in case we need them in the future.
+		// Confirm the API Key is retained, as it's needed for Legacy Forms.
 		$I->assertArrayHasKey('api_key', $settings);
-		$I->assertArrayHasKey('api_secret', $settings);
 		$I->assertEquals($settings['api_key'], $_ENV['CONVERTKIT_API_KEY']);
-		$I->assertEquals($settings['api_secret'], $_ENV['CONVERTKIT_API_SECRET']);
 
 		// Go to the Plugin's Settings Screen.
 		$I->loadKitSettingsGeneralScreen($I);


### PR DESCRIPTION
## Summary

Whenever a new Plugin release is published and the creator updates to the latest version, checks if a v3 API Secret exists, and if so deletes it from the Plugin's settings.

v3 API Keys and Secrets were retained following the introduction of the v4 API, to [permit automatic exchange](https://github.com/Kit/convertkit-wordpress/pull/656) of v3 API Keys for v4 tokens. This was in July 2024, so by now the API secret isn't needed.

The v3 API Key is retained for the time being, to support legacy forms. A future PR will notify users who have this setting, and advise them how to add this to their `wp-config.php` file.

## Testing

- `testV3APISecretRemovedFromSettings`: Test that a v3 API Secret is removed from the Plugin's settings when specified.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)