### PR TITLE
Block Editor: Improve settings sidebar descriptions

### DIFF
--- a/includes/plugin-sidebars/class-convertkit-plugin-sidebar-post-settings.php
+++ b/includes/plugin-sidebars/class-convertkit-plugin-sidebar-post-settings.php
@@ -197,9 +197,25 @@ class ConvertKit_Plugin_Sidebar_Post_Settings extends ConvertKit_Plugin_Sidebar 
 				'label'         => __( 'Form', 'convertkit' ),
 				'type'          => 'select',
 				'description'   => array(
-					__( 'Default', 'convertkit' ) . ': ' . __( 'Uses the form specified on the settings page.', 'convertkit' ),
-					__( 'None', 'convertkit' ) . ': ' . __( 'do not display a form.', 'convertkit' ),
+					sprintf(
+						'<code>%s</code>: %s <a href="%s" target="_blank">%s</a>',
+						esc_html__( 'Default', 'convertkit' ),
+						esc_html__( 'Uses the form specified on the', 'convertkit' ),
+						esc_url( convertkit_get_settings_link() ),
+						esc_html__( 'settings page', 'convertkit' )
+					),
+					sprintf(
+						'<code>%s</code>: %s',
+						esc_html__( 'None', 'convertkit' ),
+						esc_html__( 'do not display a form.', 'convertkit' )
+					),
 					__( 'Any other option will display that form after the main content.', 'convertkit' ),
+					sprintf(
+						'%s <a href="%s" target="_blank">%s</a>',
+						esc_html__( 'To make changes to your forms,', 'convertkit' ),
+						esc_url( convertkit_get_sign_in_url() ),
+						esc_html__( 'sign in to Kit', 'convertkit' )
+					),
 				),
 				'values'        => $forms,
 				'resource_type' => 'forms',
@@ -207,7 +223,14 @@ class ConvertKit_Plugin_Sidebar_Post_Settings extends ConvertKit_Plugin_Sidebar 
 			'landing_page'     => array(
 				'label'         => __( 'Landing Page', 'convertkit' ),
 				'type'          => 'select',
-				'description'   => __( 'Select a landing page to make it appear in place of this page.', 'convertkit' ),
+				'description'   => array(
+					esc_html__( 'Select a landing page to make it appear in place of this page.', 'convertkit' ),
+					sprintf(
+						/* translators: Link to sign in to ConvertKit */
+						esc_html__( 'To make changes to your landing pages, %s', 'convertkit' ),
+						'<a href="' . esc_url( convertkit_get_sign_in_url() ) . '" target="_blank">' . esc_html__( 'sign in to Kit', 'convertkit' ) . '</a>'
+					),
+				),
 				'values'        => $landing_pages,
 				'post_type'     => 'page',
 				'resource_type' => 'landing_pages',
@@ -215,14 +238,34 @@ class ConvertKit_Plugin_Sidebar_Post_Settings extends ConvertKit_Plugin_Sidebar 
 			'tag'              => array(
 				'label'         => __( 'Tag', 'convertkit' ),
 				'type'          => 'select',
-				'description'   => __( 'Select a tag to apply to visitors of this page who are subscribed. A visitor is deemed to be subscribed if they have clicked a link in an email to this site which includes their subscriber ID, or have entered their email address in a Kit Form on this site.', 'convertkit' ),
+				'description'   => array(
+					esc_html__( 'Select a tag to apply to visitors of this page who are subscribed.', 'convertkit' ),
+					esc_html__( 'A visitor is deemed to be subscribed if they have clicked a link in an email to this site which includes their subscriber ID, or have entered their email address in a Kit Form on this site.', 'convertkit' ),
+				),
 				'values'        => $tags,
 				'resource_type' => 'tags',
 			),
 			'restrict_content' => array(
 				'label'         => __( 'Restrict Content', 'convertkit' ),
 				'type'          => 'select',
-				'description'   => __( 'Select the Kit form, tag or product that the visitor must be subscribed to, permitting them access to view this member-only content.', 'convertkit' ),
+				'description'   => array(
+					esc_html__( 'Select the Kit form, tag or product that the visitor must be subscribed to, permitting them access to view this member-only content.', 'convertkit' ),
+					sprintf(
+						'<code>%s</code>: %s',
+						esc_html__( 'Form', 'convertkit' ),
+						esc_html__( 'Displays the Kit form. On submission, the email address will be subscribed to the selected form, granting access to the member-only content. Useful to gate free content in return for an email address.', 'convertkit' )
+					),
+					sprintf(
+						'<code>%s</code>: %s',
+						esc_html__( 'Tag', 'convertkit' ),
+						esc_html__( 'Displays a WordPress styled subscription form. On submission, the email address will be subscribed to the selected tag, granting access to the member-only content. Useful to gate free content in return for an email address.', 'convertkit' )
+					),
+					sprintf(
+						'<code>%s</code>: %s',
+						esc_html__( 'Product', 'convertkit' ),
+						esc_html__( 'Displays a link to the Kit product, and a login form. Useful to gate content that can only be accessed by purchasing the Kit product.', 'convertkit' )
+					),
+				),
 				'values'        => $restrict_content,
 				'resource_type' => 'restrict_content',
 			),

--- a/resources/backend/css/wp-list-table-buttons.css
+++ b/resources/backend/css/wp-list-table-buttons.css
@@ -1,10 +1,12 @@
 .wrap .page-title-action.convertkit-action {
+	display: inline-block;
 	width: 127px;
 	background: url(../images/logomark.svg);
 	background-repeat: no-repeat;
 	background-size: 16px 16px;
 	background-position: 8px 50%;
 	padding-left: 30px;
+	box-sizing: border-box;
 }
 
 .wrap .page-title-action.convertkit-action::after {
@@ -19,7 +21,6 @@
 	display: none;
 	opacity: 0;
 	position: absolute;
-	margin: 0;
 	padding: 10px;
 	left: -1px;
 	z-index: 99999;

--- a/resources/backend/css/wp-list-table-buttons.css
+++ b/resources/backend/css/wp-list-table-buttons.css
@@ -1,5 +1,5 @@
 .wrap .page-title-action.convertkit-action {
-	width: 124px;
+	width: 127px;
 	background: url(../images/logomark.svg);
 	background-repeat: no-repeat;
 	background-size: 16px 16px;
@@ -14,7 +14,7 @@
 	padding: 5px 0 0 0;
 }
 
-.wrap .page-title-action.convertkit-action span {
+.wrap .page-title-action.convertkit-action span.convertkit-actions {
 	visibility: hidden;
 	display: none;
 	opacity: 0;
@@ -22,20 +22,33 @@
 	margin: 0;
 	padding: 10px;
 	left: -1px;
+	z-index: 99999;
 	background-color: #f0f0f1;
 	border-left: 1px solid #0a4b78;
 	border-right: 1px solid #0a4b78;
 	border-bottom: 1px solid #0a4b78;
 }
 
-.wrap .page-title-action.convertkit-action span a {
+.wrap .page-title-action.convertkit-action span.convertkit-actions a {
 	display: block;
 	text-decoration: none;
 }
 
-.wrap .page-title-action.convertkit-action:hover > span,
-.wrap .page-title-action.convertkit-action span:hover {
+.wrap .page-title-action.convertkit-action:hover > span.convertkit-actions,
+.wrap .page-title-action.convertkit-action span.convertkit-actions:hover {
 	visibility: visible;
 	opacity: 1;
 	display: block;
 }
+
+@media screen and (max-width: 782px) {
+
+	.wrap .page-title-action.convertkit-action {
+		width: 134px;
+	}
+
+	.wrap .page-title-action.convertkit-action::after {
+		padding-top: 10px;
+	}
+}
+

--- a/resources/backend/js/gutenberg.js
+++ b/resources/backend/js/gutenberg.js
@@ -1011,14 +1011,35 @@ function convertKitGutenbergRegisterPluginSidebar(sidebar) {
 					values: fieldValues[key] || field.values,
 				});
 
+				// Build the help element. Supports HTML in the description by
+				// rendering each line as a paragraph via element.RawHTML, which
+				// allows inline tags like <code> and <a> to render correctly.
+				let helpElement;
+				if (Array.isArray(field.description)) {
+					helpElement = el(
+						'span',
+						{},
+						field.description.map(function (line, index) {
+							return el(
+								'p',
+								{
+									key: 'help-' + index,
+									style: { margin: '0 0 0.5em 0' },
+								},
+								el(element.RawHTML, {}, line)
+							);
+						})
+					);
+				} else if (field.description) {
+					helpElement = el(element.RawHTML, {}, field.description);
+				}
+
 				// Define some field properties shared across all field types.
 				const fieldProperties = {
 					key: 'convertkit_plugin_sidebar_' + key,
 					id: 'convertkit_plugin_sidebar_' + key,
 					label: field.label,
-					help: Array.isArray(field.description)
-						? field.description.join('\n\n')
-						: field.description,
+					help: helpElement,
 					value: settings[key] || field.default_value || '',
 
 					// Add __next40pxDefaultSize and __nextHasNoMarginBottom properties,


### PR DESCRIPTION
## Summary

Improves the descriptions on settings field in a Post/Page/CPT when using the block editor, to match the Classic Editor experience.

Before:
<img width="277" height="770" alt="Screenshot 2026-06-17 at 21 59 43" src="https://github.com/user-attachments/assets/c26b8aef-a592-43e8-98ff-6a0fe450e6bd" />

After:
<img width="294" height="1171" alt="Screenshot 2026-06-17 at 21 57 44" src="https://github.com/user-attachments/assets/3486fc79-8e59-418a-aab6-be7660c07b83" />

Classic Editor, for reference:
<img width="1228" height="692" alt="Screenshot 2026-06-17 at 21 52 18" src="https://github.com/user-attachments/assets/956786f9-1dc0-40da-b0fc-51af546a60c9" />

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)