### PR TITLE
Add Security Disclosure Policy

### DIFF
--- a/ACTIONS-FILTERS.md
+++ b/ACTIONS-FILTERS.md
@@ -1667,7 +1667,7 @@ add_filter( 'convertkit_settings_get_defaults', function( $defaults ) {
 </pre>
 <h3 id="convertkit_is_admin_or_frontend_editor">
 						convertkit_is_admin_or_frontend_editor
-						<code>includes/class-wp-convertkit.php::336</code>
+						<code>includes/class-wp-convertkit.php::337</code>
 					</h3><h4>Overview</h4>
 						<p>Filters whether the current request is a WordPress Administration / Frontend Editor request or not. Page Builders can set this to true to allow ConvertKit to load its administration functionality.</p><h4>Parameters</h4>
 					<table>
@@ -2018,7 +2018,7 @@ do_action( 'convertkit_settings_base_render_after', function(  ) {
 </pre>
 <h3 id="convertkit_settings_base_render_before">
 						convertkit_settings_base_render_before
-						<code>admin/section/class-convertkit-admin-section-tools.php::379</code>
+						<code>admin/section/class-convertkit-admin-section-tools.php::380</code>
 					</h3><h4>Parameters</h4>
 					<table>
 						<thead>
@@ -2038,7 +2038,7 @@ do_action( 'convertkit_settings_base_render_before', function(  ) {
 </pre>
 <h3 id="convertkit_settings_base_render_after">
 						convertkit_settings_base_render_after
-						<code>admin/section/class-convertkit-admin-section-tools.php::402</code>
+						<code>admin/section/class-convertkit-admin-section-tools.php::403</code>
 					</h3><h4>Parameters</h4>
 					<table>
 						<thead>
@@ -2533,7 +2533,7 @@ do_action( 'convertkit_output_landing_page_before', function( $landing_page, $la
 </pre>
 <h3 id="convertkit_initialize_admin">
 						convertkit_initialize_admin
-						<code>includes/class-wp-convertkit.php::104</code>
+						<code>includes/class-wp-convertkit.php::105</code>
 					</h3><h4>Parameters</h4>
 					<table>
 						<thead>
@@ -2553,7 +2553,7 @@ do_action( 'convertkit_initialize_admin', function(  ) {
 </pre>
 <h3 id="convertkit_initialize_admin_or_frontend_editor">
 						convertkit_initialize_admin_or_frontend_editor
-						<code>includes/class-wp-convertkit.php::125</code>
+						<code>includes/class-wp-convertkit.php::126</code>
 					</h3><h4>Parameters</h4>
 					<table>
 						<thead>
@@ -2573,7 +2573,7 @@ do_action( 'convertkit_initialize_admin_or_frontend_editor', function(  ) {
 </pre>
 <h3 id="convertkit_initialize_cli_cron">
 						convertkit_initialize_cli_cron
-						<code>includes/class-wp-convertkit.php::146</code>
+						<code>includes/class-wp-convertkit.php::147</code>
 					</h3><h4>Parameters</h4>
 					<table>
 						<thead>
@@ -2593,7 +2593,7 @@ do_action( 'convertkit_initialize_cli_cron', function(  ) {
 </pre>
 <h3 id="convertkit_initialize_frontend">
 						convertkit_initialize_frontend
-						<code>includes/class-wp-convertkit.php::171</code>
+						<code>includes/class-wp-convertkit.php::172</code>
 					</h3><h4>Parameters</h4>
 					<table>
 						<thead>
@@ -2613,7 +2613,7 @@ do_action( 'convertkit_initialize_frontend', function(  ) {
 </pre>
 <h3 id="convertkit_initialize_global">
 						convertkit_initialize_global
-						<code>includes/class-wp-convertkit.php::215</code>
+						<code>includes/class-wp-convertkit.php::216</code>
 					</h3><h4>Parameters</h4>
 					<table>
 						<thead>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 3.3.5 2026-07-07
+* Added: Settings: Tools: Kit Legacy Forms: Migrate from legacy forms to newer Kit forms
+* Fix: Settings: Tools: Migrations: Use `form` instead of `id` for [convertkit_form] shortcode when migrating from third party form Plugins
+* Fix: Uninstall: Improve Access and Refresh Token revokation
+* Updated: WordPress Libraries to 2.1.7
+
 ### 3.3.4 2026-06-19
 * Fix: Pages: Add New: Dropdown menu alignment and mobile layout
 * Fix: Block Editor: Refresh button icon alignment

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ This security policy applies to public projects under the [Kit organization](htt
 
 If you discover a security vulnerability, please report via any of the below:
 
-- [BugCrowd](https://docs.bugcrowd.com/researchers/reporting-managing-submissions/reporting-a-bug/#creating-a-vulnerability-report)
+- [Kit](https://kit.com/report-vulnerability)
 - [PatchStack](https://patchstack.com/database/vdp/1010ebe1-02b2-4144-8297-b8cddba0ce7d)
 - [GitHub](https://github.com/Kit/convertkit-wordpress/security/advisories)
 - [Email](mailto:security@kit.com)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+This security policy applies to public projects under the [Kit organization](https://github.com/kit) on GitHub.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report via any of the below:
+
+- [BugCrowd](https://docs.bugcrowd.com/researchers/reporting-managing-submissions/reporting-a-bug/#creating-a-vulnerability-report)
+- [PatchStack](https://patchstack.com/database/vdp/1010ebe1-02b2-4144-8297-b8cddba0ce7d)
+- [GitHub](https://github.com/Kit/convertkit-wordpress/security/advisories)
+- [Email](mailto:security@kit.com)
+
+Please do **not** report security issues publicly via GitHub issues or discussions. Security reports sent via the above channels be acknowledged within 48 hours.
+
+## Security Disclosure Process
+
+When reporting a security vulnerability, please include:
+
+1. **Description** - A clear description of the vulnerability
+2. **Impact** - What kind of vulnerability it is and who it impacts
+3. **Reproduction** - Detailed steps to reproduce the issue
+4. **Proof of Concept** - If applicable, include proof-of-concept code
+5. **Suggested Fix** - If you have ideas for how to fix the issue
+
+## Security Response Timeline
+
+- **Initial Response**: Within 48 hours of receiving the report
+- **Investigation**: We will investigate and validate the reported vulnerability
+- **Fix Development**: Development of a patch or mitigation strategy
+- **Release**: Coordinated disclosure and release of security update
+- **Public Disclosure**: After users have had time to upgrade

--- a/languages/convertkit.pot
+++ b/languages/convertkit.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPLv3 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Kit (formerly ConvertKit) 3.3.4\n"
+"Project-Id-Version: Kit (formerly ConvertKit) 3.3.5\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/convertkit\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-06-19T00:20:58+00:00\n"
+"POT-Creation-Date: 2026-07-07T07:55:47+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: convertkit\n"
@@ -152,7 +152,11 @@ msgstr ""
 msgid "Split Tests"
 msgstr ""
 
-#: admin/importers/class-convertkit-admin-importer.php:318
+#: admin/importers/class-convertkit-admin-importer-convertkit-legacy-forms.php:85
+msgid "Kit Legacy Forms are being phased out. Use this tool to replace Kit Form shortcodes and blocks using a Legacy Form with a new Kit Form."
+msgstr ""
+
+#: admin/importers/class-convertkit-admin-importer.php:351
 msgid "Default Form"
 msgstr ""
 
@@ -888,22 +892,26 @@ msgid "Campaign Monitor forms migrated successfully."
 msgstr ""
 
 #: admin/section/class-convertkit-admin-section-tools.php:63
-msgid "MC4WP forms migrated successfully."
+msgid "Kit Legacy Forms migrated successfully."
 msgstr ""
 
 #: admin/section/class-convertkit-admin-section-tools.php:64
-msgid "MailPoet forms migrated successfully."
+msgid "MC4WP forms migrated successfully."
 msgstr ""
 
 #: admin/section/class-convertkit-admin-section-tools.php:65
+msgid "MailPoet forms migrated successfully."
+msgstr ""
+
+#: admin/section/class-convertkit-admin-section-tools.php:66
 msgid "Newsletter forms migrated successfully."
 msgstr ""
 
-#: admin/section/class-convertkit-admin-section-tools.php:413
+#: admin/section/class-convertkit-admin-section-tools.php:414
 msgid "Tools to help you manage Kit on your site."
 msgstr ""
 
-#: admin/section/class-convertkit-admin-section-tools.php:441
+#: admin/section/class-convertkit-admin-section-tools.php:442
 msgid "WordPress 5.2 or higher is required for system information report."
 msgstr ""
 
@@ -1490,7 +1498,7 @@ msgid "Kit Form ID %s has no embed_js property."
 msgstr ""
 
 #: includes/blocks/class-convertkit-block-form.php:100
-#: views/backend/settings/tools.php:142
+#: views/backend/settings/tools.php:146
 #: views/backend/setup-wizard/convertkit-setup/content-form-importer.php:37
 #: views/backend/term/fields-add.php:11
 #: views/backend/term/fields-edit.php:12
@@ -1733,12 +1741,12 @@ msgid "Access Token not configured in Plugin Settings."
 msgstr ""
 
 #. translators: %1$s: PHP class name
-#: includes/class-wp-convertkit.php:397
+#: includes/class-wp-convertkit.php:398
 #, php-format
 msgid "Kit Error: Could not load Plugin class <strong>%1$s</strong>"
 msgstr ""
 
-#: includes/class-wp-convertkit.php:407
+#: includes/class-wp-convertkit.php:408
 msgid "Kit Error"
 msgstr ""
 
@@ -2222,20 +2230,20 @@ msgid "%s: Migrate Configuration"
 msgstr ""
 
 #. translators: %s: Importer title
-#: views/backend/settings/tools.php:123
+#: views/backend/settings/tools.php:126
 #, php-format
 msgid "Automatically replace %s form shortcodes and blocks with Kit form shortcodes and blocks."
 msgstr ""
 
 #. translators: %s: Importer title
 #. translators: %s: Form importer title
-#: views/backend/settings/tools.php:137
+#: views/backend/settings/tools.php:141
 #: views/backend/setup-wizard/convertkit-setup/content-form-importer.php:31
 #, php-format
 msgid "%s Form"
 msgstr ""
 
-#: views/backend/settings/tools.php:172
+#: views/backend/settings/tools.php:176
 msgid "Migrate"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: email marketing, email newsletter, subscribers, landing page, membership
 Requires at least: 5.6
 Tested up to: 7.0
 Requires PHP: 7.1
-Stable tag: 3.3.4
+Stable tag: 3.3.5
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -345,6 +345,12 @@ Please report security bugs found in the source code of the Kit (formerly Conver
 10. Track email subscriber growth, newsletter performance, landing page conversions, and membership site analytics in real-time
 
 == Changelog ==
+
+### 3.3.5 2026-07-07
+* Added: Settings: Tools: Kit Legacy Forms: Migrate from legacy forms to newer Kit forms
+* Fix: Settings: Tools: Migrations: Use `form` instead of `id` for [convertkit_form] shortcode when migrating from third party form Plugins
+* Fix: Uninstall: Improve Access and Refresh Token revokation
+* Updated: WordPress Libraries to 2.1.7
 
 ### 3.3.4 2026-06-19
 * Fix: Pages: Add New: Dropdown menu alignment and mobile layout

--- a/readme.txt
+++ b/readme.txt
@@ -328,6 +328,9 @@ Comprehensive documentation is available at: [Kit WordPress Plugin Setup Guide](
 
 The documentation covers newsletter form setup, landing page configuration, membership site creation, email marketing automation, subscriber segmentation, and all plugin features for growing your email newsletter.
 
+= Where do I report security bugs found in this plugin? =
+Please report security bugs found in the source code of the Kit (formerly ConvertKit) plugin through the [Patchstack Vulnerability Disclosure Program](https://patchstack.com/database/vdp/1010ebe1-02b2-4144-8297-b8cddba0ce7d). The Patchstack team will assist you with verification, CVE assignment, and notify the developers of this plugin.
+
 == Screenshots ==
 
 1. Create stunning email newsletter subscription forms and landing pages in Kit's visual editor optimized for email subscriber conversion

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -9,7 +9,7 @@
  * Plugin Name: Kit (formerly ConvertKit)
  * Plugin URI: https://kit.com/
  * Description: Display Kit (formerly ConvertKit) email subscription forms, landing pages, products, broadcasts and more.
- * Version: 3.3.4
+ * Version: 3.3.5
  * Author: Kit
  * Author URI: https://kit.com/
  * Text Domain: convertkit
@@ -27,7 +27,7 @@ define( 'CONVERTKIT_PLUGIN_NAME', 'ConvertKit' ); // Used for user-agent in API 
 define( 'CONVERTKIT_PLUGIN_FILE', plugin_basename( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CONVERTKIT_PLUGIN_PATH', __DIR__ );
-define( 'CONVERTKIT_PLUGIN_VERSION', '3.3.4' );
+define( 'CONVERTKIT_PLUGIN_VERSION', '3.3.5' );
 define( 'CONVERTKIT_OAUTH_CLIENT_ID', 'HXZlOCj-K5r0ufuWCtyoyo3f688VmMAYSsKg1eGvw0Y' );
 define( 'CONVERTKIT_OAUTH_CLIENT_REDIRECT_URI', 'https://app.kit.com/wordpress/redirect' );
 


### PR DESCRIPTION
## Summary

Adds a security disclosure policy, including the required update to the Plugin's readme.txt file for PatchStack to permit us to [view security vulnerability disclosures](https://wpzinc.slack.com/archives/C02KFR6N1GF/p1783383622365749) for this Plugin.

<img width="543" height="725" alt="Screenshot 2026-07-07 at 15 51 05" src="https://github.com/user-attachments/assets/5863643c-15de-4143-a1ae-e7bc3e819572" />

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)