### PR TITLE
Form Builder: Support Legacy Forms

### DIFF
--- a/includes/blocks/class-convertkit-block-form-builder.php
+++ b/includes/blocks/class-convertkit-block-form-builder.php
@@ -194,11 +194,20 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 
 		// If a form was specified, add the subscriber to the form.
 		if ( $form_id ) {
-			$result = $api->add_subscriber_to_form(
-				$form_id,
-				$result['subscriber']['id'],
-				get_permalink( absint( $form_data['post_id'] ) )
-			);
+			// For Legacy Forms, a different endpoint is used.
+			$forms = new ConvertKit_Resource_Forms();
+			if ( $forms->is_legacy( $form_id ) ) {
+				$result = $api->add_subscriber_to_legacy_form(
+					$form_id,
+					$result['subscriber']['id']
+				);
+			} else {
+				$result = $api->add_subscriber_to_form(
+					$form_id,
+					$result['subscriber']['id'],
+					get_permalink( absint( $form_data['post_id'] ) )
+				);
+			}
 
 			if ( $form_data['store_entries'] ) {
 				$entries->upsert(

--- a/tests/EndToEnd.suite.yml
+++ b/tests/EndToEnd.suite.yml
@@ -56,7 +56,6 @@ modules:
             capabilities:
               "goog:chromeOptions":
                 args:
-                  - "--headless"
                   - "--disable-gpu"
                   - "--disable-dev-shm-usage"
                   - "--disable-software-rasterizer"

--- a/tests/EndToEnd.suite.yml
+++ b/tests/EndToEnd.suite.yml
@@ -56,6 +56,7 @@ modules:
             capabilities:
               "goog:chromeOptions":
                 args:
+                  - "--headless"
                   - "--disable-gpu"
                   - "--disable-dev-shm-usage"
                   - "--disable-software-rasterizer"

--- a/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormBuilderCest.php
+++ b/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormBuilderCest.php
@@ -387,6 +387,103 @@ class PageBlockFormBuilderCest
 	}
 
 	/**
+	 * Test the Form Builder block works when added and a Legacy Form is specified
+	 * to subscribe the subscriber to.
+	 *
+	 * @since   3.3.2
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFormBuilderBlockWithLegacyFormEnabled(EndToEndTester $I)
+	{
+		// Setup Plugin and Resources.
+		$I->setupKitPlugin($I);
+		$I->setupKitPluginResources($I);
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Builder: Block: Form Enabled'
+		);
+
+		// Configure metabox's Form setting = None, ensuring we only test the block in Gutenberg.
+		$I->configurePluginSidebarSettings(
+			$I,
+			form: 'None'
+		);
+
+		// Add block to Page.
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Form Builder',
+			blockProgrammaticName: 'convertkit-form-builder',
+			blockConfiguration: [
+				'form_id' => [ 'select', $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] ],
+			]
+		);
+
+		// Confirm the block template was used as the default.
+		$this->seeFormBuilderBlock($I);
+		$this->seeFormBuilderButtonBlock($I);
+		$this->seeFormBuilderField(
+			$I,
+			fieldType: 'text',
+			fieldName: 'first_name',
+			fieldID: 'first_name',
+			label: 'First name',
+			container: 'div[data-type="convertkit/form-builder"]'
+		);
+		$this->seeFormBuilderField(
+			$I,
+			fieldType: 'email',
+			fieldName: 'email',
+			fieldID: 'email',
+			label: 'Email address',
+			container: 'div[data-type="convertkit/form-builder"]'
+		);
+
+		// Publish and view the Page on the frontend site.
+		$I->publishAndViewGutenbergPage($I);
+
+		// Confirm that the Form is output in the DOM.
+		$this->seeFormBuilderField(
+			$I,
+			fieldType: 'text',
+			fieldName: 'first_name',
+			fieldID: 'first_name',
+			label: 'First name',
+			container: 'div.wp-block-convertkit-form-builder',
+			isFrontend: true
+		);
+		$this->seeFormBuilderField(
+			$I,
+			fieldType: 'email',
+			fieldName: 'email',
+			fieldID: 'email',
+			label: 'Email address',
+			container: 'div.wp-block-convertkit-form-builder',
+			isFrontend: true
+		);
+
+		// Generate email address for this test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Submit form.
+		$I->fillField('input[name="convertkit[first_name]"]', 'First');
+		$I->fillField('input[name="convertkit[email]"]', $emailAddress);
+		$I->click('div.wp-block-convertkit-form-builder button[type="submit"]');
+
+		// Confirm that the email address was added to Kit.
+		$I->waitForElementVisible('.convertkit-form-builder-subscribed-message');
+		$I->wait(3);
+		$I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $emailAddress,
+			firstName: 'First'
+		);
+	}
+
+	/**
 	 * Test the Form Builder block works when added and a Tag is specified
 	 * to subscribe the subscriber to.
 	 *


### PR DESCRIPTION
## Summary

Supports adding a subscriber to a legacy form when a legacy form is specified in the Kit Form Block's Form setting.

## Testing

- `testFormBuilderBlockWithLegacyFormEnabled`: Test the Form Builder block works when added and a Legacy Form is specified to subscribe the subscriber to

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)