### PR TITLE
Refresh Resources: Member Content: Include Forms

### DIFF
--- a/admin/class-convertkit-admin-refresh-resources.php
+++ b/admin/class-convertkit-admin-refresh-resources.php
@@ -105,6 +105,15 @@ class ConvertKit_Admin_Refresh_Resources {
 				break;
 
 			case 'restrict_content':
+				// Fetch Forms.
+				$forms         = new ConvertKit_Resource_Forms( 'user_refresh_resource' );
+				$results_forms = $forms->refresh();
+
+				// Bail if an error occured.
+				if ( is_wp_error( $results_forms ) ) {
+					return rest_ensure_response( $results_forms );
+				}
+
 				// Fetch Tags.
 				$tags         = new ConvertKit_Resource_Tags( 'user_refresh_resource' );
 				$results_tags = $tags->refresh();
@@ -126,6 +135,7 @@ class ConvertKit_Admin_Refresh_Resources {
 				// Return resources.
 				return rest_ensure_response(
 					array(
+						'forms'    => array_values( $results_forms ),
 						'tags'     => array_values( $results_tags ),
 						'products' => array_values( $results_products ),
 					)

--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -96,7 +96,26 @@ function convertKitRefreshResources(button) {
 			// Depending on the resource we're refreshing, populate the <select> options.
 			switch (resource) {
 				case 'restrict_content':
-					// Populate select `optgroup`` from response data, which comprises of Tags and Products.
+					// Populate select `optgroup` from response data, which comprises of Forms, Tags and Products.
+					// Forms.
+					response.forms.forEach(function (item) {
+						document
+							.querySelector(
+								field + ' optgroup[data-resource=forms]'
+							)
+							.appendChild(
+								new Option(
+									item.name +
+										' [' +
+										(item.format ? item.format : 'inline') +
+										']',
+									'form_' + item.id,
+									false,
+									selectedOption === 'form_' + item.id
+								)
+							);
+					});
+
 					// Tags.
 					response.tags.forEach(function (item) {
 						document

--- a/tests/EndToEnd/general/other/RefreshResourcesButtonCest.php
+++ b/tests/EndToEnd/general/other/RefreshResourcesButtonCest.php
@@ -122,6 +122,14 @@ class RefreshResourcesButtonCest
 		// Wait for button to change its state from disabled.
 		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="restrict_content"]:not(:disabled)');
 
+		// Confirm that the expected Form is within the Forms option group and selectable.
+		$I->seeElementInDOM('select#wp-convertkit-restrict_content optgroup[data-resource="forms"] option[value="form_' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-wp-convertkit-restrict_content-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
+
 		// Confirm that the expected Tag is within the Tags option group and selectable.
 		$I->seeElementInDOM('select#wp-convertkit-restrict_content optgroup[data-resource="tags"] option[value="tag_' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]');
 		$I->fillSelect2Field(
@@ -195,6 +203,10 @@ class RefreshResourcesButtonCest
 
 		// Wait for button to change its state from disabled.
 		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="restrict_content"]:not(:disabled)');
+
+		// Confirm that the expected Form is within the Forms option group and selectable.
+		$I->seeElementInDOM('#convertkit_plugin_sidebar_restrict_content optgroup[label="Forms"] option[value="form_' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+		$I->selectOption('#convertkit_plugin_sidebar_restrict_content', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
 		// Confirm that the expected Tag is within the Tags option group and selectable.
 		$I->seeElementInDOM('#convertkit_plugin_sidebar_restrict_content optgroup[label="Tags"] option[value="tag_' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]');

--- a/tests/EndToEnd/general/other/RefreshResourcesButtonCest.php
+++ b/tests/EndToEnd/general/other/RefreshResourcesButtonCest.php
@@ -288,6 +288,10 @@ class RefreshResourcesButtonCest
 		// Wait for button to change its state from disabled.
 		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="restrict_content"]:not(:disabled)');
 
+		// Confirm that the expected Form is within the Forms option group and selectable.
+		$I->seeElementInDOM('#wp-convertkit-quick-edit-restrict_content optgroup[data-resource="forms"] option[value="form_' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+		$I->selectOption('#wp-convertkit-quick-edit-restrict_content', $_ENV['CONVERTKIT_API_FORM_NAME']);
+
 		// Confirm that the expected Tag is within the Tags option group and selectable.
 		$I->seeElementInDOM('#wp-convertkit-quick-edit-restrict_content optgroup[data-resource="tags"] option[value="tag_' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]');
 		$I->selectOption('#wp-convertkit-quick-edit-restrict_content', $_ENV['CONVERTKIT_API_TAG_NAME']);
@@ -374,6 +378,10 @@ class RefreshResourcesButtonCest
 
 		// Wait for button to change its state from disabled.
 		$I->waitForElementVisible('button.wp-convertkit-refresh-resources[data-resource="restrict_content"]:not(:disabled)');
+
+		// Confirm that the expected Form is within the Forms option group and selectable.
+		$I->seeElementInDOM('#wp-convertkit-bulk-edit-restrict_content optgroup[data-resource="forms"] option[value="form_' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"]');
+		$I->selectOption('#wp-convertkit-bulk-edit-restrict_content', $_ENV['CONVERTKIT_API_FORM_NAME']);
 
 		// Confirm that the expected Tag is within the Tags option group and selectable.
 		$I->seeElementInDOM('#wp-convertkit-bulk-edit-restrict_content optgroup[data-resource="tags"] option[value="tag_' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]');

--- a/tests/Integration/RESTAPITest.php
+++ b/tests/Integration/RESTAPITest.php
@@ -295,6 +295,11 @@ class RESTAPITest extends WPRestApiTestCase
 		$data = $response->get_data();
 		$this->assertIsArray( $data );
 
+		// Assert forms response data has the expected keys.
+		$this->assertArrayHasKey( 'forms', $data );
+		$this->assertIsArray( $data['forms'] );
+		$this->assertArrayHasKeys( $data['forms'][0], [ 'id', 'name', 'created_at' ] );
+
 		// Assert tags response data has the expected keys.
 		$this->assertArrayHasKey( 'tags', $data );
 		$this->assertIsArray( $data['tags'] );


### PR DESCRIPTION
## Summary

Clicking the refresh resources button for Member Content would result in the Forms section not populating (Tags and Products would re-populate), due to the refresh_resources() method not fetching Forms.

This wasn't caught previously, as Forms were a later addition to Member Content and tests weren't updated to check that Forms exist once a Member Content field's refresh button was clicked.

## Testing

- Updates tests in `RefreshResourcesButtonCest` to confirm that the expected Form is selectable when refreshing the Member Content setting across the Classic Editor, Block Editor, Bulk Edit and Quick Edit.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)