### PR TITLE
Run PHPStan against PHP 7.1+

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -151,5 +151,4 @@ jobs:
       # Run PHPStan for static analysis.
       - name: Run PHPStan Static Analysis
         working-directory: ${{ env.PLUGIN_DIR }}
-        if: ${{ contains('8.0 8.1 8.2 8.3 8.4', matrix.php-versions) }}
         run: php vendor/bin/phpstan analyse --memory-limit=1250M

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,6 +6,11 @@ includes:
 
 # Parameters
 parameters:
+    # Analyse against the minimum supported PHP version.
+    # This flags features (union types, enums, str_contains, etc.) that would
+    # fail on older PHP versions regardless of which PHP version PHPStan runs on.
+    phpVersion: 70100
+    
     # Paths to scan
     # This should comprise of the base Plugin PHP file, plus directories that contain Plugin PHP files
     paths:

--- a/phpstan.neon.example
+++ b/phpstan.neon.example
@@ -6,6 +6,11 @@ includes:
 
 # Parameters
 parameters:
+    # Analyse against the minimum supported PHP version.
+    # This flags features (union types, enums, str_contains, etc.) that would
+    # fail on older PHP versions regardless of which PHP version PHPStan runs on.
+    phpVersion: 70100
+    
     # Paths to scan
     # This should comprise of the base Plugin PHP file, plus directories that contain Plugin PHP files
     paths:


### PR DESCRIPTION
## Summary

3.2.2 and 3.2.2.1 shipped with Kit WordPress Libraries 2.1.4, which introduced a parse error on PHP ≤7.4 due to union types (PHP 8+ only) in the SDK:

`syntax error, unexpected '|', expecting variable (T_VARIABLE)`

3.2.3 was released, restoring the Kit WordPress Libraries back to 2.1.3. PHP 7.1+ compatibility was then restored in the Kit WordPress Libraries 2.1.5 via a [backport](https://github.com/Kit/convertkit-wordpress-libraries/pull/114).

This PR sets PHPStan’s phpVersion to ensure analysis targets PHP 7.1+ for the Plugin's code, to protect against a similar issue stemming from outside the Kit WordPress Libraries in the future.

While dropping older PHP support would be ideal, [current usage](https://linear.app/kit/issue/WP-79/wp-high-fatal-error-occurring-for-kit-plugins-in-wordpress) indicates it’s not yet practical.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)