### PR TITLE
Block Editor: Settings Sidebar: Add Refresh Resource Buttons

### DIFF
--- a/admin/class-convertkit-admin-refresh-resources.php
+++ b/admin/class-convertkit-admin-refresh-resources.php
@@ -105,6 +105,15 @@ class ConvertKit_Admin_Refresh_Resources {
 				break;
 
 			case 'restrict_content':
+				// Fetch Forms.
+				$forms         = new ConvertKit_Resource_Forms( 'user_refresh_resource' );
+				$results_forms = $forms->refresh();
+
+				// Bail if an error occured.
+				if ( is_wp_error( $results_forms ) ) {
+					return rest_ensure_response( $results_forms );
+				}
+
 				// Fetch Tags.
 				$tags         = new ConvertKit_Resource_Tags( 'user_refresh_resource' );
 				$results_tags = $tags->refresh();
@@ -126,6 +135,7 @@ class ConvertKit_Admin_Refresh_Resources {
 				// Return resources.
 				return rest_ensure_response(
 					array(
+						'forms'    => array_values( $results_forms ),
 						'tags'     => array_values( $results_tags ),
 						'products' => array_values( $results_products ),
 					)

--- a/includes/class-convertkit-gutenberg.php
+++ b/includes/class-convertkit-gutenberg.php
@@ -323,9 +323,11 @@ class ConvertKit_Gutenberg {
 			'convertkit-gutenberg',
 			'convertkit_gutenberg',
 			array(
-				'ajaxurl'           => rest_url( 'kit/v1/blocks' ),
-				'block_api_version' => $this->get_block_api_version(),
-				'get_blocks_nonce'  => wp_create_nonce( 'wp_rest' ),
+				'ajaxurl'                 => rest_url( 'kit/v1/blocks' ),
+				'block_api_version'       => $this->get_block_api_version(),
+				'get_blocks_nonce'        => wp_create_nonce( 'wp_rest' ),
+				'refresh_resources_url'   => rest_url( 'kit/v1/resources/refresh/' ),
+				'refresh_resources_nonce' => wp_create_nonce( 'wp_rest' ),
 			)
 		);
 

--- a/includes/plugin-sidebars/class-convertkit-plugin-sidebar-post-settings.php
+++ b/includes/plugin-sidebars/class-convertkit-plugin-sidebar-post-settings.php
@@ -194,37 +194,37 @@ class ConvertKit_Plugin_Sidebar_Post_Settings extends ConvertKit_Plugin_Sidebar 
 
 		return array(
 			'form'             => array(
-				'label'       => __( 'Form', 'convertkit' ),
-				'type'        => 'resource',
-				'description' => array(
+				'label'         => __( 'Form', 'convertkit' ),
+				'type'          => 'select',
+				'description'   => array(
 					__( 'Default', 'convertkit' ) . ': ' . __( 'Uses the form specified on the settings page.', 'convertkit' ),
 					__( 'None', 'convertkit' ) . ': ' . __( 'do not display a form.', 'convertkit' ),
 					__( 'Any other option will display that form after the main content.', 'convertkit' ),
 				),
-				'values'      => $forms,
-				'resource'    => 'forms',
+				'values'        => $forms,
+				'resource_type' => 'forms',
 			),
 			'landing_page'     => array(
-				'label'       => __( 'Landing Page', 'convertkit' ),
-				'type'        => 'resource',
-				'description' => __( 'Select a landing page to make it appear in place of this page.', 'convertkit' ),
-				'values'      => $landing_pages,
-				'post_type'   => 'page',
-				'resource'    => 'landing_pages',
+				'label'         => __( 'Landing Page', 'convertkit' ),
+				'type'          => 'select',
+				'description'   => __( 'Select a landing page to make it appear in place of this page.', 'convertkit' ),
+				'values'        => $landing_pages,
+				'post_type'     => 'page',
+				'resource_type' => 'landing_pages',
 			),
 			'tag'              => array(
-				'label'       => __( 'Tag', 'convertkit' ),
-				'type'        => 'resource',
-				'description' => __( 'Select a tag to apply to visitors of this page who are subscribed. A visitor is deemed to be subscribed if they have clicked a link in an email to this site which includes their subscriber ID, or have entered their email address in a Kit Form on this site.', 'convertkit' ),
-				'values'      => $tags,
-				'resource'    => 'tags',
+				'label'         => __( 'Tag', 'convertkit' ),
+				'type'          => 'select',
+				'description'   => __( 'Select a tag to apply to visitors of this page who are subscribed. A visitor is deemed to be subscribed if they have clicked a link in an email to this site which includes their subscriber ID, or have entered their email address in a Kit Form on this site.', 'convertkit' ),
+				'values'        => $tags,
+				'resource_type' => 'tags',
 			),
 			'restrict_content' => array(
-				'label'       => __( 'Restrict Content', 'convertkit' ),
-				'type'        => 'resource',
-				'description' => __( 'Select the Kit form, tag or product that the visitor must be subscribed to, permitting them access to view this member-only content.', 'convertkit' ),
-				'values'      => $restrict_content,
-				'resource'    => 'restrict_content',
+				'label'         => __( 'Restrict Content', 'convertkit' ),
+				'type'          => 'select',
+				'description'   => __( 'Select the Kit form, tag or product that the visitor must be subscribed to, permitting them access to view this member-only content.', 'convertkit' ),
+				'values'        => $restrict_content,
+				'resource_type' => 'restrict_content',
 			),
 		);
 

--- a/includes/plugin-sidebars/class-convertkit-plugin-sidebar-post-settings.php
+++ b/includes/plugin-sidebars/class-convertkit-plugin-sidebar-post-settings.php
@@ -195,32 +195,36 @@ class ConvertKit_Plugin_Sidebar_Post_Settings extends ConvertKit_Plugin_Sidebar 
 		return array(
 			'form'             => array(
 				'label'       => __( 'Form', 'convertkit' ),
-				'type'        => 'select',
+				'type'        => 'resource',
 				'description' => array(
 					__( 'Default', 'convertkit' ) . ': ' . __( 'Uses the form specified on the settings page.', 'convertkit' ),
 					__( 'None', 'convertkit' ) . ': ' . __( 'do not display a form.', 'convertkit' ),
 					__( 'Any other option will display that form after the main content.', 'convertkit' ),
 				),
 				'values'      => $forms,
+				'resource'    => 'forms',
 			),
 			'landing_page'     => array(
 				'label'       => __( 'Landing Page', 'convertkit' ),
-				'type'        => 'select',
+				'type'        => 'resource',
 				'description' => __( 'Select a landing page to make it appear in place of this page.', 'convertkit' ),
 				'values'      => $landing_pages,
 				'post_type'   => 'page',
+				'resource'    => 'landing_pages',
 			),
 			'tag'              => array(
 				'label'       => __( 'Tag', 'convertkit' ),
-				'type'        => 'select',
+				'type'        => 'resource',
 				'description' => __( 'Select a tag to apply to visitors of this page who are subscribed. A visitor is deemed to be subscribed if they have clicked a link in an email to this site which includes their subscriber ID, or have entered their email address in a Kit Form on this site.', 'convertkit' ),
 				'values'      => $tags,
+				'resource'    => 'tags',
 			),
 			'restrict_content' => array(
 				'label'       => __( 'Restrict Content', 'convertkit' ),
-				'type'        => 'select',
+				'type'        => 'resource',
 				'description' => __( 'Select the Kit form, tag or product that the visitor must be subscribed to, permitting them access to view this member-only content.', 'convertkit' ),
 				'values'      => $restrict_content,
+				'resource'    => 'restrict_content',
 			),
 		);
 

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -964,6 +964,18 @@ function convertKitGutenbergRegisterPluginSidebar(sidebar) {
 			const settings = meta[sidebar.meta_key] || sidebar.default_values;
 			const currentPostType = select('core/editor').getCurrentPostType();
 
+			// Seed each field's `values` into component state, so that when a
+			// refresh button is clicked we can update the field's options
+			// and trigger a re-render without mutating the global
+			// convertkit_plugin_sidebars object.
+			const [fieldValues, setFieldValues] = useState(function () {
+				const initial = {};
+				for (const key in sidebar.fields) {
+					initial[key] = sidebar.fields[key].values;
+				}
+				return initial;
+			});
+
 			/**
 			 * Updates the Post meta meta_key object.
 			 *
@@ -992,6 +1004,12 @@ function convertKitGutenbergRegisterPluginSidebar(sidebar) {
 			 * @return {Object}        Field element.
 			 */
 			const getField = function (field, key) {
+				// Override field.values with the latest values from state, which
+				// may have been refreshed by clicking the refresh button.
+				field = Object.assign({}, field, {
+					values: fieldValues[key] || field.values,
+				});
+
 				// Define some field properties shared across all field types.
 				const fieldProperties = {
 					key: 'convertkit_plugin_sidebar_' + key,
@@ -1016,31 +1034,37 @@ function convertKitGutenbergRegisterPluginSidebar(sidebar) {
 				// Define additional Field Properties and the Field Element,
 				// depending on the Field Type (select, textarea, text etc).
 				switch (field.type) {
-					case 'resource':
-						return el(
-							Flex,
-							{
-								align: 'start',
-							},
-							[
-								el(
-									FlexItem,
-									{
-										key: key + '-select',
-									},
-									getSelectField(field, fieldProperties)
-								),
-								el(
-									FlexItem,
-									{
-										key: key + '-refresh',
-									},
-									InlineRefreshButton(field.resource)
-								),
-							]
-						);
-
 					case 'select':
+						// If the field has a resource_type, wrap the select in a
+						// Flex container alongside a refresh button.
+						if (field.resource_type) {
+							return el(
+								Flex,
+								{
+									align: 'start',
+								},
+								[
+									el(
+										FlexItem,
+										{
+											key: key + '-select',
+										},
+										getSelectField(field, fieldProperties)
+									),
+									el(
+										FlexItem,
+										{
+											key: key + '-refresh',
+										},
+										el(InlineRefreshButton, {
+											resource: field.resource_type,
+											fieldKey: key,
+										})
+									),
+								]
+							);
+						}
+
 						return getSelectField(field, fieldProperties);
 
 					default:
@@ -1156,18 +1180,20 @@ function convertKitGutenbergRegisterPluginSidebar(sidebar) {
 			};
 
 			/**
-			 * Returns an inline refresh button, used to refresh a block's resources.
+			 * Returns an inline refresh button, used to refresh a sidebar field's resources.
 			 *
 			 * @since 	3.3.1
 			 *
-			 * @param {string} resource Resource type (forms,tags,landing_pages,restrict_content).
-			 * @return {Object} 	     Button.
+			 * @param {Object} props          Component props.
+			 * @param {string} props.resource Resource type (forms,tags,landing_pages,restrict_content).
+			 * @param {string} props.fieldKey The sidebar field key whose values should be updated on refresh.
+			 * @return {Object} 	          Button.
 			 */
-			const InlineRefreshButton = function (resource) {
+			const InlineRefreshButton = function ({ resource, fieldKey }) {
 				const [buttonDisabled, setButtonDisabled] = useState(false);
 
 				return el(Button, {
-					key: resource + '-refresh-button',
+					key: fieldKey + '-refresh-button',
 					className:
 						'button button-secondary wp-convertkit-refresh-resources' +
 						(buttonDisabled ? ' is-refreshing' : ''),
@@ -1175,20 +1201,145 @@ function convertKitGutenbergRegisterPluginSidebar(sidebar) {
 					icon: iconType('update'),
 					onClick() {
 						// Refresh resources.
-						refreshResources(resource, setButtonDisabled);
+						refreshResources(resource, fieldKey, setButtonDisabled);
 					},
 				});
 			};
 
 			/**
-			 * Refreshes resources for the given resource type.
+			 * Returns a label for a resource item. If the item has a `format`
+			 * property (as forms do), append it in square brackets; otherwise
+			 * return the name on its own.
 			 *
 			 * @since 	3.3.1
 			 *
-			 * @param {string}   resource          Resource type (forms,tags,landing_pages,restrict_content).
+			 * @param {Object} item API response item.
+			 * @return {string}     Label.
+			 */
+			const labelForItem = function (item) {
+				// Detect whether this collection of items includes a `format`
+				// property anywhere in the item (legacy forms may omit it, in
+				// which case we fall back to 'inline').
+				if (Object.prototype.hasOwnProperty.call(item, 'format')) {
+					return (
+						item.name +
+						' [' +
+						(item.format ? item.format : 'inline') +
+						']'
+					);
+				}
+
+				return item.name;
+			};
+
+			/**
+			 * Builds a flat values map from an array of API items, preserving
+			 * any existing placeholder options (those whose value is a string,
+			 * rather than an optgroup object) from the current field values.
+			 *
+			 * @since 	3.3.1
+			 *
+			 * @param {Array}  items          API response items.
+			 * @param {Object} existingValues Current values map for the field.
+			 * @return {Object}               Rebuilt values map.
+			 */
+			const buildFlatValues = function (items, existingValues) {
+				const values = {};
+
+				// Preserve existing placeholder options (Default, None, etc.)
+				// from the current values. Placeholders are identified by
+				// having a string value rather than an optgroup object.
+				for (const existingKey in existingValues) {
+					if (typeof existingValues[existingKey] === 'string') {
+						values[existingKey] = existingValues[existingKey];
+					}
+				}
+
+				// Add the refreshed items.
+				items.forEach(function (item) {
+					values[item.id] = labelForItem(item);
+				});
+
+				return values;
+			};
+
+			/**
+			 * Builds an optgroup-style values map from a response object whose
+			 * keys are group names and whose values are arrays of items. Each
+			 * option key within an optgroup is prefixed with the singularized
+			 * group name (e.g. `forms` => `form_123`), matching the
+			 * prefixing convention used on the PHP side for grouped fields.
+			 *
+			 * Preserves any existing top-level placeholder options from the
+			 * current field values.
+			 *
+			 * @since 	3.3.1
+			 *
+			 * @param {Object} groups         API response keyed by group name.
+			 * @param {Object} existingValues Current values map for the field.
+			 * @return {Object}               Rebuilt values map.
+			 */
+			const buildOptgroupValues = function (groups, existingValues) {
+				const values = {};
+
+				// Preserve any top-level placeholder options (e.g. 'Do not restrict...').
+				for (const existingKey in existingValues) {
+					if (typeof existingValues[existingKey] !== 'object') {
+						values[existingKey] = existingValues[existingKey];
+					}
+				}
+
+				// Build each optgroup from the response.
+				for (const groupKey in groups) {
+					const items = groups[groupKey];
+					if (!Array.isArray(items) || items.length === 0) {
+						continue;
+					}
+
+					// Derive the per-item key prefix from the group name
+					// (e.g. 'forms' => 'form_', 'tags' => 'tag_').
+					const itemKeyPrefix = groupKey.replace(/s$/, '') + '_';
+
+					// Label the optgroup using the group name with the first
+					// letter capitalized (e.g. 'forms' => 'Forms').
+					const label =
+						groupKey.charAt(0).toUpperCase() + groupKey.slice(1);
+
+					const groupValues = {};
+					items.forEach(function (item) {
+						groupValues[itemKeyPrefix + item.id] =
+							labelForItem(item);
+					});
+
+					values[groupKey] = {
+						label,
+						values: groupValues,
+					};
+				}
+
+				return values;
+			};
+
+			/**
+			 * Refreshes resources for the given resource type, updating
+			 * the specified field's values on success so the SelectControl
+			 * re-renders with the latest options.
+			 *
+			 * The values shape is inferred from the API response: an array
+			 * produces a flat list of options; an object keyed by group name
+			 * produces optgroups.
+			 *
+			 * @since 	3.3.1
+			 *
+			 * @param {string}   resource          Resource type, appended to the refresh URL.
+			 * @param {string}   fieldKey          The sidebar field key whose values should be updated.
 			 * @param {Function} setButtonDisabled Function to enable or disable the refresh button.
 			 */
-			const refreshResources = function (resource, setButtonDisabled) {
+			const refreshResources = function (
+				resource,
+				fieldKey,
+				setButtonDisabled
+			) {
 				// Disable the button.
 				setButtonDisabled(true);
 
@@ -1224,25 +1375,25 @@ function convertKitGutenbergRegisterPluginSidebar(sidebar) {
 							return;
 						}
 
-						// @TODO Update something here - convertkit_plugin_sidebars?
+						// Rebuild the field's values from the response, and
+						// update state so the SelectControl re-renders with
+						// the latest options. The currently-selected value is
+						// stored in post meta and so is preserved automatically.
+						//
+						// The response shape determines the values shape:
+						// an array produces a flat list; an object keyed by
+						// group name (e.g. { forms: [...], tags: [...] })
+						// produces optgroups.
+						setFieldValues(function (prev) {
+							const existing = prev[fieldKey] || {};
+							const values = Array.isArray(response)
+								? buildFlatValues(response, existing)
+								: buildOptgroupValues(response, existing);
 
-						// @TODO Refresh/redraw the field?
-						// The below code is how we do it for a block, but that doesn't apply to a block editor sidebar.
-						/*
-						// Update global ConvertKit Blocks object, so that any updated resources
-						// are reflected when adding new ConvertKit Blocks.
-						convertkit_blocks = response;
-
-						// Update this block's properties, so that has_access_token, has_resources
-						// and the resources properties are updated.
-						block = convertkit_blocks[block.name];
-
-						// Call setAttributes on props to trigger the editBlock() function, which will re-render
-						// the block, reflecting any changes to its properties.
-						props.setAttributes({
-							refresh: Date.now(),
+							return Object.assign({}, prev, {
+								[fieldKey]: values,
+							});
 						});
-						*/
 
 						// Enable refresh button.
 						setButtonDisabled(false);

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -1328,20 +1328,27 @@ function convertKitGutenbergRegisterPluginSidebar(sidebar) {
 				}
 
 				// Build each optgroup from the response.
-				for (const groupKey in groups) {
-					const items = groups[groupKey];
+				for (const optGroupKey in groups) {
+					// Skip if this optgroup doesn't have any options.
+					const items = groups[optGroupKey];
 					if (!Array.isArray(items) || items.length === 0) {
 						continue;
 					}
 
 					// Derive the per-item key prefix from the group name
 					// (e.g. 'forms' => 'form_', 'tags' => 'tag_').
-					const itemKeyPrefix = groupKey.replace(/s$/, '') + '_';
+					const itemKeyPrefix = optGroupKey.replace(/s$/, '') + '_';
 
-					// Label the optgroup using the group name with the first
-					// letter capitalized (e.g. 'forms' => 'Forms').
+					// Reuse the existing optgroup label if one exists, falling
+					// back to the capitalized group key if not.
+					const existingGroup = existingValues[optGroupKey];
 					const label =
-						groupKey.charAt(0).toUpperCase() + groupKey.slice(1);
+						existingGroup &&
+						typeof existingGroup === 'object' &&
+						existingGroup.label
+							? existingGroup.label
+							: optGroupKey.charAt(0).toUpperCase() +
+								optGroupKey.slice(1);
 
 					const groupValues = {};
 					items.forEach(function (item) {
@@ -1349,7 +1356,7 @@ function convertKitGutenbergRegisterPluginSidebar(sidebar) {
 							labelForItem(item);
 					});
 
-					values[groupKey] = {
+					values[optGroupKey] = {
 						label,
 						values: groupValues,
 					};

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -1243,7 +1243,7 @@ function convertKitGutenbergRegisterPluginSidebar(sidebar) {
 			 * @param {Object} existingValues Current values map for the field.
 			 * @return {Object}               Rebuilt values map.
 			 */
-			const buildFlatValues = function (items, existingValues) {
+			const buildSelectValues = function (items, existingValues) {
 				const values = {};
 
 				// Preserve existing placeholder options (Default, None, etc.)
@@ -1279,7 +1279,10 @@ function convertKitGutenbergRegisterPluginSidebar(sidebar) {
 			 * @param {Object} existingValues Current values map for the field.
 			 * @return {Object}               Rebuilt values map.
 			 */
-			const buildOptgroupValues = function (groups, existingValues) {
+			const buildSelectOptGroupValues = function (
+				groups,
+				existingValues
+			) {
 				const values = {};
 
 				// Preserve any top-level placeholder options (e.g. 'Do not restrict...').
@@ -1324,10 +1327,6 @@ function convertKitGutenbergRegisterPluginSidebar(sidebar) {
 			 * Refreshes resources for the given resource type, updating
 			 * the specified field's values on success so the SelectControl
 			 * re-renders with the latest options.
-			 *
-			 * The values shape is inferred from the API response: an array
-			 * produces a flat list of options; an object keyed by group name
-			 * produces optgroups.
 			 *
 			 * @since 	3.3.1
 			 *
@@ -1377,9 +1376,7 @@ function convertKitGutenbergRegisterPluginSidebar(sidebar) {
 
 						// Rebuild the field's values from the response, and
 						// update state so the SelectControl re-renders with
-						// the latest options. The currently-selected value is
-						// stored in post meta and so is preserved automatically.
-						//
+						// the latest options.
 						// The response shape determines the values shape:
 						// an array produces a flat list; an object keyed by
 						// group name (e.g. { forms: [...], tags: [...] })
@@ -1387,8 +1384,8 @@ function convertKitGutenbergRegisterPluginSidebar(sidebar) {
 						setFieldValues(function (prev) {
 							const existing = prev[fieldKey] || {};
 							const values = Array.isArray(response)
-								? buildFlatValues(response, existing)
-								: buildOptgroupValues(response, existing);
+								? buildSelectValues(response, existing)
+								: buildSelectOptGroupValues(response, existing);
 
 							return Object.assign({}, prev, {
 								[fieldKey]: values,

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -1014,6 +1014,7 @@ function convertKitGutenbergRegisterPluginSidebar(sidebar) {
 				// Define some field properties shared across all field types.
 				const fieldProperties = {
 					key: 'convertkit_plugin_sidebar_' + key,
+					id: 'convertkit_plugin_sidebar_' + key,
 					label: field.label,
 					help: Array.isArray(field.description)
 						? field.description.join('\n\n')
@@ -1230,6 +1231,9 @@ function convertKitGutenbergRegisterPluginSidebar(sidebar) {
 						(buttonDisabled ? ' is-refreshing' : ''),
 					disabled: buttonDisabled,
 					icon: iconType('update'),
+					// `data-resource` is used by tests and as a stable hook
+					// matching the classic-editor refresh button.
+					'data-resource': resource,
 					onClick() {
 						// Refresh resources.
 						refreshResources(resource, fieldKey, setButtonDisabled);

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -942,6 +942,7 @@ function convertKitGutenbergRegisterPluginSidebar(sidebar) {
 			SelectControl,
 			Flex,
 			FlexItem,
+			FlexBlock,
 			PanelBody,
 			PanelRow,
 			Button,
@@ -1038,30 +1039,60 @@ function convertKitGutenbergRegisterPluginSidebar(sidebar) {
 						// If the field has a resource_type, wrap the select in a
 						// Flex container alongside a refresh button.
 						if (field.resource_type) {
+							const selectFieldProperties = Object.assign(
+								{},
+								fieldProperties,
+								{ help: undefined }
+							);
+
 							return el(
-								Flex,
+								'div',
 								{
-									align: 'start',
+									key:
+										'convertkit_plugin_sidebar_' +
+										key +
+										'_wrapper',
 								},
-								[
-									el(
-										FlexItem,
-										{
-											key: key + '-select',
-										},
-										getSelectField(field, fieldProperties)
-									),
-									el(
-										FlexItem,
-										{
-											key: key + '-refresh',
-										},
-										el(InlineRefreshButton, {
-											resource: field.resource_type,
-											fieldKey: key,
-										})
-									),
-								]
+								el(
+									Flex,
+									{
+										align: 'end',
+										gap: 2,
+									},
+									[
+										el(
+											FlexBlock,
+											{
+												key: key + '-select',
+											},
+											getSelectField(
+												field,
+												selectFieldProperties
+											)
+										),
+										el(
+											FlexItem,
+											{
+												key: key + '-refresh',
+											},
+											el(InlineRefreshButton, {
+												resource: field.resource_type,
+												fieldKey: key,
+											})
+										),
+									]
+								),
+								fieldProperties.help
+									? el(
+											'p',
+											{
+												key: key + '-help',
+												className:
+													'components-base-control__help',
+											},
+											fieldProperties.help
+										)
+									: null
 							);
 						}
 

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -935,7 +935,17 @@ function convertKitGutenbergRegisterPluginSidebar(sidebar) {
 		const el = element.createElement;
 		const { registerPlugin } = plugins;
 		const { PluginSidebar } = editor;
-		const { TextControl, SelectControl, PanelBody, PanelRow } = components;
+		const { useState } = element;
+		const {
+			Icon,
+			TextControl,
+			SelectControl,
+			Flex,
+			FlexItem,
+			PanelBody,
+			PanelRow,
+			Button,
+		} = components;
 		const { useSelect, useDispatch, select } = data;
 
 		/**
@@ -1006,98 +1016,248 @@ function convertKitGutenbergRegisterPluginSidebar(sidebar) {
 				// Define additional Field Properties and the Field Element,
 				// depending on the Field Type (select, textarea, text etc).
 				switch (field.type) {
-					case 'select':
-						// Check if any values are optgroups.
-						const hasOptgroups = Object.keys(field.values).some(
-							(subKey) =>
-								typeof field.values[subKey] === 'object' &&
-								field.values[subKey].label &&
-								field.values[subKey].values
+					case 'resource':
+						return el(
+							Flex,
+							{
+								align: 'start',
+							},
+							[
+								el(
+									FlexItem,
+									{
+										key: key + '-select',
+									},
+									getSelectField(field, fieldProperties)
+								),
+								el(
+									FlexItem,
+									{
+										key: key + '-refresh',
+									},
+									InlineRefreshButton(field.resource)
+								),
+							]
 						);
 
-						if (hasOptgroups) {
-							const children = [];
-
-							for (const value of Object.keys(field.values)) {
-								if (
-									typeof field.values[value] === 'object' &&
-									field.values[value].label &&
-									field.values[value].values
-								) {
-									// Optgroup.
-									const groupChildren = [];
-									for (const groupValue of Object.keys(
-										field.values[value].values
-									)) {
-										groupChildren.push(
-											el(
-												'option',
-												{
-													value: groupValue,
-													key: groupValue,
-												},
-												field.values[value].values[
-													groupValue
-												]
-											)
-										);
-									}
-									children.push(
-										el(
-											'optgroup',
-											{
-												label: field.values[value]
-													.label,
-												key: value,
-											},
-											...groupChildren
-										)
-									);
-								} else {
-									// Option within optgroup.
-									children.push(
-										el(
-											'option',
-											{ value, key: value },
-											field.values[value]
-										)
-									);
-								}
-							}
-
-							return el(
-								SelectControl,
-								fieldProperties,
-								...children
-							);
-						}
-
-						// Options only, no optgroups.
-						const fieldOptions = [];
-						for (const value of Object.keys(field.values)) {
-							fieldOptions.push({
-								label: field.values[value],
-								value,
-							});
-						}
-
-						// Sort options alphabetically by label.
-						fieldOptions.sort(function (x, y) {
-							const a = x.label.toUpperCase(),
-								b = y.label.toUpperCase();
-							return a.localeCompare(b);
-						});
-
-						// Assign options to field properties.
-						fieldProperties.options = fieldOptions;
-
-						// Return field element.
-						return el(SelectControl, fieldProperties);
+					case 'select':
+						return getSelectField(field, fieldProperties);
 
 					default:
 						// Return field element.
 						return el(TextControl, fieldProperties);
 				}
+			};
+
+			/**
+			 * Returns a select field element, with optgroups and options
+			 * depending on the field's values.
+			 *
+			 * @since   3.3.1
+			 *
+			 * @param {Object} field           Field properties.
+			 * @param {Object} fieldProperties Field properties.
+			 * @return {Object}       Select field element.
+			 */
+			const getSelectField = function (field, fieldProperties) {
+				// Check if any values are optgroups.
+				const hasOptgroups = Object.keys(field.values).some(
+					(subKey) =>
+						typeof field.values[subKey] === 'object' &&
+						field.values[subKey].label &&
+						field.values[subKey].values
+				);
+
+				if (hasOptgroups) {
+					const children = [];
+
+					for (const value of Object.keys(field.values)) {
+						if (
+							typeof field.values[value] === 'object' &&
+							field.values[value].label &&
+							field.values[value].values
+						) {
+							// Optgroup.
+							const groupChildren = [];
+							for (const groupValue of Object.keys(
+								field.values[value].values
+							)) {
+								groupChildren.push(
+									el(
+										'option',
+										{
+											value: groupValue,
+											key: groupValue,
+										},
+										field.values[value].values[groupValue]
+									)
+								);
+							}
+							children.push(
+								el(
+									'optgroup',
+									{
+										label: field.values[value].label,
+										key: value,
+									},
+									...groupChildren
+								)
+							);
+						} else {
+							// Option within optgroup.
+							children.push(
+								el(
+									'option',
+									{ value, key: value },
+									field.values[value]
+								)
+							);
+						}
+					}
+
+					return el(SelectControl, fieldProperties, ...children);
+				}
+
+				// Options only, no optgroups.
+				const fieldOptions = [];
+				for (const value of Object.keys(field.values)) {
+					fieldOptions.push({
+						label: field.values[value],
+						value,
+					});
+				}
+
+				// Sort options alphabetically by label.
+				fieldOptions.sort(function (x, y) {
+					const a = x.label.toUpperCase(),
+						b = y.label.toUpperCase();
+					return a.localeCompare(b);
+				});
+
+				// Assign options to field properties.
+				fieldProperties.options = fieldOptions;
+
+				// Return field element.
+				return el(SelectControl, fieldProperties);
+			};
+
+			/**
+			 * Returns a WordPress Icon element.
+			 *
+			 * @since 	3.3.1
+			 *
+			 * @param {string} iconName Icon Name.
+			 * @return {Object} 		 Icon.
+			 */
+			const iconType = function (iconName) {
+				return el(Icon, {
+					icon: iconName,
+				});
+			};
+
+			/**
+			 * Returns an inline refresh button, used to refresh a block's resources.
+			 *
+			 * @since 	3.3.1
+			 *
+			 * @param {string} resource Resource type (forms,tags,landing_pages,restrict_content).
+			 * @return {Object} 	     Button.
+			 */
+			const InlineRefreshButton = function (resource) {
+				const [buttonDisabled, setButtonDisabled] = useState(false);
+
+				return el(Button, {
+					key: resource + '-refresh-button',
+					className:
+						'button button-secondary wp-convertkit-refresh-resources' +
+						(buttonDisabled ? ' is-refreshing' : ''),
+					disabled: buttonDisabled,
+					icon: iconType('update'),
+					onClick() {
+						// Refresh resources.
+						refreshResources(resource, setButtonDisabled);
+					},
+				});
+			};
+
+			/**
+			 * Refreshes resources for the given resource type.
+			 *
+			 * @since 	3.3.1
+			 *
+			 * @param {string}   resource          Resource type (forms,tags,landing_pages,restrict_content).
+			 * @param {Function} setButtonDisabled Function to enable or disable the refresh button.
+			 */
+			const refreshResources = function (resource, setButtonDisabled) {
+				// Disable the button.
+				setButtonDisabled(true);
+
+				// Send AJAX request.
+				fetch(convertkit_gutenberg.refresh_resources_url + resource, {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						'X-WP-Nonce':
+							convertkit_gutenberg.refresh_resources_nonce,
+					},
+				})
+					.then(function (response) {
+						// Convert response JSON string to object.
+						return response.json();
+					})
+					.then(function (response) {
+						if (convertkit_gutenberg.debug) {
+							console.log(response);
+						}
+
+						// If the response includes a code, show an error notice.
+						if (typeof response.code !== 'undefined') {
+							// Show an error in the Gutenberg editor.
+							wp.data
+								.dispatch('core/notices')
+								.createErrorNotice('Kit: ' + response.message, {
+									id: 'convertkit-error',
+								});
+
+							// Enable refresh button.
+							setButtonDisabled(false);
+							return;
+						}
+
+						// @TODO Update something here - convertkit_plugin_sidebars?
+
+						// @TODO Refresh/redraw the field?
+						// The below code is how we do it for a block, but that doesn't apply to a block editor sidebar.
+						/*
+						// Update global ConvertKit Blocks object, so that any updated resources
+						// are reflected when adding new ConvertKit Blocks.
+						convertkit_blocks = response;
+
+						// Update this block's properties, so that has_access_token, has_resources
+						// and the resources properties are updated.
+						block = convertkit_blocks[block.name];
+
+						// Call setAttributes on props to trigger the editBlock() function, which will re-render
+						// the block, reflecting any changes to its properties.
+						props.setAttributes({
+							refresh: Date.now(),
+						});
+						*/
+
+						// Enable refresh button.
+						setButtonDisabled(false);
+					})
+					.catch(function (error) {
+						// Show an error in the Gutenberg editor.
+						wp.data
+							.dispatch('core/notices')
+							.createErrorNotice('Kit: ' + error, {
+								id: 'convertkit-error',
+							});
+
+						// Enable refresh button.
+						setButtonDisabled(false);
+					});
 			};
 
 			/**

--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -96,7 +96,26 @@ function convertKitRefreshResources(button) {
 			// Depending on the resource we're refreshing, populate the <select> options.
 			switch (resource) {
 				case 'restrict_content':
-					// Populate select `optgroup`` from response data, which comprises of Tags and Products.
+					// Populate select `optgroup` from response data, which comprises of Forms, Tags and Products.
+					// Forms.
+					response.forms.forEach(function (item) {
+						document
+							.querySelector(
+								field + ' optgroup[data-resource=forms]'
+							)
+							.appendChild(
+								new Option(
+									item.name +
+										' [' +
+										(item.format ? item.format : 'inline') +
+										']',
+									'form_' + item.id,
+									false,
+									selectedOption === 'form_' + item.id
+								)
+							);
+					});
+
 					// Tags.
 					response.tags.forEach(function (item) {
 						document

--- a/tests/EndToEnd/general/other/RefreshResourcesButtonCest.php
+++ b/tests/EndToEnd/general/other/RefreshResourcesButtonCest.php
@@ -122,6 +122,14 @@ class RefreshResourcesButtonCest
 		// Wait for button to change its state from disabled.
 		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="restrict_content"]:not(:disabled)');
 
+		// Confirm that the expected Form is within the Forms option group and selectable.
+		$I->seeElementInDOM('select#wp-convertkit-restrict_content optgroup[data-resource="forms"] option[value="form_' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-restrict_content-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
+
 		// Confirm that the expected Tag is within the Tags option group and selectable.
 		$I->seeElementInDOM('select#wp-convertkit-restrict_content optgroup[data-resource="tags"] option[value="tag_' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]');
 		$I->fillSelect2Field(
@@ -195,6 +203,10 @@ class RefreshResourcesButtonCest
 
 		// Wait for button to change its state from disabled.
 		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="restrict_content"]:not(:disabled)');
+
+		// Confirm that the expected Form is within the Forms option group and selectable.
+		$I->seeElementInDOM('#convertkit_plugin_sidebar_restrict_content optgroup[label="Forms"] option[value="form_' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+		$I->selectOption('#convertkit_plugin_sidebar_restrict_content', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
 		// Confirm that the expected Tag is within the Tags option group and selectable.
 		$I->seeElementInDOM('#convertkit_plugin_sidebar_restrict_content optgroup[label="Tags"] option[value="tag_' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]');

--- a/tests/EndToEnd/general/other/RefreshResourcesButtonCest.php
+++ b/tests/EndToEnd/general/other/RefreshResourcesButtonCest.php
@@ -28,13 +28,14 @@ class RefreshResourcesButtonCest
 	}
 
 	/**
-	 * Test that the refresh buttons for Forms, Landing Pages, Tags and Restrict Content works when adding a new Page.
+	 * Test that the refresh buttons for Forms, Landing Pages, Tags and Restrict Content works when adding a new Page
+	 * using the Classic Editor.
 	 *
 	 * @since   1.9.8.0
 	 *
 	 * @param   EndToEndTester $I  Tester.
 	 */
-	public function testRefreshResourcesOnPage(EndToEndTester $I)
+	public function testRefreshResourcesInClassicEditor(EndToEndTester $I)
 	{
 		// Activate Classic Editor Plugin.
 		$I->activateThirdPartyPlugin($I, 'classic-editor');
@@ -136,6 +137,75 @@ class RefreshResourcesButtonCest
 			container: '#select2-wp-convertkit-restrict_content-container',
 			value: $_ENV['CONVERTKIT_API_PRODUCT_NAME']
 		);
+	}
+
+	/**
+	 * Test that the refresh buttons for Forms, Landing Pages, Tags and Restrict Content works when adding a new Page
+	 * using the Gutenberg editor.
+	 *
+	 * @since   3.3.1
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testRefreshResourcesInGutenbergEditor(EndToEndTester $I)
+	{
+		// Setup Kit Plugin.
+		$I->setupKitPlugin($I);
+
+		// Add a Post using the Gutenberg editor.
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Refresh Resources: Gutenberg Editor',
+			postType: 'page'
+		);
+
+		// Open the Plugin sidebar settings.
+		$I->openPluginSidebarSettings($I);
+
+		// Click the Forms refresh button.
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="forms"]');
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="forms"]:not(:disabled)');
+
+		// Change resource to value specified in the .env file, which should now be available.
+		// If the expected dropdown value does not exist in the Select field, this will fail the test.
+		$I->selectOption('#convertkit_plugin_sidebar_form', $_ENV['CONVERTKIT_API_FORM_NAME']);
+
+		// Click the Landing Pages refresh button.
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="landing_pages"]');
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="landing_pages"]:not(:disabled)');
+
+		// Change resource to value specified in the .env file, which should now be available.
+		$I->selectOption('#convertkit_plugin_sidebar_landing_page', $_ENV['CONVERTKIT_API_LANDING_PAGE_NAME']);
+
+		// Click the Tags refresh button.
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="tags"]');
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="tags"]:not(:disabled)');
+
+		// Change resource to value specified in the .env file, which should now be available.
+		$I->selectOption('#convertkit_plugin_sidebar_tag', $_ENV['CONVERTKIT_API_TAG_NAME']);
+
+		// Click the Restrict Content refresh button.
+		$I->click('button.wp-convertkit-refresh-resources[data-resource="restrict_content"]');
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="restrict_content"]:not(:disabled)');
+
+		// Confirm that the expected Tag is within the Tags option group and selectable.
+		$I->seeElementInDOM('#convertkit_plugin_sidebar_restrict_content optgroup[label="Tags"] option[value="tag_' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]');
+		$I->selectOption('#convertkit_plugin_sidebar_restrict_content', $_ENV['CONVERTKIT_API_TAG_NAME']);
+
+		// Confirm that the expected Product is within the Products option group and selectable.
+		$I->seeElementInDOM('#convertkit_plugin_sidebar_restrict_content optgroup[label="Products"] option[value="product_' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '"]');
+		$I->selectOption('#convertkit_plugin_sidebar_restrict_content', $_ENV['CONVERTKIT_API_PRODUCT_NAME']);
+
+		// Close the Plugin sidebar settings.
+		$I->closePluginSidebarSettings($I);
 	}
 
 	/**

--- a/tests/EndToEnd/general/other/RefreshResourcesButtonCest.php
+++ b/tests/EndToEnd/general/other/RefreshResourcesButtonCest.php
@@ -288,6 +288,10 @@ class RefreshResourcesButtonCest
 		// Wait for button to change its state from disabled.
 		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="restrict_content"]:not(:disabled)');
 
+		// Confirm that the expected Form is within the Forms option group and selectable.
+		$I->seeElementInDOM('#wp-convertkit-quick-edit-restrict_content optgroup[data-resource="forms"] option[value="form_' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+		$I->selectOption('#wp-convertkit-quick-edit-restrict_content', $_ENV['CONVERTKIT_API_FORM_NAME']);
+
 		// Confirm that the expected Tag is within the Tags option group and selectable.
 		$I->seeElementInDOM('#wp-convertkit-quick-edit-restrict_content optgroup[data-resource="tags"] option[value="tag_' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]');
 		$I->selectOption('#wp-convertkit-quick-edit-restrict_content', $_ENV['CONVERTKIT_API_TAG_NAME']);
@@ -374,6 +378,10 @@ class RefreshResourcesButtonCest
 
 		// Wait for button to change its state from disabled.
 		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="restrict_content"]:not(:disabled)');
+
+		// Confirm that the expected Form is within the Forms option group and selectable.
+		$I->seeElementInDOM('#wp-convertkit-bulk-edit-restrict_content optgroup[data-resource="forms"] option[value="form_' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+		$I->selectOption('#wp-convertkit-bulk-edit-restrict_content', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
 		// Confirm that the expected Tag is within the Tags option group and selectable.
 		$I->seeElementInDOM('#wp-convertkit-bulk-edit-restrict_content optgroup[data-resource="tags"] option[value="tag_' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]');

--- a/tests/Integration/RESTAPITest.php
+++ b/tests/Integration/RESTAPITest.php
@@ -295,6 +295,11 @@ class RESTAPITest extends WPRestApiTestCase
 		$data = $response->get_data();
 		$this->assertIsArray( $data );
 
+		// Assert forms response data has the expected keys.
+		$this->assertArrayHasKey( 'forms', $data );
+		$this->assertIsArray( $data['forms'] );
+		$this->assertArrayHasKeys( $data['forms'][0], [ 'id', 'name', 'created_at' ] );
+
 		// Assert tags response data has the expected keys.
 		$this->assertArrayHasKey( 'tags', $data );
 		$this->assertIsArray( $data['tags'] );


### PR DESCRIPTION
## Summary

Adds refresh resource buttons when the block editor / Gutenberg is used, and the user wants to refresh resources (forms, tags, landing pages etc), as they would in the Classic Editor:

<img width="271" height="835" alt="Screenshot 2026-04-24 at 16 51 44" src="https://github.com/user-attachments/assets/d9321a03-ac56-4da8-9804-cb58680c7572" />

## Testing

- `testRefreshResourcesInGutenbergEditor`: Test that the refresh resource buttons in the block editor plugin sidebar work. 

## Checklist

* [ ] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [ ] I have [run all tests](TESTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)