### PR TITLE
Abilities API: Plugin Settings: General

### DIFF
--- a/admin/section/class-convertkit-admin-section-base.php
+++ b/admin/section/class-convertkit-admin-section-base.php
@@ -100,6 +100,26 @@ abstract class ConvertKit_Admin_Section_Base {
 	}
 
 	/**
+	 * Registers this settings section's MCP abilities.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @param   array $abilities     Abilities to Register.
+	 * @return  array
+	 */
+	public function register_abilities( $abilities ) {
+
+		return array_merge(
+			$abilities,
+			array(
+				'kit/' . $this->settings->get_name() . '-get'   => new ConvertKit_MCP_Ability_Settings_Get( $this->settings ),
+				'kit/' . $this->settings->get_name() . '-update' => new ConvertKit_MCP_Ability_Settings_Update( $this->settings ),
+			)
+		);
+
+	}
+
+	/**
 	 * Helper method to determine if we're viewing the current settings screen.
 	 *
 	 * @since   2.5.0

--- a/admin/section/class-convertkit-admin-section-general.php
+++ b/admin/section/class-convertkit-admin-section-general.php
@@ -93,6 +93,9 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 		add_action( 'convertkit_admin_settings_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 		add_action( 'convertkit_admin_settings_enqueue_styles', array( $this, 'enqueue_styles' ) );
 
+		// Register MCP abilities.
+		add_filter( 'convertkit_abilities', array( $this, 'register_abilities' ) );
+
 		parent::__construct();
 
 		$this->check_credentials();

--- a/admin/section/class-convertkit-admin-section-general.php
+++ b/admin/section/class-convertkit-admin-section-general.php
@@ -53,8 +53,8 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 		$this->settings_key = $this->settings::SETTINGS_NAME;
 
 		// Define the programmatic name, Title and Tab Text.
-		$this->name     = 'general';
-		$this->title    = __( 'General Settings', 'convertkit' );
+		$this->name     = $this->settings->get_name();
+		$this->title    = $this->settings->get_title();
 		$this->tab_text = __( 'General', 'convertkit' );
 
 		// Define settings sections.

--- a/includes/class-convertkit-settings.php
+++ b/includes/class-convertkit-settings.php
@@ -569,6 +569,109 @@ class ConvertKit_Settings {
 	}
 
 	/**
+	 * Returns this settings group's programmatic name.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_name() {
+
+		return 'general';
+
+	}
+
+	/**
+	 * Returns the keys in this settings group that hold credentials or other
+	 * sensitive values.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string[]
+	 */
+	public function get_secret_keys() {
+
+		return array(
+			'access_token',
+			'refresh_token',
+			'token_expires',
+			'api_key',
+			'api_secret',
+			'recaptcha_secret_key',
+		);
+
+	}
+
+	/**
+	 * Returns the JSON Schema describing this settings group, in the shape
+	 * stored by save() / returned by get(), excluding secret keys.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  array
+	 */
+	public function get_schema() {
+
+		return array(
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'properties'           => array(
+				'non_inline_form'                    => array(
+					'type'        => 'array',
+					'items'       => array( 'type' => 'integer' ),
+					'description' => __( 'IDs of non-inline Forms to display site-wide.', 'convertkit' ),
+				),
+				'non_inline_form_honor_none_setting' => array(
+					'type'        => 'string',
+					'enum'        => array( '', 'on' ),
+					'description' => __( 'Whether the site-wide non-inline Form honors a per-Page / per-Post "None" Form setting.', 'convertkit' ),
+				),
+				'non_inline_form_limit_per_session'  => array(
+					'type'        => 'string',
+					'enum'        => array( '', 'on' ),
+					'description' => __( 'Whether to limit non-inline Form display to once per session.', 'convertkit' ),
+				),
+				'recaptcha_site_key'                 => array(
+					'type'        => 'string',
+					'description' => __( 'Google reCAPTCHA v3 site key.', 'convertkit' ),
+				),
+				'recaptcha_minimum_score'            => array(
+					'type'        => 'number',
+					'minimum'     => 0,
+					'maximum'     => 1,
+					'description' => __( 'Minimum Google reCAPTCHA v3 score (0.0 - 1.0) below which a request is treated as spam.', 'convertkit' ),
+				),
+				'debug'                              => array(
+					'type'        => 'string',
+					'enum'        => array( '', 'on' ),
+					'description' => __( 'Whether debug logging is enabled.', 'convertkit' ),
+				),
+				'no_scripts'                         => array(
+					'type'        => 'string',
+					'enum'        => array( '', 'on' ),
+					'description' => __( 'Whether the Plugin\'s frontend JavaScript is disabled.', 'convertkit' ),
+				),
+				'no_css'                             => array(
+					'type'        => 'string',
+					'enum'        => array( '', 'on' ),
+					'description' => __( 'Whether the Plugin\'s frontend CSS is disabled.', 'convertkit' ),
+				),
+				'no_add_new_button'                  => array(
+					'type'        => 'string',
+					'enum'        => array( '', 'on' ),
+					'description' => __( 'Whether the "Add New" button for Landing Pages / Member Content is hidden in the WordPress Admin.', 'convertkit' ),
+				),
+				'usage_tracking'                     => array(
+					'type'        => 'string',
+					'enum'        => array( '', 'on' ),
+					'description' => __( 'Whether anonymous usage tracking is enabled.', 'convertkit' ),
+				),
+			),
+		);
+
+	}
+
+	/**
 	 * The default settings, used when the ConvertKit Plugin Settings haven't been saved
 	 * e.g. on a new installation.
 	 *

--- a/includes/class-convertkit-settings.php
+++ b/includes/class-convertkit-settings.php
@@ -582,6 +582,19 @@ class ConvertKit_Settings {
 	}
 
 	/**
+	 * Returns the title of this settings group.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_title() {
+
+		return __( 'General Settings', 'convertkit' );
+
+	}
+
+	/**
 	 * Returns the keys in this settings group that hold credentials or other
 	 * sensitive values.
 	 *
@@ -636,7 +649,7 @@ class ConvertKit_Settings {
 					'description' => __( 'Google reCAPTCHA v3 site key.', 'convertkit' ),
 				),
 				'recaptcha_minimum_score'            => array(
-					'type'        => 'number',
+					'type'        => 'float',
 					'minimum'     => 0,
 					'maximum'     => 1,
 					'description' => __( 'Minimum Google reCAPTCHA v3 score (0.0 - 1.0) below which a request is treated as spam.', 'convertkit' ),

--- a/includes/mcp/abilities/settings/class-convertkit-mcp-ability-settings-get.php
+++ b/includes/mcp/abilities/settings/class-convertkit-mcp-ability-settings-get.php
@@ -57,9 +57,9 @@ class ConvertKit_MCP_Ability_Settings_Get extends ConvertKit_MCP_Ability_Setting
 	public function get_label() {
 
 		return sprintf(
-			/* translators: %s: Settings group slug, e.g. 'general'. */
-			__( 'Get Kit %s settings', 'convertkit' ),
-			$this->settings->get_name()
+			/* translators: %s: Settings Title, e.g. 'General Settings'. */
+			__( 'Get Kit Plugin %s', 'convertkit' ),
+			$this->settings->get_title()
 		);
 
 	}
@@ -74,9 +74,9 @@ class ConvertKit_MCP_Ability_Settings_Get extends ConvertKit_MCP_Ability_Setting
 	public function get_description() {
 
 		return sprintf(
-			/* translators: %s: Settings group slug, e.g. 'general'. */
-			__( 'Returns the current values of the Kit "%s" settings group.', 'convertkit' ),
-			$this->settings->get_name()
+			/* translators: %s: Settings Title, e.g. 'General Settings'. */
+			__( 'Returns the current values of the Kit Plugin "%s".', 'convertkit' ),
+			$this->settings->get_title()
 		);
 
 	}

--- a/includes/mcp/abilities/settings/class-convertkit-mcp-ability-settings-get.php
+++ b/includes/mcp/abilities/settings/class-convertkit-mcp-ability-settings-get.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Kit MCP Ability: Get Settings.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Ability that returns the current values of a Kit settings group.
+ *
+ * Produces an ability named `kit/settings-<name>-get` (e.g. `kit/settings-general-get`).
+ *
+ * @package ConvertKit
+ * @author  ConvertKit
+ */
+class ConvertKit_MCP_Ability_Settings_Get extends ConvertKit_MCP_Ability_Settings {
+
+	/**
+	 * Sets whether the ability is readonly.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     bool
+	 */
+	private $readonly = true; // @phpstan-ignore-line
+
+	/**
+	 * Sets whether the ability is idempotent.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     bool
+	 */
+	private $idempotent = true; // @phpstan-ignore-line
+
+	/**
+	 * Returns the operation suffix used in the ability name.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	protected function get_operation() {
+
+		return 'get';
+
+	}
+
+	/**
+	 * Returns the ability's human-readable label.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_label() {
+
+		return sprintf(
+			/* translators: %s: Settings group slug, e.g. 'general'. */
+			__( 'Get Kit %s settings', 'convertkit' ),
+			$this->settings->get_name()
+		);
+
+	}
+
+	/**
+	 * Returns the ability's human-readable description.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_description() {
+
+		return sprintf(
+			/* translators: %s: Settings group slug, e.g. 'general'. */
+			__( 'Returns the current values of the Kit "%s" settings group.', 'convertkit' ),
+			$this->settings->get_name()
+		);
+
+	}
+
+	/**
+	 * Returns the ability's input JSON Schema.
+	 *
+	 * Get takes no input.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  array
+	 */
+	public function get_input_schema() {
+
+		return array(
+			'type'       => 'object',
+			'properties' => new stdClass(),
+		);
+
+	}
+
+	/**
+	 * Returns the ability's output JSON Schema.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  array
+	 */
+	public function get_output_schema() {
+
+		return $this->get_public_schema();
+
+	}
+
+	/**
+	 * Executes the ability: returns the current settings, scoped to the keys
+	 * declared in the public schema.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @param   array $input   Ability input (unused).
+	 * @return  array|WP_Error
+	 */
+	public function execute_callback( $input ) {
+
+		$values = $this->settings->get();
+		$schema = $this->get_public_schema();
+		$result = array();
+
+		if ( ! isset( $schema['properties'] ) || ! is_array( $schema['properties'] ) ) {
+			return $result;
+		}
+
+		foreach ( array_keys( $schema['properties'] ) as $key ) {
+			if ( array_key_exists( $key, $values ) ) {
+				$result[ $key ] = $values[ $key ];
+			}
+		}
+
+		return $result;
+
+	}
+
+}

--- a/includes/mcp/abilities/settings/class-convertkit-mcp-ability-settings-update.php
+++ b/includes/mcp/abilities/settings/class-convertkit-mcp-ability-settings-update.php
@@ -119,7 +119,7 @@ class ConvertKit_MCP_Ability_Settings_Update extends ConvertKit_MCP_Ability_Sett
 	public function execute_callback( $input ) {
 
 		// Bail if no input is provided.
-		if ( ! is_array( $input ) ) {
+		if ( ! count( $input ) ) {
 			return new WP_Error(
 				'convertkit_mcp_settings_invalid_input',
 				__( 'Input must be an object of settings keys and values.', 'convertkit' )

--- a/includes/mcp/abilities/settings/class-convertkit-mcp-ability-settings-update.php
+++ b/includes/mcp/abilities/settings/class-convertkit-mcp-ability-settings-update.php
@@ -49,9 +49,9 @@ class ConvertKit_MCP_Ability_Settings_Update extends ConvertKit_MCP_Ability_Sett
 	public function get_label() {
 
 		return sprintf(
-			/* translators: %s: Settings group slug, e.g. 'general'. */
-			__( 'Update Kit %s settings', 'convertkit' ),
-			$this->settings->get_slug()
+			/* translators: %s: Settings Title, e.g. 'General Settings'. */
+			__( 'Update Kit Plugin %s', 'convertkit' ),
+			$this->settings->get_title()
 		);
 
 	}
@@ -66,9 +66,9 @@ class ConvertKit_MCP_Ability_Settings_Update extends ConvertKit_MCP_Ability_Sett
 	public function get_description() {
 
 		return sprintf(
-			/* translators: %s: Settings group slug, e.g. 'general'. */
-			__( 'Updates one or more values in the Kit "%s" settings group. Only keys declared in the input schema can be updated; secret values (API keys, OAuth tokens) cannot be set via this ability.', 'convertkit' ),
-			$this->settings->get_name()
+			/* translators: %s: Settings Title, e.g. 'General Settings'. */
+			__( 'Updates one or more values in the Kit Plugin "%s". Only keys declared in the input schema can be updated; secret values (API keys, OAuth tokens) cannot be set via this ability.', 'convertkit' ),
+			$this->settings->get_title()
 		);
 
 	}

--- a/includes/mcp/abilities/settings/class-convertkit-mcp-ability-settings-update.php
+++ b/includes/mcp/abilities/settings/class-convertkit-mcp-ability-settings-update.php
@@ -107,7 +107,7 @@ class ConvertKit_MCP_Ability_Settings_Update extends ConvertKit_MCP_Ability_Sett
 
 	/**
 	 * Executes the ability.
-	 * 
+	 *
 	 * Validates the input, rejecting unknown and secret keys
 	 * and saves via the settings class.
 	 *
@@ -127,7 +127,7 @@ class ConvertKit_MCP_Ability_Settings_Update extends ConvertKit_MCP_Ability_Sett
 		}
 
 		// Get the public schema, allowed and secret keys.
-		$schema 	  = $this->get_public_schema();
+		$schema       = $this->get_public_schema();
 		$allowed_keys = array_keys( $schema['properties'] );
 		$secret_keys  = $this->settings->get_secret_keys();
 

--- a/includes/mcp/abilities/settings/class-convertkit-mcp-ability-settings-update.php
+++ b/includes/mcp/abilities/settings/class-convertkit-mcp-ability-settings-update.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Kit MCP Ability: Update Settings.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Ability that updates one or more values in a Kit settings group, scoped to
+ * the keys declared in the settings class's get_schema().
+ *
+ * Produces an ability named `kit/settings-<name>-update` (e.g. `kit/settings-general-update`).
+ *
+ * @package ConvertKit
+ * @author  ConvertKit
+ */
+class ConvertKit_MCP_Ability_Settings_Update extends ConvertKit_MCP_Ability_Settings {
+
+	/**
+	 * Sets whether the ability is idempotent.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     bool
+	 */
+	private $idempotent = true; // @phpstan-ignore-line
+
+	/**
+	 * Returns the operation suffix used in the ability name.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	protected function get_operation() {
+
+		return 'update';
+
+	}
+
+	/**
+	 * Returns the ability's human-readable label.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_label() {
+
+		return sprintf(
+			/* translators: %s: Settings group slug, e.g. 'general'. */
+			__( 'Update Kit %s settings', 'convertkit' ),
+			$this->settings->get_slug()
+		);
+
+	}
+
+	/**
+	 * Returns the ability's human-readable description.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_description() {
+
+		return sprintf(
+			/* translators: %s: Settings group slug, e.g. 'general'. */
+			__( 'Updates one or more values in the Kit "%s" settings group. Only keys declared in the input schema can be updated; secret values (API keys, OAuth tokens) cannot be set via this ability.', 'convertkit' ),
+			$this->settings->get_name()
+		);
+
+	}
+
+	/**
+	 * Returns the ability's input JSON Schema.
+	 *
+	 * Mirrors the settings class's get_schema() with secret keys removed, so
+	 * partial updates are possible (no top-level `required`).
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  array
+	 */
+	public function get_input_schema() {
+
+		return $this->get_public_schema();
+
+	}
+
+	/**
+	 * Returns the ability's output JSON Schema.
+	 *
+	 * Returns the same shape as kit/settings-<slug>-get so a caller can chain
+	 * update → confirm in one round trip.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  array
+	 */
+	public function get_output_schema() {
+
+		return $this->get_public_schema();
+
+	}
+
+	/**
+	 * Executes the ability.
+	 * 
+	 * Validates the input, rejecting unknown and secret keys
+	 * and saves via the settings class.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @param   array $input   Ability input.
+	 * @return  array|WP_Error
+	 */
+	public function execute_callback( $input ) {
+
+		// Bail if no input is provided.
+		if ( ! is_array( $input ) ) {
+			return new WP_Error(
+				'convertkit_mcp_settings_invalid_input',
+				__( 'Input must be an object of settings keys and values.', 'convertkit' )
+			);
+		}
+
+		// Get the public schema, allowed and secret keys.
+		$schema 	  = $this->get_public_schema();
+		$allowed_keys = array_keys( $schema['properties'] );
+		$secret_keys  = $this->settings->get_secret_keys();
+
+		// Bail if any secret keys are provided in the input.
+		$secret_attempts = array_intersect( array_keys( $input ), $secret_keys );
+		if ( ! empty( $secret_attempts ) ) {
+			return new WP_Error(
+				'convertkit_mcp_settings_secret_write',
+				sprintf(
+					/* translators: %s: Comma-separated list of secret keys. */
+					__( 'The following settings cannot be updated via MCP: %s.', 'convertkit' ),
+					implode( ', ', $secret_attempts )
+				)
+			);
+		}
+
+		// Bail if any unknown keys are provided in the input.
+		$unknown_attempts = array_diff( array_keys( $input ), $allowed_keys );
+		if ( ! empty( $unknown_attempts ) ) {
+			return new WP_Error(
+				'convertkit_mcp_settings_unknown_keys',
+				sprintf(
+					/* translators: %s: Comma-separated list of unknown keys. */
+					__( 'The following settings keys are not recognised: %s.', 'convertkit' ),
+					implode( ', ', $unknown_attempts )
+				)
+			);
+		}
+
+		// Validate each provided value against its declared schema.
+		$validated = array();
+		foreach ( $input as $key => $value ) {
+			$valid = rest_validate_value_from_schema( $value, $schema['properties'][ $key ], $key );
+
+			// Bail if the value is invalid.
+			if ( is_wp_error( $valid ) ) {
+				return $valid;
+			}
+
+			$validated[ $key ] = rest_sanitize_value_from_schema( $value, $schema['properties'][ $key ], $key );
+		}
+
+		// Save via the settings class so its own sanitisation runs.
+		$this->settings->save( $validated );
+
+		// Return the post-save state.
+		$get_ability = new ConvertKit_MCP_Ability_Settings_Get( $this->settings );
+		return $get_ability->execute_callback( array() );
+
+	}
+
+}

--- a/includes/mcp/abilities/settings/class-convertkit-mcp-ability-settings.php
+++ b/includes/mcp/abilities/settings/class-convertkit-mcp-ability-settings.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Kit MCP Ability: Settings base class.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Base class for abilities to read and update Plugin Settings.
+ *
+ * @package ConvertKit
+ * @author  ConvertKit
+ */
+abstract class ConvertKit_MCP_Ability_Settings extends ConvertKit_MCP_Ability {
+
+	/**
+	 * Holds the settings class for the ability.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     false|ConvertKit_Settings|ConvertKit_ContactForm7_Settings|ConvertKit_Wishlist_Settings|ConvertKit_Settings_Restrict_Content|ConvertKit_Settings_Broadcasts|ConvertKit_Forminator_Settings|ConvertKit_Settings_MCP
+	 */
+	protected $settings;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @param   ConvertKit_Settings|ConvertKit_ContactForm7_Settings|ConvertKit_Wishlist_Settings|ConvertKit_Settings_Restrict_Content|ConvertKit_Settings_Broadcasts|ConvertKit_Forminator_Settings|ConvertKit_Settings_MCP $settings Settings class.
+	 */
+	public function __construct( $settings ) {
+
+		$this->settings = $settings;
+
+	}
+
+	/**
+	 * Returns the operation suffix used in the ability name (e.g. 'get',
+	 * 'update'). Combined with the settings name to produce the full
+	 * `kit/settings-<name>-<operation>` name.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	abstract protected function get_operation();
+
+	/**
+	 * Returns the ability name, derived from the settings name and operation
+	 * (e.g. `kit/settings-general-get`).
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_name() {
+
+		return 'kit/settings-' . $this->settings->get_name() . '-' . $this->get_operation();
+
+	}
+
+	/**
+	 * Permission callback for settings abilities.
+	 *
+	 * Plugin settings are restricted to users who can manage options, matching
+	 * the capability that gates the Plugin's own settings screens.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @param   array $input   Ability input (unused).
+	 * @return  bool|WP_Error
+	 */
+	public function permission_callback( $input ) {
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error(
+				'convertkit_mcp_cannot_manage_settings',
+				__( 'You do not have permission to read or update Kit Plugin settings.', 'convertkit' )
+			);
+		}
+
+		return true;
+
+	}
+
+	/**
+	 * Returns the ability's input and output JSON schemas.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  array
+	 */
+	protected function get_public_schema() {
+
+		$schema = $this->settings->get_schema();
+		$secret = $this->settings->get_secret_keys();
+
+		if ( isset( $schema['properties'] ) && is_array( $schema['properties'] ) ) {
+			foreach ( $secret as $key ) {
+				unset( $schema['properties'][ $key ] );
+			}
+		}
+
+		return $schema;
+
+	}
+
+}

--- a/includes/mcp/class-convertkit-mcp.php
+++ b/includes/mcp/class-convertkit-mcp.php
@@ -75,8 +75,43 @@ class ConvertKit_MCP {
 		// so they're added here rather than via a per-class register_abilities().
 		add_filter( 'convertkit_abilities', array( $this, 'register_resource_abilities' ) );
 
+		// Register settings get / update abilities for each Plugin settings
+		// These are owned by the Plugin (not by any single feature),
+		// so they're added here rather than via a per-class register_abilities().
+		add_filter( 'convertkit_abilities', array( $this, 'register_settings_abilities' ) );
+
 		// Register the MCP server.
 		add_action( 'mcp_adapter_init', array( $this, 'register_mcp_server' ) );
+
+	}
+
+	/**
+	 * Appends the settings get / update abilities for each Plugin settings
+	 * group to the convertkit_abilities filter, so they are registered with
+	 * the Abilities API and exposed via the MCP server.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @param   array $abilities   Abilities to register.
+	 * @return  array
+	 */
+	public function register_settings_abilities( $abilities ) {
+
+		// Settings instances to register with MCP.
+		$groups = array(
+			new ConvertKit_Settings(),
+		);
+
+		// Iterate through settings groups, registering the get and update abilities.
+		foreach ( $groups as $settings ) {
+			$get    = new ConvertKit_MCP_Ability_Settings_Get( $settings );
+			$update = new ConvertKit_MCP_Ability_Settings_Update( $settings );
+
+			$abilities[ $get->get_name() ]    = $get;
+			$abilities[ $update->get_name() ] = $update;
+		}
+
+		return $abilities;
 
 	}
 

--- a/tests/Integration/MCPSettingsGeneralTest.php
+++ b/tests/Integration/MCPSettingsGeneralTest.php
@@ -1,0 +1,271 @@
+<?php
+
+namespace Tests;
+
+use lucatume\WPBrowser\TestCase\WPTestCase;
+
+/**
+ * Tests for the Kit MCP settings abilities bound to the General settings group:
+ *
+ * - kit/settings-general-get    (ConvertKit_MCP_Ability_Settings_Get)
+ * - kit/settings-general-update (ConvertKit_MCP_Ability_Settings_Update)
+ *
+ * @since   3.4.0
+ */
+class MCPSettingsGeneralTest extends WPTestCase
+{
+	/**
+	 * The testing implementation.
+	 *
+	 * @var \WpunitTester.
+	 */
+	protected $tester;
+
+	/**
+	 * The name of the settings option.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     string
+	 */
+	private const SETTINGS_NAME = '_wp_convertkit_settings';
+
+	/**
+	 * The ability names registered by the General settings group.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     string[]
+	 */
+	private const ABILITY_NAMES = array(
+		'kit/settings-general-get',
+		'kit/settings-general-update',
+	);
+
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		// Activate Plugin.
+		activate_plugins('convertkit/wp-convertkit.php');
+	}
+
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function tearDown(): void
+	{
+		// Restore the current user.
+		wp_set_current_user(0);
+
+		// Deactivate Plugin.
+		deactivate_plugins('convertkit/wp-convertkit.php');
+
+		// Delete settings.
+		delete_option(self::SETTINGS_NAME);
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that the General settings group registers abilities via
+	 * the convertkit_abilities filter with the expected names.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testAbilitiesRegistered()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// The ability names and classes expected to be registered.
+		$expected = array(
+			'kit/settings-general-get'    => \ConvertKit_MCP_Ability_Settings_Get::class,
+			'kit/settings-general-update' => \ConvertKit_MCP_Ability_Settings_Update::class,
+		);
+
+		// Assert that the abilities are registered and are instances of the expected classes.
+		foreach ( $expected as $name => $class ) {
+			$this->assertArrayHasKey($name, $abilities);
+			$this->assertInstanceOf($class, $abilities[ $name ]);
+		}
+	}
+
+	/**
+	 * Test that the permission_callback() rejects a user who cannot manage options.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackDeniesWithoutManageOptionsCapability()
+	{
+		// Become a Subscriber (no manage_options capability).
+		$subscriber_id = static::factory()->user->create([ 'role' => 'subscriber' ]);
+		wp_set_current_user($subscriber_id);
+
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Assert that the abilities are permission denied.
+		foreach ( self::ABILITY_NAMES as $name ) {
+			// Execute the ability.
+			$result = $abilities[ $name ]->permission_callback([]);
+
+			// Assert that the result is a WP_Error.
+			$this->assertInstanceOf(\WP_Error::class, $result);
+		}
+	}
+
+	/**
+	 * Test that kit/settings-general-get returns the current settings.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testGetSettings()
+	{
+		// Populate settings.
+		$this->populateSettings();
+
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/settings-general-get']->execute_callback([]);
+
+		// Confirm secret keys are not returned.
+		$this->assertArrayNotHasKey('access_token', $result);
+		$this->assertArrayNotHasKey('refresh_token', $result);
+		$this->assertArrayNotHasKey('token_expires', $result);
+		$this->assertArrayNotHasKey('api_key', $result);
+		$this->assertArrayNotHasKey('api_secret', $result);
+		$this->assertArrayNotHasKey('recaptcha_secret_key', $result);
+
+		// Confirm expected settings are returned.
+		$this->assertArrayHasKey('non_inline_form', $result);
+		$this->assertArrayHasKey('non_inline_form_honor_none_setting', $result);
+		$this->assertArrayHasKey('non_inline_form_limit_per_session', $result);
+		$this->assertArrayHasKey('recaptcha_site_key', $result);
+		$this->assertArrayHasKey('recaptcha_minimum_score', $result);
+		$this->assertArrayHasKey('debug', $result);
+		$this->assertEquals('on', $result['debug']);
+		$this->assertArrayHasKey('no_scripts', $result);
+		$this->assertArrayHasKey('no_css', $result);
+		$this->assertArrayHasKey('no_add_new_button', $result);
+		$this->assertArrayHasKey('usage_tracking', $result);
+	}
+
+	/**
+	 * Test that kit/settings-general-update updates the settings.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateSettings()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/settings-general-update']->execute_callback(
+			[
+				'recaptcha_site_key' => '12345',
+				'debug'              => '',
+				'no_scripts'         => 'on',
+				'no_css'             => 'on',
+				'no_add_new_button'  => 'on',
+				'usage_tracking'     => 'on',
+			]
+		);
+
+		// Confirm secret keys are not returned.
+		$this->assertArrayNotHasKey('access_token', $result);
+		$this->assertArrayNotHasKey('refresh_token', $result);
+		$this->assertArrayNotHasKey('token_expires', $result);
+		$this->assertArrayNotHasKey('api_key', $result);
+		$this->assertArrayNotHasKey('api_secret', $result);
+		$this->assertArrayNotHasKey('recaptcha_secret_key', $result);
+
+		// Confirm expected settings are returned.
+		$this->assertArrayHasKey('non_inline_form', $result);
+		$this->assertArrayHasKey('non_inline_form_honor_none_setting', $result);
+		$this->assertArrayHasKey('non_inline_form_limit_per_session', $result);
+		$this->assertArrayHasKey('recaptcha_site_key', $result);
+		$this->assertArrayHasKey('recaptcha_minimum_score', $result);
+		$this->assertArrayHasKey('debug', $result);
+		$this->assertArrayHasKey('no_scripts', $result);
+		$this->assertArrayHasKey('no_css', $result);
+		$this->assertArrayHasKey('no_add_new_button', $result);
+		$this->assertArrayHasKey('usage_tracking', $result);
+
+		// Confirm settings are updated.
+		$this->assertEquals('12345', $result['recaptcha_site_key']);
+		$this->assertEquals('', $result['debug']);
+		$this->assertEquals('on', $result['no_scripts']);
+		$this->assertEquals('on', $result['no_css']);
+		$this->assertEquals('on', $result['no_add_new_button']);
+		$this->assertEquals('on', $result['usage_tracking']);
+	}
+
+	/**
+	 * Test that kit/settings-general-update returns an error if an invalid key is provided.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateSettingsWithInvalidKeyReturnsError()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/settings-general-update']->execute_callback([ 'invalid_key' => 'invalid_value' ]);
+	}
+
+	/**
+	 * Test that kit/settings-general-update returns an error if a secret key is provided.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateSettingsWithSecretKeyReturnsError()
+	{
+		// Resolve the abilities array via the same helper the MCP server uses.
+		$abilities = convertkit_get_abilities();
+
+		// Execute the ability.
+		$result = $abilities['kit/settings-general-update']->execute_callback([ 'access_token' => 'invalid_value' ]);
+	}
+
+	/**
+	 * Populate the settings with some sensible values for testing.
+	 *
+	 * @since   3.4.0
+	 */
+	private function populateSettings()
+	{
+		update_option(
+			self::SETTINGS_NAME,
+			[
+				'access_token'                       => $_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
+				'refresh_token'                      => $_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN'],
+				'debug'                              => 'on',
+				'no_scripts'                         => '',
+				'no_css'                             => '',
+				'no_add_new_button'                  => '',
+				'usage_tracking'                     => '',
+				'post_form'                          => $_ENV['CONVERTKIT_API_FORM_ID'],
+				'page_form'                          => $_ENV['CONVERTKIT_API_FORM_ID'],
+				'article_form'                       => $_ENV['CONVERTKIT_API_FORM_ID'],
+				'product_form'                       => $_ENV['CONVERTKIT_API_FORM_ID'],
+				'non_inline_form'                    => array(),
+				'non_inline_form_honor_none_setting' => '',
+				'recaptcha_site_key'                 => '',
+				'recaptcha_secret_key'               => '',
+				'recaptcha_minimum_score'            => '',
+			]
+		);
+	}
+}

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -114,6 +114,9 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/resources/class-c
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/resources/class-convertkit-mcp-ability-resource-tags.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/resources/class-convertkit-mcp-ability-resource-landing-pages.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/resources/class-convertkit-mcp-ability-resource-products.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/settings/class-convertkit-mcp-ability-settings.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/settings/class-convertkit-mcp-ability-settings-get.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/settings/class-convertkit-mcp-ability-settings-update.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/plugin-sidebars/class-convertkit-plugin-sidebar.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/plugin-sidebars/class-convertkit-plugin-sidebar-post-settings.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/pre-publish-actions/class-convertkit-pre-publish-action.php';


### PR DESCRIPTION
## Summary

Registers get and update abilities (MCP tools) for the Plugin's General Settings (Settings > Kit > General), so an MCP client can fetch and update settings.

Secret credentials, such as API Keys and OAuth Tokens, cannot be read or updated.

<img width="604" height="160" alt="Screenshot 2026-06-18 at 15 21 53" src="https://github.com/user-attachments/assets/a3817f00-7fb6-4143-823f-a0f19f1faf7a" />

Ability | Description | Required input | Output
-- | -- | -- | --
kit/settings-general-get | Returns the current values of the Kit General settings group. Secret values (API keys, OAuth tokens, reCAPTCHA secret) are never returned. | _none_ | { non_inline_form, non_inline_form_honor_none_setting, non_inline_form_limit_per_session, recaptcha_site_key, recaptcha_minimum_score, debug, no_scripts, no_css, no_add_new_button, usage_tracking }
kit/settings-general-update | Updates one or more values in the Kit General settings group. Only keys declared in the input schema can be updated; secret values cannot be set via this ability. Unknown keys are rejected. | _partial object of any subset of_: non_inline_form, non_inline_form_honor_none_setting, non_inline_form_limit_per_session, recaptcha_site_key, recaptcha_minimum_score, debug, no_scripts, no_css, no_add_new_button, usage_tracking | _same shape as kit/settings-general-get (post-save state)_

## Testing

- `MCPSettingsGeneralTest`: Tests that MCP tools are registered, permissions are honored and get/update tools work for the Plugin's general settings.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)