### PR TITLE
Settings: Broadcasts: Refresh settings on save; remove unused methods

### DIFF
--- a/includes/class-convertkit-settings-broadcasts.php
+++ b/includes/class-convertkit-settings-broadcasts.php
@@ -191,33 +191,6 @@ class ConvertKit_Settings_Broadcasts {
 	}
 
 	/**
-	 * Returns whether imported Broadcasts should have their Restrict Content
-	 * setting defined, if the Broadcast is marked as paid.
-	 *
-	 * @since   2.2.9
-	 *
-	 * @return  bool
-	 */
-	public function restrict_content_enabled() {
-
-		return ! empty( $this->settings['restrict_content'] );
-
-	}
-
-	/**
-	 * Returns the Restrict Content setting to assign to imported Broadcasts
-	 *
-	 * @since   2.2.9
-	 *
-	 * @return  string
-	 */
-	public function restrict_content() {
-
-		return $this->settings['restrict_content'];
-
-	}
-
-	/**
 	 * The default settings, used when the ConvertKit Broadcasts Settings haven't been saved
 	 * e.g. on a new installation.
 	 *
@@ -266,6 +239,27 @@ class ConvertKit_Settings_Broadcasts {
 	public function save( $settings ) {
 
 		update_option( self::SETTINGS_NAME, array_merge( $this->get(), $settings ) );
+
+		// Reload settings in class, to reflect changes.
+		$this->refresh_settings();
+
+	}
+
+	/**
+	 * Reloads settings from the options table so this instance has the latest values.
+	 *
+	 * @since  3.3.4
+	 */
+	private function refresh_settings() {
+
+		$settings = get_option( self::SETTINGS_NAME );
+
+		if ( ! $settings ) {
+			$this->settings = $this->get_defaults();
+			return;
+		}
+
+		$this->settings = array_merge( $this->get_defaults(), $settings );
 
 	}
 


### PR DESCRIPTION
## Summary

Follows the pattern used in `ConvertKit_Settings` by refreshing the settings stored in the class when settings are saved, ensuring the updated settings are available.

Removes unused `restrict_content` methods, [which haven't been used since August 2023 where gating content is determined by the individual broadcast posts](https://github.com/Kit/convertkit-wordpress/commit/b789f26d805fca56f3bea7658d4110c0e48e7126#diff-0582139d7ecf8a2a67198c355c9d24b98d49bd9294ac98b90887e51feef375b0R80-L140), not Plugin-wide settings.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)