### PR TITLE
Abilities API: Register Resources

### DIFF
--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -27,6 +27,9 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 		// Register this as a Gutenberg block in the ConvertKit Plugin.
 		add_filter( 'convertkit_blocks', array( $this, 'register' ) );
 
+		// Register this block's MCP abilities.
+		add_filter( 'convertkit_abilities', array( $this, 'register_abilities' ) );
+
 		// Enqueue scripts and styles for this Gutenberg Block in the editor and frontend views.
 		add_action( 'convertkit_gutenberg_enqueue_scripts_editor_and_frontend', array( $this, 'enqueue_scripts' ) );
 		add_action( 'convertkit_gutenberg_enqueue_styles_editor_and_frontend', array( $this, 'enqueue_styles' ) );
@@ -166,6 +169,19 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 	 * @since   3.1.1
 	 */
 	public function get_title() {
+
+		return __( 'Kit Broadcasts', 'convertkit' );
+
+	}
+
+	/**
+	 * Returns this block's plural title.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_title_plural() {
 
 		return __( 'Kit Broadcasts', 'convertkit' );
 

--- a/includes/blocks/class-convertkit-block-form-trigger.php
+++ b/includes/blocks/class-convertkit-block-form-trigger.php
@@ -27,6 +27,9 @@ class ConvertKit_Block_Form_Trigger extends ConvertKit_Block {
 		// Register this as a Gutenberg block in the ConvertKit Plugin.
 		add_filter( 'convertkit_blocks', array( $this, 'register' ) );
 
+		// Register this block's MCP abilities.
+		add_filter( 'convertkit_abilities', array( $this, 'register_abilities' ) );
+
 		// Enqueue scripts and styles for this Gutenberg Block in the editor and frontend views.
 		add_action( 'convertkit_gutenberg_enqueue_styles_editor_and_frontend', array( $this, 'enqueue_styles' ) );
 
@@ -70,6 +73,19 @@ class ConvertKit_Block_Form_Trigger extends ConvertKit_Block {
 	public function get_title() {
 
 		return __( 'Kit Form Trigger', 'convertkit' );
+
+	}
+
+	/**
+	 * Returns this block's plural title.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_title_plural() {
+
+		return __( 'Kit Form Triggers', 'convertkit' );
 
 	}
 

--- a/includes/blocks/class-convertkit-block-form.php
+++ b/includes/blocks/class-convertkit-block-form.php
@@ -27,6 +27,9 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 		// Register this as a Gutenberg block in the ConvertKit Plugin.
 		add_filter( 'convertkit_blocks', array( $this, 'register' ) );
 
+		// Register this block's MCP abilities.
+		add_filter( 'convertkit_abilities', array( $this, 'register_abilities' ) );
+
 		// Enqueue scripts for this Gutenberg Block in the editor view.
 		add_action( 'convertkit_gutenberg_enqueue_scripts', array( $this, 'enqueue_scripts_editor' ) );
 
@@ -98,6 +101,19 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 	public function get_title() {
 
 		return __( 'Kit Form', 'convertkit' );
+
+	}
+
+	/**
+	 * Returns this block's plural title.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_title_plural() {
+
+		return __( 'Kit Forms', 'convertkit' );
 
 	}
 

--- a/includes/blocks/class-convertkit-block-product.php
+++ b/includes/blocks/class-convertkit-block-product.php
@@ -27,6 +27,9 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 		// Register this as a Gutenberg block in the ConvertKit Plugin.
 		add_filter( 'convertkit_blocks', array( $this, 'register' ) );
 
+		// Register this block's MCP abilities.
+		add_filter( 'convertkit_abilities', array( $this, 'register_abilities' ) );
+
 		// Enqueue scripts and styles for this Gutenberg Block in the editor and frontend views.
 		add_action( 'convertkit_gutenberg_enqueue_scripts_editor_and_frontend', array( $this, 'enqueue_scripts' ) );
 		add_action( 'convertkit_gutenberg_enqueue_styles_editor_and_frontend', array( $this, 'enqueue_styles' ) );
@@ -92,6 +95,19 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 	public function get_title() {
 
 		return __( 'Kit Product', 'convertkit' );
+
+	}
+
+	/**
+	 * Returns this block's plural title.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_title_plural() {
+
+		return __( 'Kit Products', 'convertkit' );
 
 	}
 

--- a/includes/blocks/class-convertkit-block.php
+++ b/includes/blocks/class-convertkit-block.php
@@ -68,10 +68,10 @@ class ConvertKit_Block {
 		return array_merge(
 			$abilities,
 			array(
-				new ConvertKit_MCP_Ability_Content_List( $this ),
-				new ConvertKit_MCP_Ability_Content_Insert( $this ),
-				new ConvertKit_MCP_Ability_Content_Update( $this ),
-				new ConvertKit_MCP_Ability_Content_Delete( $this ),
+				'kit/' . $this->get_name() . '-list'   => new ConvertKit_MCP_Ability_Content_List( $this ),
+				'kit/' . $this->get_name() . '-insert' => new ConvertKit_MCP_Ability_Content_Insert( $this ),
+				'kit/' . $this->get_name() . '-update' => new ConvertKit_MCP_Ability_Content_Update( $this ),
+				'kit/' . $this->get_name() . '-delete' => new ConvertKit_MCP_Ability_Content_Delete( $this ),
 			)
 		);
 

--- a/includes/blocks/class-convertkit-block.php
+++ b/includes/blocks/class-convertkit-block.php
@@ -106,6 +106,19 @@ class ConvertKit_Block {
 	}
 
 	/**
+	 * Returns this block's plural title.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_title_plural() {
+
+		return '';
+
+	}
+
+	/**
 	 * Returns this block's icon.
 	 *
 	 * @since   3.1.1

--- a/includes/mcp/abilities/content/class-convertkit-mcp-ability-content-delete.php
+++ b/includes/mcp/abilities/content/class-convertkit-mcp-ability-content-delete.php
@@ -51,7 +51,7 @@ class ConvertKit_MCP_Ability_Content_Delete extends ConvertKit_MCP_Ability_Conte
 
 		return sprintf(
 			/* translators: %s: block title */
-			__( 'Delete an existing %s element from a post', 'convertkit' ),
+			__( 'Delete Existing %s from a Post, Page or Custom Post', 'convertkit' ),
 			$this->block->get_title()
 		);
 
@@ -67,10 +67,9 @@ class ConvertKit_MCP_Ability_Content_Delete extends ConvertKit_MCP_Ability_Conte
 	public function get_description() {
 
 		return sprintf(
-			/* translators: 1: block full name e.g. convertkit/form, 2: block title */
-			__( 'Removes a single occurrence of the %1$s (%2$s) element from the given post.', 'convertkit' ),
-			'convertkit/' . $this->block->get_name(),
-			$this->block->get_title()
+			/* translators: Block Name */
+			__( 'Removes an existing %s from a Post, Page or Custom Post using the supplied zero-based occurrence index.', 'convertkit' ),
+			$this->block->get_title_plural()
 		);
 
 	}

--- a/includes/mcp/abilities/content/class-convertkit-mcp-ability-content-insert.php
+++ b/includes/mcp/abilities/content/class-convertkit-mcp-ability-content-insert.php
@@ -42,7 +42,7 @@ class ConvertKit_MCP_Ability_Content_Insert extends ConvertKit_MCP_Ability_Conte
 
 		return sprintf(
 			/* translators: %s: block title */
-			__( 'Insert a %s element into a post', 'convertkit' ),
+			__( 'Insert %s into a Page, Post or Custom Post', 'convertkit' ),
 			$this->block->get_title()
 		);
 
@@ -59,9 +59,8 @@ class ConvertKit_MCP_Ability_Content_Insert extends ConvertKit_MCP_Ability_Conte
 
 		return sprintf(
 			/* translators: 1: block full name e.g. convertkit/form, 2: block title */
-			__( 'Inserts a new %1$s (%2$s) element into the given post\'s content. The element can be appended (default), prepended, or positioned relative to an existing element using a zero-based index.', 'convertkit' ),
-			'convertkit/' . $this->block->get_name(),
-			$this->block->get_title()
+			__( 'Inserts a new %s in a Page, Post or Custom Post\'s content. The element can be appended (default), prepended, or inserted relative to an existing element using a zero-based index.', 'convertkit' ),
+			$this->block->get_title_plural()
 		);
 
 	}

--- a/includes/mcp/abilities/content/class-convertkit-mcp-ability-content-list.php
+++ b/includes/mcp/abilities/content/class-convertkit-mcp-ability-content-list.php
@@ -60,8 +60,8 @@ class ConvertKit_MCP_Ability_Content_List extends ConvertKit_MCP_Ability_Content
 
 		return sprintf(
 			/* translators: %s: block title */
-			__( 'List %s elements in a post', 'convertkit' ),
-			$this->block->get_title()
+			__( 'List %s in a Post, Page or Custom Post', 'convertkit' ),
+			$this->block->get_title_plural()
 		);
 
 	}
@@ -76,10 +76,9 @@ class ConvertKit_MCP_Ability_Content_List extends ConvertKit_MCP_Ability_Content
 	public function get_description() {
 
 		return sprintf(
-			/* translators: 1: block full name e.g. convertkit/form, 2: block title */
-			__( 'Lists every occurrence of the %1$s (%2$s) element in the given post, including each occurrence\'s zero-based index and current attribute values.', 'convertkit' ),
-			'convertkit/' . $this->block->get_name(),
-			$this->block->get_title()
+			/* translators: Block Name */
+			__( 'Lists every %s in the given Post, Page or Custom Post, including each occurrence\'s zero-based index and current attribute values.', 'convertkit' ),
+			$this->block->get_title_plural()
 		);
 
 	}

--- a/includes/mcp/abilities/content/class-convertkit-mcp-ability-content-update.php
+++ b/includes/mcp/abilities/content/class-convertkit-mcp-ability-content-update.php
@@ -51,7 +51,7 @@ class ConvertKit_MCP_Ability_Content_Update extends ConvertKit_MCP_Ability_Conte
 
 		return sprintf(
 			/* translators: %s: block title */
-			__( 'Update an existing %s element in a post', 'convertkit' ),
+			__( 'Update Existing %s in a Page, Post or Custom Post', 'convertkit' ),
 			$this->block->get_title()
 		);
 
@@ -67,10 +67,9 @@ class ConvertKit_MCP_Ability_Content_Update extends ConvertKit_MCP_Ability_Conte
 	public function get_description() {
 
 		return sprintf(
-			/* translators: 1: block full name e.g. convertkit/form, 2: block title */
-			__( 'Updates the attributes of a single occurrence of the %1$s (%2$s) element in the given post. By default the provided attributes are merged into the existing attributes.', 'convertkit' ),
-			'convertkit/' . $this->block->get_name(),
-			$this->block->get_title()
+			/* translators: Block Name */
+			__( 'Updates the attributes of an existing %s in a Page, Post or Custom Post. The provided attributes are merged into the existing attributes.', 'convertkit' ),
+			$this->block->get_title_plural()
 		);
 
 	}

--- a/includes/mcp/abilities/content/class-convertkit-mcp-ability-content.php
+++ b/includes/mcp/abilities/content/class-convertkit-mcp-ability-content.php
@@ -165,6 +165,9 @@ abstract class ConvertKit_MCP_Ability_Content extends ConvertKit_MCP_Ability {
 
 		switch ( $type ) {
 			case 'resource':
+			case 'text':
+			case 'color':
+			case 'select':
 				return 'string';
 
 			case 'number':
@@ -174,7 +177,8 @@ abstract class ConvertKit_MCP_Ability_Content extends ConvertKit_MCP_Ability {
 				return 'boolean';
 
 			default:
-				return $type;
+				// Unknown field type — fall back to string.
+				return 'string';
 		}
 
 	}

--- a/includes/mcp/abilities/resources/class-convertkit-mcp-ability-resource-forms.php
+++ b/includes/mcp/abilities/resources/class-convertkit-mcp-ability-resource-forms.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Kit MCP Ability: List Forms.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Ability that lists every Kit Form cached from the connected Kit account,
+ * returning each form's ID, name and format (inline / modal / slide in /
+ * sticky bar).
+ *
+ * Produces an ability named `kit/forms-list`.
+ *
+ * @package ConvertKit
+ * @author  ConvertKit
+ */
+class ConvertKit_MCP_Ability_Resource_Forms extends ConvertKit_MCP_Ability_Resource {
+
+	/**
+	 * Returns the resource slug for this ability.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	protected function get_resource() {
+
+		return 'forms';
+
+	}
+
+	/**
+	 * Returns the class name of the ConvertKit_Resource_* implementation
+	 * backing this ability.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	protected function get_resource_class() {
+
+		return 'ConvertKit_Resource_Forms';
+
+	}
+
+	/**
+	 * Returns the ability's human-readable label.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_label() {
+
+		return __( 'List Kit Forms', 'convertkit' );
+
+	}
+
+	/**
+	 * Returns the ability's human-readable description.
+	 *
+	 * Phrased as guidance to the model: state what the ability returns and
+	 * (importantly) when to chain it ahead of insert / update / settings
+	 * abilities so a user can refer to a Form by name rather than ID.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_description() {
+
+		return __( 'Lists every Kit Form configured on the connected Kit account, returning each form\'s numeric ID, name and format (inline, modal, slide in or sticky bar). Use this before kit/form-insert, kit/form-update, kit/post-settings-update or kit/settings-update when the user refers to a Form by name rather than ID, to look up the corresponding numeric Form ID.', 'convertkit' );
+
+	}
+
+	/**
+	 * Maps a single raw Form item from the resource cache into the output
+	 * shape, adding `format` so the model can distinguish inline forms (which
+	 * render in-place) from non-inline forms (modal / slide in / sticky bar,
+	 * which trigger from elsewhere). Legacy forms omit the `format` key in
+	 * the cached data; they are treated as inline to match the rest of the
+	 * Plugin\'s behaviour.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @param   array $item   Raw Form item.
+	 * @return  array
+	 */
+	protected function map_item( $item ) {
+
+		return array(
+			'id'     => (int) ( $item['id'] ?? 0 ),
+			'name'   => (string) ( $item['name'] ?? '' ),
+			'format' => isset( $item['format'] ) && $item['format'] !== '' ? (string) $item['format'] : 'inline',
+		);
+
+	}
+
+	/**
+	 * Returns the JSON Schema for a single Form item, including the `format`
+	 * field added by map_item().
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  array
+	 */
+	protected function get_item_schema() {
+
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'id', 'name', 'format' ),
+			'properties' => array(
+				'id'     => array(
+					'type'        => 'integer',
+					'description' => __( 'Numeric ID of the Kit Form.', 'convertkit' ),
+				),
+				'name'   => array(
+					'type'        => 'string',
+					'description' => __( 'Human-readable name of the Kit Form.', 'convertkit' ),
+				),
+				'format' => array(
+					'type'        => 'string',
+					'enum'        => array( 'inline', 'modal', 'slide in', 'sticky bar' ),
+					'description' => __( 'Where and how the Form is displayed. Inline forms render in post content; modal / slide in / sticky bar forms are site-wide overlays triggered elsewhere.', 'convertkit' ),
+				),
+			),
+		);
+
+	}
+
+}

--- a/includes/mcp/abilities/resources/class-convertkit-mcp-ability-resource-landing-pages.php
+++ b/includes/mcp/abilities/resources/class-convertkit-mcp-ability-resource-landing-pages.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Kit MCP Ability: List Landing Pages.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Ability that lists every Kit Landing Page cached from the connected Kit
+ * account, returning each landing page's ID and name.
+ *
+ * Produces an ability named `kit/landing-pages-list`.
+ *
+ * @package ConvertKit
+ * @author  ConvertKit
+ */
+class ConvertKit_MCP_Ability_Resource_Landing_Pages extends ConvertKit_MCP_Ability_Resource {
+
+	/**
+	 * Returns the resource slug for this ability.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	protected function get_resource() {
+
+		return 'landing-pages';
+
+	}
+
+	/**
+	 * Returns the class name of the ConvertKit_Resource_* implementation
+	 * backing this ability.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	protected function get_resource_class() {
+
+		return 'ConvertKit_Resource_Landing_Pages';
+
+	}
+
+	/**
+	 * Returns the ability's human-readable label.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_label() {
+
+		return __( 'List Kit Landing Pages', 'convertkit' );
+
+	}
+
+	/**
+	 * Returns the ability's human-readable description.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_description() {
+
+		return __( 'Lists every Kit Landing Page configured on the connected Kit account, returning each landing page\'s numeric ID and name. Use this before kit/post-settings-update when the user refers to a Landing Page by name rather than ID, to look up the corresponding numeric Landing Page ID. Landing Pages can only be assigned to WordPress Pages, not Posts or Custom Post Types.', 'convertkit' );
+
+	}
+
+}

--- a/includes/mcp/abilities/resources/class-convertkit-mcp-ability-resource-products.php
+++ b/includes/mcp/abilities/resources/class-convertkit-mcp-ability-resource-products.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Kit MCP Ability: List Products.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Ability that lists every Kit Product cached from the connected Kit account,
+ * returning each product's ID and name.
+ *
+ * Produces an ability named `kit/products-list`.
+ *
+ * @package ConvertKit
+ * @author  ConvertKit
+ */
+class ConvertKit_MCP_Ability_Resource_Products extends ConvertKit_MCP_Ability_Resource {
+
+	/**
+	 * Returns the resource slug for this ability.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	protected function get_resource() {
+
+		return 'products';
+
+	}
+
+	/**
+	 * Returns the class name of the ConvertKit_Resource_* implementation
+	 * backing this ability.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	protected function get_resource_class() {
+
+		return 'ConvertKit_Resource_Products';
+
+	}
+
+	/**
+	 * Returns the ability's human-readable label.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_label() {
+
+		return __( 'List Kit Products', 'convertkit' );
+
+	}
+
+	/**
+	 * Returns the ability's human-readable description.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_description() {
+
+		return __( 'Lists every Kit Product configured on the connected Kit account, returning each product\'s numeric ID and name. Use this before kit/post-settings-update or kit/product-insert when the user refers to a Product by name rather than ID, to look up the corresponding numeric Product ID. For restrict-content products the same ID is used with a "product_" prefix.', 'convertkit' );
+
+	}
+
+}

--- a/includes/mcp/abilities/resources/class-convertkit-mcp-ability-resource-tags.php
+++ b/includes/mcp/abilities/resources/class-convertkit-mcp-ability-resource-tags.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Kit MCP Ability: List Tags.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Ability that lists every Kit Tag cached from the connected Kit account,
+ * returning each tag's ID and name.
+ *
+ * Produces an ability named `kit/tags-list`.
+ *
+ * @package ConvertKit
+ * @author  ConvertKit
+ */
+class ConvertKit_MCP_Ability_Resource_Tags extends ConvertKit_MCP_Ability_Resource {
+
+	/**
+	 * Returns the resource slug for this ability.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	protected function get_resource() {
+
+		return 'tags';
+
+	}
+
+	/**
+	 * Returns the class name of the ConvertKit_Resource_* implementation
+	 * backing this ability.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	protected function get_resource_class() {
+
+		return 'ConvertKit_Resource_Tags';
+
+	}
+
+	/**
+	 * Returns the ability's human-readable label.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_label() {
+
+		return __( 'List Kit Tags', 'convertkit' );
+
+	}
+
+	/**
+	 * Returns the ability's human-readable description.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_description() {
+
+		return __( 'Lists every Kit Tag configured on the connected Kit account, returning each tag\'s numeric ID and name. Use this before kit/post-settings-update or kit/settings-update when the user refers to a Tag by name rather than ID, to look up the corresponding numeric Tag ID. For restrict-content tags the same ID is used with a "tag_" prefix.', 'convertkit' );
+
+	}
+
+}

--- a/includes/mcp/abilities/resources/class-convertkit-mcp-ability-resource.php
+++ b/includes/mcp/abilities/resources/class-convertkit-mcp-ability-resource.php
@@ -1,0 +1,249 @@
+<?php
+/**
+ * Kit MCP Ability: Resource list base class.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Base class for abilities to list resources (Forms, Tags, Landing Pages, Products).
+ *
+ * Each subclass represents a single resouce type.
+ *
+ * @package ConvertKit
+ * @author  ConvertKit
+ */
+abstract class ConvertKit_MCP_Ability_Resource extends ConvertKit_MCP_Ability {
+
+	/**
+	 * Sets whether the ability is readonly.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     bool
+	 */
+	private $readonly = true; // @phpstan-ignore-line
+
+	/**
+	 * Sets whether the ability is idempotent.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     bool
+	 */
+	private $idempotent = true; // @phpstan-ignore-line
+
+	/**
+	 * Returns the ability name, derived from the resource slug.
+	 *
+	 * For example, the Forms list ability is named `kit/forms-list`.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_name() {
+
+		return 'kit/' . $this->get_resource() . '-list';
+
+	}
+
+	/**
+	 * Returns the resource slug for this ability, used in the ability name
+	 * and as a hint for clients (e.g. `forms`, `tags`, `landing-pages`,
+	 * `products`).
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	abstract protected function get_resource();
+
+	/**
+	 * Returns the fully-qualified class name of the ConvertKit_Resource_*
+	 * implementation backing this ability.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	abstract protected function get_resource_class();
+
+	/**
+	 * Maps a single raw resource item from the resource class' get() method
+	 * into the shape exposed in this ability's output.
+	 *
+	 * The default implementation returns just id and name. Subclasses may
+	 * override to expose additional per-item fields (e.g. Forms includes
+	 * `format`) — output_schema() should be overridden to match.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @param   array $item   Raw item from the resource class' get() method.
+	 * @return  array
+	 */
+	protected function map_item( $item ) {
+
+		return array(
+			'id'   => (int) ( $item['id'] ?? 0 ),
+			'name' => (string) ( $item['name'] ?? '' ),
+		);
+
+	}
+
+	/**
+	 * Returns the JSON Schema describing a single item in the output `items`
+	 * array.
+	 *
+	 * Subclasses may override to add per-resource fields. Keep in sync with
+	 * map_item() — both describe the same shape, one in schema form and one
+	 * in PHP.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  array
+	 */
+	protected function get_item_schema() {
+
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'id', 'name' ),
+			'properties' => array(
+				'id'   => array(
+					'type'        => 'integer',
+					'description' => __( 'Numeric ID of the resource item.', 'convertkit' ),
+				),
+				'name' => array(
+					'type'        => 'string',
+					'description' => __( 'Human-readable name of the resource item.', 'convertkit' ),
+				),
+			),
+		);
+
+	}
+
+	/**
+	 * Permission callback for resource-list abilities.
+	 *
+	 * Listing available Kit resources is permitted for anyone who can edit
+	 * posts — the same capability gate that allows placing a Kit element on
+	 * a post, where these lists are typically used as a lookup.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @param   array $input   Ability input (unused).
+	 * @return  bool|WP_Error
+	 */
+	public function permission_callback( $input ) {
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			return new WP_Error(
+				'convertkit_mcp_cannot_list_resources',
+				__( 'You do not have permission to list Kit resources.', 'convertkit' )
+			);
+		}
+
+		return true;
+
+	}
+
+	/**
+	 * Returns the ability's input JSON Schema.
+	 *
+	 * Resource-list abilities take no input.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  array
+	 */
+	public function get_input_schema() {
+
+		return array(
+			'type'       => 'object',
+			'properties' => new stdClass(),
+		);
+
+	}
+
+	/**
+	 * Returns the ability's output JSON Schema.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  array
+	 */
+	public function get_output_schema() {
+
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'count', 'items' ),
+			'properties' => array(
+				'count' => array(
+					'type'        => 'integer',
+					'minimum'     => 0,
+					'description' => __( 'The number of items returned.', 'convertkit' ),
+				),
+				'items' => array(
+					'type'        => 'array',
+					'description' => __( 'The resource items.', 'convertkit' ),
+					'items'       => $this->get_item_schema(),
+				),
+			),
+		);
+
+	}
+
+	/**
+	 * Executes the ability: instantiate the backing resource class, fetch
+	 * its cached items, and return them mapped to this ability's output
+	 * shape.
+	 *
+	 * A "no items" result (e.g. the Plugin has not yet cached this resource
+	 * from the Kit API) is returned as a successful empty list rather than
+	 * an error, so the model can explain the absence to the user.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @param   array $input   Ability input (unused).
+	 * @return  array|WP_Error
+	 */
+	public function execute_callback( $input ) {
+
+		// Instantiate the backing resource class.
+		$resource_class = $this->get_resource_class();
+		if ( ! class_exists( $resource_class ) ) {
+			return new WP_Error(
+				'convertkit_mcp_resource_class_missing',
+				sprintf(
+					/* translators: %s: Resource class name */
+					__( 'The resource class "%s" does not exist.', 'convertkit' ),
+					$resource_class
+				)
+			);
+		}
+
+		$resource = new $resource_class();
+
+		// Fetch the items from the resource cache. ConvertKit_Resource::get()
+		// returns false when nothing has been cached; normalise that to an
+		// empty array so the output shape is always consistent.
+		$items = $resource->get();
+		if ( ! is_array( $items ) ) {
+			$items = array();
+		}
+
+		// Map each raw item to the ability's output shape.
+		$mapped = array();
+		foreach ( $items as $item ) {
+			$mapped[] = $this->map_item( $item );
+		}
+
+		return array(
+			'count' => count( $mapped ),
+			'items' => $mapped,
+		);
+
+	}
+
+}

--- a/includes/mcp/class-convertkit-mcp.php
+++ b/includes/mcp/class-convertkit-mcp.php
@@ -70,8 +70,37 @@ class ConvertKit_MCP {
 		// Register abilities.
 		add_action( 'wp_abilities_api_init', array( $this, 'register_abilities' ) );
 
+		// Register resource-list abilities (Forms, Tags, Landing Pages, Products).
+		// These are owned by the Plugin (not by any single block or feature),
+		// so they're added here rather than via a per-class register_abilities().
+		add_filter( 'convertkit_abilities', array( $this, 'register_resource_abilities' ) );
+
 		// Register the MCP server.
 		add_action( 'mcp_adapter_init', array( $this, 'register_mcp_server' ) );
+
+	}
+
+	/**
+	 * Appends the resource-list abilities (Forms, Tags, Landing Pages,
+	 * Products) to the convertkit_abilities filter, so they are registered
+	 * with the Abilities API and exposed via the MCP server.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @param   array $abilities   Abilities to register.
+	 * @return  array
+	 */
+	public function register_resource_abilities( $abilities ) {
+
+		return array_merge(
+			$abilities,
+			array(
+				new ConvertKit_MCP_Ability_Resource_Forms(),
+				new ConvertKit_MCP_Ability_Resource_Tags(),
+				new ConvertKit_MCP_Ability_Resource_Landing_Pages(),
+				new ConvertKit_MCP_Ability_Resource_Products(),
+			)
+		);
 
 	}
 

--- a/includes/mcp/class-convertkit-mcp.php
+++ b/includes/mcp/class-convertkit-mcp.php
@@ -95,10 +95,10 @@ class ConvertKit_MCP {
 		return array_merge(
 			$abilities,
 			array(
-				new ConvertKit_MCP_Ability_Resource_Forms(),
-				new ConvertKit_MCP_Ability_Resource_Tags(),
-				new ConvertKit_MCP_Ability_Resource_Landing_Pages(),
-				new ConvertKit_MCP_Ability_Resource_Products(),
+				'kit/forms-list'         => new ConvertKit_MCP_Ability_Resource_Forms(),
+				'kit/tags-list'          => new ConvertKit_MCP_Ability_Resource_Tags(),
+				'kit/landing-pages-list' => new ConvertKit_MCP_Ability_Resource_Landing_Pages(),
+				'kit/products-list'      => new ConvertKit_MCP_Ability_Resource_Products(),
 			)
 		);
 

--- a/tests/Integration/MCPContentBroadcastsTest.php
+++ b/tests/Integration/MCPContentBroadcastsTest.php
@@ -1,0 +1,368 @@
+<?php
+
+namespace Tests;
+
+use lucatume\WPBrowser\TestCase\WPTestCase;
+
+/**
+ * Tests for the Kit MCP content abilities bound to the Broadcasts block:
+ *
+ * - kit/broadcasts-list    (ConvertKit_MCP_Ability_Content_List)
+ * - kit/broadcasts-insert  (ConvertKit_MCP_Ability_Content_Insert)
+ * - kit/broadcasts-update  (ConvertKit_MCP_Ability_Content_Update)
+ * - kit/broadcasts-delete  (ConvertKit_MCP_Ability_Content_Delete)
+ *
+ * @since   3.4.0
+ */
+class MCPContentBroadcastsTest extends WPTestCase
+{
+	/**
+	 * The testing implementation.
+	 *
+	 * @var \WpunitTester.
+	 */
+	protected $tester;
+
+	/**
+	 * Holds the Post ID created in setUp(), used by tests that exercise
+	 * list / update / delete against a post containing two Broadcasts
+	 * blocks.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     int
+	 */
+	private $postID;
+
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		// Activate Plugin.
+		activate_plugins('convertkit/wp-convertkit.php');
+
+		// Create a Post containing two Broadcasts blocks, so list / update /
+		// delete have something to act on.
+		$this->postID = $this->createPostWithBroadcastsBlocks();
+	}
+
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function tearDown(): void
+	{
+		// Restore the current user.
+		wp_set_current_user(0);
+
+		// Deactivate Plugin.
+		deactivate_plugins('convertkit/wp-convertkit.php');
+
+		parent::tearDown();
+	}
+
+	/**
+	 * The ability names registered by the Broadcasts block.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     string[]
+	 */
+	private const BROADCASTS_ABILITY_NAMES = array(
+		'kit/broadcasts-list',
+		'kit/broadcasts-insert',
+		'kit/broadcasts-update',
+		'kit/broadcasts-delete',
+	);
+
+	/**
+	 * Test that the Broadcasts block registers all four content abilities via
+	 * the convertkit_abilities filter with the expected names.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testAbilitiesRegistered()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// The ability names and classes expected to be registered.
+		$expected = array(
+			'kit/broadcasts-list'   => \ConvertKit_MCP_Ability_Content_List::class,
+			'kit/broadcasts-insert' => \ConvertKit_MCP_Ability_Content_Insert::class,
+			'kit/broadcasts-update' => \ConvertKit_MCP_Ability_Content_Update::class,
+			'kit/broadcasts-delete' => \ConvertKit_MCP_Ability_Content_Delete::class,
+		);
+
+		// Assert that the abilities are registered and are instances of the expected classes.
+		foreach ( $expected as $name => $class ) {
+			$this->assertArrayHasKey($name, $abilities);
+			$this->assertInstanceOf($class, $abilities[ $name ]);
+		}
+	}
+
+	/**
+	 * Test that the permission_callback() rejects a user who cannot edit the
+	 * given post.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackDeniesWithoutEditPostCapability()
+	{
+		// Become a Subscriber (no edit_post capability).
+		$subscriber_id = static::factory()->user->create([ 'role' => 'subscriber' ]);
+		wp_set_current_user($subscriber_id);
+
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Assert that the abilities are permission denied.
+		foreach ( self::BROADCASTS_ABILITY_NAMES as $name ) {
+			// Execute the ability.
+			$result = $abilities[ $name ]->permission_callback([ 'post_id' => $this->postID ]);
+
+			// Assert that the result is a WP_Error.
+			$this->assertInstanceOf(\WP_Error::class, $result);
+		}
+	}
+
+	/**
+	 * Test that the permission_callback() rejects a request with no post_id,
+	 * with a clear error code.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackDeniesWithoutPostId()
+	{
+		// Become an Administrator (has every capability, so the only thing
+		// that can fail here is the missing post_id check).
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Assert that the abilities are permission denied.
+		foreach ( self::BROADCASTS_ABILITY_NAMES as $name ) {
+			// Execute the ability.
+			$result = $abilities[ $name ]->permission_callback([]);
+
+			// Assert that the result is a WP_Error.
+			$this->assertInstanceOf(\WP_Error::class, $result);
+		}
+	}
+
+	/**
+	 * Test that the permission_callback() permits an Administrator on a
+	 * valid post_id.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackPermitsAdministrator()
+	{
+		// Become an Administrator.
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Assert that the abilities are permission granted.
+		foreach ( self::BROADCASTS_ABILITY_NAMES as $name ) {
+			// Execute the ability.
+			$this->assertTrue($abilities[ $name ]->permission_callback([ 'post_id' => $this->postID ]));
+		}
+	}
+
+	/**
+	 * Test that kit/broadcasts-list returns every Broadcasts block occurrence
+	 * in the post.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testListReturnsAllBroadcastsOccurrencesInPost()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/broadcasts-list']->execute_callback([ 'post_id' => $this->postID ]);
+
+		$this->assertIsArray($result);
+		$this->assertSame($this->postID, $result['post_id']);
+		$this->assertSame(2, $result['count']);
+		$this->assertCount(2, $result['occurrences']);
+
+		// Each occurrence carries an occurrence_index and an attrs object
+		// holding the limit attribute from the seeded post content.
+		foreach ($result['occurrences'] as $i => $occurrence) {
+			$this->assertSame($i, $occurrence['occurrence_index']);
+			$this->assertArrayHasKey('attrs', $occurrence);
+			$this->assertSame(5, (int) $occurrence['attrs']['limit']);
+		}
+	}
+
+	/**
+	 * Test that kit/broadcasts-insert appends a new Broadcasts block to the
+	 * post, and returns the new occurrence_index.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testInsertAppendsBroadcastsBlock()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/broadcasts-insert']->execute_callback(
+			array(
+				'post_id'  => $this->postID,
+				'attrs'    => array(
+					'limit'         => 3,
+					'display_image' => true,
+				),
+				'position' => 'append',
+			)
+		);
+
+		$this->assertIsArray($result);
+		$this->assertSame($this->postID, $result['post_id']);
+		$this->assertSame(2, $result['occurrence_index']);
+
+		// Confirm the post now contains three Broadcasts blocks.
+		$listed = $abilities['kit/broadcasts-list']->execute_callback([ 'post_id' => $this->postID ]);
+		$this->assertSame(3, $listed['count']);
+
+		// Confirm the newly inserted block carries the attrs we passed in.
+		$this->assertSame(3, (int) $listed['occurrences'][2]['attrs']['limit']);
+		$this->assertTrue( (bool) $listed['occurrences'][2]['attrs']['display_image']);
+	}
+
+	/**
+	 * Test that kit/broadcasts-update changes the attrs of a specific
+	 * occurrence, leaving other occurrences untouched.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateModifiesSingleOccurrence()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Update the second Broadcasts block (occurrence_index 1) to a different limit.
+		$result = $abilities['kit/broadcasts-update']->execute_callback(
+			array(
+				'post_id'          => $this->postID,
+				'occurrence_index' => 1,
+				'attrs'            => array( 'limit' => 25 ),
+			)
+		);
+
+		$this->assertIsArray($result);
+		$this->assertSame(1, $result['occurrence_index']);
+
+		// Re-list and confirm: occurrence 0 unchanged, occurrence 1 has the new limit.
+		$listed = $abilities['kit/broadcasts-list']->execute_callback([ 'post_id' => $this->postID ]);
+		$this->assertSame(
+			5,
+			(int) $listed['occurrences'][0]['attrs']['limit'],
+			'kit/broadcasts-update must not modify other occurrences.'
+		);
+		$this->assertSame(
+			25,
+			(int) $listed['occurrences'][1]['attrs']['limit'],
+			'kit/broadcasts-update did not apply the new limit to the requested occurrence.'
+		);
+	}
+
+	/**
+	 * Test that kit/broadcasts-delete removes a specific occurrence and the
+	 * post now contains one fewer Broadcasts block.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testDeleteRemovesSingleOccurrence()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/broadcasts-delete']->execute_callback(
+			array(
+				'post_id'          => $this->postID,
+				'occurrence_index' => 0,
+			)
+		);
+
+		$this->assertIsArray($result);
+		$this->assertSame(0, $result['occurrence_index']);
+
+		// Confirm the post now contains a single Broadcasts block.
+		$listed = $abilities['kit/broadcasts-list']->execute_callback([ 'post_id' => $this->postID ]);
+		$this->assertSame(1, $listed['count']);
+	}
+
+	/**
+	 * Test that kit/broadcasts-update returns a WP_Error when asked to update
+	 * an occurrence that does not exist, rather than silently mutating
+	 * something else.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateOnMissingOccurrenceReturnsError()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/broadcasts-update']->execute_callback(
+			array(
+				'post_id'          => $this->postID,
+				'occurrence_index' => 99,
+				'attrs'            => array( 'limit' => 5 ),
+			)
+		);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+	}
+
+	/**
+	 * Creates a Post containing two convertkit/broadcasts blocks interleaved
+	 * with non-Kit blocks, mirroring the fixture used by BlockPostHelperTest.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  int
+	 */
+	private function createPostWithBroadcastsBlocks(): int
+	{
+		return $this->factory->post->create(
+			array(
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_title'   => 'Broadcasts Abilities Fixture',
+				'post_content' => '<!-- wp:paragraph -->
+<p>Intro paragraph.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:convertkit/broadcasts {"limit":5} /-->
+
+<!-- wp:paragraph -->
+<p>Middle paragraph.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:convertkit/broadcasts {"limit":5} /-->
+
+<!-- wp:paragraph -->
+<p>Closing paragraph.</p>
+<!-- /wp:paragraph -->',
+			)
+		);
+	}
+}

--- a/tests/Integration/MCPContentFormTest.php
+++ b/tests/Integration/MCPContentFormTest.php
@@ -1,0 +1,356 @@
+<?php
+
+namespace Tests;
+
+use lucatume\WPBrowser\TestCase\WPTestCase;
+
+/**
+ * Tests for the Kit MCP content abilities bound to the Form block:
+ *
+ * - kit/form-list    (ConvertKit_MCP_Ability_Content_List)
+ * - kit/form-insert  (ConvertKit_MCP_Ability_Content_Insert)
+ * - kit/form-update  (ConvertKit_MCP_Ability_Content_Update)
+ * - kit/form-delete  (ConvertKit_MCP_Ability_Content_Delete)
+ *
+ * @since   3.4.0
+ */
+class MCPContentFormTest extends WPTestCase
+{
+	/**
+	 * The testing implementation.
+	 *
+	 * @var \WpunitTester.
+	 */
+	protected $tester;
+
+	/**
+	 * Holds the Post ID created in setUp(), used by tests that exercise
+	 * list / insert / update / delete against a post containing two Form
+	 * blocks.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     int
+	 */
+	private $postID;
+
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		// Activate Plugin.
+		activate_plugins('convertkit/wp-convertkit.php');
+
+		// Create a Post containing two Form blocks, so list / update /
+		// delete have something to act on.
+		$this->postID = $this->createPostWithFormBlocks();
+	}
+
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function tearDown(): void
+	{
+		// Restore the current user.
+		wp_set_current_user(0);
+
+		// Deactivate Plugin.
+		deactivate_plugins('convertkit/wp-convertkit.php');
+
+		parent::tearDown();
+	}
+
+	/**
+	 * The ability names registered by the Form block.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     string[]
+	 */
+	private const FORM_ABILITY_NAMES = array(
+		'kit/form-list',
+		'kit/form-insert',
+		'kit/form-update',
+		'kit/form-delete',
+	);
+
+	/**
+	 * Test that the Form block registers all four content abilities via the
+	 * convertkit_abilities filter with the expected names.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testAbilitiesRegistered()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// The ability names and classes expected to be registered.
+		$expected = array(
+			'kit/form-list'   => \ConvertKit_MCP_Ability_Content_List::class,
+			'kit/form-insert' => \ConvertKit_MCP_Ability_Content_Insert::class,
+			'kit/form-update' => \ConvertKit_MCP_Ability_Content_Update::class,
+			'kit/form-delete' => \ConvertKit_MCP_Ability_Content_Delete::class,
+		);
+
+		// Assert that the abilities are registered and are instances of the expected classes.
+		foreach ( $expected as $name => $class ) {
+			$this->assertArrayHasKey($name, $abilities);
+			$this->assertInstanceOf($class, $abilities[ $name ]);
+		}
+	}
+
+	/**
+	 * Test that the permission_callback() rejects a user who cannot edit the
+	 * given post.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackDeniesWithoutEditPostCapability()
+	{
+		// Become a Subscriber (no edit_post capability).
+		$subscriber_id = static::factory()->user->create([ 'role' => 'subscriber' ]);
+		wp_set_current_user($subscriber_id);
+
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Assert that the abilities are permission denied.
+		foreach ( self::FORM_ABILITY_NAMES as $name ) {
+			// Execute the ability.
+			$result = $abilities[ $name ]->permission_callback([ 'post_id' => $this->postID ]);
+
+			// Assert that the result is a WP_Error.
+			$this->assertInstanceOf(\WP_Error::class, $result);
+		}
+	}
+
+	/**
+	 * Test that the permission_callback() rejects a request with no post_id,
+	 * with a clear error code.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackDeniesWithoutPostId()
+	{
+		// Become an Administrator (has every capability, so the only thing
+		// that can fail here is the missing post_id check).
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Assert that the abilities are permission denied.
+		foreach ( self::FORM_ABILITY_NAMES as $name ) {
+			// Execute the ability.
+			$result = $abilities[ $name ]->permission_callback([]);
+
+			// Assert that the result is a WP_Error.
+			$this->assertInstanceOf(\WP_Error::class, $result);
+		}
+	}
+
+	/**
+	 * Test that the permission_callback() permits an Administrator on a
+	 * valid post_id.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackPermitsAdministrator()
+	{
+		// Become an Administrator.
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Assert that the abilities are permission granted.
+		foreach ( self::FORM_ABILITY_NAMES as $name ) {
+			// Execute the ability.
+			$this->assertTrue($abilities[ $name ]->permission_callback([ 'post_id' => $this->postID ]));
+		}
+	}
+
+	/**
+	 * Test that kit/form-list returns every Form block occurrence in the
+	 * post, with shape { post_id, count, occurrences: [{occurrence_index, attrs}] }.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testListReturnsAllFormOccurrencesInPost()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/form-list']->execute_callback([ 'post_id' => $this->postID ]);
+
+		$this->assertIsArray($result);
+		$this->assertSame($this->postID, $result['post_id']);
+		$this->assertSame(2, $result['count']);
+		$this->assertCount(2, $result['occurrences']);
+
+		// Each occurrence carries an occurrence_index and an attrs object
+		// holding the form ID from the seeded post content.
+		foreach ($result['occurrences'] as $i => $occurrence) {
+			$this->assertSame($i, $occurrence['occurrence_index']);
+			$this->assertArrayHasKey('attrs', $occurrence);
+			$this->assertSame(
+				(string) $_ENV['CONVERTKIT_API_FORM_ID'],
+				(string) $occurrence['attrs']['form']
+			);
+		}
+	}
+
+	/**
+	 * Test that kit/form-insert appends a new Form block to the post, and
+	 * returns the new occurrence_index.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testInsertAppendsFormBlock()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/form-insert']->execute_callback(array(
+			'post_id'  => $this->postID,
+			'attrs'    => array( 'form' => $_ENV['CONVERTKIT_API_FORM_ID'] ),
+			'position' => 'append',
+		));
+
+		$this->assertIsArray($result);
+		$this->assertSame($this->postID, $result['post_id']);
+		$this->assertSame(2, $result['occurrence_index']);
+
+		// Confirm the post now contains three Form blocks.
+		$listed = $abilities['kit/form-list']->execute_callback([ 'post_id' => $this->postID ]);
+		$this->assertSame(3, $listed['count']);
+	}
+
+	/**
+	 * Test that kit/form-update changes the attrs of a specific occurrence,
+	 * leaving other occurrences untouched.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateModifiesSingleOccurrence()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Update the second Form block (occurrence_index 1) to a different form ID.
+		$new_form_id = (string) ( (int) $_ENV['CONVERTKIT_API_FORM_ID'] + 1 );
+		$result      = $abilities['kit/form-update']->execute_callback(array(
+			'post_id'          => $this->postID,
+			'occurrence_index' => 1,
+			'attrs'            => array( 'form' => $new_form_id ),
+		));
+
+		$this->assertIsArray($result);
+		$this->assertSame(1, $result['occurrence_index']);
+
+		// Re-list and confirm: occurrence 0 unchanged, occurrence 1 has the new form ID.
+		$listed = $abilities['kit/form-list']->execute_callback([ 'post_id' => $this->postID ]);
+		$this->assertSame(
+			(string) $_ENV['CONVERTKIT_API_FORM_ID'],
+			(string) $listed['occurrences'][0]['attrs']['form'],
+			'kit/form-update must not modify other occurrences.'
+		);
+		$this->assertSame(
+			$new_form_id,
+			(string) $listed['occurrences'][1]['attrs']['form'],
+			'kit/form-update did not apply the new form ID to the requested occurrence.'
+		);
+	}
+
+	/**
+	 * Test that kit/form-delete removes a specific occurrence and the post
+	 * now contains one fewer Form block.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testDeleteRemovesSingleOccurrence()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/form-delete']->execute_callback(array(
+			'post_id'          => $this->postID,
+			'occurrence_index' => 0,
+		));
+
+		$this->assertIsArray($result);
+		$this->assertSame(0, $result['occurrence_index']);
+
+		// Confirm the post now contains a single Form block.
+		$listed = $abilities['kit/form-list']->execute_callback([ 'post_id' => $this->postID ]);
+		$this->assertSame(1, $listed['count']);
+	}
+
+	/**
+	 * Test that kit/form-update returns a WP_Error when asked to update an
+	 * occurrence that does not exist, rather than silently mutating
+	 * something else.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateOnMissingOccurrenceReturnsError()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/form-update']->execute_callback(array(
+			'post_id'          => $this->postID,
+			'occurrence_index' => 99,
+			'attrs'            => array( 'form' => $_ENV['CONVERTKIT_API_FORM_ID'] ),
+		));
+
+		// Assert that the result is a WP_Error.
+		$this->assertInstanceOf(\WP_Error::class, $result);
+	}
+
+	/**
+	 * Creates a Post containing two convertkit/form blocks interleaved with
+	 * non-Kit blocks, mirroring the fixture used by BlockPostHelperTest.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  int
+	 */
+	private function createPostWithFormBlocks(): int
+	{
+		return $this->factory->post->create(array(
+			'post_type'    => 'page',
+			'post_status'  => 'publish',
+			'post_title'   => 'Form Abilities Fixture',
+			'post_content' => '<!-- wp:paragraph -->
+<p>Intro paragraph.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:convertkit/form {"form":"' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"} /-->
+
+<!-- wp:paragraph -->
+<p>Middle paragraph.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:convertkit/form {"form":"' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"} /-->
+
+<!-- wp:paragraph -->
+<p>Closing paragraph.</p>
+<!-- /wp:paragraph -->',
+		));
+	}
+}

--- a/tests/Integration/MCPContentFormTest.php
+++ b/tests/Integration/MCPContentFormTest.php
@@ -223,11 +223,13 @@ class MCPContentFormTest extends WPTestCase
 		$abilities = convertkit_get_abilities();
 
 		// Execute the ability.
-		$result = $abilities['kit/form-insert']->execute_callback(array(
-			'post_id'  => $this->postID,
-			'attrs'    => array( 'form' => $_ENV['CONVERTKIT_API_FORM_ID'] ),
-			'position' => 'append',
-		));
+		$result = $abilities['kit/form-insert']->execute_callback(
+			array(
+				'post_id'  => $this->postID,
+				'attrs'    => array( 'form' => $_ENV['CONVERTKIT_API_FORM_ID'] ),
+				'position' => 'append',
+			)
+		);
 
 		$this->assertIsArray($result);
 		$this->assertSame($this->postID, $result['post_id']);
@@ -251,11 +253,13 @@ class MCPContentFormTest extends WPTestCase
 
 		// Update the second Form block (occurrence_index 1) to a different form ID.
 		$new_form_id = (string) ( (int) $_ENV['CONVERTKIT_API_FORM_ID'] + 1 );
-		$result      = $abilities['kit/form-update']->execute_callback(array(
-			'post_id'          => $this->postID,
-			'occurrence_index' => 1,
-			'attrs'            => array( 'form' => $new_form_id ),
-		));
+		$result      = $abilities['kit/form-update']->execute_callback(
+			array(
+				'post_id'          => $this->postID,
+				'occurrence_index' => 1,
+				'attrs'            => array( 'form' => $new_form_id ),
+			)
+		);
 
 		$this->assertIsArray($result);
 		$this->assertSame(1, $result['occurrence_index']);
@@ -286,10 +290,12 @@ class MCPContentFormTest extends WPTestCase
 		$abilities = convertkit_get_abilities();
 
 		// Execute the ability.
-		$result = $abilities['kit/form-delete']->execute_callback(array(
-			'post_id'          => $this->postID,
-			'occurrence_index' => 0,
-		));
+		$result = $abilities['kit/form-delete']->execute_callback(
+			array(
+				'post_id'          => $this->postID,
+				'occurrence_index' => 0,
+			)
+		);
 
 		$this->assertIsArray($result);
 		$this->assertSame(0, $result['occurrence_index']);
@@ -312,11 +318,13 @@ class MCPContentFormTest extends WPTestCase
 		$abilities = convertkit_get_abilities();
 
 		// Execute the ability.
-		$result = $abilities['kit/form-update']->execute_callback(array(
-			'post_id'          => $this->postID,
-			'occurrence_index' => 99,
-			'attrs'            => array( 'form' => $_ENV['CONVERTKIT_API_FORM_ID'] ),
-		));
+		$result = $abilities['kit/form-update']->execute_callback(
+			array(
+				'post_id'          => $this->postID,
+				'occurrence_index' => 99,
+				'attrs'            => array( 'form' => $_ENV['CONVERTKIT_API_FORM_ID'] ),
+			)
+		);
 
 		// Assert that the result is a WP_Error.
 		$this->assertInstanceOf(\WP_Error::class, $result);
@@ -332,11 +340,12 @@ class MCPContentFormTest extends WPTestCase
 	 */
 	private function createPostWithFormBlocks(): int
 	{
-		return $this->factory->post->create(array(
-			'post_type'    => 'page',
-			'post_status'  => 'publish',
-			'post_title'   => 'Form Abilities Fixture',
-			'post_content' => '<!-- wp:paragraph -->
+		return $this->factory->post->create(
+			array(
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_title'   => 'Form Abilities Fixture',
+				'post_content' => '<!-- wp:paragraph -->
 <p>Intro paragraph.</p>
 <!-- /wp:paragraph -->
 
@@ -351,6 +360,7 @@ class MCPContentFormTest extends WPTestCase
 <!-- wp:paragraph -->
 <p>Closing paragraph.</p>
 <!-- /wp:paragraph -->',
-		));
+			)
+		);
 	}
 }

--- a/tests/Integration/MCPContentFormTriggerTest.php
+++ b/tests/Integration/MCPContentFormTriggerTest.php
@@ -1,0 +1,366 @@
+<?php
+
+namespace Tests;
+
+use lucatume\WPBrowser\TestCase\WPTestCase;
+
+/**
+ * Tests for the Kit MCP content abilities bound to the Form Trigger block:
+ *
+ * - kit/formtrigger-list    (ConvertKit_MCP_Ability_Content_List)
+ * - kit/formtrigger-insert  (ConvertKit_MCP_Ability_Content_Insert)
+ * - kit/formtrigger-update  (ConvertKit_MCP_Ability_Content_Update)
+ * - kit/formtrigger-delete  (ConvertKit_MCP_Ability_Content_Delete)
+ *
+ * @since   3.4.0
+ */
+class MCPContentFormTriggerTest extends WPTestCase
+{
+	/**
+	 * The testing implementation.
+	 *
+	 * @var \WpunitTester.
+	 */
+	protected $tester;
+
+	/**
+	 * Holds the Post ID created in setUp(), used by tests that exercise
+	 * list / insert / update / delete against a post containing two Form
+	 * blocks.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     int
+	 */
+	private $postID;
+
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		// Activate Plugin.
+		activate_plugins('convertkit/wp-convertkit.php');
+
+		// Create a Post containing two Form Trigger blocks, so list / update /
+		// delete have something to act on.
+		$this->postID = $this->createPostWithFormTriggerBlocks();
+	}
+
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function tearDown(): void
+	{
+		// Restore the current user.
+		wp_set_current_user(0);
+
+		// Deactivate Plugin.
+		deactivate_plugins('convertkit/wp-convertkit.php');
+
+		parent::tearDown();
+	}
+
+	/**
+	 * The ability names registered by the Form Trigger block.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     string[]
+	 */
+	private const FORM_TRIGGER_ABILITY_NAMES = array(
+		'kit/formtrigger-list',
+		'kit/formtrigger-insert',
+		'kit/formtrigger-update',
+		'kit/formtrigger-delete',
+	);
+
+	/**
+	 * Test that the Form Trigger block registers all four content abilities via the
+	 * convertkit_abilities filter with the expected names.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testAbilitiesRegistered()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// The ability names and classes expected to be registered.
+		$expected = array(
+			'kit/formtrigger-list'   => \ConvertKit_MCP_Ability_Content_List::class,
+			'kit/formtrigger-insert' => \ConvertKit_MCP_Ability_Content_Insert::class,
+			'kit/formtrigger-update' => \ConvertKit_MCP_Ability_Content_Update::class,
+			'kit/formtrigger-delete' => \ConvertKit_MCP_Ability_Content_Delete::class,
+		);
+
+		// Assert that the abilities are registered and are instances of the expected classes.
+		foreach ( $expected as $name => $class ) {
+			$this->assertArrayHasKey($name, $abilities);
+			$this->assertInstanceOf($class, $abilities[ $name ]);
+		}
+	}
+
+	/**
+	 * Test that the permission_callback() rejects a user who cannot edit the
+	 * given post.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackDeniesWithoutEditPostCapability()
+	{
+		// Become a Subscriber (no edit_post capability).
+		$subscriber_id = static::factory()->user->create([ 'role' => 'subscriber' ]);
+		wp_set_current_user($subscriber_id);
+
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Assert that the abilities are permission denied.
+		foreach ( self::FORM_TRIGGER_ABILITY_NAMES as $name ) {
+			// Execute the ability.
+			$result = $abilities[ $name ]->permission_callback([ 'post_id' => $this->postID ]);
+
+			// Assert that the result is a WP_Error.
+			$this->assertInstanceOf(\WP_Error::class, $result);
+		}
+	}
+
+	/**
+	 * Test that the permission_callback() rejects a request with no post_id,
+	 * with a clear error code.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackDeniesWithoutPostId()
+	{
+		// Become an Administrator (has every capability, so the only thing
+		// that can fail here is the missing post_id check).
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Assert that the abilities are permission denied.
+		foreach ( self::FORM_TRIGGER_ABILITY_NAMES as $name ) {
+			// Execute the ability.
+			$result = $abilities[ $name ]->permission_callback([]);
+
+			// Assert that the result is a WP_Error.
+			$this->assertInstanceOf(\WP_Error::class, $result);
+		}
+	}
+
+	/**
+	 * Test that the permission_callback() permits an Administrator on a
+	 * valid post_id.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackPermitsAdministrator()
+	{
+		// Become an Administrator.
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Assert that the abilities are permission granted.
+		foreach ( self::FORM_TRIGGER_ABILITY_NAMES as $name ) {
+			// Execute the ability.
+			$this->assertTrue($abilities[ $name ]->permission_callback([ 'post_id' => $this->postID ]));
+		}
+	}
+
+	/**
+	 * Test that kit/formtrigger-list returns every Form Trigger block occurrence in the
+	 * post, with shape { post_id, count, occurrences: [{occurrence_index, attrs}] }.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testListReturnsAllFormTriggerOccurrencesInPost()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/formtrigger-list']->execute_callback([ 'post_id' => $this->postID ]);
+
+		$this->assertIsArray($result);
+		$this->assertSame($this->postID, $result['post_id']);
+		$this->assertSame(2, $result['count']);
+		$this->assertCount(2, $result['occurrences']);
+
+		// Each occurrence carries an occurrence_index and an attrs object
+		// holding the form ID from the seeded post content.
+		foreach ($result['occurrences'] as $i => $occurrence) {
+			$this->assertSame($i, $occurrence['occurrence_index']);
+			$this->assertArrayHasKey('attrs', $occurrence);
+			$this->assertSame(
+				(string) $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'],
+				(string) $occurrence['attrs']['form']
+			);
+		}
+	}
+
+	/**
+	 * Test that kit/formtrigger-insert appends a new Form Trigger block to the post, and
+	 * returns the new occurrence_index.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testInsertAppendsFormTriggerBlock()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/formtrigger-insert']->execute_callback(
+			array(
+				'post_id'  => $this->postID,
+				'attrs'    => array( 'form' => $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] ),
+				'position' => 'append',
+			)
+		);
+
+		$this->assertIsArray($result);
+		$this->assertSame($this->postID, $result['post_id']);
+		$this->assertSame(2, $result['occurrence_index']);
+
+		// Confirm the post now contains three Form Trigger blocks.
+		$listed = $abilities['kit/formtrigger-list']->execute_callback([ 'post_id' => $this->postID ]);
+		$this->assertSame(3, $listed['count']);
+	}
+
+	/**
+	 * Test that kit/formtrigger-update changes the attrs of a specific occurrence,
+	 * leaving other occurrences untouched.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateModifiesSingleOccurrence()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Update the second Form Trigger block (occurrence_index 1) to a different form ID.
+		$new_form_id = (string) ( (int) $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] + 1 );
+		$result      = $abilities['kit/formtrigger-update']->execute_callback(
+			array(
+				'post_id'          => $this->postID,
+				'occurrence_index' => 1,
+				'attrs'            => array( 'form' => $new_form_id ),
+			)
+		);
+
+		$this->assertIsArray($result);
+		$this->assertSame(1, $result['occurrence_index']);
+
+		// Re-list and confirm: occurrence 0 unchanged, occurrence 1 has the new form ID.
+		$listed = $abilities['kit/formtrigger-list']->execute_callback([ 'post_id' => $this->postID ]);
+		$this->assertSame(
+			(string) $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'],
+			(string) $listed['occurrences'][0]['attrs']['form'],
+			'kit/formtrigger-update must not modify other occurrences.'
+		);
+		$this->assertSame(
+			$new_form_id,
+			(string) $listed['occurrences'][1]['attrs']['form'],
+			'kit/formtrigger-update did not apply the new form ID to the requested occurrence.'
+		);
+	}
+
+	/**
+	 * Test that kit/formtrigger-delete removes a specific occurrence and the post
+	 * now contains one fewer Form Trigger block.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testDeleteRemovesSingleOccurrence()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/formtrigger-delete']->execute_callback(
+			array(
+				'post_id'          => $this->postID,
+				'occurrence_index' => 0,
+			)
+		);
+
+		$this->assertIsArray($result);
+		$this->assertSame(0, $result['occurrence_index']);
+
+		// Confirm the post now contains a single Form Trigger block.
+		$listed = $abilities['kit/formtrigger-list']->execute_callback([ 'post_id' => $this->postID ]);
+		$this->assertSame(1, $listed['count']);
+	}
+
+	/**
+	 * Test that kit/formtrigger-update returns a WP_Error when asked to update an
+	 * occurrence that does not exist, rather than silently mutating
+	 * something else.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateOnMissingOccurrenceReturnsError()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/formtrigger-update']->execute_callback(
+			array(
+				'post_id'          => $this->postID,
+				'occurrence_index' => 99,
+				'attrs'            => array( 'form' => $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] ),
+			)
+		);
+
+		// Assert that the result is a WP_Error.
+		$this->assertInstanceOf(\WP_Error::class, $result);
+	}
+
+	/**
+	 * Creates a Post containing two convertkit/formtrigger blocks interleaved with
+	 * non-Kit blocks, mirroring the fixture used by BlockPostHelperTest.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  int
+	 */
+	private function createPostWithFormTriggerBlocks(): int
+	{
+		return $this->factory->post->create(
+			array(
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_title'   => 'Form Trigger Abilities Fixture',
+				'post_content' => '<!-- wp:paragraph -->
+<p>Intro paragraph.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:convertkit/formtrigger {"form":"' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '"} /-->
+
+<!-- wp:paragraph -->
+<p>Middle paragraph.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:convertkit/formtrigger {"form":"' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '"} /-->
+
+<!-- wp:paragraph -->
+<p>Closing paragraph.</p>
+<!-- /wp:paragraph -->',
+			)
+		);
+	}
+}

--- a/tests/Integration/MCPContentProductTest.php
+++ b/tests/Integration/MCPContentProductTest.php
@@ -1,0 +1,394 @@
+<?php
+
+namespace Tests;
+
+use lucatume\WPBrowser\TestCase\WPTestCase;
+
+/**
+ * Tests for the Kit MCP content abilities bound to the Product block:
+ *
+ * - kit/product-list    (ConvertKit_MCP_Ability_Content_List)
+ * - kit/product-insert  (ConvertKit_MCP_Ability_Content_Insert)
+ * - kit/product-update  (ConvertKit_MCP_Ability_Content_Update)
+ * - kit/product-delete  (ConvertKit_MCP_Ability_Content_Delete)
+ *
+ * @since   3.4.0
+ */
+class MCPContentProductTest extends WPTestCase
+{
+	/**
+	 * The testing implementation.
+	 *
+	 * @var \WpunitTester.
+	 */
+	protected $tester;
+
+	/**
+	 * Holds the Post ID created in setUp(), used by tests that exercise
+	 * list / update / delete against a post containing two Product blocks.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     int
+	 */
+	private $postID;
+
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		// Activate Plugin.
+		activate_plugins('convertkit/wp-convertkit.php');
+
+		// Create a Post containing two Product blocks, so list / update /
+		// delete have something to act on.
+		$this->postID = $this->createPostWithProductBlocks();
+	}
+
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function tearDown(): void
+	{
+		// Restore the current user.
+		wp_set_current_user(0);
+
+		// Deactivate Plugin.
+		deactivate_plugins('convertkit/wp-convertkit.php');
+
+		parent::tearDown();
+	}
+
+	/**
+	 * The ability names registered by the Product block.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     string[]
+	 */
+	private const PRODUCT_ABILITY_NAMES = array(
+		'kit/product-list',
+		'kit/product-insert',
+		'kit/product-update',
+		'kit/product-delete',
+	);
+
+	/**
+	 * Test that the Product block registers all four content abilities via
+	 * the convertkit_abilities filter with the expected names.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testAbilitiesRegistered()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// The ability names and classes expected to be registered.
+		$expected = array(
+			'kit/product-list'   => \ConvertKit_MCP_Ability_Content_List::class,
+			'kit/product-insert' => \ConvertKit_MCP_Ability_Content_Insert::class,
+			'kit/product-update' => \ConvertKit_MCP_Ability_Content_Update::class,
+			'kit/product-delete' => \ConvertKit_MCP_Ability_Content_Delete::class,
+		);
+
+		// Assert that the abilities are registered and are instances of the expected classes.
+		foreach ( $expected as $name => $class ) {
+			$this->assertArrayHasKey($name, $abilities);
+			$this->assertInstanceOf($class, $abilities[ $name ]);
+		}
+	}
+
+	/**
+	 * Test that the permission_callback() rejects a user who cannot edit the
+	 * given post.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackDeniesWithoutEditPostCapability()
+	{
+		// Become a Subscriber (no edit_post capability).
+		$subscriber_id = static::factory()->user->create([ 'role' => 'subscriber' ]);
+		wp_set_current_user($subscriber_id);
+
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Assert that the abilities are permission denied.
+		foreach ( self::PRODUCT_ABILITY_NAMES as $name ) {
+			// Execute the ability.
+			$result = $abilities[ $name ]->permission_callback([ 'post_id' => $this->postID ]);
+
+			// Assert that the result is a WP_Error.
+			$this->assertInstanceOf(\WP_Error::class, $result);
+		}
+	}
+
+	/**
+	 * Test that the permission_callback() rejects a request with no post_id,
+	 * with a clear error code.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackDeniesWithoutPostId()
+	{
+		// Become an Administrator (has every capability, so the only thing
+		// that can fail here is the missing post_id check).
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Assert that the abilities are permission denied.
+		foreach ( self::PRODUCT_ABILITY_NAMES as $name ) {
+			// Execute the ability.
+			$result = $abilities[ $name ]->permission_callback([]);
+
+			// Assert that the result is a WP_Error.
+			$this->assertInstanceOf(\WP_Error::class, $result);
+		}
+	}
+
+	/**
+	 * Test that the permission_callback() permits an Administrator on a
+	 * valid post_id.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackPermitsAdministrator()
+	{
+		// Become an Administrator.
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Assert that the abilities are permission granted.
+		foreach ( self::PRODUCT_ABILITY_NAMES as $name ) {
+			// Execute the ability.
+			$this->assertTrue($abilities[ $name ]->permission_callback([ 'post_id' => $this->postID ]));
+		}
+	}
+
+	/**
+	 * Test that kit/product-list returns every Product block occurrence in
+	 * the post.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testListReturnsAllProductOccurrencesInPost()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/product-list']->execute_callback([ 'post_id' => $this->postID ]);
+
+		$this->assertIsArray($result);
+		$this->assertSame($this->postID, $result['post_id']);
+		$this->assertSame(2, $result['count']);
+		$this->assertCount(2, $result['occurrences']);
+
+		// Each occurrence carries an occurrence_index and an attrs object
+		// holding the product ID from the seeded post content.
+		foreach ($result['occurrences'] as $i => $occurrence) {
+			$this->assertSame($i, $occurrence['occurrence_index']);
+			$this->assertArrayHasKey('attrs', $occurrence);
+			$this->assertSame(
+				(string) $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+				(string) $occurrence['attrs']['product']
+			);
+		}
+	}
+
+	/**
+	 * Test that kit/product-insert appends a new Product block to the post,
+	 * and returns the new occurrence_index. Exercises all four primary
+	 * Product attributes so each round-trips through the block helper.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testInsertAppendsProductBlock()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/product-insert']->execute_callback(
+			array(
+				'post_id'  => $this->postID,
+				'attrs'    => array(
+					'product'       => $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+					'text'          => 'Buy this product',
+					'discount_code' => $_ENV['CONVERTKIT_API_PRODUCT_DISCOUNT_CODE'],
+					'checkout'      => true,
+				),
+				'position' => 'append',
+			)
+		);
+
+		$this->assertIsArray($result);
+		$this->assertSame($this->postID, $result['post_id']);
+		// Two Product blocks existed in setUp(); the newly inserted one is the third.
+		$this->assertSame(2, $result['occurrence_index']);
+
+		// Confirm the post now contains three Product blocks.
+		$listed = $abilities['kit/product-list']->execute_callback([ 'post_id' => $this->postID ]);
+		$this->assertSame(3, $listed['count']);
+
+		// Confirm the newly inserted block carries the attrs we passed in.
+		$this->assertSame(
+			(string) $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+			(string) $listed['occurrences'][2]['attrs']['product']
+		);
+		$this->assertSame('Buy this product', $listed['occurrences'][2]['attrs']['text']);
+		$this->assertSame(
+			(string) $_ENV['CONVERTKIT_API_PRODUCT_DISCOUNT_CODE'],
+			(string) $listed['occurrences'][2]['attrs']['discount_code']
+		);
+		$this->assertTrue( (bool) $listed['occurrences'][2]['attrs']['checkout']);
+	}
+
+	/**
+	 * Test that kit/product-update changes the attrs of a specific
+	 * occurrence, leaving other occurrences untouched.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateModifiesSingleOccurrence()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Update the second Product block (occurrence_index 1) to a different
+		// product ID and text.
+		$new_product_id = (string) ( (int) $_ENV['CONVERTKIT_API_PRODUCT_ID'] + 1 );
+		$result         = $abilities['kit/product-update']->execute_callback(
+			array(
+				'post_id'          => $this->postID,
+				'occurrence_index' => 1,
+				'attrs'            => array(
+					'product' => $new_product_id,
+					'text'    => 'Updated CTA',
+				),
+			)
+		);
+
+		$this->assertIsArray($result);
+		$this->assertSame(1, $result['occurrence_index']);
+
+		// Re-list and confirm: occurrence 0 unchanged, occurrence 1 has the
+		// new product ID and text.
+		$listed = $abilities['kit/product-list']->execute_callback([ 'post_id' => $this->postID ]);
+		$this->assertSame(
+			(string) $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+			(string) $listed['occurrences'][0]['attrs']['product'],
+			'kit/product-update must not modify other occurrences.'
+		);
+		$this->assertSame(
+			$new_product_id,
+			(string) $listed['occurrences'][1]['attrs']['product'],
+			'kit/product-update did not apply the new product ID to the requested occurrence.'
+		);
+		$this->assertSame(
+			'Updated CTA',
+			$listed['occurrences'][1]['attrs']['text'],
+			'kit/product-update did not apply the new text to the requested occurrence.'
+		);
+	}
+
+	/**
+	 * Test that kit/product-delete removes a specific occurrence and the
+	 * post now contains one fewer Product block.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testDeleteRemovesSingleOccurrence()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/product-delete']->execute_callback(
+			array(
+				'post_id'          => $this->postID,
+				'occurrence_index' => 0,
+			)
+		);
+
+		$this->assertIsArray($result);
+		$this->assertSame(0, $result['occurrence_index']);
+
+		// Confirm the post now contains a single Product block.
+		$listed = $abilities['kit/product-list']->execute_callback([ 'post_id' => $this->postID ]);
+		$this->assertSame(1, $listed['count']);
+	}
+
+	/**
+	 * Test that kit/product-update returns a WP_Error when asked to update
+	 * an occurrence that does not exist, rather than silently mutating
+	 * something else.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateOnMissingOccurrenceReturnsError()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/product-update']->execute_callback(
+			array(
+				'post_id'          => $this->postID,
+				'occurrence_index' => 99,
+				'attrs'            => array( 'product' => $_ENV['CONVERTKIT_API_PRODUCT_ID'] ),
+			)
+		);
+
+		// Assert that the result is a WP_Error.
+		$this->assertInstanceOf(\WP_Error::class, $result);
+	}
+
+	/**
+	 * Creates a Post containing two convertkit/product blocks interleaved
+	 * with non-Kit blocks, mirroring the fixture used by BlockPostHelperTest.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  int
+	 */
+	private function createPostWithProductBlocks(): int
+	{
+		return $this->factory->post->create(
+			array(
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_title'   => 'Product Abilities Fixture',
+				'post_content' => '<!-- wp:paragraph -->
+<p>Intro paragraph.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:convertkit/product {"product":"' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '"} /-->
+
+<!-- wp:paragraph -->
+<p>Middle paragraph.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:convertkit/product {"product":"' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '"} /-->
+
+<!-- wp:paragraph -->
+<p>Closing paragraph.</p>
+<!-- /wp:paragraph -->',
+			)
+		);
+	}
+}

--- a/tests/Integration/MCPResourceTest.php
+++ b/tests/Integration/MCPResourceTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests;
+
+use lucatume\WPBrowser\TestCase\WPTestCase;
+
+/**
+ * Tests for the Kit MCP Form Resources
+ *
+ * @since   3.4.0
+ */
+class MCPResourceFormsTest extends WPTestCase
+{
+	/**
+	 * The testing implementation.
+	 *
+	 * @var \WpunitTester.
+	 */
+	protected $tester;
+
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since   1.9.7.4
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		// Activate Plugin.
+		activate_plugins('convertkit/wp-convertkit.php');
+	}
+
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since   1.9.6.9
+	 */
+	public function tearDown(): void
+	{
+		// Deactivate Plugin.
+		deactivate_plugins('convertkit/wp-convertkit.php');
+
+		parent::tearDown();
+	}
+
+    /**
+	 * Test that the ability returns a 401 when the user is not authorized.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testWhenUnauthorized()
+	{
+		$request  = new \WP_REST_Request( 'GET', '/kit/v1/blocks' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 401, $response->get_status() );
+	}
+
+    public function testWhenNoResourcesExist()
+    {
+
+    }
+
+    public function testWhenResourcesExist()
+    {
+
+    }
+}

--- a/tests/Integration/MCPResourceTest.php
+++ b/tests/Integration/MCPResourceTest.php
@@ -102,7 +102,7 @@ class MCPResourceTest extends WPTestCase
 	 *
 	 * @return  array<string, array{0: \ConvertKit_MCP_Ability_Resource, 1: object}>
 	 */
-	public function abilityProvider(): array
+	private function abilityProvider(): array
 	{
 		return [
 			'forms'         => [
@@ -125,16 +125,30 @@ class MCPResourceTest extends WPTestCase
 	}
 
 	/**
-	 * Test that each ability's name is the expected `kit/<resource>-list`.
+	 * Test that the four resource-list abilities are registered with the
+	 * `convertkit_abilities` filter, so they are picked up by the Abilities
+	 * API and exposed by the MCP server.
 	 *
 	 * @since   3.4.0
 	 */
-	public function testAbilityNames()
+	public function testAbilitiesRegistered()
 	{
-		$this->assertSame('kit/forms-list', ( new \ConvertKit_MCP_Ability_Resource_Forms() )->get_name());
-		$this->assertSame('kit/tags-list', ( new \ConvertKit_MCP_Ability_Resource_Tags() )->get_name());
-		$this->assertSame('kit/landing-pages-list', ( new \ConvertKit_MCP_Ability_Resource_Landing_Pages() )->get_name());
-		$this->assertSame('kit/products-list', ( new \ConvertKit_MCP_Ability_Resource_Products() )->get_name());
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// The ability names and classes expected to be registered.
+		$expected = array(
+			'kit/forms-list'         => \ConvertKit_MCP_Ability_Resource_Forms::class,
+			'kit/tags-list'          => \ConvertKit_MCP_Ability_Resource_Tags::class,
+			'kit/landing-pages-list' => \ConvertKit_MCP_Ability_Resource_Landing_Pages::class,
+			'kit/products-list'      => \ConvertKit_MCP_Ability_Resource_Products::class,
+		);
+
+		// Assert that the abilities are registered and are instances of the expected classes.
+		foreach ( $expected as $name => $class ) {
+			$this->assertArrayHasKey($name, $abilities);
+			$this->assertInstanceOf($class, $abilities[ $name ]);
+		}
 	}
 
 	/**
@@ -256,7 +270,7 @@ class MCPResourceTest extends WPTestCase
 
 		foreach ($result['items'] as $item) {
 			$this->assertArrayHasKey('format', $item);
-			$this->assertContains($item['format'],$allowedFormats);
+			$this->assertContains($item['format'], $allowedFormats);
 		}
 	}
 
@@ -290,7 +304,7 @@ class MCPResourceTest extends WPTestCase
 			sort($itemSchemaKeys);
 			sort($itemKeys);
 
-			$this->assertSame($itemSchemaKeys,$itemKeys);
+			$this->assertSame($itemSchemaKeys, $itemKeys);
 		}
 	}
 }

--- a/tests/Integration/MCPResourceTest.php
+++ b/tests/Integration/MCPResourceTest.php
@@ -12,11 +12,6 @@ use lucatume\WPBrowser\TestCase\WPTestCase;
  * - kit/landing-pages-list  (ConvertKit_MCP_Ability_Resource_Landing_Pages)
  * - kit/products-list       (ConvertKit_MCP_Ability_Resource_Products)
  *
- * Each ability is exercised by instantiating its PHP class directly and
- * calling permission_callback() / execute_callback(). The MCP transport
- * layer is covered by E2E tests; this suite proves the abilities themselves
- * read from the resource cache and shape the output correctly.
- *
  * @since   3.4.0
  */
 class MCPResourceTest extends WPTestCase
@@ -72,14 +67,8 @@ class MCPResourceTest extends WPTestCase
 		// Delete credentials and any cached resources so each test starts clean.
 		delete_option($this->settings::SETTINGS_NAME);
 
-		foreach (
-			[
-				new \ConvertKit_Resource_Forms(),
-				new \ConvertKit_Resource_Tags(),
-				new \ConvertKit_Resource_Landing_Pages(),
-				new \ConvertKit_Resource_Products(),
-			] as $resource
-		) {
+		foreach ( self::RESOURCE_CLASSES as $resource_class ) {
+			$resource = new $resource_class();
 			delete_option($resource->settings_name);
 			delete_option($resource->settings_name . '_last_queried');
 		}
@@ -94,35 +83,20 @@ class MCPResourceTest extends WPTestCase
 	}
 
 	/**
-	 * Returns each of the four resource-list abilities, paired with the
-	 * resource class that backs it. Used by tests that should run identically
-	 * across all four abilities.
+	 * Map of resource-list ability names to the ConvertKit_Resource_* class
+	 * backing them. Used by tests that need to seed / clear the resource
+	 * cache alongside the ability under test.
 	 *
 	 * @since   3.4.0
 	 *
-	 * @return  array<string, array{0: \ConvertKit_MCP_Ability_Resource, 1: object}>
+	 * @var     array<string, class-string>
 	 */
-	private function abilityProvider(): array
-	{
-		return [
-			'forms'         => [
-				new \ConvertKit_MCP_Ability_Resource_Forms(),
-				new \ConvertKit_Resource_Forms(),
-			],
-			'tags'          => [
-				new \ConvertKit_MCP_Ability_Resource_Tags(),
-				new \ConvertKit_Resource_Tags(),
-			],
-			'landing_pages' => [
-				new \ConvertKit_MCP_Ability_Resource_Landing_Pages(),
-				new \ConvertKit_Resource_Landing_Pages(),
-			],
-			'products'      => [
-				new \ConvertKit_MCP_Ability_Resource_Products(),
-				new \ConvertKit_Resource_Products(),
-			],
-		];
-	}
+	private const RESOURCE_CLASSES = array(
+		'kit/forms-list'         => \ConvertKit_Resource_Forms::class,
+		'kit/tags-list'          => \ConvertKit_Resource_Tags::class,
+		'kit/landing-pages-list' => \ConvertKit_Resource_Landing_Pages::class,
+		'kit/products-list'      => \ConvertKit_Resource_Products::class,
+	);
 
 	/**
 	 * Test that the four resource-list abilities are registered with the
@@ -163,13 +137,16 @@ class MCPResourceTest extends WPTestCase
 		$subscriber_id = static::factory()->user->create([ 'role' => 'subscriber' ]);
 		wp_set_current_user($subscriber_id);
 
-		foreach ($this->abilityProvider() as $row) {
-			[ $ability ] = $row;
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
 
-			$result = $ability->permission_callback([]);
+		// Assert that the abilities are permission denied.
+		foreach ( array_keys( self::RESOURCE_CLASSES ) as $name ) {
+			// Execute the ability.
+			$result = $abilities[ $name ]->permission_callback([]);
 
+			// Assert that the result is a WP_Error.
 			$this->assertInstanceOf(\WP_Error::class, $result);
-			$this->assertSame('convertkit_mcp_cannot_list_resources', $result->get_error_code());
 		}
 	}
 
@@ -185,10 +162,13 @@ class MCPResourceTest extends WPTestCase
 		$editor_id = static::factory()->user->create([ 'role' => 'editor' ]);
 		wp_set_current_user($editor_id);
 
-		foreach ($this->abilityProvider() as $row) {
-			[ $ability ] = $row;
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
 
-			$this->assertTrue($ability->permission_callback([]));
+		// Assert that the abilities are permission granted.
+		foreach ( array_keys( self::RESOURCE_CLASSES ) as $name ) {
+			// Execute the ability.
+			$this->assertTrue($abilities[ $name ]->permission_callback([]));
 		}
 	}
 
@@ -200,13 +180,15 @@ class MCPResourceTest extends WPTestCase
 	 */
 	public function testReturnsEmptyListWhenNoResourcesAreCached()
 	{
-		foreach ($this->abilityProvider() as $row) {
-			[ $ability, $resource ] = $row;
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
 
+		foreach ( self::RESOURCE_CLASSES as $name => $resource_class ) {
 			// Ensure the cache is empty for this resource.
-			delete_option($resource->settings_name);
+			delete_option( ( new $resource_class() )->settings_name );
 
-			$result = $ability->execute_callback([]);
+			// Execute the ability.
+			$result = $abilities[ $name ]->execute_callback([]);
 
 			$this->assertIsArray($result);
 			$this->assertArrayHasKey('count', $result);
@@ -225,13 +207,16 @@ class MCPResourceTest extends WPTestCase
 	 */
 	public function testReturnsCachedItems()
 	{
-		foreach ($this->abilityProvider() as $key => $row) {
-			[ $ability, $resource ] = $row;
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
 
+		// Execute the abilities.
+		foreach ( self::RESOURCE_CLASSES as $name => $resource_class ) {
 			// Populate the resource cache from the Kit API.
-			$resource->init();
+			( new $resource_class() )->init();
 
-			$result = $ability->execute_callback([]);
+			// Execute the ability.
+			$result = $abilities[ $name ]->execute_callback([]);
 
 			$this->assertIsArray($result);
 			$this->assertArrayHasKey('count', $result);
@@ -258,16 +243,20 @@ class MCPResourceTest extends WPTestCase
 	 */
 	public function testFormsItemsIncludeFormat()
 	{
-		$ability  = new \ConvertKit_MCP_Ability_Resource_Forms();
-		$resource = new \ConvertKit_Resource_Forms();
-		$resource->init();
+		// Populate the resource cache from the Kit API.
+		( new \ConvertKit_Resource_Forms() )->init();
 
-		$result = $ability->execute_callback([]);
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
 
+		// Execute the ability.
+		$result    = $abilities['kit/forms-list']->execute_callback([]);
+
+		// Assert that the result is an array.
 		$this->assertGreaterThan(0, $result['count']);
 
+		// Assert that the result has items.
 		$allowedFormats = [ 'inline', 'modal', 'slide in', 'sticky bar' ];
-
 		foreach ($result['items'] as $item) {
 			$this->assertArrayHasKey('format', $item);
 			$this->assertContains($item['format'], $allowedFormats);
@@ -284,20 +273,28 @@ class MCPResourceTest extends WPTestCase
 	 */
 	public function testOutputSchemaMatchesExecuteShape()
 	{
-		foreach ($this->abilityProvider() as $key => $row) {
-			[ $ability, $resource ] = $row;
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
 
-			$resource->init();
-			$result = $ability->execute_callback([]);
+		// Execute the abilities.
+		foreach ( self::RESOURCE_CLASSES as $name => $resource_class ) {
+			// Populate the resource cache from the Kit API.
+			( new $resource_class() )->init();
+
+			// Execute the ability.
+			$result = $abilities[ $name ]->execute_callback([]);
+
 			if ($result['count'] === 0) {
 				// No items to compare against; skip this ability.
 				continue;
 			}
 
+			// Assert that the output schema is an object.
 			$schema = $ability->get_output_schema();
 			$this->assertSame('object', $schema['type']);
 			$this->assertSame([ 'count', 'items' ], $schema['required']);
 
+			// Assert that the item schema keys match the result item keys.
 			$itemSchemaKeys = array_keys($schema['properties']['items']['items']['properties']);
 			$itemKeys       = array_keys($result['items'][0]);
 

--- a/tests/Integration/MCPResourceTest.php
+++ b/tests/Integration/MCPResourceTest.php
@@ -250,7 +250,7 @@ class MCPResourceTest extends WPTestCase
 		$abilities = convertkit_get_abilities();
 
 		// Execute the ability.
-		$result    = $abilities['kit/forms-list']->execute_callback([]);
+		$result = $abilities['kit/forms-list']->execute_callback([]);
 
 		// Assert that the result is an array.
 		$this->assertGreaterThan(0, $result['count']);

--- a/tests/Integration/MCPResourceTest.php
+++ b/tests/Integration/MCPResourceTest.php
@@ -5,11 +5,21 @@ namespace Tests;
 use lucatume\WPBrowser\TestCase\WPTestCase;
 
 /**
- * Tests for the Kit MCP Form Resources
+ * Tests for the Kit MCP resource-list abilities:
+ *
+ * - kit/forms-list          (ConvertKit_MCP_Ability_Resource_Forms)
+ * - kit/tags-list           (ConvertKit_MCP_Ability_Resource_Tags)
+ * - kit/landing-pages-list  (ConvertKit_MCP_Ability_Resource_Landing_Pages)
+ * - kit/products-list       (ConvertKit_MCP_Ability_Resource_Products)
+ *
+ * Each ability is exercised by instantiating its PHP class directly and
+ * calling permission_callback() / execute_callback(). The MCP transport
+ * layer is covered by E2E tests; this suite proves the abilities themselves
+ * read from the resource cache and shape the output correctly.
  *
  * @since   3.4.0
  */
-class MCPResourceFormsTest extends WPTestCase
+class MCPResourceTest extends WPTestCase
 {
 	/**
 	 * The testing implementation.
@@ -19,9 +29,19 @@ class MCPResourceFormsTest extends WPTestCase
 	protected $tester;
 
 	/**
+	 * Holds the ConvertKit Settings class, so we can seed credentials in
+	 * setUp() and clean up in tearDown().
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     \ConvertKit_Settings
+	 */
+	private $settings;
+
+	/**
 	 * Performs actions before each test.
 	 *
-	 * @since   1.9.7.4
+	 * @since   3.4.0
 	 */
 	public function setUp(): void
 	{
@@ -29,40 +49,248 @@ class MCPResourceFormsTest extends WPTestCase
 
 		// Activate Plugin.
 		activate_plugins('convertkit/wp-convertkit.php');
+
+		// Store credentials in Plugin's settings, so the resource classes
+		// can fetch live data from the Kit API when init() is called.
+		$this->settings = new \ConvertKit_Settings();
+		update_option(
+			$this->settings::SETTINGS_NAME,
+			[
+				'access_token'  => $_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
+				'refresh_token' => $_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN'],
+			]
+		);
 	}
 
 	/**
 	 * Performs actions after each test.
 	 *
-	 * @since   1.9.6.9
+	 * @since   3.4.0
 	 */
 	public function tearDown(): void
 	{
+		// Delete credentials and any cached resources so each test starts clean.
+		delete_option($this->settings::SETTINGS_NAME);
+
+		foreach (
+			[
+				new \ConvertKit_Resource_Forms(),
+				new \ConvertKit_Resource_Tags(),
+				new \ConvertKit_Resource_Landing_Pages(),
+				new \ConvertKit_Resource_Products(),
+			] as $resource
+		) {
+			delete_option($resource->settings_name);
+			delete_option($resource->settings_name . '_last_queried');
+		}
+
+		// Restore the current user.
+		wp_set_current_user(0);
+
 		// Deactivate Plugin.
 		deactivate_plugins('convertkit/wp-convertkit.php');
 
 		parent::tearDown();
 	}
 
-    /**
-	 * Test that the ability returns a 401 when the user is not authorized.
+	/**
+	 * Returns each of the four resource-list abilities, paired with the
+	 * resource class that backs it. Used by tests that should run identically
+	 * across all four abilities.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  array<string, array{0: \ConvertKit_MCP_Ability_Resource, 1: object}>
+	 */
+	public function abilityProvider(): array
+	{
+		return [
+			'forms'         => [
+				new \ConvertKit_MCP_Ability_Resource_Forms(),
+				new \ConvertKit_Resource_Forms(),
+			],
+			'tags'          => [
+				new \ConvertKit_MCP_Ability_Resource_Tags(),
+				new \ConvertKit_Resource_Tags(),
+			],
+			'landing_pages' => [
+				new \ConvertKit_MCP_Ability_Resource_Landing_Pages(),
+				new \ConvertKit_Resource_Landing_Pages(),
+			],
+			'products'      => [
+				new \ConvertKit_MCP_Ability_Resource_Products(),
+				new \ConvertKit_Resource_Products(),
+			],
+		];
+	}
+
+	/**
+	 * Test that each ability's name is the expected `kit/<resource>-list`.
 	 *
 	 * @since   3.4.0
 	 */
-	public function testWhenUnauthorized()
+	public function testAbilityNames()
 	{
-		$request  = new \WP_REST_Request( 'GET', '/kit/v1/blocks' );
-		$response = rest_get_server()->dispatch( $request );
-		$this->assertSame( 401, $response->get_status() );
+		$this->assertSame('kit/forms-list', ( new \ConvertKit_MCP_Ability_Resource_Forms() )->get_name());
+		$this->assertSame('kit/tags-list', ( new \ConvertKit_MCP_Ability_Resource_Tags() )->get_name());
+		$this->assertSame('kit/landing-pages-list', ( new \ConvertKit_MCP_Ability_Resource_Landing_Pages() )->get_name());
+		$this->assertSame('kit/products-list', ( new \ConvertKit_MCP_Ability_Resource_Products() )->get_name());
 	}
 
-    public function testWhenNoResourcesExist()
-    {
+	/**
+	 * Test that the permission_callback() rejects a user without the
+	 * edit_posts capability.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackDeniesWithoutEditPostsCapability()
+	{
+		// Become a Subscriber (no edit_posts capability).
+		$subscriber_id = static::factory()->user->create([ 'role' => 'subscriber' ]);
+		wp_set_current_user($subscriber_id);
 
-    }
+		foreach ($this->abilityProvider() as $row) {
+			[ $ability ] = $row;
 
-    public function testWhenResourcesExist()
-    {
+			$result = $ability->permission_callback([]);
 
-    }
+			$this->assertInstanceOf(\WP_Error::class, $result);
+			$this->assertSame('convertkit_mcp_cannot_list_resources', $result->get_error_code());
+		}
+	}
+
+	/**
+	 * Test that the permission_callback() permits a user with the edit_posts
+	 * capability (e.g. an Editor or Administrator).
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackPermitsWithEditPostsCapability()
+	{
+		// Become an Editor (has edit_posts capability).
+		$editor_id = static::factory()->user->create([ 'role' => 'editor' ]);
+		wp_set_current_user($editor_id);
+
+		foreach ($this->abilityProvider() as $row) {
+			[ $ability ] = $row;
+
+			$this->assertTrue($ability->permission_callback([]));
+		}
+	}
+
+	/**
+	 * Test that the execute_callback() returns an empty (but successful) list
+	 * when the resource cache is empty, rather than an error.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testReturnsEmptyListWhenNoResourcesAreCached()
+	{
+		foreach ($this->abilityProvider() as $row) {
+			[ $ability, $resource ] = $row;
+
+			// Ensure the cache is empty for this resource.
+			delete_option($resource->settings_name);
+
+			$result = $ability->execute_callback([]);
+
+			$this->assertIsArray($result);
+			$this->assertArrayHasKey('count', $result);
+			$this->assertArrayHasKey('items', $result);
+			$this->assertSame(0, $result['count']);
+			$this->assertSame([], $result['items']);
+		}
+	}
+
+	/**
+	 * Test that execute_callback() returns the cached items, shaped as
+	 * { count, items: [{ id, name, ... }] }, when the resource cache is
+	 * populated.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testReturnsCachedItems()
+	{
+		foreach ($this->abilityProvider() as $key => $row) {
+			[ $ability, $resource ] = $row;
+
+			// Populate the resource cache from the Kit API.
+			$resource->init();
+
+			$result = $ability->execute_callback([]);
+
+			$this->assertIsArray($result);
+			$this->assertArrayHasKey('count', $result);
+			$this->assertArrayHasKey('items', $result);
+			$this->assertGreaterThan(0, $result['count']);
+			$this->assertCount($result['count'], $result['items']);
+
+			// Each item must have id and name.
+			foreach ($result['items'] as $item) {
+				$this->assertArrayHasKey('id', $item);
+				$this->assertArrayHasKey('name', $item);
+				$this->assertIsInt($item['id']);
+				$this->assertIsString($item['name']);
+			}
+		}
+	}
+
+	/**
+	 * Test that the Forms ability includes the `format` field on each item,
+	 * and that legacy forms (which omit `format` in the raw resource cache)
+	 * fall back to 'inline'.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testFormsItemsIncludeFormat()
+	{
+		$ability  = new \ConvertKit_MCP_Ability_Resource_Forms();
+		$resource = new \ConvertKit_Resource_Forms();
+		$resource->init();
+
+		$result = $ability->execute_callback([]);
+
+		$this->assertGreaterThan(0, $result['count']);
+
+		$allowedFormats = [ 'inline', 'modal', 'slide in', 'sticky bar' ];
+
+		foreach ($result['items'] as $item) {
+			$this->assertArrayHasKey('format', $item);
+			$this->assertContains($item['format'],$allowedFormats);
+		}
+	}
+
+	/**
+	 * Test that the output schema returned by each ability advertises the
+	 * same keys (id, name, plus format for forms) that execute_callback()
+	 * actually returns. Guards against drift between map_item() and
+	 * get_item_schema().
+	 *
+	 * @since   3.4.0
+	 */
+	public function testOutputSchemaMatchesExecuteShape()
+	{
+		foreach ($this->abilityProvider() as $key => $row) {
+			[ $ability, $resource ] = $row;
+
+			$resource->init();
+			$result = $ability->execute_callback([]);
+			if ($result['count'] === 0) {
+				// No items to compare against; skip this ability.
+				continue;
+			}
+
+			$schema = $ability->get_output_schema();
+			$this->assertSame('object', $schema['type']);
+			$this->assertSame([ 'count', 'items' ], $schema['required']);
+
+			$itemSchemaKeys = array_keys($schema['properties']['items']['items']['properties']);
+			$itemKeys       = array_keys($result['items'][0]);
+
+			sort($itemSchemaKeys);
+			sort($itemKeys);
+
+			$this->assertSame($itemSchemaKeys,$itemKeys);
+		}
+	}
 }

--- a/tests/Integration/MCPResourceTest.php
+++ b/tests/Integration/MCPResourceTest.php
@@ -290,7 +290,7 @@ class MCPResourceTest extends WPTestCase
 			}
 
 			// Assert that the output schema is an object.
-			$schema = $ability->get_output_schema();
+			$schema = $abilities[ $name ]->get_output_schema();
 			$this->assertSame('object', $schema['type']);
 			$this->assertSame([ 'count', 'items' ], $schema['required']);
 

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -109,6 +109,11 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/content/class-con
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/content/class-convertkit-mcp-ability-content-insert.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/content/class-convertkit-mcp-ability-content-update.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/content/class-convertkit-mcp-ability-content-delete.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/resources/class-convertkit-mcp-ability-resource.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/resources/class-convertkit-mcp-ability-resource-forms.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/resources/class-convertkit-mcp-ability-resource-tags.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/resources/class-convertkit-mcp-ability-resource-landing-pages.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/resources/class-convertkit-mcp-ability-resource-products.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/plugin-sidebars/class-convertkit-plugin-sidebar.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/plugin-sidebars/class-convertkit-plugin-sidebar-post-settings.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/pre-publish-actions/class-convertkit-pre-publish-action.php';


### PR DESCRIPTION
## Summary

Adds four read-only MCP abilities that list the Kit resources cached from the connected Kit account, so an MCP client can map a user-supplied resource name (e.g. "the Auto Confirm Form") to the numeric ID required by every other Kit ability.

<img width="695" height="577" alt="Screenshot 2026-05-27 at 21 35 15" src="https://github.com/user-attachments/assets/eaf03213-a6f7-46de-8a84-68a240505a8f" />

Without these, AI can call the existing MCP tools e.g. `kit/form-update`, but the model but has no way to discover which Form / Tag / Landing Page / Product IDs are valid, meaning prompts like "replace the Page Form on /pricing with the Auto Opt In Form" either fail or hallucinate IDs.

Ability | Description | Backed by | Per-item shape
-- | -- | -- | --
kit/forms-list | Lists every Kit Form (id, name, format). | ConvertKit_Resource_Forms | { id, name, format }
kit/tags-list | Lists every Kit Tag (id, name). Prefix with tag_ for restrict-content fields. | ConvertKit_Resource_Tags | { id, name }
kit/landing-pages-list | Lists every Kit Landing Page (id, name). Applies only to WordPress Pages. | ConvertKit_Resource_Landing_Pages | { id, name }
kit/products-list | Lists every Kit Product (id, name). Prefix with product_ for restrict-content fields. | ConvertKit_Resource_Products | { id, name }

## Testing

- `MCPResourceTest`: Test that each resource is registered as an ability and loads the correct data.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)