### PR TITLE
LiteSpeed Cache: Exclude JS from Combine

### DIFF
--- a/includes/class-convertkit-cache-plugins.php
+++ b/includes/class-convertkit-cache-plugins.php
@@ -67,6 +67,10 @@ class ConvertKit_Cache_Plugins {
 		add_filter( 'convertkit_output_script_footer', array( $this, 'litespeed_cache_exclude_js_defer' ) );
 		add_filter( 'convertkit_resource_forms_output_script', array( $this, 'litespeed_cache_exclude_js_defer' ) );
 
+		// LiteSpeed: Exclude Forms from JS optimization.
+		add_filter( 'convertkit_output_script_footer', array( $this, 'litespeed_cache_exclude_js_optimize' ) );
+		add_filter( 'convertkit_resource_forms_output_script', array( $this, 'litespeed_cache_exclude_js_optimize' ) );
+
 		// Perfmatters: Exclude Forms from Delay JavaScript.
 		add_filter( 'convertkit_output_script_footer', array( $this, 'perfmatters_exclude_delay_js' ) );
 		add_filter( 'convertkit_resource_forms_output_script', array( $this, 'perfmatters_exclude_delay_js' ) );
@@ -151,6 +155,26 @@ class ConvertKit_Cache_Plugins {
 			$script,
 			array(
 				'data-no-defer' => '1',
+			)
+		);
+
+	}
+
+	/**
+	 * Disable JS Optimization on Kit scripts when the LiteSpeed Cache Plugin is installed, active
+	 * and its "JS Combine" setting is enabled.
+	 *
+	 * @since   3.3.1
+	 *
+	 * @param   array $script     Script key/value pairs to output as <script> tag.
+	 * @return  array
+	 */
+	public function litespeed_cache_exclude_js_optimize( $script ) {
+
+		return array_merge(
+			$script,
+			array(
+				'data-no-optimize' => '1',
 			)
 		);
 

--- a/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormPerformancePluginsCest.php
+++ b/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormPerformancePluginsCest.php
@@ -246,7 +246,7 @@ class PageBlockFormPerformancePluginsCest
 
 	/**
 	 * Test that the Form <script> embed is output in the content, and not the footer of the site
-	 * when the LiteSpeed Cache Plugin is active and its "Load JS Deferred" setting is enabled.
+	 * when the LiteSpeed Cache Plugin is active and its "Load JS Deferred" and "JS Combine" settings are enabled.
 	 *
 	 * @since   2.4.5
 	 *
@@ -262,8 +262,8 @@ class PageBlockFormPerformancePluginsCest
 		$I->activateThirdPartyPlugin($I, 'litespeed-cache');
 		$I->enableCachingLiteSpeedCachePlugin($I);
 
-		// Enable LiteSpeed Cache's "Load JS Deferred" setting.
-		$I->enableLiteSpeedCacheLoadJSDeferred($I);
+		// Enable LiteSpeed Cache's "Load JS Deferred" and "JS Combine" settings.
+		$I->enableLiteSpeedCacheLoadJSDeferredAndCombine($I);
 
 		// Add a Page using the Gutenberg editor.
 		$I->addGutenbergPage(

--- a/tests/EndToEnd/forms/blocks-shortcodes/PageShortcodeFormCest.php
+++ b/tests/EndToEnd/forms/blocks-shortcodes/PageShortcodeFormCest.php
@@ -665,7 +665,7 @@ class PageShortcodeFormCest
 
 	/**
 	 * Test that the Form <script> embed is output in the content, and not the footer of the site
-	 * when the LiteSpeed Cache Plugin is active and its "Load JS Deferred" setting is enabled.
+	 * when the LiteSpeed Cache Plugin is active and its "Load JS Deferred" and "JS Combine" settings are enabled.
 	 *
 	 * @since   2.4.5
 	 *
@@ -681,8 +681,8 @@ class PageShortcodeFormCest
 		$I->activateThirdPartyPlugin($I, 'litespeed-cache');
 		$I->enableCachingLiteSpeedCachePlugin($I);
 
-		// Enable LiteSpeed Cache's "Load JS Deferred" setting.
-		$I->enableLiteSpeedCacheLoadJSDeferred($I);
+		// Enable LiteSpeed Cache's "Load JS Deferred" and "JS Combine" settings.
+		$I->enableLiteSpeedCacheLoadJSDeferredAndCombine($I);
 
 		// Add a Page using the Classic Editor.
 		$I->addClassicEditorPage(

--- a/tests/EndToEnd/forms/post-types/BlockEditorFormCest.php
+++ b/tests/EndToEnd/forms/post-types/BlockEditorFormCest.php
@@ -786,7 +786,7 @@ class BlockEditorFormCest
 
 	/**
 	 * Test that the Modal Form is output once when the LiteSpeed Cache Plugin is active and
-	 * its "Load JS Deferred" setting is enabled for a WordPress Page, Post or Article.
+	 * its "Load JS Deferred" and "JS Combine" settings are enabled for a WordPress Page, Post or Article.
 	 *
 	 * @since   2.4.5
 	 *
@@ -802,8 +802,8 @@ class BlockEditorFormCest
 		$I->activateThirdPartyPlugin($I, 'litespeed-cache');
 		$I->enableCachingLiteSpeedCachePlugin($I);
 
-		// Enable LiteSpeed Cache's "Load JS Deferred" setting.
-		$I->enableLiteSpeedCacheLoadJSDeferred($I);
+		// Enable LiteSpeed Cache's "Load JS Deferred" and "JS Combine" settings.
+		$I->enableLiteSpeedCacheLoadJSDeferredAndCombine($I);
 
 		// Test each Post Type.
 		foreach ( $this->postTypes as $postType ) {

--- a/tests/EndToEnd/forms/post-types/ClassicEditorFormCest.php
+++ b/tests/EndToEnd/forms/post-types/ClassicEditorFormCest.php
@@ -863,7 +863,7 @@ class ClassicEditorFormCest
 
 	/**
 	 * Test that the Modal Form is output once when the LiteSpeed Cache Plugin is active and
-	 * its "Load JS Deferred" setting is enabled for a WordPress Page, Post or Article.
+	 * its "Load JS Deferred" and "JS Combine" settings are enabled for a WordPress Page, Post or Article.
 	 *
 	 * @since   2.4.5
 	 *
@@ -879,8 +879,8 @@ class ClassicEditorFormCest
 		$I->activateThirdPartyPlugin($I, 'litespeed-cache');
 		$I->enableCachingLiteSpeedCachePlugin($I);
 
-		// Enable LiteSpeed Cache's "Load JS Deferred" setting.
-		$I->enableLiteSpeedCacheLoadJSDeferred($I);
+		// Enable LiteSpeed Cache's "Load JS Deferred" and "JS Combine" settings.
+		$I->enableLiteSpeedCacheLoadJSDeferredAndCombine($I);
 
 		// Test each Post Type.
 		foreach ( $this->postTypes as $postType ) {

--- a/tests/Integration/ResourceFormsTest.php
+++ b/tests/Integration/ResourceFormsTest.php
@@ -365,7 +365,7 @@ class ResourceFormsTest extends WPTestCase
 	{
 		$result = $this->resource->get_html($_ENV['CONVERTKIT_API_FORM_ID']);
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
-		$this->assertSame($result, '<script async data-uid="85629c512d" src="https://cheerful-architect-3237.kit.com/85629c512d/index.js" data-jetpack-boost="ignore" data-no-defer="1" nowprocket></script>');
+		$this->assertSame($result, '<script async data-uid="85629c512d" src="https://cheerful-architect-3237.kit.com/85629c512d/index.js" data-jetpack-boost="ignore" data-no-defer="1" data-no-optimize="1" nowprocket></script>');
 	}
 
 	/**

--- a/tests/Support/Helper/WPCachePlugins.php
+++ b/tests/Support/Helper/WPCachePlugins.php
@@ -61,14 +61,20 @@ class WPCachePlugins extends \Codeception\Module
 	 *
 	 * @param   EndToEndTester $I      EndToEnd Tester.
 	 */
-	public function enableLiteSpeedCacheLoadJSDeferred($I)
+	public function enableLiteSpeedCacheLoadJSDeferredAndCombine($I)
 	{
 		// Enable LiteSpeed Cache's "Load JS Deferred" setting.
 		$I->amOnAdminPage('admin.php?page=litespeed-page_optm#settings_js');
 
 		// Wait for the LiteSpeed Cache settings to load.
+		$I->waitForElementVisible('label[for=input_radio_optmjs_comb_1]');
 		$I->waitForElementVisible('label[for=input_radio_optmjs_defer_1]');
+
+		// Enable JS Combine and Deferred.
+		$I->click('label[for=input_radio_optmjs_comb_1]');
 		$I->click('label[for=input_radio_optmjs_defer_1]');
+
+		// Save.
 		$I->click('Save Changes');
 
 		// Confirm LiteSpeed Cache settings saved.


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/conversation/215473898389686?view=List) by excluding Kit's scripts from LiteSpeed cache's JS Combine setting

## Testing

Modified existing LiteSpeed cache tests to also enable the JS Combine setting, confirming forms display correctly.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)