### PR TITLE
Member Content: Exclude Pages from Siteground Speed Optimizer's Cache

### DIFF
--- a/includes/class-convertkit-cache-plugins.php
+++ b/includes/class-convertkit-cache-plugins.php
@@ -80,6 +80,9 @@ class ConvertKit_Cache_Plugins {
 		add_filter( 'convertkit_output_script_footer', array( $this, 'siteground_speed_optimizer_exclude_js_combine' ) );
 		add_filter( 'convertkit_resource_forms_output_script', array( $this, 'siteground_speed_optimizer_exclude_js_combine' ) );
 
+		// Siteground Speed Optimizer: Set Member Content Pages in "Exclude URLs from Caching".
+		add_filter( 'sgo_exclude_urls_from_cache', array( $this, 'exclude_restrict_content_pages_from_caching' ) );
+
 		// Rocket LazyLoad: Exclude images from lazy loading.
 		add_filter( 'rocket_lazyload_excluded_src', array( $this, 'exclude_hosts' ) );
 
@@ -337,6 +340,33 @@ class ConvertKit_Cache_Plugins {
 	public function exclude_local_js_from_minification( $scripts ) {
 
 		return array_merge( $scripts, $this->exclude_plugin_js );
+
+	}
+
+	/**
+	 * Exclude Restrict Content Pages from caching when the Siteground Speed Optimizer Plugin is installed, active
+	 * and its "Exclude URLs from Caching" setting is enabled.
+	 *
+	 * @since   3.3.6
+	 *
+	 * @param   array $excluded_urls    URLs to exclude from caching.
+	 * @return  array
+	 */
+	public function exclude_restrict_content_pages_from_caching( $excluded_urls ) {
+
+		// Get the list of relative URLs for posts with restrict_content enabled
+		// from the Plugin's cache.
+		$restrict_content_cache = WP_ConvertKit()->get_class( 'restrict_content_cache' );
+		if ( ! $restrict_content_cache ) {
+			return $excluded_urls;
+		}
+
+		// Cache stores Restrict Content pages as id => relative url pairs.
+		// Siteground just needs to the relative URLs.
+		$restrict_content_urls = array_values( $restrict_content_cache->get() );
+
+		// Merge the list of relative URLs with the list of URLs already excluded from caching.
+		return array_merge( $excluded_urls, $restrict_content_urls );
 
 	}
 

--- a/tests/EndToEnd/restrict-content/general/RestrictContentCacheCest.php
+++ b/tests/EndToEnd/restrict-content/general/RestrictContentCacheCest.php
@@ -540,6 +540,96 @@ class RestrictContentCacheCest
 	}
 
 	/**
+	 * Tests that the SiteGround Speed Optimizer Plugin does not interfere with
+	 * Restrict Content output when a ck_subscriber_id cookie is present, and
+	 * that the Restrict Content Page is registered against the
+	 * sgo_exclude_urls_from_cache filter via the Plugin's cache option.
+	 *
+	 * @since   3.3.6
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testRestrictContentSitegroundSpeedOptimizer(EndToEndTester $I)
+	{
+		// Activate SiteGround Speed Optimizer Plugin.
+		$I->activateThirdPartyPlugin($I, 'sg-cachepress');
+
+		// Enable SG Speed Optimizer's Dynamic Cache so its exclusion logic is active.
+		$I->haveOptionInDatabase('siteground_optimizer_enable_cache', 1);
+
+		// Configure SG Speed Optimizer's Heartbeat, to prevent the Plugin from
+		// making requests to the site during the test.
+		$I->haveOptionInDatabase('siteground_optimizer_heartbeat_post_interval', 120);
+		$I->haveOptionInDatabase('siteground_optimizer_heartbeat_dashboard_interval', 120);
+		$I->haveOptionInDatabase('siteground_optimizer_heartbeat_frontend_interval', 120);
+
+		// Confirm the Plugin's Restrict Content cache option is empty, as no
+		// Restrict Content Page has been configured yet.
+		$cache = $I->grabOptionFromDatabase('_wp_convertkit_restrict_content_posts');
+		$I->assertTrue( empty( $cache ) );
+
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Restrict Content: Product: SG Speed Optimizer'
+		);
+
+		// Configure metabox's Restrict Content setting = Product name.
+		$I->configurePluginSidebarSettings(
+			$I,
+			form: 'None',
+			restrictContent: $_ENV['CONVERTKIT_API_PRODUCT_NAME']
+		);
+
+		// Add blocks.
+		$I->addGutenbergParagraphBlock($I, 'Visible content.');
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'More',
+			blockProgrammaticName: 'more'
+		);
+		$I->addGutenbergParagraphBlock($I, 'Member-only content.');
+
+		// Publish Page.
+		$url = $I->publishGutenbergPage($I);
+
+		// Load the Dashboard.
+		$I->amOnAdminPage('index.php');
+		$I->waitForElementVisible('body.index-php');
+
+		// Confirm the Plugin's Restrict Content cache option now includes
+		// the relative URL for this Page. This URL is fed to
+		// SiteGround Speed Optimizer via the sgo_exclude_urls_from_cache
+		// filter at runtime, so that SG excludes the Restrict Content Page
+		// from its cache.
+		$cache = $I->grabOptionFromDatabase('_wp_convertkit_restrict_content_posts');
+		$I->assertIsArray($cache);
+		$I->assertContains(wp_make_link_relative($url), array_values($cache));
+
+		// Log out, so that caching is honored.
+		$I->logOut();
+
+		// Navigate to the page.
+		$I->amOnUrl($url);
+
+		// Test that the restricted content CTA displays when no valid signed subscriber ID is used,
+		// to confirm caching does not show member-only content.
+		$I->testRestrictContentByProductHidesContentWithCTA($I);
+
+		// Test that the restricted content displays when a valid signed subscriber ID is used,
+		// to confirm caching does not show the incorrect content.
+		$I->setRestrictContentCookieAndReload(
+			$I,
+			subscriberID: $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID'],
+			urlOrPageID: $url
+		);
+		$I->testRestrictContentDisplaysContent($I);
+
+		// Deactivate SiteGround Speed Optimizer Plugin.
+		$I->deactivateThirdPartyPlugin($I, 'sg-cachepress');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/Integration/RestrictContentCacheTest.php
+++ b/tests/Integration/RestrictContentCacheTest.php
@@ -686,6 +686,26 @@ class RestrictContentCacheTest extends WPTestCase
 	}
 
 	/**
+	 * Test that the SiteGround Speed Optimizer filter integration returns the
+	 * restrict content post URLs. This proves the end-to-end integration:
+	 * ConvertKit_Cache_Plugins::exclude_restrict_content_pages_from_caching()
+	 * consumes the cache and merges the URLs into the excluded URLs list.
+	 *
+	 * @since   3.3.6
+	 */
+	public function testSitegroundExcludeRestrictContentUrlsFilter()
+	{
+		$post_id = $this->createRestrictContentPost();
+
+		$excluded_urls = apply_filters( 'sgo_exclude_urls_from_cache', array() );
+
+		$this->assertContains(
+			wp_make_link_relative( get_permalink( $post_id ) ),
+			$excluded_urls
+		);
+	}
+
+	/**
 	 * Helper: create a Post with Kit meta setting restrict_content to the given value.
 	 *
 	 * @since   3.3.6

--- a/tests/Support/Helper/KitPlugin.php
+++ b/tests/Support/Helper/KitPlugin.php
@@ -603,6 +603,7 @@ class KitPlugin extends \Codeception\Module
 
 		// Cache.
 		$I->dontHaveOptionInDatabase('convertkit_restrict_content_enabled');
+		$I->dontHaveOptionInDatabase('_wp_convertkit_restrict_content_posts');
 
 		// Cookies.
 		$I->resetCookie('ck_subscriber_id');


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://linear.app/kit/issue/WP-86/wp-p3-member-restricted-content-appearing-for-non-members) by automatically excluding Member Content pages from being cached by Siteground's Speed Optimizer Plugin, ensuring they correctly display the non-member or member content, depending on whether the visitor is logged in and has access.

## Testing

`testRestrictContentSitegroundSpeedOptimizer`

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)