### PR TITLE
Settings: Fix `input` and `select` alignments

### DIFF
--- a/resources/backend/css/settings.css
+++ b/resources/backend/css/settings.css
@@ -116,6 +116,11 @@ body.settings_page__wp_convertkit_settings .wrap .postbox p {
 	font-size: 14px;
 }
 
+body.settings_page__wp_convertkit_settings .wrap .postbox input,
+body.settings_page__wp_convertkit_settings .wrap .postbox select {
+	vertical-align: middle;
+}
+
 body.settings_page__wp_convertkit_settings p.submit {
 	margin-bottom: 20px;
 	padding: 0;


### PR DESCRIPTION
## Summary

Fixes alignment of the `input` and `select` fields on the Settings screen.

WordPress 7.0, Before:
<img width="607" height="187" alt="Screenshot 2026-06-17 at 17 25 22" src="https://github.com/user-attachments/assets/d6c41d2a-681e-451a-a76b-7c432369e41c" />

WordPress 7.0, After:
<img width="626" height="188" alt="Screenshot 2026-06-17 at 17 23 05" src="https://github.com/user-attachments/assets/fe65ebbe-858a-425d-a62d-26280613aeab" />


WordPress 6.2.8, Before:
<img width="604" height="162" alt="Screenshot 2026-06-17 at 17 25 25" src="https://github.com/user-attachments/assets/490b538a-c0e2-420f-8304-56c4967cac88" />

WordPress 6.2.8, After:
<img width="643" height="177" alt="Screenshot 2026-06-17 at 17 23 23" src="https://github.com/user-attachments/assets/be98ad19-9155-4471-b029-b2fd2a513081" />


## Testing

Existing tests pass. Manual checks performed across the settings screen to confirm no breaking changes.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)