### PR TITLE
Abilities API: Forms

### DIFF
--- a/includes/blocks/class-convertkit-block-broadcasts.php
+++ b/includes/blocks/class-convertkit-block-broadcasts.php
@@ -27,6 +27,9 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 		// Register this as a Gutenberg block in the ConvertKit Plugin.
 		add_filter( 'convertkit_blocks', array( $this, 'register' ) );
 
+		// Register this block's MCP abilities.
+		add_filter( 'convertkit_abilities', array( $this, 'register_abilities' ) );
+
 		// Enqueue scripts and styles for this Gutenberg Block in the editor and frontend views.
 		add_action( 'convertkit_gutenberg_enqueue_scripts_editor_and_frontend', array( $this, 'enqueue_scripts' ) );
 		add_action( 'convertkit_gutenberg_enqueue_styles_editor_and_frontend', array( $this, 'enqueue_styles' ) );
@@ -166,6 +169,19 @@ class ConvertKit_Block_Broadcasts extends ConvertKit_Block {
 	 * @since   3.1.1
 	 */
 	public function get_title() {
+
+		return __( 'Kit Broadcasts', 'convertkit' );
+
+	}
+
+	/**
+	 * Returns this block's plural title.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_title_plural() {
 
 		return __( 'Kit Broadcasts', 'convertkit' );
 

--- a/includes/blocks/class-convertkit-block-form-trigger.php
+++ b/includes/blocks/class-convertkit-block-form-trigger.php
@@ -27,6 +27,9 @@ class ConvertKit_Block_Form_Trigger extends ConvertKit_Block {
 		// Register this as a Gutenberg block in the ConvertKit Plugin.
 		add_filter( 'convertkit_blocks', array( $this, 'register' ) );
 
+		// Register this block's MCP abilities.
+		add_filter( 'convertkit_abilities', array( $this, 'register_abilities' ) );
+
 		// Enqueue scripts and styles for this Gutenberg Block in the editor and frontend views.
 		add_action( 'convertkit_gutenberg_enqueue_styles_editor_and_frontend', array( $this, 'enqueue_styles' ) );
 
@@ -70,6 +73,19 @@ class ConvertKit_Block_Form_Trigger extends ConvertKit_Block {
 	public function get_title() {
 
 		return __( 'Kit Form Trigger', 'convertkit' );
+
+	}
+
+	/**
+	 * Returns this block's plural title.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_title_plural() {
+
+		return __( 'Kit Form Triggers', 'convertkit' );
 
 	}
 

--- a/includes/blocks/class-convertkit-block-form.php
+++ b/includes/blocks/class-convertkit-block-form.php
@@ -27,6 +27,9 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 		// Register this as a Gutenberg block in the ConvertKit Plugin.
 		add_filter( 'convertkit_blocks', array( $this, 'register' ) );
 
+		// Register this block's MCP abilities.
+		add_filter( 'convertkit_abilities', array( $this, 'register_abilities' ) );
+
 		// Enqueue scripts for this Gutenberg Block in the editor view.
 		add_action( 'convertkit_gutenberg_enqueue_scripts', array( $this, 'enqueue_scripts_editor' ) );
 
@@ -98,6 +101,19 @@ class ConvertKit_Block_Form extends ConvertKit_Block {
 	public function get_title() {
 
 		return __( 'Kit Form', 'convertkit' );
+
+	}
+
+	/**
+	 * Returns this block's plural title.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_title_plural() {
+
+		return __( 'Kit Forms', 'convertkit' );
 
 	}
 

--- a/includes/blocks/class-convertkit-block-product.php
+++ b/includes/blocks/class-convertkit-block-product.php
@@ -27,6 +27,9 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 		// Register this as a Gutenberg block in the ConvertKit Plugin.
 		add_filter( 'convertkit_blocks', array( $this, 'register' ) );
 
+		// Register this block's MCP abilities.
+		add_filter( 'convertkit_abilities', array( $this, 'register_abilities' ) );
+
 		// Enqueue scripts and styles for this Gutenberg Block in the editor and frontend views.
 		add_action( 'convertkit_gutenberg_enqueue_scripts_editor_and_frontend', array( $this, 'enqueue_scripts' ) );
 		add_action( 'convertkit_gutenberg_enqueue_styles_editor_and_frontend', array( $this, 'enqueue_styles' ) );
@@ -92,6 +95,19 @@ class ConvertKit_Block_Product extends ConvertKit_Block {
 	public function get_title() {
 
 		return __( 'Kit Product', 'convertkit' );
+
+	}
+
+	/**
+	 * Returns this block's plural title.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_title_plural() {
+
+		return __( 'Kit Products', 'convertkit' );
 
 	}
 

--- a/includes/blocks/class-convertkit-block.php
+++ b/includes/blocks/class-convertkit-block.php
@@ -68,10 +68,10 @@ class ConvertKit_Block {
 		return array_merge(
 			$abilities,
 			array(
-				new ConvertKit_MCP_Ability_Content_List( $this ),
-				new ConvertKit_MCP_Ability_Content_Insert( $this ),
-				new ConvertKit_MCP_Ability_Content_Update( $this ),
-				new ConvertKit_MCP_Ability_Content_Delete( $this ),
+				'kit/' . $this->get_name() . '-list'   => new ConvertKit_MCP_Ability_Content_List( $this ),
+				'kit/' . $this->get_name() . '-insert' => new ConvertKit_MCP_Ability_Content_Insert( $this ),
+				'kit/' . $this->get_name() . '-update' => new ConvertKit_MCP_Ability_Content_Update( $this ),
+				'kit/' . $this->get_name() . '-delete' => new ConvertKit_MCP_Ability_Content_Delete( $this ),
 			)
 		);
 

--- a/includes/blocks/class-convertkit-block.php
+++ b/includes/blocks/class-convertkit-block.php
@@ -106,6 +106,19 @@ class ConvertKit_Block {
 	}
 
 	/**
+	 * Returns this block's plural title.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_title_plural() {
+
+		return '';
+
+	}
+
+	/**
 	 * Returns this block's icon.
 	 *
 	 * @since   3.1.1

--- a/includes/mcp/abilities/content/class-convertkit-mcp-ability-content-delete.php
+++ b/includes/mcp/abilities/content/class-convertkit-mcp-ability-content-delete.php
@@ -51,7 +51,7 @@ class ConvertKit_MCP_Ability_Content_Delete extends ConvertKit_MCP_Ability_Conte
 
 		return sprintf(
 			/* translators: %s: block title */
-			__( 'Delete an existing %s element from a post', 'convertkit' ),
+			__( 'Delete Existing %s from a Post, Page or Custom Post', 'convertkit' ),
 			$this->block->get_title()
 		);
 
@@ -67,10 +67,9 @@ class ConvertKit_MCP_Ability_Content_Delete extends ConvertKit_MCP_Ability_Conte
 	public function get_description() {
 
 		return sprintf(
-			/* translators: 1: block full name e.g. convertkit/form, 2: block title */
-			__( 'Removes a single occurrence of the %1$s (%2$s) element from the given post.', 'convertkit' ),
-			'convertkit/' . $this->block->get_name(),
-			$this->block->get_title()
+			/* translators: Block Name */
+			__( 'Removes an existing %s from a Post, Page or Custom Post using the supplied zero-based occurrence index.', 'convertkit' ),
+			$this->block->get_title_plural()
 		);
 
 	}

--- a/includes/mcp/abilities/content/class-convertkit-mcp-ability-content-insert.php
+++ b/includes/mcp/abilities/content/class-convertkit-mcp-ability-content-insert.php
@@ -42,7 +42,7 @@ class ConvertKit_MCP_Ability_Content_Insert extends ConvertKit_MCP_Ability_Conte
 
 		return sprintf(
 			/* translators: %s: block title */
-			__( 'Insert a %s element into a post', 'convertkit' ),
+			__( 'Insert %s into a Page, Post or Custom Post', 'convertkit' ),
 			$this->block->get_title()
 		);
 
@@ -59,9 +59,8 @@ class ConvertKit_MCP_Ability_Content_Insert extends ConvertKit_MCP_Ability_Conte
 
 		return sprintf(
 			/* translators: 1: block full name e.g. convertkit/form, 2: block title */
-			__( 'Inserts a new %1$s (%2$s) element into the given post\'s content. The element can be appended (default), prepended, or positioned relative to an existing element using a zero-based index.', 'convertkit' ),
-			'convertkit/' . $this->block->get_name(),
-			$this->block->get_title()
+			__( 'Inserts a new %s in a Page, Post or Custom Post\'s content. The element can be appended (default), prepended, or inserted relative to an existing element using a zero-based index.', 'convertkit' ),
+			$this->block->get_title_plural()
 		);
 
 	}

--- a/includes/mcp/abilities/content/class-convertkit-mcp-ability-content-list.php
+++ b/includes/mcp/abilities/content/class-convertkit-mcp-ability-content-list.php
@@ -60,8 +60,8 @@ class ConvertKit_MCP_Ability_Content_List extends ConvertKit_MCP_Ability_Content
 
 		return sprintf(
 			/* translators: %s: block title */
-			__( 'List %s elements in a post', 'convertkit' ),
-			$this->block->get_title()
+			__( 'List %s in a Post, Page or Custom Post', 'convertkit' ),
+			$this->block->get_title_plural()
 		);
 
 	}
@@ -76,10 +76,9 @@ class ConvertKit_MCP_Ability_Content_List extends ConvertKit_MCP_Ability_Content
 	public function get_description() {
 
 		return sprintf(
-			/* translators: 1: block full name e.g. convertkit/form, 2: block title */
-			__( 'Lists every occurrence of the %1$s (%2$s) element in the given post, including each occurrence\'s zero-based index and current attribute values.', 'convertkit' ),
-			'convertkit/' . $this->block->get_name(),
-			$this->block->get_title()
+			/* translators: Block Name */
+			__( 'Lists every %s in the given Post, Page or Custom Post, including each occurrence\'s zero-based index and current attribute values.', 'convertkit' ),
+			$this->block->get_title_plural()
 		);
 
 	}

--- a/includes/mcp/abilities/content/class-convertkit-mcp-ability-content-update.php
+++ b/includes/mcp/abilities/content/class-convertkit-mcp-ability-content-update.php
@@ -51,7 +51,7 @@ class ConvertKit_MCP_Ability_Content_Update extends ConvertKit_MCP_Ability_Conte
 
 		return sprintf(
 			/* translators: %s: block title */
-			__( 'Update an existing %s element in a post', 'convertkit' ),
+			__( 'Update Existing %s in a Page, Post or Custom Post', 'convertkit' ),
 			$this->block->get_title()
 		);
 
@@ -67,10 +67,9 @@ class ConvertKit_MCP_Ability_Content_Update extends ConvertKit_MCP_Ability_Conte
 	public function get_description() {
 
 		return sprintf(
-			/* translators: 1: block full name e.g. convertkit/form, 2: block title */
-			__( 'Updates the attributes of a single occurrence of the %1$s (%2$s) element in the given post. By default the provided attributes are merged into the existing attributes.', 'convertkit' ),
-			'convertkit/' . $this->block->get_name(),
-			$this->block->get_title()
+			/* translators: Block Name */
+			__( 'Updates the attributes of an existing %s in a Page, Post or Custom Post. The provided attributes are merged into the existing attributes.', 'convertkit' ),
+			$this->block->get_title_plural()
 		);
 
 	}

--- a/includes/mcp/abilities/content/class-convertkit-mcp-ability-content.php
+++ b/includes/mcp/abilities/content/class-convertkit-mcp-ability-content.php
@@ -165,6 +165,9 @@ abstract class ConvertKit_MCP_Ability_Content extends ConvertKit_MCP_Ability {
 
 		switch ( $type ) {
 			case 'resource':
+			case 'text':
+			case 'color':
+			case 'select':
 				return 'string';
 
 			case 'number':
@@ -174,7 +177,8 @@ abstract class ConvertKit_MCP_Ability_Content extends ConvertKit_MCP_Ability {
 				return 'boolean';
 
 			default:
-				return $type;
+				// Unknown field type — fall back to string.
+				return 'string';
 		}
 
 	}

--- a/tests/Integration/MCPContentBroadcastsTest.php
+++ b/tests/Integration/MCPContentBroadcastsTest.php
@@ -1,0 +1,368 @@
+<?php
+
+namespace Tests;
+
+use lucatume\WPBrowser\TestCase\WPTestCase;
+
+/**
+ * Tests for the Kit MCP content abilities bound to the Broadcasts block:
+ *
+ * - kit/broadcasts-list    (ConvertKit_MCP_Ability_Content_List)
+ * - kit/broadcasts-insert  (ConvertKit_MCP_Ability_Content_Insert)
+ * - kit/broadcasts-update  (ConvertKit_MCP_Ability_Content_Update)
+ * - kit/broadcasts-delete  (ConvertKit_MCP_Ability_Content_Delete)
+ *
+ * @since   3.4.0
+ */
+class MCPContentBroadcastsTest extends WPTestCase
+{
+	/**
+	 * The testing implementation.
+	 *
+	 * @var \WpunitTester.
+	 */
+	protected $tester;
+
+	/**
+	 * Holds the Post ID created in setUp(), used by tests that exercise
+	 * list / update / delete against a post containing two Broadcasts
+	 * blocks.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     int
+	 */
+	private $postID;
+
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		// Activate Plugin.
+		activate_plugins('convertkit/wp-convertkit.php');
+
+		// Create a Post containing two Broadcasts blocks, so list / update /
+		// delete have something to act on.
+		$this->postID = $this->createPostWithBroadcastsBlocks();
+	}
+
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function tearDown(): void
+	{
+		// Restore the current user.
+		wp_set_current_user(0);
+
+		// Deactivate Plugin.
+		deactivate_plugins('convertkit/wp-convertkit.php');
+
+		parent::tearDown();
+	}
+
+	/**
+	 * The ability names registered by the Broadcasts block.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     string[]
+	 */
+	private const BROADCASTS_ABILITY_NAMES = array(
+		'kit/broadcasts-list',
+		'kit/broadcasts-insert',
+		'kit/broadcasts-update',
+		'kit/broadcasts-delete',
+	);
+
+	/**
+	 * Test that the Broadcasts block registers all four content abilities via
+	 * the convertkit_abilities filter with the expected names.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testAbilitiesRegistered()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// The ability names and classes expected to be registered.
+		$expected = array(
+			'kit/broadcasts-list'   => \ConvertKit_MCP_Ability_Content_List::class,
+			'kit/broadcasts-insert' => \ConvertKit_MCP_Ability_Content_Insert::class,
+			'kit/broadcasts-update' => \ConvertKit_MCP_Ability_Content_Update::class,
+			'kit/broadcasts-delete' => \ConvertKit_MCP_Ability_Content_Delete::class,
+		);
+
+		// Assert that the abilities are registered and are instances of the expected classes.
+		foreach ( $expected as $name => $class ) {
+			$this->assertArrayHasKey($name, $abilities);
+			$this->assertInstanceOf($class, $abilities[ $name ]);
+		}
+	}
+
+	/**
+	 * Test that the permission_callback() rejects a user who cannot edit the
+	 * given post.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackDeniesWithoutEditPostCapability()
+	{
+		// Become a Subscriber (no edit_post capability).
+		$subscriber_id = static::factory()->user->create([ 'role' => 'subscriber' ]);
+		wp_set_current_user($subscriber_id);
+
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Assert that the abilities are permission denied.
+		foreach ( self::BROADCASTS_ABILITY_NAMES as $name ) {
+			// Execute the ability.
+			$result = $abilities[ $name ]->permission_callback([ 'post_id' => $this->postID ]);
+
+			// Assert that the result is a WP_Error.
+			$this->assertInstanceOf(\WP_Error::class, $result);
+		}
+	}
+
+	/**
+	 * Test that the permission_callback() rejects a request with no post_id,
+	 * with a clear error code.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackDeniesWithoutPostId()
+	{
+		// Become an Administrator (has every capability, so the only thing
+		// that can fail here is the missing post_id check).
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Assert that the abilities are permission denied.
+		foreach ( self::BROADCASTS_ABILITY_NAMES as $name ) {
+			// Execute the ability.
+			$result = $abilities[ $name ]->permission_callback([]);
+
+			// Assert that the result is a WP_Error.
+			$this->assertInstanceOf(\WP_Error::class, $result);
+		}
+	}
+
+	/**
+	 * Test that the permission_callback() permits an Administrator on a
+	 * valid post_id.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackPermitsAdministrator()
+	{
+		// Become an Administrator.
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Assert that the abilities are permission granted.
+		foreach ( self::BROADCASTS_ABILITY_NAMES as $name ) {
+			// Execute the ability.
+			$this->assertTrue($abilities[ $name ]->permission_callback([ 'post_id' => $this->postID ]));
+		}
+	}
+
+	/**
+	 * Test that kit/broadcasts-list returns every Broadcasts block occurrence
+	 * in the post.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testListReturnsAllBroadcastsOccurrencesInPost()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/broadcasts-list']->execute_callback([ 'post_id' => $this->postID ]);
+
+		$this->assertIsArray($result);
+		$this->assertSame($this->postID, $result['post_id']);
+		$this->assertSame(2, $result['count']);
+		$this->assertCount(2, $result['occurrences']);
+
+		// Each occurrence carries an occurrence_index and an attrs object
+		// holding the limit attribute from the seeded post content.
+		foreach ($result['occurrences'] as $i => $occurrence) {
+			$this->assertSame($i, $occurrence['occurrence_index']);
+			$this->assertArrayHasKey('attrs', $occurrence);
+			$this->assertSame(5, (int) $occurrence['attrs']['limit']);
+		}
+	}
+
+	/**
+	 * Test that kit/broadcasts-insert appends a new Broadcasts block to the
+	 * post, and returns the new occurrence_index.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testInsertAppendsBroadcastsBlock()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/broadcasts-insert']->execute_callback(
+			array(
+				'post_id'  => $this->postID,
+				'attrs'    => array(
+					'limit'         => 3,
+					'display_image' => true,
+				),
+				'position' => 'append',
+			)
+		);
+
+		$this->assertIsArray($result);
+		$this->assertSame($this->postID, $result['post_id']);
+		$this->assertSame(2, $result['occurrence_index']);
+
+		// Confirm the post now contains three Broadcasts blocks.
+		$listed = $abilities['kit/broadcasts-list']->execute_callback([ 'post_id' => $this->postID ]);
+		$this->assertSame(3, $listed['count']);
+
+		// Confirm the newly inserted block carries the attrs we passed in.
+		$this->assertSame(3, (int) $listed['occurrences'][2]['attrs']['limit']);
+		$this->assertTrue( (bool) $listed['occurrences'][2]['attrs']['display_image']);
+	}
+
+	/**
+	 * Test that kit/broadcasts-update changes the attrs of a specific
+	 * occurrence, leaving other occurrences untouched.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateModifiesSingleOccurrence()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Update the second Broadcasts block (occurrence_index 1) to a different limit.
+		$result = $abilities['kit/broadcasts-update']->execute_callback(
+			array(
+				'post_id'          => $this->postID,
+				'occurrence_index' => 1,
+				'attrs'            => array( 'limit' => 25 ),
+			)
+		);
+
+		$this->assertIsArray($result);
+		$this->assertSame(1, $result['occurrence_index']);
+
+		// Re-list and confirm: occurrence 0 unchanged, occurrence 1 has the new limit.
+		$listed = $abilities['kit/broadcasts-list']->execute_callback([ 'post_id' => $this->postID ]);
+		$this->assertSame(
+			5,
+			(int) $listed['occurrences'][0]['attrs']['limit'],
+			'kit/broadcasts-update must not modify other occurrences.'
+		);
+		$this->assertSame(
+			25,
+			(int) $listed['occurrences'][1]['attrs']['limit'],
+			'kit/broadcasts-update did not apply the new limit to the requested occurrence.'
+		);
+	}
+
+	/**
+	 * Test that kit/broadcasts-delete removes a specific occurrence and the
+	 * post now contains one fewer Broadcasts block.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testDeleteRemovesSingleOccurrence()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/broadcasts-delete']->execute_callback(
+			array(
+				'post_id'          => $this->postID,
+				'occurrence_index' => 0,
+			)
+		);
+
+		$this->assertIsArray($result);
+		$this->assertSame(0, $result['occurrence_index']);
+
+		// Confirm the post now contains a single Broadcasts block.
+		$listed = $abilities['kit/broadcasts-list']->execute_callback([ 'post_id' => $this->postID ]);
+		$this->assertSame(1, $listed['count']);
+	}
+
+	/**
+	 * Test that kit/broadcasts-update returns a WP_Error when asked to update
+	 * an occurrence that does not exist, rather than silently mutating
+	 * something else.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateOnMissingOccurrenceReturnsError()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/broadcasts-update']->execute_callback(
+			array(
+				'post_id'          => $this->postID,
+				'occurrence_index' => 99,
+				'attrs'            => array( 'limit' => 5 ),
+			)
+		);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+	}
+
+	/**
+	 * Creates a Post containing two convertkit/broadcasts blocks interleaved
+	 * with non-Kit blocks, mirroring the fixture used by BlockPostHelperTest.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  int
+	 */
+	private function createPostWithBroadcastsBlocks(): int
+	{
+		return $this->factory->post->create(
+			array(
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_title'   => 'Broadcasts Abilities Fixture',
+				'post_content' => '<!-- wp:paragraph -->
+<p>Intro paragraph.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:convertkit/broadcasts {"limit":5} /-->
+
+<!-- wp:paragraph -->
+<p>Middle paragraph.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:convertkit/broadcasts {"limit":5} /-->
+
+<!-- wp:paragraph -->
+<p>Closing paragraph.</p>
+<!-- /wp:paragraph -->',
+			)
+		);
+	}
+}

--- a/tests/Integration/MCPContentFormTest.php
+++ b/tests/Integration/MCPContentFormTest.php
@@ -1,0 +1,356 @@
+<?php
+
+namespace Tests;
+
+use lucatume\WPBrowser\TestCase\WPTestCase;
+
+/**
+ * Tests for the Kit MCP content abilities bound to the Form block:
+ *
+ * - kit/form-list    (ConvertKit_MCP_Ability_Content_List)
+ * - kit/form-insert  (ConvertKit_MCP_Ability_Content_Insert)
+ * - kit/form-update  (ConvertKit_MCP_Ability_Content_Update)
+ * - kit/form-delete  (ConvertKit_MCP_Ability_Content_Delete)
+ *
+ * @since   3.4.0
+ */
+class MCPContentFormTest extends WPTestCase
+{
+	/**
+	 * The testing implementation.
+	 *
+	 * @var \WpunitTester.
+	 */
+	protected $tester;
+
+	/**
+	 * Holds the Post ID created in setUp(), used by tests that exercise
+	 * list / insert / update / delete against a post containing two Form
+	 * blocks.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     int
+	 */
+	private $postID;
+
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		// Activate Plugin.
+		activate_plugins('convertkit/wp-convertkit.php');
+
+		// Create a Post containing two Form blocks, so list / update /
+		// delete have something to act on.
+		$this->postID = $this->createPostWithFormBlocks();
+	}
+
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function tearDown(): void
+	{
+		// Restore the current user.
+		wp_set_current_user(0);
+
+		// Deactivate Plugin.
+		deactivate_plugins('convertkit/wp-convertkit.php');
+
+		parent::tearDown();
+	}
+
+	/**
+	 * The ability names registered by the Form block.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     string[]
+	 */
+	private const FORM_ABILITY_NAMES = array(
+		'kit/form-list',
+		'kit/form-insert',
+		'kit/form-update',
+		'kit/form-delete',
+	);
+
+	/**
+	 * Test that the Form block registers all four content abilities via the
+	 * convertkit_abilities filter with the expected names.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testAbilitiesRegistered()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// The ability names and classes expected to be registered.
+		$expected = array(
+			'kit/form-list'   => \ConvertKit_MCP_Ability_Content_List::class,
+			'kit/form-insert' => \ConvertKit_MCP_Ability_Content_Insert::class,
+			'kit/form-update' => \ConvertKit_MCP_Ability_Content_Update::class,
+			'kit/form-delete' => \ConvertKit_MCP_Ability_Content_Delete::class,
+		);
+
+		// Assert that the abilities are registered and are instances of the expected classes.
+		foreach ( $expected as $name => $class ) {
+			$this->assertArrayHasKey($name, $abilities);
+			$this->assertInstanceOf($class, $abilities[ $name ]);
+		}
+	}
+
+	/**
+	 * Test that the permission_callback() rejects a user who cannot edit the
+	 * given post.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackDeniesWithoutEditPostCapability()
+	{
+		// Become a Subscriber (no edit_post capability).
+		$subscriber_id = static::factory()->user->create([ 'role' => 'subscriber' ]);
+		wp_set_current_user($subscriber_id);
+
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Assert that the abilities are permission denied.
+		foreach ( self::FORM_ABILITY_NAMES as $name ) {
+			// Execute the ability.
+			$result = $abilities[ $name ]->permission_callback([ 'post_id' => $this->postID ]);
+
+			// Assert that the result is a WP_Error.
+			$this->assertInstanceOf(\WP_Error::class, $result);
+		}
+	}
+
+	/**
+	 * Test that the permission_callback() rejects a request with no post_id,
+	 * with a clear error code.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackDeniesWithoutPostId()
+	{
+		// Become an Administrator (has every capability, so the only thing
+		// that can fail here is the missing post_id check).
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Assert that the abilities are permission denied.
+		foreach ( self::FORM_ABILITY_NAMES as $name ) {
+			// Execute the ability.
+			$result = $abilities[ $name ]->permission_callback([]);
+
+			// Assert that the result is a WP_Error.
+			$this->assertInstanceOf(\WP_Error::class, $result);
+		}
+	}
+
+	/**
+	 * Test that the permission_callback() permits an Administrator on a
+	 * valid post_id.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackPermitsAdministrator()
+	{
+		// Become an Administrator.
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Assert that the abilities are permission granted.
+		foreach ( self::FORM_ABILITY_NAMES as $name ) {
+			// Execute the ability.
+			$this->assertTrue($abilities[ $name ]->permission_callback([ 'post_id' => $this->postID ]));
+		}
+	}
+
+	/**
+	 * Test that kit/form-list returns every Form block occurrence in the
+	 * post, with shape { post_id, count, occurrences: [{occurrence_index, attrs}] }.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testListReturnsAllFormOccurrencesInPost()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/form-list']->execute_callback([ 'post_id' => $this->postID ]);
+
+		$this->assertIsArray($result);
+		$this->assertSame($this->postID, $result['post_id']);
+		$this->assertSame(2, $result['count']);
+		$this->assertCount(2, $result['occurrences']);
+
+		// Each occurrence carries an occurrence_index and an attrs object
+		// holding the form ID from the seeded post content.
+		foreach ($result['occurrences'] as $i => $occurrence) {
+			$this->assertSame($i, $occurrence['occurrence_index']);
+			$this->assertArrayHasKey('attrs', $occurrence);
+			$this->assertSame(
+				(string) $_ENV['CONVERTKIT_API_FORM_ID'],
+				(string) $occurrence['attrs']['form']
+			);
+		}
+	}
+
+	/**
+	 * Test that kit/form-insert appends a new Form block to the post, and
+	 * returns the new occurrence_index.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testInsertAppendsFormBlock()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/form-insert']->execute_callback(array(
+			'post_id'  => $this->postID,
+			'attrs'    => array( 'form' => $_ENV['CONVERTKIT_API_FORM_ID'] ),
+			'position' => 'append',
+		));
+
+		$this->assertIsArray($result);
+		$this->assertSame($this->postID, $result['post_id']);
+		$this->assertSame(2, $result['occurrence_index']);
+
+		// Confirm the post now contains three Form blocks.
+		$listed = $abilities['kit/form-list']->execute_callback([ 'post_id' => $this->postID ]);
+		$this->assertSame(3, $listed['count']);
+	}
+
+	/**
+	 * Test that kit/form-update changes the attrs of a specific occurrence,
+	 * leaving other occurrences untouched.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateModifiesSingleOccurrence()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Update the second Form block (occurrence_index 1) to a different form ID.
+		$new_form_id = (string) ( (int) $_ENV['CONVERTKIT_API_FORM_ID'] + 1 );
+		$result      = $abilities['kit/form-update']->execute_callback(array(
+			'post_id'          => $this->postID,
+			'occurrence_index' => 1,
+			'attrs'            => array( 'form' => $new_form_id ),
+		));
+
+		$this->assertIsArray($result);
+		$this->assertSame(1, $result['occurrence_index']);
+
+		// Re-list and confirm: occurrence 0 unchanged, occurrence 1 has the new form ID.
+		$listed = $abilities['kit/form-list']->execute_callback([ 'post_id' => $this->postID ]);
+		$this->assertSame(
+			(string) $_ENV['CONVERTKIT_API_FORM_ID'],
+			(string) $listed['occurrences'][0]['attrs']['form'],
+			'kit/form-update must not modify other occurrences.'
+		);
+		$this->assertSame(
+			$new_form_id,
+			(string) $listed['occurrences'][1]['attrs']['form'],
+			'kit/form-update did not apply the new form ID to the requested occurrence.'
+		);
+	}
+
+	/**
+	 * Test that kit/form-delete removes a specific occurrence and the post
+	 * now contains one fewer Form block.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testDeleteRemovesSingleOccurrence()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/form-delete']->execute_callback(array(
+			'post_id'          => $this->postID,
+			'occurrence_index' => 0,
+		));
+
+		$this->assertIsArray($result);
+		$this->assertSame(0, $result['occurrence_index']);
+
+		// Confirm the post now contains a single Form block.
+		$listed = $abilities['kit/form-list']->execute_callback([ 'post_id' => $this->postID ]);
+		$this->assertSame(1, $listed['count']);
+	}
+
+	/**
+	 * Test that kit/form-update returns a WP_Error when asked to update an
+	 * occurrence that does not exist, rather than silently mutating
+	 * something else.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateOnMissingOccurrenceReturnsError()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/form-update']->execute_callback(array(
+			'post_id'          => $this->postID,
+			'occurrence_index' => 99,
+			'attrs'            => array( 'form' => $_ENV['CONVERTKIT_API_FORM_ID'] ),
+		));
+
+		// Assert that the result is a WP_Error.
+		$this->assertInstanceOf(\WP_Error::class, $result);
+	}
+
+	/**
+	 * Creates a Post containing two convertkit/form blocks interleaved with
+	 * non-Kit blocks, mirroring the fixture used by BlockPostHelperTest.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  int
+	 */
+	private function createPostWithFormBlocks(): int
+	{
+		return $this->factory->post->create(array(
+			'post_type'    => 'page',
+			'post_status'  => 'publish',
+			'post_title'   => 'Form Abilities Fixture',
+			'post_content' => '<!-- wp:paragraph -->
+<p>Intro paragraph.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:convertkit/form {"form":"' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"} /-->
+
+<!-- wp:paragraph -->
+<p>Middle paragraph.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:convertkit/form {"form":"' . $_ENV['CONVERTKIT_API_FORM_ID'] . '"} /-->
+
+<!-- wp:paragraph -->
+<p>Closing paragraph.</p>
+<!-- /wp:paragraph -->',
+		));
+	}
+}

--- a/tests/Integration/MCPContentFormTest.php
+++ b/tests/Integration/MCPContentFormTest.php
@@ -223,11 +223,13 @@ class MCPContentFormTest extends WPTestCase
 		$abilities = convertkit_get_abilities();
 
 		// Execute the ability.
-		$result = $abilities['kit/form-insert']->execute_callback(array(
-			'post_id'  => $this->postID,
-			'attrs'    => array( 'form' => $_ENV['CONVERTKIT_API_FORM_ID'] ),
-			'position' => 'append',
-		));
+		$result = $abilities['kit/form-insert']->execute_callback(
+			array(
+				'post_id'  => $this->postID,
+				'attrs'    => array( 'form' => $_ENV['CONVERTKIT_API_FORM_ID'] ),
+				'position' => 'append',
+			)
+		);
 
 		$this->assertIsArray($result);
 		$this->assertSame($this->postID, $result['post_id']);
@@ -251,11 +253,13 @@ class MCPContentFormTest extends WPTestCase
 
 		// Update the second Form block (occurrence_index 1) to a different form ID.
 		$new_form_id = (string) ( (int) $_ENV['CONVERTKIT_API_FORM_ID'] + 1 );
-		$result      = $abilities['kit/form-update']->execute_callback(array(
-			'post_id'          => $this->postID,
-			'occurrence_index' => 1,
-			'attrs'            => array( 'form' => $new_form_id ),
-		));
+		$result      = $abilities['kit/form-update']->execute_callback(
+			array(
+				'post_id'          => $this->postID,
+				'occurrence_index' => 1,
+				'attrs'            => array( 'form' => $new_form_id ),
+			)
+		);
 
 		$this->assertIsArray($result);
 		$this->assertSame(1, $result['occurrence_index']);
@@ -286,10 +290,12 @@ class MCPContentFormTest extends WPTestCase
 		$abilities = convertkit_get_abilities();
 
 		// Execute the ability.
-		$result = $abilities['kit/form-delete']->execute_callback(array(
-			'post_id'          => $this->postID,
-			'occurrence_index' => 0,
-		));
+		$result = $abilities['kit/form-delete']->execute_callback(
+			array(
+				'post_id'          => $this->postID,
+				'occurrence_index' => 0,
+			)
+		);
 
 		$this->assertIsArray($result);
 		$this->assertSame(0, $result['occurrence_index']);
@@ -312,11 +318,13 @@ class MCPContentFormTest extends WPTestCase
 		$abilities = convertkit_get_abilities();
 
 		// Execute the ability.
-		$result = $abilities['kit/form-update']->execute_callback(array(
-			'post_id'          => $this->postID,
-			'occurrence_index' => 99,
-			'attrs'            => array( 'form' => $_ENV['CONVERTKIT_API_FORM_ID'] ),
-		));
+		$result = $abilities['kit/form-update']->execute_callback(
+			array(
+				'post_id'          => $this->postID,
+				'occurrence_index' => 99,
+				'attrs'            => array( 'form' => $_ENV['CONVERTKIT_API_FORM_ID'] ),
+			)
+		);
 
 		// Assert that the result is a WP_Error.
 		$this->assertInstanceOf(\WP_Error::class, $result);
@@ -332,11 +340,12 @@ class MCPContentFormTest extends WPTestCase
 	 */
 	private function createPostWithFormBlocks(): int
 	{
-		return $this->factory->post->create(array(
-			'post_type'    => 'page',
-			'post_status'  => 'publish',
-			'post_title'   => 'Form Abilities Fixture',
-			'post_content' => '<!-- wp:paragraph -->
+		return $this->factory->post->create(
+			array(
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_title'   => 'Form Abilities Fixture',
+				'post_content' => '<!-- wp:paragraph -->
 <p>Intro paragraph.</p>
 <!-- /wp:paragraph -->
 
@@ -351,6 +360,7 @@ class MCPContentFormTest extends WPTestCase
 <!-- wp:paragraph -->
 <p>Closing paragraph.</p>
 <!-- /wp:paragraph -->',
-		));
+			)
+		);
 	}
 }

--- a/tests/Integration/MCPContentFormTriggerTest.php
+++ b/tests/Integration/MCPContentFormTriggerTest.php
@@ -1,0 +1,366 @@
+<?php
+
+namespace Tests;
+
+use lucatume\WPBrowser\TestCase\WPTestCase;
+
+/**
+ * Tests for the Kit MCP content abilities bound to the Form Trigger block:
+ *
+ * - kit/formtrigger-list    (ConvertKit_MCP_Ability_Content_List)
+ * - kit/formtrigger-insert  (ConvertKit_MCP_Ability_Content_Insert)
+ * - kit/formtrigger-update  (ConvertKit_MCP_Ability_Content_Update)
+ * - kit/formtrigger-delete  (ConvertKit_MCP_Ability_Content_Delete)
+ *
+ * @since   3.4.0
+ */
+class MCPContentFormTriggerTest extends WPTestCase
+{
+	/**
+	 * The testing implementation.
+	 *
+	 * @var \WpunitTester.
+	 */
+	protected $tester;
+
+	/**
+	 * Holds the Post ID created in setUp(), used by tests that exercise
+	 * list / insert / update / delete against a post containing two Form
+	 * blocks.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     int
+	 */
+	private $postID;
+
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		// Activate Plugin.
+		activate_plugins('convertkit/wp-convertkit.php');
+
+		// Create a Post containing two Form Trigger blocks, so list / update /
+		// delete have something to act on.
+		$this->postID = $this->createPostWithFormTriggerBlocks();
+	}
+
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function tearDown(): void
+	{
+		// Restore the current user.
+		wp_set_current_user(0);
+
+		// Deactivate Plugin.
+		deactivate_plugins('convertkit/wp-convertkit.php');
+
+		parent::tearDown();
+	}
+
+	/**
+	 * The ability names registered by the Form Trigger block.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     string[]
+	 */
+	private const FORM_TRIGGER_ABILITY_NAMES = array(
+		'kit/formtrigger-list',
+		'kit/formtrigger-insert',
+		'kit/formtrigger-update',
+		'kit/formtrigger-delete',
+	);
+
+	/**
+	 * Test that the Form Trigger block registers all four content abilities via the
+	 * convertkit_abilities filter with the expected names.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testAbilitiesRegistered()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// The ability names and classes expected to be registered.
+		$expected = array(
+			'kit/formtrigger-list'   => \ConvertKit_MCP_Ability_Content_List::class,
+			'kit/formtrigger-insert' => \ConvertKit_MCP_Ability_Content_Insert::class,
+			'kit/formtrigger-update' => \ConvertKit_MCP_Ability_Content_Update::class,
+			'kit/formtrigger-delete' => \ConvertKit_MCP_Ability_Content_Delete::class,
+		);
+
+		// Assert that the abilities are registered and are instances of the expected classes.
+		foreach ( $expected as $name => $class ) {
+			$this->assertArrayHasKey($name, $abilities);
+			$this->assertInstanceOf($class, $abilities[ $name ]);
+		}
+	}
+
+	/**
+	 * Test that the permission_callback() rejects a user who cannot edit the
+	 * given post.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackDeniesWithoutEditPostCapability()
+	{
+		// Become a Subscriber (no edit_post capability).
+		$subscriber_id = static::factory()->user->create([ 'role' => 'subscriber' ]);
+		wp_set_current_user($subscriber_id);
+
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Assert that the abilities are permission denied.
+		foreach ( self::FORM_TRIGGER_ABILITY_NAMES as $name ) {
+			// Execute the ability.
+			$result = $abilities[ $name ]->permission_callback([ 'post_id' => $this->postID ]);
+
+			// Assert that the result is a WP_Error.
+			$this->assertInstanceOf(\WP_Error::class, $result);
+		}
+	}
+
+	/**
+	 * Test that the permission_callback() rejects a request with no post_id,
+	 * with a clear error code.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackDeniesWithoutPostId()
+	{
+		// Become an Administrator (has every capability, so the only thing
+		// that can fail here is the missing post_id check).
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Assert that the abilities are permission denied.
+		foreach ( self::FORM_TRIGGER_ABILITY_NAMES as $name ) {
+			// Execute the ability.
+			$result = $abilities[ $name ]->permission_callback([]);
+
+			// Assert that the result is a WP_Error.
+			$this->assertInstanceOf(\WP_Error::class, $result);
+		}
+	}
+
+	/**
+	 * Test that the permission_callback() permits an Administrator on a
+	 * valid post_id.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackPermitsAdministrator()
+	{
+		// Become an Administrator.
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Assert that the abilities are permission granted.
+		foreach ( self::FORM_TRIGGER_ABILITY_NAMES as $name ) {
+			// Execute the ability.
+			$this->assertTrue($abilities[ $name ]->permission_callback([ 'post_id' => $this->postID ]));
+		}
+	}
+
+	/**
+	 * Test that kit/formtrigger-list returns every Form Trigger block occurrence in the
+	 * post, with shape { post_id, count, occurrences: [{occurrence_index, attrs}] }.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testListReturnsAllFormTriggerOccurrencesInPost()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/formtrigger-list']->execute_callback([ 'post_id' => $this->postID ]);
+
+		$this->assertIsArray($result);
+		$this->assertSame($this->postID, $result['post_id']);
+		$this->assertSame(2, $result['count']);
+		$this->assertCount(2, $result['occurrences']);
+
+		// Each occurrence carries an occurrence_index and an attrs object
+		// holding the form ID from the seeded post content.
+		foreach ($result['occurrences'] as $i => $occurrence) {
+			$this->assertSame($i, $occurrence['occurrence_index']);
+			$this->assertArrayHasKey('attrs', $occurrence);
+			$this->assertSame(
+				(string) $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'],
+				(string) $occurrence['attrs']['form']
+			);
+		}
+	}
+
+	/**
+	 * Test that kit/formtrigger-insert appends a new Form Trigger block to the post, and
+	 * returns the new occurrence_index.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testInsertAppendsFormTriggerBlock()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/formtrigger-insert']->execute_callback(
+			array(
+				'post_id'  => $this->postID,
+				'attrs'    => array( 'form' => $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] ),
+				'position' => 'append',
+			)
+		);
+
+		$this->assertIsArray($result);
+		$this->assertSame($this->postID, $result['post_id']);
+		$this->assertSame(2, $result['occurrence_index']);
+
+		// Confirm the post now contains three Form Trigger blocks.
+		$listed = $abilities['kit/formtrigger-list']->execute_callback([ 'post_id' => $this->postID ]);
+		$this->assertSame(3, $listed['count']);
+	}
+
+	/**
+	 * Test that kit/formtrigger-update changes the attrs of a specific occurrence,
+	 * leaving other occurrences untouched.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateModifiesSingleOccurrence()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Update the second Form Trigger block (occurrence_index 1) to a different form ID.
+		$new_form_id = (string) ( (int) $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] + 1 );
+		$result      = $abilities['kit/formtrigger-update']->execute_callback(
+			array(
+				'post_id'          => $this->postID,
+				'occurrence_index' => 1,
+				'attrs'            => array( 'form' => $new_form_id ),
+			)
+		);
+
+		$this->assertIsArray($result);
+		$this->assertSame(1, $result['occurrence_index']);
+
+		// Re-list and confirm: occurrence 0 unchanged, occurrence 1 has the new form ID.
+		$listed = $abilities['kit/formtrigger-list']->execute_callback([ 'post_id' => $this->postID ]);
+		$this->assertSame(
+			(string) $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'],
+			(string) $listed['occurrences'][0]['attrs']['form'],
+			'kit/formtrigger-update must not modify other occurrences.'
+		);
+		$this->assertSame(
+			$new_form_id,
+			(string) $listed['occurrences'][1]['attrs']['form'],
+			'kit/formtrigger-update did not apply the new form ID to the requested occurrence.'
+		);
+	}
+
+	/**
+	 * Test that kit/formtrigger-delete removes a specific occurrence and the post
+	 * now contains one fewer Form Trigger block.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testDeleteRemovesSingleOccurrence()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/formtrigger-delete']->execute_callback(
+			array(
+				'post_id'          => $this->postID,
+				'occurrence_index' => 0,
+			)
+		);
+
+		$this->assertIsArray($result);
+		$this->assertSame(0, $result['occurrence_index']);
+
+		// Confirm the post now contains a single Form Trigger block.
+		$listed = $abilities['kit/formtrigger-list']->execute_callback([ 'post_id' => $this->postID ]);
+		$this->assertSame(1, $listed['count']);
+	}
+
+	/**
+	 * Test that kit/formtrigger-update returns a WP_Error when asked to update an
+	 * occurrence that does not exist, rather than silently mutating
+	 * something else.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateOnMissingOccurrenceReturnsError()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/formtrigger-update']->execute_callback(
+			array(
+				'post_id'          => $this->postID,
+				'occurrence_index' => 99,
+				'attrs'            => array( 'form' => $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] ),
+			)
+		);
+
+		// Assert that the result is a WP_Error.
+		$this->assertInstanceOf(\WP_Error::class, $result);
+	}
+
+	/**
+	 * Creates a Post containing two convertkit/formtrigger blocks interleaved with
+	 * non-Kit blocks, mirroring the fixture used by BlockPostHelperTest.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  int
+	 */
+	private function createPostWithFormTriggerBlocks(): int
+	{
+		return $this->factory->post->create(
+			array(
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_title'   => 'Form Trigger Abilities Fixture',
+				'post_content' => '<!-- wp:paragraph -->
+<p>Intro paragraph.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:convertkit/formtrigger {"form":"' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '"} /-->
+
+<!-- wp:paragraph -->
+<p>Middle paragraph.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:convertkit/formtrigger {"form":"' . $_ENV['CONVERTKIT_API_FORM_FORMAT_MODAL_ID'] . '"} /-->
+
+<!-- wp:paragraph -->
+<p>Closing paragraph.</p>
+<!-- /wp:paragraph -->',
+			)
+		);
+	}
+}

--- a/tests/Integration/MCPContentProductTest.php
+++ b/tests/Integration/MCPContentProductTest.php
@@ -1,0 +1,394 @@
+<?php
+
+namespace Tests;
+
+use lucatume\WPBrowser\TestCase\WPTestCase;
+
+/**
+ * Tests for the Kit MCP content abilities bound to the Product block:
+ *
+ * - kit/product-list    (ConvertKit_MCP_Ability_Content_List)
+ * - kit/product-insert  (ConvertKit_MCP_Ability_Content_Insert)
+ * - kit/product-update  (ConvertKit_MCP_Ability_Content_Update)
+ * - kit/product-delete  (ConvertKit_MCP_Ability_Content_Delete)
+ *
+ * @since   3.4.0
+ */
+class MCPContentProductTest extends WPTestCase
+{
+	/**
+	 * The testing implementation.
+	 *
+	 * @var \WpunitTester.
+	 */
+	protected $tester;
+
+	/**
+	 * Holds the Post ID created in setUp(), used by tests that exercise
+	 * list / update / delete against a post containing two Product blocks.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     int
+	 */
+	private $postID;
+
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		// Activate Plugin.
+		activate_plugins('convertkit/wp-convertkit.php');
+
+		// Create a Post containing two Product blocks, so list / update /
+		// delete have something to act on.
+		$this->postID = $this->createPostWithProductBlocks();
+	}
+
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function tearDown(): void
+	{
+		// Restore the current user.
+		wp_set_current_user(0);
+
+		// Deactivate Plugin.
+		deactivate_plugins('convertkit/wp-convertkit.php');
+
+		parent::tearDown();
+	}
+
+	/**
+	 * The ability names registered by the Product block.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     string[]
+	 */
+	private const PRODUCT_ABILITY_NAMES = array(
+		'kit/product-list',
+		'kit/product-insert',
+		'kit/product-update',
+		'kit/product-delete',
+	);
+
+	/**
+	 * Test that the Product block registers all four content abilities via
+	 * the convertkit_abilities filter with the expected names.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testAbilitiesRegistered()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// The ability names and classes expected to be registered.
+		$expected = array(
+			'kit/product-list'   => \ConvertKit_MCP_Ability_Content_List::class,
+			'kit/product-insert' => \ConvertKit_MCP_Ability_Content_Insert::class,
+			'kit/product-update' => \ConvertKit_MCP_Ability_Content_Update::class,
+			'kit/product-delete' => \ConvertKit_MCP_Ability_Content_Delete::class,
+		);
+
+		// Assert that the abilities are registered and are instances of the expected classes.
+		foreach ( $expected as $name => $class ) {
+			$this->assertArrayHasKey($name, $abilities);
+			$this->assertInstanceOf($class, $abilities[ $name ]);
+		}
+	}
+
+	/**
+	 * Test that the permission_callback() rejects a user who cannot edit the
+	 * given post.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackDeniesWithoutEditPostCapability()
+	{
+		// Become a Subscriber (no edit_post capability).
+		$subscriber_id = static::factory()->user->create([ 'role' => 'subscriber' ]);
+		wp_set_current_user($subscriber_id);
+
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Assert that the abilities are permission denied.
+		foreach ( self::PRODUCT_ABILITY_NAMES as $name ) {
+			// Execute the ability.
+			$result = $abilities[ $name ]->permission_callback([ 'post_id' => $this->postID ]);
+
+			// Assert that the result is a WP_Error.
+			$this->assertInstanceOf(\WP_Error::class, $result);
+		}
+	}
+
+	/**
+	 * Test that the permission_callback() rejects a request with no post_id,
+	 * with a clear error code.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackDeniesWithoutPostId()
+	{
+		// Become an Administrator (has every capability, so the only thing
+		// that can fail here is the missing post_id check).
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Assert that the abilities are permission denied.
+		foreach ( self::PRODUCT_ABILITY_NAMES as $name ) {
+			// Execute the ability.
+			$result = $abilities[ $name ]->permission_callback([]);
+
+			// Assert that the result is a WP_Error.
+			$this->assertInstanceOf(\WP_Error::class, $result);
+		}
+	}
+
+	/**
+	 * Test that the permission_callback() permits an Administrator on a
+	 * valid post_id.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackPermitsAdministrator()
+	{
+		// Become an Administrator.
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Assert that the abilities are permission granted.
+		foreach ( self::PRODUCT_ABILITY_NAMES as $name ) {
+			// Execute the ability.
+			$this->assertTrue($abilities[ $name ]->permission_callback([ 'post_id' => $this->postID ]));
+		}
+	}
+
+	/**
+	 * Test that kit/product-list returns every Product block occurrence in
+	 * the post.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testListReturnsAllProductOccurrencesInPost()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/product-list']->execute_callback([ 'post_id' => $this->postID ]);
+
+		$this->assertIsArray($result);
+		$this->assertSame($this->postID, $result['post_id']);
+		$this->assertSame(2, $result['count']);
+		$this->assertCount(2, $result['occurrences']);
+
+		// Each occurrence carries an occurrence_index and an attrs object
+		// holding the product ID from the seeded post content.
+		foreach ($result['occurrences'] as $i => $occurrence) {
+			$this->assertSame($i, $occurrence['occurrence_index']);
+			$this->assertArrayHasKey('attrs', $occurrence);
+			$this->assertSame(
+				(string) $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+				(string) $occurrence['attrs']['product']
+			);
+		}
+	}
+
+	/**
+	 * Test that kit/product-insert appends a new Product block to the post,
+	 * and returns the new occurrence_index. Exercises all four primary
+	 * Product attributes so each round-trips through the block helper.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testInsertAppendsProductBlock()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/product-insert']->execute_callback(
+			array(
+				'post_id'  => $this->postID,
+				'attrs'    => array(
+					'product'       => $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+					'text'          => 'Buy this product',
+					'discount_code' => $_ENV['CONVERTKIT_API_PRODUCT_DISCOUNT_CODE'],
+					'checkout'      => true,
+				),
+				'position' => 'append',
+			)
+		);
+
+		$this->assertIsArray($result);
+		$this->assertSame($this->postID, $result['post_id']);
+		// Two Product blocks existed in setUp(); the newly inserted one is the third.
+		$this->assertSame(2, $result['occurrence_index']);
+
+		// Confirm the post now contains three Product blocks.
+		$listed = $abilities['kit/product-list']->execute_callback([ 'post_id' => $this->postID ]);
+		$this->assertSame(3, $listed['count']);
+
+		// Confirm the newly inserted block carries the attrs we passed in.
+		$this->assertSame(
+			(string) $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+			(string) $listed['occurrences'][2]['attrs']['product']
+		);
+		$this->assertSame('Buy this product', $listed['occurrences'][2]['attrs']['text']);
+		$this->assertSame(
+			(string) $_ENV['CONVERTKIT_API_PRODUCT_DISCOUNT_CODE'],
+			(string) $listed['occurrences'][2]['attrs']['discount_code']
+		);
+		$this->assertTrue( (bool) $listed['occurrences'][2]['attrs']['checkout']);
+	}
+
+	/**
+	 * Test that kit/product-update changes the attrs of a specific
+	 * occurrence, leaving other occurrences untouched.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateModifiesSingleOccurrence()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Update the second Product block (occurrence_index 1) to a different
+		// product ID and text.
+		$new_product_id = (string) ( (int) $_ENV['CONVERTKIT_API_PRODUCT_ID'] + 1 );
+		$result         = $abilities['kit/product-update']->execute_callback(
+			array(
+				'post_id'          => $this->postID,
+				'occurrence_index' => 1,
+				'attrs'            => array(
+					'product' => $new_product_id,
+					'text'    => 'Updated CTA',
+				),
+			)
+		);
+
+		$this->assertIsArray($result);
+		$this->assertSame(1, $result['occurrence_index']);
+
+		// Re-list and confirm: occurrence 0 unchanged, occurrence 1 has the
+		// new product ID and text.
+		$listed = $abilities['kit/product-list']->execute_callback([ 'post_id' => $this->postID ]);
+		$this->assertSame(
+			(string) $_ENV['CONVERTKIT_API_PRODUCT_ID'],
+			(string) $listed['occurrences'][0]['attrs']['product'],
+			'kit/product-update must not modify other occurrences.'
+		);
+		$this->assertSame(
+			$new_product_id,
+			(string) $listed['occurrences'][1]['attrs']['product'],
+			'kit/product-update did not apply the new product ID to the requested occurrence.'
+		);
+		$this->assertSame(
+			'Updated CTA',
+			$listed['occurrences'][1]['attrs']['text'],
+			'kit/product-update did not apply the new text to the requested occurrence.'
+		);
+	}
+
+	/**
+	 * Test that kit/product-delete removes a specific occurrence and the
+	 * post now contains one fewer Product block.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testDeleteRemovesSingleOccurrence()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/product-delete']->execute_callback(
+			array(
+				'post_id'          => $this->postID,
+				'occurrence_index' => 0,
+			)
+		);
+
+		$this->assertIsArray($result);
+		$this->assertSame(0, $result['occurrence_index']);
+
+		// Confirm the post now contains a single Product block.
+		$listed = $abilities['kit/product-list']->execute_callback([ 'post_id' => $this->postID ]);
+		$this->assertSame(1, $listed['count']);
+	}
+
+	/**
+	 * Test that kit/product-update returns a WP_Error when asked to update
+	 * an occurrence that does not exist, rather than silently mutating
+	 * something else.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateOnMissingOccurrenceReturnsError()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/product-update']->execute_callback(
+			array(
+				'post_id'          => $this->postID,
+				'occurrence_index' => 99,
+				'attrs'            => array( 'product' => $_ENV['CONVERTKIT_API_PRODUCT_ID'] ),
+			)
+		);
+
+		// Assert that the result is a WP_Error.
+		$this->assertInstanceOf(\WP_Error::class, $result);
+	}
+
+	/**
+	 * Creates a Post containing two convertkit/product blocks interleaved
+	 * with non-Kit blocks, mirroring the fixture used by BlockPostHelperTest.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  int
+	 */
+	private function createPostWithProductBlocks(): int
+	{
+		return $this->factory->post->create(
+			array(
+				'post_type'    => 'page',
+				'post_status'  => 'publish',
+				'post_title'   => 'Product Abilities Fixture',
+				'post_content' => '<!-- wp:paragraph -->
+<p>Intro paragraph.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:convertkit/product {"product":"' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '"} /-->
+
+<!-- wp:paragraph -->
+<p>Middle paragraph.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:convertkit/product {"product":"' . $_ENV['CONVERTKIT_API_PRODUCT_ID'] . '"} /-->
+
+<!-- wp:paragraph -->
+<p>Closing paragraph.</p>
+<!-- /wp:paragraph -->',
+			)
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Registers four abilities (MCP tools) for the Form block/shortcode, so an MCP client can list, insert, update and delete Kit Forms inside a post's content.

<img width="603" height="343" alt="Screenshot 2026-05-27 at 22 53 02" src="https://github.com/user-attachments/assets/baef0aab-65a7-4a8b-b550-78a4ec8ab9b0" />

Ability | Description | Required input | Output
-- | -- | -- | --
kit/form-list | Lists every Kit Form block in the given post, with each occurrence's index and form ID. | post_id | { post_id, count, occurrences: [{ occurrence_index, attrs }] }
kit/form-insert | Inserts a new Kit Form block. Position: append (default), prepend, or index with numeric index. | post_id, attrs.form | { post_id, occurrence_index }
kit/form-update | Updates the attrs of a specific Form block by occurrence index. | post_id, occurrence_index, attrs.form | { post_id, occurrence_index }
kit/form-delete | Removes a specific Form block by occurrence index. | post_id, occurrence_index | { post_id, occurrence_index }

Improves the descriptions of the tools.

## Testing

- `MCPContentFormTest`: Tests that MCP tools are registered, permissions are honored, insert/update/delete tools work.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)