### PR TITLE
Update Beta Label Colors

### DIFF
--- a/resources/backend/css/settings.css
+++ b/resources/backend/css/settings.css
@@ -167,24 +167,25 @@ body.settings_page__wp_convertkit_settings .wrap .postbox textarea.convertkit-mo
  * Beta Label
  */
 body.settings_page__wp_convertkit_settings ul.convertkit-tabs li a span.convertkit-beta-label {
-	background-color: #f0fff3;
+	background-color: #f3e3f9;
 	border-radius: 9999px;
-	color: #4ec776;
+	color: #4a265a;
 	margin: 0 0 0 12px;
-	padding: 1px 8px;
-	font-weight: 400;
+	padding: 3px 8px;
+	font-weight: 600;
 	font-size: 12px;
 }
 
 body.settings_page__wp_convertkit_settings .wrap .postbox.convertkit-beta span.convertkit-beta-label {
 	display: inline-block;
-	background-color: #f0fff3;
+	background-color: #f3e3f9;
 	border-radius: 9999px;
-	color: #4ec776;
+	color: #4a265a;
 	border-width: 1px;
-	margin: 7px 0 0 12px;
-	padding: 1px 8px;
+	margin: 4px 0 0 12px;
+	padding: 4px 8px;
 	vertical-align: top;
+	font-weight: 600;
 	font-size: 12px;
 }
 


### PR DESCRIPTION
## Summary

Updates the beta label colors and spacing to better match those used on app.kit.com

Before:
<img width="357" height="310" alt="Screenshot 2026-05-25 at 21 08 39" src="https://github.com/user-attachments/assets/54a5e22c-0476-40a9-b9a0-44ca901677fe" />

After:
<img width="359" height="302" alt="Screenshot 2026-05-25 at 21 08 14" src="https://github.com/user-attachments/assets/ed06c899-f946-405c-bf21-ebdd90f075f7" />

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)