### PR TITLE
Check Cached Resources Structure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "2.1.5"
+        "convertkit/convertkit-wordpress-libraries": "dev-ignore-invalid-resource-arrays"
     },
     "require-dev": {
         "php-webdriver/webdriver": "^1.0",

--- a/includes/class-convertkit-setup.php
+++ b/includes/class-convertkit-setup.php
@@ -154,6 +154,7 @@ class ConvertKit_Setup {
 		// Actions that should run regardless of the version number
 		// whenever the Plugin is updated.
 		$this->remove_v3_api_secret_from_settings();
+		$this->maybe_delete_old_cached_resource_structure();
 
 		// Update the installed version number in the options table.
 		update_option( 'convertkit_version', CONVERTKIT_PLUGIN_VERSION );
@@ -173,6 +174,46 @@ class ConvertKit_Setup {
 				'api_secret' => '',
 			)
 		);
+
+	}
+
+	/**
+	 * Deletes any cached resources stored in the options table if they are a flat array
+	 * that originates from between 1.6.0 and 1.9.5.2 of the Plugin.
+	 * i.e. [id => name], rather than the expected [id => [id => '...', name => '...', ...]].
+	 *
+	 * This will permit the Resources classes to fetch and cache the Form resources correctly
+	 * from the API, and prevent fatal errors when a user activates the latest version of the Plugin
+	 * on a site that previously had a very old Plugin version installed.
+	 *
+	 * @since   3.2.5
+	 */
+	private function maybe_delete_old_cached_resource_structure() {
+
+		// Define the resource options to check.
+		$resource_options = array(
+			'convertkit_forms',
+			'convertkit_landing_pages',
+			'convertkit_tags',
+		);
+
+		foreach ( $resource_options as $resource_option ) {
+			// Get the resource option.
+			$resource = get_option( $resource_option, false );
+
+			// If the resource option does not exist, there's nothing to delete.
+			if ( false === $resource ) {
+				return;
+			}
+
+			// If the resource structure is correct e.g. [id => [name => '...']], there's nothing to delete.
+			if ( is_array( reset( $resource ) ) ) {
+				return;
+			}
+
+			// Delete the cached resource.
+			delete_option( $resource_option );
+		}
 
 	}
 

--- a/tests/EndToEnd/general/other/UpgradePathsCest.php
+++ b/tests/EndToEnd/general/other/UpgradePathsCest.php
@@ -294,6 +294,8 @@ class UpgradePathsCest
 	 * i.e. [id => name], rather than the expected [id => [id => '...', name => '...', ...]].
 	 *
 	 * @since   3.2.5
+	 *
+	 * @param   EndToEndTester $I  Tester.
 	 */
 	public function testFlatArrayResourcesDeleted(EndToEndTester $I)
 	{
@@ -333,6 +335,8 @@ class UpgradePathsCest
 	 * the credentials are defined.
 	 *
 	 * @since   3.2.5
+	 *
+	 * @param   EndToEndTester $I  Tester.
 	 */
 	public function testFlatArrayResourcesDeletedWhenCredentialsAreDefined(EndToEndTester $I)
 	{

--- a/tests/EndToEnd/general/other/UpgradePathsCest.php
+++ b/tests/EndToEnd/general/other/UpgradePathsCest.php
@@ -290,6 +290,98 @@ class UpgradePathsCest
 	}
 
 	/**
+	 * Tests that cached resources are deleted when they originate from between 1.6.0 and 1.9.5.2 of the Plugin
+	 * i.e. [id => name], rather than the expected [id => [id => '...', name => '...', ...]].
+	 *
+	 * @since   3.2.5
+	 */
+	public function testFlatArrayResourcesDeleted(EndToEndTester $I)
+	{
+		// Setup the Kit Plugin as if it's cached resources were created with 1.6.0 to 1.9.5.2 of the Plugin.
+		$I->haveOptionInDatabase('convertkit_version', '1.6.0');
+		$I->haveOptionInDatabase(
+			'convertkit_forms',
+			[
+				330786 => 'Form 1',
+			]
+		);
+		$I->haveOptionInDatabase(
+			'convertkit_landing_pages',
+			[
+				330787 => 'Landing Page 1',
+			]
+		);
+		$I->haveOptionInDatabase(
+			'convertkit_tags',
+			[
+				330788 => 'Tag 1',
+			]
+		);
+
+		// Activate the Plugin.
+		$I->activateKitPlugin($I);
+
+		// Confirm the invalid resource options are deleted.
+		$I->dontSeeOptionInDatabase('convertkit_forms');
+		$I->dontSeeOptionInDatabase('convertkit_landing_pages');
+		$I->dontSeeOptionInDatabase('convertkit_tags');
+	}
+
+	/**
+	 * Tests that cached resources are deleted when they originate from between 1.6.0 and 1.9.5.2 of the Plugin
+	 * i.e. [id => name], rather than the expected [id => [id => '...', name => '...', ...]], and
+	 * the credentials are defined.
+	 *
+	 * @since   3.2.5
+	 */
+	public function testFlatArrayResourcesDeletedWhenCredentialsAreDefined(EndToEndTester $I)
+	{
+		// Setup the Kit Plugin with API credentials.
+		$I->setupKitPlugin($I);
+
+		// Setup the Kit Plugin as if it's cached resources were created with 1.6.0 to 1.9.5.2 of the Plugin.
+		$I->haveOptionInDatabase('convertkit_version', '1.6.0');
+		$I->haveOptionInDatabase(
+			'convertkit_forms',
+			[
+				330786 => 'Form 1',
+			]
+		);
+		$I->haveOptionInDatabase(
+			'convertkit_landing_pages',
+			[
+				330787 => 'Landing Page 1',
+			]
+		);
+		$I->haveOptionInDatabase(
+			'convertkit_tags',
+			[
+				330788 => 'Tag 1',
+			]
+		);
+
+		// Activate the Plugin.
+		$I->activateKitPlugin($I, false);
+
+		// Confirm the invalid resource options are deleted.
+		$I->dontSeeOptionInDatabase('convertkit_forms');
+		$I->dontSeeOptionInDatabase('convertkit_landing_pages');
+		$I->dontSeeOptionInDatabase('convertkit_tags');
+
+		// Navigate to the Plugin's Settings Screen.
+		$I->loadKitSettingsGeneralScreen($I);
+
+		// Confirm the Plugin is authorized by checking for a Disconnect button.
+		$I->see('Kit WordPress');
+		$I->see('Disconnect');
+
+		// Confirm the resources are cached.
+		$I->seeOptionInDatabase('convertkit_forms');
+		$I->seeOptionInDatabase('convertkit_landing_pages');
+		$I->seeOptionInDatabase('convertkit_tags');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/Integration/ResourceFormsTest.php
+++ b/tests/Integration/ResourceFormsTest.php
@@ -335,6 +335,28 @@ class ResourceFormsTest extends WPTestCase
 	}
 
 	/**
+	 * Test that the exist() function returns false when invalid data is stored in the options table.
+	 *
+	 * @since   3.2.5
+	 */
+	public function testExistWithInvalidData()
+	{
+		// Define invalid form data.
+		update_option(
+			$this->resource->settings_name,
+			[
+				12345 => 'Form Name',
+			]
+		);
+
+		// Initialize the resource class we want to test.
+		$resource = new \ConvertKit_Resource_Forms();
+
+		// Confirm that the function returns false, because resources are invalid.
+		$this->assertFalse($resource->exist());
+	}
+
+	/**
 	 * Test that the get_html() function returns the expected data.
 	 *
 	 * @since   2.0.4

--- a/tests/Integration/ResourceLandingPagesTest.php
+++ b/tests/Integration/ResourceLandingPagesTest.php
@@ -235,6 +235,28 @@ class ResourceLandingPagesTest extends WPTestCase
 	}
 
 	/**
+	 * Test that the exist() function returns false when invalid data is stored in the options table.
+	 *
+	 * @since   3.2.5
+	 */
+	public function testExistWithInvalidData()
+	{
+		// Define invalid landing page data.
+		update_option(
+			$this->resource->settings_name,
+			[
+				12345 => 'Landing Page Name',
+			]
+		);
+
+		// Initialize the resource class we want to test.
+		$resource = new \ConvertKit_Resource_Landing_Pages();
+
+		// Confirm that the function returns false, because resources are invalid.
+		$this->assertFalse($resource->exist());
+	}
+
+	/**
 	 * Test that the get_html() function returns the expected data.
 	 *
 	 * @since   2.0.4

--- a/tests/Integration/ResourceTagsTest.php
+++ b/tests/Integration/ResourceTagsTest.php
@@ -233,4 +233,26 @@ class ResourceTagsTest extends WPTestCase
 		$result = $this->resource->exist();
 		$this->assertSame($result, true);
 	}
+
+	/**
+	 * Test that the exist() function returns false when invalid data is stored in the options table.
+	 *
+	 * @since   3.2.5
+	 */
+	public function testExistWithInvalidData()
+	{
+		// Define invalid tag data.
+		update_option(
+			$this->resource->settings_name,
+			[
+				12345 => 'Tag Name',
+			]
+		);
+
+		// Initialize the resource class we want to test.
+		$resource = new \ConvertKit_Resource_Tags();
+
+		// Confirm that the function returns false, because resources are invalid.
+		$this->assertFalse($resource->exist());
+	}
 }


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://linear.app/kit/issue/WP-80/wp-medium-fatal-error-occurring-with-kit-plugins-latest-update-324), where the site in question had cached Kit Forms in a flat array, introduced in 1.6.0 and superseded by a more detailed array of form data in 1.9.6:

<img width="831" height="780" alt="Screenshot 2026-04-16 at 11 23 43" src="https://github.com/user-attachments/assets/27896554-36fa-403c-8d22-45e3bfb5f201" />

Example of how this should look:
```
3003590 => [
	'id'         => 3003590,
	'name'       => 'Third Party Integrations Form',
	'created_at' => '2022-02-17T15:05:31.000Z',
	'type'       => 'embed',
	'format'     => 'inline',
	'embed_js'   => 'https://cheerful-architect-3237.kit.com/71cbcc4042/index.js',
	'embed_url'  => 'https://cheerful-architect-3237.kit.com/71cbcc4042',
	'archived'   => false,
	'uid'        => '71cbcc4042',
],
2780977 => [
	'id'         => 2780977,
	'name'       => 'Modal Form',
	'created_at' => '2021-11-17T04:22:06.000Z',
	'type'       => 'embed',
	'format'     => 'modal',
	'embed_js'   => 'https://cheerful-architect-3237.kit.com/397e876257/index.js',
	'embed_url'  => 'https://cheerful-architect-3237.kit.com/397e876257',
	'archived'   => false,
	'uid'        => '397e876257',
],
```

This appears to happen when a creator either:
- upgrades from Plugin version 1.6.0 through 1.9.5.x to 1.9.6 or higher, or
- previously installed the Plugin version 1.6.0 through 1.9.5.x, uninstalled it and later installed a Plugin version 1.9.6 or higher

This PR resolves by:
- using the latest Kit WordPress Libraries, which won't load any cached resources and return `exists()` as false, if the cached resource structure is invalid,
- performing a check each time the Plugin is upgraded to ensure the cached resources are stored in the correct, expected array structure, removing them if not.

## Testing

- `UpgradePathsCest`: Added tests to mimic the above screenshot example of cached resources from between 1.6.0 and 1.9.5.x, ensuring they're removed/updated as necessary, depending on whether the Plugin has a connection to Kit.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)