### PR TITLE
Block Editor: Fix refresh button alignment

### DIFF
--- a/resources/backend/css/gutenberg.css
+++ b/resources/backend/css/gutenberg.css
@@ -6,7 +6,7 @@
 }
 
 .components-flex-item button.wp-convertkit-refresh-resources span.dashicons {
-	vertical-align: sub;
+	vertical-align: middle;
 }
 
 /* Block editor */


### PR DESCRIPTION
## Summary

Fixes the refresh button icon's alignment within the button when used in the block editor, both within the plugin settings sidebar any any Kit registered blocks, such as the Form block.

Before:
<img width="277" height="313" alt="Screenshot 2026-06-17 at 22 15 38" src="https://github.com/user-attachments/assets/f818ab99-c31f-4789-b572-41fbfeee62df" />
<img width="271" height="224" alt="Screenshot 2026-06-17 at 22 13 47" src="https://github.com/user-attachments/assets/cb28a28f-d38c-482e-ab5f-99733cc9616a" />

After:
<img width="275" height="299" alt="Screenshot 2026-06-17 at 22 15 45" src="https://github.com/user-attachments/assets/95ab3409-e05c-4831-a40f-fc510f32ba94" />
<img width="265" height="172" alt="Screenshot 2026-06-17 at 22 15 21" src="https://github.com/user-attachments/assets/2bdf193e-f31f-424b-b02a-f56752ee5747" />


## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)