### PR TITLE
Coding Standards: JS: Pin Typescript Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@wordpress/prettier-config": "^4.30.0",
     "@wordpress/scripts": "^30.23.0",
     "eslint-config-prettier": "^10.1.8",
+    "typescript": "~5.4.5",
     "sass": "^1.97.3",
     "stylelint-scss": "^6.14.0"
   }


### PR DESCRIPTION
## Summary

Fixes JS linting due to Typescript 7's release yesterday, which some npm packages don't yet support:

```
wp-scripts lint-js --max-warnings=0
Oops! Something went wrong! :(
ESLint: 8.57.1
TypeError: Failed to load plugin '@typescript-eslint' declared in '.eslintrc.js » plugin:@wordpress/recommended': Cannot read properties of undefined (reading 'Intrinsic')
Referenced from: /Users/tim/Local Sites/_plugins/convertkit-wpforms/node_modules/@wordpress/eslint-plugin/index.js
    at Object.<anonymous> (/Users/tim/Local Sites/_plugins/convertkit-wpforms/node_modules/ts-api-utils/lib/index.cjs:779:57)
    at Module._compile (node:internal/modules/cjs/loader:1688:14)
    at Object..js (node:internal/modules/cjs/loader:1820:10)
    at Module.load (node:internal/modules/cjs/loader:1423:32)
    at Function._load (node:internal/modules/cjs/loader:1246:12)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:235:24)
    at Module.require (node:internal/modules/cjs/loader:1445:12)
    at require (node:internal/modules/helpers:135:16)
    at Object.<anonymous> (/Users/tim/Local Sites/_plugins/convertkit-wpforms/node_modules/@typescript-eslint/type-utils/dist/containsAllTypesByName.js:27:30)
```

<img width="1309" height="588" alt="Screenshot 2026-07-09 at 11 00 08" src="https://github.com/user-attachments/assets/586b81b1-3000-4047-b5da-966dcdc91c59" />

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)