### PR TITLE
Block Editor: Settings Sidebar: Support `optgroup` for Member Content

### DIFF
--- a/includes/plugin-sidebars/class-convertkit-plugin-sidebar-post-settings.php
+++ b/includes/plugin-sidebars/class-convertkit-plugin-sidebar-post-settings.php
@@ -157,7 +157,7 @@ class ConvertKit_Plugin_Sidebar_Post_Settings extends ConvertKit_Plugin_Sidebar 
 
 		// Get Products.
 		$restrict_content = array(
-			'0' => esc_html__( 'Don\'t restrict content to member-only', 'convertkit' ),
+			'0' => esc_html__( 'Do not restrict content to member-only', 'convertkit' ),
 		);
 		if ( $convertkit_forms->exist() ) {
 			$restrict_content['forms'] = array(

--- a/includes/plugin-sidebars/class-convertkit-plugin-sidebar-post-settings.php
+++ b/includes/plugin-sidebars/class-convertkit-plugin-sidebar-post-settings.php
@@ -160,9 +160,13 @@ class ConvertKit_Plugin_Sidebar_Post_Settings extends ConvertKit_Plugin_Sidebar 
 			'0' => esc_html__( 'Don\'t restrict content to member-only', 'convertkit' ),
 		);
 		if ( $convertkit_forms->exist() ) {
+			$restrict_content['forms'] = array(
+				'label'  => esc_html__( 'Forms', 'convertkit' ),
+				'values' => array(),
+			);
 			foreach ( $convertkit_forms->get() as $form ) {
 				// Legacy forms don't include a `format` key, so define them as inline.
-				$restrict_content[ 'form_' . absint( $form['id'] ) ] = sprintf(
+				$restrict_content['forms']['values'][ 'form_' . absint( $form['id'] ) ] = sprintf(
 					'%s [%s]',
 					sanitize_text_field( $form['name'] ),
 					( ! empty( $form['format'] ) ? sanitize_text_field( $form['format'] ) : 'inline' )
@@ -170,13 +174,21 @@ class ConvertKit_Plugin_Sidebar_Post_Settings extends ConvertKit_Plugin_Sidebar 
 			}
 		}
 		if ( $convertkit_tags->exist() ) {
+			$restrict_content['tags'] = array(
+				'label'  => esc_html__( 'Tags', 'convertkit' ),
+				'values' => array(),
+			);
 			foreach ( $convertkit_tags->get() as $tag ) {
-				$restrict_content[ 'tag_' . absint( $tag['id'] ) ] = sanitize_text_field( $tag['name'] );
+				$restrict_content['tags']['values'][ 'tag_' . absint( $tag['id'] ) ] = sanitize_text_field( $tag['name'] );
 			}
 		}
 		if ( $convertkit_products->exist() ) {
+			$restrict_content['products'] = array(
+				'label'  => esc_html__( 'Products', 'convertkit' ),
+				'values' => array(),
+			);
 			foreach ( $convertkit_products->get() as $product ) {
-				$restrict_content[ 'product_' . $product['id'] ] = sanitize_text_field( $product['name'] );
+				$restrict_content['products']['values'][ 'product_' . $product['id'] ] = sanitize_text_field( $product['name'] );
 			}
 		}
 

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -1009,25 +1009,104 @@ function convertKitGutenbergRegisterPluginSidebar(sidebar) {
 				// depending on the Field Type (select, textarea, text etc).
 				switch (field.type) {
 					case 'select':
-						// Build options for <select> input.
+						// Check if any values are optgroups.
+						const hasOptgroups = Object.keys(field.values).some(
+							(subKey) =>
+								typeof field.values[subKey] === 'object' &&
+								field.values[subKey].label &&
+								field.values[subKey].values
+						);
+
+						if (hasOptgroups) {
+							const children = [];
+
+							for (const value of Object.keys(field.values)) {
+								if (
+									typeof field.values[value] === 'object' &&
+									field.values[value].label &&
+									field.values[value].values
+								) {
+									// Optgroup.
+									const groupChildren = [];
+									for (const groupValue of Object.keys(
+										field.values[value].values
+									)) {
+										const label =
+											typeof field.values[value].values[
+												groupValue
+											] === 'string'
+												? field.values[value].values[
+														groupValue
+													].replace(
+														/&#0*39;|&#x27;|&apos;/g,
+														"'"
+													)
+												: field.values[value].values[
+														groupValue
+													];
+										groupChildren.push(
+											el(
+												'option',
+												{
+													value: groupValue,
+													key: groupValue,
+												},
+												label
+											)
+										);
+									}
+									children.push(
+										el(
+											'optgroup',
+											{
+												label: field.values[value]
+													.label,
+												key: value,
+											},
+											...groupChildren
+										)
+									);
+								} else {
+									// Flat option.
+									const label = field.values[value].replace(
+										/&#0*39;|&#x27;|&apos;/g,
+										"'"
+									);
+									children.push(
+										el(
+											'option',
+											{ value, key: value },
+											label
+										)
+									);
+								}
+							}
+
+							return el(
+								SelectControl,
+								fieldProperties,
+								...children
+							);
+						}
+
+						// Non-optgroup: existing logic using options prop.
 						for (const value of Object.keys(field.values)) {
 							fieldOptions.push({
-								label: field.values[value],
+								label: field.values[value].replace(
+									/&#0*39;|&#x27;|&apos;/g,
+									"'"
+								),
 								value,
 							});
 						}
 
-						// Sort field's options alphabetically by label.
 						fieldOptions.sort(function (x, y) {
 							const a = x.label.toUpperCase(),
 								b = y.label.toUpperCase();
 							return a.localeCompare(b);
 						});
 
-						// Assign options to field.
 						fieldProperties.options = fieldOptions;
-
-						// Return field element.
 						return el(SelectControl, fieldProperties);
 
 					default:

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -1003,8 +1003,6 @@ function convertKitGutenbergRegisterPluginSidebar(sidebar) {
 					},
 				};
 
-				const fieldOptions = [];
-
 				// Define additional Field Properties and the Field Element,
 				// depending on the Field Type (select, textarea, text etc).
 				switch (field.type) {
@@ -1031,19 +1029,6 @@ function convertKitGutenbergRegisterPluginSidebar(sidebar) {
 									for (const groupValue of Object.keys(
 										field.values[value].values
 									)) {
-										const label =
-											typeof field.values[value].values[
-												groupValue
-											] === 'string'
-												? field.values[value].values[
-														groupValue
-													].replace(
-														/&#0*39;|&#x27;|&apos;/g,
-														"'"
-													)
-												: field.values[value].values[
-														groupValue
-													];
 										groupChildren.push(
 											el(
 												'option',
@@ -1051,7 +1036,9 @@ function convertKitGutenbergRegisterPluginSidebar(sidebar) {
 													value: groupValue,
 													key: groupValue,
 												},
-												label
+												field.values[value].values[
+													groupValue
+												]
 											)
 										);
 									}
@@ -1067,16 +1054,12 @@ function convertKitGutenbergRegisterPluginSidebar(sidebar) {
 										)
 									);
 								} else {
-									// Flat option.
-									const label = field.values[value].replace(
-										/&#0*39;|&#x27;|&apos;/g,
-										"'"
-									);
+									// Option within optgroup.
 									children.push(
 										el(
 											'option',
 											{ value, key: value },
-											label
+											field.values[value]
 										)
 									);
 								}
@@ -1089,24 +1072,26 @@ function convertKitGutenbergRegisterPluginSidebar(sidebar) {
 							);
 						}
 
-						// Non-optgroup: existing logic using options prop.
+						// Options only, no optgroups.
+						const fieldOptions = [];
 						for (const value of Object.keys(field.values)) {
 							fieldOptions.push({
-								label: field.values[value].replace(
-									/&#0*39;|&#x27;|&apos;/g,
-									"'"
-								),
+								label: field.values[value],
 								value,
 							});
 						}
 
+						// Sort options alphabetically by label.
 						fieldOptions.sort(function (x, y) {
 							const a = x.label.toUpperCase(),
 								b = y.label.toUpperCase();
 							return a.localeCompare(b);
 						});
 
+						// Assign options to field properties.
 						fieldProperties.options = fieldOptions;
+
+						// Return field element.
 						return el(SelectControl, fieldProperties);
 
 					default:


### PR DESCRIPTION
## Summary

Groups Member Content options within `optgroup` in the same way the meta box functions:

<img width="319" height="618" alt="Screenshot 2026-04-15 at 19 13 18" src="https://github.com/user-attachments/assets/c8442909-1f82-4c6a-b444-15ee7bbb2818" />

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)