### PR TITLE
Abilities API: Post Settings

### DIFF
--- a/includes/mcp/abilities/category-settings/class-convertkit-mcp-ability-category-settings-get.php
+++ b/includes/mcp/abilities/category-settings/class-convertkit-mcp-ability-category-settings-get.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Kit MCP Ability: Get Category Settings.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Ability that returns the current Kit settings for a Category.
+ *
+ * Produces an ability named `kit/category-settings-get`.
+ *
+ * @package ConvertKit
+ * @author  ConvertKit
+ */
+class ConvertKit_MCP_Ability_Category_Settings_Get extends ConvertKit_MCP_Ability_Category_Settings {
+
+	/**
+	 * Sets whether the ability is readonly.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     bool
+	 */
+	private $readonly = true; // @phpstan-ignore-line
+
+	/**
+	 * Sets whether the ability is idempotent.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     bool
+	 */
+	private $idempotent = true; // @phpstan-ignore-line
+
+	/**
+	 * Returns the operation suffix used in the ability name.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	protected function get_operation() {
+
+		return 'get';
+
+	}
+
+	/**
+	 * Returns the ability's human-readable label.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_label() {
+
+		return __( 'Get Kit Category Settings', 'convertkit' );
+
+	}
+
+	/**
+	 * Returns the ability's human-readable description.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_description() {
+
+		return __( 'Returns the current Kit settings (form, form_position) for the given Category (WordPress `category` taxonomy term).', 'convertkit' );
+
+	}
+
+	/**
+	 * Returns the ability's input JSON Schema.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  array
+	 */
+	public function get_input_schema() {
+
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'term_id' ),
+			'properties' => array(
+				'term_id' => array(
+					'type'        => 'integer',
+					'description' => __( 'The Category (term) ID to read Kit settings for.', 'convertkit' ),
+					'minimum'     => 1,
+				),
+			),
+		);
+
+	}
+
+	/**
+	 * Executes the ability.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @param   array $input   Ability input.
+	 * @return  array|WP_Error
+	 */
+	public function execute_callback( $input ) {
+
+		$term_id = isset( $input['term_id'] ) ? absint( $input['term_id'] ) : 0;
+
+		// Bail if the term does not exist or is not a Category.
+		$valid = $this->validate_term( $term_id );
+		if ( is_wp_error( $valid ) ) {
+			return $valid;
+		}
+
+		// Load the Category's settings.
+		$term_settings = new ConvertKit_Term( $term_id );
+		$settings      = $term_settings->get();
+
+		// Cast `form` to int and `form_position` to string so the output
+		// exactly matches the declared schema, regardless of how the value
+		// was stored (defaults may be '' for form, but the schema wants int).
+		$form          = isset( $settings['form'] ) && $settings['form'] !== '' ? (int) $settings['form'] : 0;
+		$form_position = isset( $settings['form_position'] ) ? (string) $settings['form_position'] : '';
+
+		return array(
+			'term_id'       => $term_id,
+			'form'          => $form,
+			'form_position' => $form_position,
+		);
+
+	}
+
+}

--- a/includes/mcp/abilities/category-settings/class-convertkit-mcp-ability-category-settings-update.php
+++ b/includes/mcp/abilities/category-settings/class-convertkit-mcp-ability-category-settings-update.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Kit MCP Ability: Update Category Settings.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Ability that updates one or more Kit settings for a Category.
+ *
+ * Produces an ability named `kit/category-settings-update`.
+ *
+ * @package ConvertKit
+ * @author  ConvertKit
+ */
+class ConvertKit_MCP_Ability_Category_Settings_Update extends ConvertKit_MCP_Ability_Category_Settings {
+
+	/**
+	 * Sets whether the ability is idempotent.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     bool
+	 */
+	private $idempotent = true; // @phpstan-ignore-line
+
+	/**
+	 * Returns the operation suffix used in the ability name.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	protected function get_operation() {
+
+		return 'update';
+
+	}
+
+	/**
+	 * Returns the ability's human-readable label.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_label() {
+
+		return __( 'Update Kit Category Settings', 'convertkit' );
+
+	}
+
+	/**
+	 * Returns the ability's human-readable description.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_description() {
+
+		return __( 'Updates one or more Kit settings (form, form_position) for the given Category (WordPress `category` taxonomy term). Only the settings provided in the input are updated; other settings are preserved.', 'convertkit' );
+
+	}
+
+	/**
+	 * Returns the ability's input JSON Schema.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  array
+	 */
+	public function get_input_schema() {
+
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'term_id' ),
+			'properties' => array_merge(
+				array(
+					'term_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'The Category (term) ID to update Kit settings for.', 'convertkit' ),
+						'minimum'     => 1,
+					),
+				),
+				$this->get_settings_schema_properties()
+			),
+		);
+
+	}
+
+	/**
+	 * Executes the ability.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @param   array $input   Ability input.
+	 * @return  array|WP_Error
+	 */
+	public function execute_callback( $input ) {
+
+		$term_id = isset( $input['term_id'] ) ? absint( $input['term_id'] ) : 0;
+
+		// Bail if the term does not exist or is not a Category.
+		$valid = $this->validate_term( $term_id );
+		if ( is_wp_error( $valid ) ) {
+			return $valid;
+		}
+
+		// Reject unknown keys.
+		$properties   = $this->get_settings_schema_properties();
+		$allowed_keys = array_merge( array( 'term_id' ), array_keys( $properties ) );
+		$unknown_keys = array_diff( array_keys( $input ), $allowed_keys );
+		if ( ! empty( $unknown_keys ) ) {
+			return new WP_Error(
+				'convertkit_mcp_category_settings_unknown_keys',
+				sprintf(
+					/* translators: %s: Comma-separated list of unknown keys. */
+					__( 'The following settings keys are not recognised: %s.', 'convertkit' ),
+					implode( ', ', $unknown_keys )
+				)
+			);
+		}
+
+		// Validate each provided setting against its declared schema.
+		$validated = array();
+		foreach ( $properties as $key => $property_schema ) {
+			if ( ! array_key_exists( $key, $input ) ) {
+				continue;
+			}
+
+			$valid = rest_validate_value_from_schema( $input[ $key ], $property_schema, $key );
+
+			// Bail if the value is invalid.
+			if ( is_wp_error( $valid ) ) {
+				return $valid;
+			}
+
+			$validated[ $key ] = rest_sanitize_value_from_schema( $input[ $key ], $property_schema, $key );
+		}
+
+		// Bail if no settings were provided.
+		if ( empty( $validated ) ) {
+			return new WP_Error(
+				'convertkit_mcp_category_settings_no_input',
+				__( 'At least one setting (form or form_position) must be provided.', 'convertkit' )
+			);
+		}
+
+		// Save. ConvertKit_Term::save() merges the provided values into the
+		// term's existing settings internally, so this is a partial update.
+		$term_settings = new ConvertKit_Term( $term_id );
+		$term_settings->save( $validated );
+
+		// Return the post-save state, using the get ability so the shape
+		// exactly matches kit/category-settings-get.
+		$get_ability = new ConvertKit_MCP_Ability_Category_Settings_Get();
+		return $get_ability->execute_callback( array( 'term_id' => $term_id ) );
+
+	}
+
+}

--- a/includes/mcp/abilities/category-settings/class-convertkit-mcp-ability-category-settings.php
+++ b/includes/mcp/abilities/category-settings/class-convertkit-mcp-ability-category-settings.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Kit MCP Ability: Category Settings base class.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Base class for abilities that read or update the per-Category Kit settings
+ * (form, form_position) stored in the `_wp_convertkit_term_meta` term meta key.
+ *
+ * Each subclass represents a single verb (get / update). Produces ability
+ * names of the form `kit/category-settings-<operation>`.
+ *
+ * Scope is limited to the `category` taxonomy, matching the admin UI
+ * (ConvertKit_Admin_Category) and the frontend read path
+ * (ConvertKit_Output::get_term_form_position()).
+ *
+ * @package ConvertKit
+ * @author  ConvertKit
+ */
+abstract class ConvertKit_MCP_Ability_Category_Settings extends ConvertKit_MCP_Ability {
+
+	/**
+	 * The taxonomy this ability operates on.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     string
+	 */
+	const TAXONOMY = 'category';
+
+	/**
+	 * Returns the operation suffix used in the ability name (e.g. 'get',
+	 * 'update').
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	abstract protected function get_operation();
+
+	/**
+	 * Returns the ability name.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_name() {
+
+		return 'kit/category-settings-' . $this->get_operation();
+
+	}
+
+	/**
+	 * Only permit an ability to be executed if the current user can edit
+	 * the given category term.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @param   array $input   Ability input.
+	 * @return  bool|WP_Error
+	 */
+	public function permission_callback( $input ) {
+
+		// Get Term ID.
+		$term_id = isset( $input['term_id'] ) ? absint( $input['term_id'] ) : 0;
+
+		// Bail if no Term ID is provided.
+		if ( ! $term_id ) {
+			return new WP_Error(
+				'convertkit_mcp_missing_term_id',
+				__( 'A term_id is required.', 'convertkit' )
+			);
+		}
+
+		// Bail if the current user cannot edit this term.
+		if ( ! current_user_can( 'edit_term', $term_id ) ) {
+			return new WP_Error(
+				'convertkit_mcp_cannot_edit_term',
+				__( 'You do not have permission to edit this category.', 'convertkit' )
+			);
+		}
+
+		return true;
+
+	}
+
+	/**
+	 * Validates that the given term exists and is in the `category` taxonomy.
+	 *
+	 * Returned as a shared helper for both verb subclasses' execute_callback.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @param   int $term_id    Term ID.
+	 * @return  true|WP_Error
+	 */
+	protected function validate_term( $term_id ) {
+
+		$term = get_term( $term_id );
+
+		// Bail if the term does not exist.
+		if ( ! $term || is_wp_error( $term ) ) {
+			return new WP_Error(
+				'convertkit_mcp_term_not_found',
+				sprintf(
+					/* translators: %d: Term ID. */
+					__( 'Term %d does not exist.', 'convertkit' ),
+					$term_id
+				)
+			);
+		}
+
+		// Bail if the term is not in the `category` taxonomy.
+		if ( $term->taxonomy !== self::TAXONOMY ) {
+			return new WP_Error(
+				'convertkit_mcp_term_wrong_taxonomy',
+				sprintf(
+					/* translators: 1: Term ID, 2: Actual taxonomy, 3: Expected taxonomy. */
+					__( 'Term %1$d is in the "%2$s" taxonomy; this ability only supports the "%3$s" taxonomy.', 'convertkit' ),
+					$term_id,
+					$term->taxonomy,
+					self::TAXONOMY
+				)
+			);
+		}
+
+		return true;
+
+	}
+
+	/**
+	 * Returns the JSON Schema properties that describe the two Kit category
+	 * settings, shared by both the input and output schemas.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  array
+	 */
+	protected function get_settings_schema_properties() {
+
+		return array(
+			'form'          => array(
+				'type'        => 'integer',
+				'description' => __( 'Form to display for Posts assigned to this Category. `-1` = use the Plugin Default Form; `0` = display no form; any other positive integer is a specific Kit Form ID.', 'convertkit' ),
+				'minimum'     => -1,
+			),
+			'form_position' => array(
+				'type'        => 'string',
+				'description' => __( 'Where the Form displays on the Category archive page. Empty string uses the Plugin default position; `before` displays it before the post list; `after` displays it after.', 'convertkit' ),
+				'enum'        => array( '', 'before', 'after' ),
+			),
+		);
+
+	}
+
+	/**
+	 * Returns the JSON Schema for the ability's output.
+	 *
+	 * Shared by get and update so a caller can chain update -> confirm.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  array
+	 */
+	public function get_output_schema() {
+
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'term_id', 'form', 'form_position' ),
+			'properties' => array_merge(
+				array(
+					'term_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'The Category (term) ID.', 'convertkit' ),
+					),
+				),
+				$this->get_settings_schema_properties()
+			),
+		);
+
+	}
+
+}

--- a/includes/mcp/abilities/post-settings/class-convertkit-mcp-ability-post-settings-get.php
+++ b/includes/mcp/abilities/post-settings/class-convertkit-mcp-ability-post-settings-get.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Kit MCP Ability: Get Post Settings.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Ability that returns the current Kit settings for a Post/Page/Custom Post Type.
+ *
+ * Produces an ability named `kit/post-settings-get`.
+ *
+ * @package ConvertKit
+ * @author  ConvertKit
+ */
+class ConvertKit_MCP_Ability_Post_Settings_Get extends ConvertKit_MCP_Ability_Post_Settings {
+
+	/**
+	 * Sets whether the ability is readonly.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     bool
+	 */
+	private $readonly = true; // @phpstan-ignore-line
+
+	/**
+	 * Sets whether the ability is idempotent.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     bool
+	 */
+	private $idempotent = true; // @phpstan-ignore-line
+
+	/**
+	 * Returns the operation suffix used in the ability name.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	protected function get_operation() {
+
+		return 'get';
+
+	}
+
+	/**
+	 * Returns the ability's human-readable label.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_label() {
+
+		return __( 'Get Kit Post Settings', 'convertkit' );
+
+	}
+
+	/**
+	 * Returns the ability's human-readable description.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_description() {
+
+		return __( 'Returns the current Kit settings (form, landing_page, tag, restrict_content) for the given Post, Page or Custom Post Type.', 'convertkit' );
+
+	}
+
+	/**
+	 * Returns the ability's input JSON Schema.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  array
+	 */
+	public function get_input_schema() {
+
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'post_id' ),
+			'properties' => array(
+				'post_id' => array(
+					'type'        => 'integer',
+					'description' => __( 'The Post/Page/Custom Post Type ID to read Kit settings for.', 'convertkit' ),
+					'minimum'     => 1,
+				),
+			),
+		);
+
+	}
+
+	/**
+	 * Executes the ability.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @param   array $input   Ability input.
+	 * @return  array|WP_Error
+	 */
+	public function execute_callback( $input ) {
+
+		$post_id = isset( $input['post_id'] ) ? absint( $input['post_id'] ) : 0;
+
+		// Bail if the Post does not exist.
+		if ( ! get_post( $post_id ) ) {
+			return new WP_Error(
+				'convertkit_mcp_post_not_found',
+				sprintf(
+					/* translators: %d: Post ID. */
+					__( 'Post %d does not exist.', 'convertkit' ),
+					$post_id
+				)
+			);
+		}
+
+		// Load the Post's settings.
+		$post_settings = new ConvertKit_Post( $post_id );
+		$settings      = $post_settings->get();
+
+		// Cast values to string so they match the output schema (Post storage
+		// keeps them as strings, but defense-in-depth for numeric coercion).
+		return array(
+			'post_id'          => $post_id,
+			'form'             => (string) $settings['form'],
+			'landing_page'     => (string) $settings['landing_page'],
+			'tag'              => (string) $settings['tag'],
+			'restrict_content' => (string) $settings['restrict_content'],
+		);
+
+	}
+
+}

--- a/includes/mcp/abilities/post-settings/class-convertkit-mcp-ability-post-settings-update.php
+++ b/includes/mcp/abilities/post-settings/class-convertkit-mcp-ability-post-settings-update.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Kit MCP Ability: Update Post Settings.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Ability that updates one or more Kit settings for a Post/Page/Custom Post Type.
+ *
+ * Produces an ability named `kit/post-settings-update`.
+ *
+ * @package ConvertKit
+ * @author  ConvertKit
+ */
+class ConvertKit_MCP_Ability_Post_Settings_Update extends ConvertKit_MCP_Ability_Post_Settings {
+
+	/**
+	 * Sets whether the ability is idempotent.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     bool
+	 */
+	private $idempotent = true; // @phpstan-ignore-line
+
+	/**
+	 * Returns the operation suffix used in the ability name.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	protected function get_operation() {
+
+		return 'update';
+
+	}
+
+	/**
+	 * Returns the ability's human-readable label.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_label() {
+
+		return __( 'Update Kit Post Settings', 'convertkit' );
+
+	}
+
+	/**
+	 * Returns the ability's human-readable description.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_description() {
+
+		return __( 'Updates one or more Kit settings (form, landing_page, tag, restrict_content) for the given Post, Page or Custom Post Type. Only the settings provided in the input are updated; other settings are preserved.', 'convertkit' );
+
+	}
+
+	/**
+	 * Returns the ability's input JSON Schema.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  array
+	 */
+	public function get_input_schema() {
+
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'post_id' ),
+			'properties' => array_merge(
+				array(
+					'post_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'The Post/Page/Custom Post Type ID to update Kit settings for.', 'convertkit' ),
+						'minimum'     => 1,
+					),
+				),
+				$this->get_settings_schema_properties()
+			),
+		);
+
+	}
+
+	/**
+	 * Executes the ability.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @param   array $input   Ability input.
+	 * @return  array|WP_Error
+	 */
+	public function execute_callback( $input ) {
+
+		$post_id = isset( $input['post_id'] ) ? absint( $input['post_id'] ) : 0;
+
+		// Bail if the Post does not exist.
+		if ( ! get_post( $post_id ) ) {
+			return new WP_Error(
+				'convertkit_mcp_post_not_found',
+				sprintf(
+					/* translators: %d: Post ID. */
+					__( 'Post %d does not exist.', 'convertkit' ),
+					$post_id
+				)
+			);
+		}
+
+		// Reject unknown keys.
+		$properties   = $this->get_settings_schema_properties();
+		$allowed_keys = array_merge( array( 'post_id' ), array_keys( $properties ) );
+		$unknown_keys = array_diff( array_keys( $input ), $allowed_keys );
+		if ( ! empty( $unknown_keys ) ) {
+			return new WP_Error(
+				'convertkit_mcp_post_settings_unknown_keys',
+				sprintf(
+					/* translators: %s: Comma-separated list of unknown keys. */
+					__( 'The following settings keys are not recognised: %s.', 'convertkit' ),
+					implode( ', ', $unknown_keys )
+				)
+			);
+		}
+
+		// Validate each provided setting against its declared schema.
+		$validated = array();
+		foreach ( $properties as $key => $property_schema ) {
+			if ( ! array_key_exists( $key, $input ) ) {
+				continue;
+			}
+
+			$valid = rest_validate_value_from_schema( $input[ $key ], $property_schema, $key );
+
+			// Bail if the value is invalid.
+			if ( is_wp_error( $valid ) ) {
+				return $valid;
+			}
+
+			$validated[ $key ] = rest_sanitize_value_from_schema( $input[ $key ], $property_schema, $key );
+		}
+
+		// Bail if no settings were provided.
+		if ( empty( $validated ) ) {
+			return new WP_Error(
+				'convertkit_mcp_post_settings_no_input',
+				__( 'At least one setting (form, landing_page, tag or restrict_content) must be provided.', 'convertkit' )
+			);
+		}
+
+		// Merge into the Post's existing settings so this is a partial update.
+		$post_settings = new ConvertKit_Post( $post_id );
+		$merged        = array_merge( $post_settings->get(), $validated );
+
+		// Save. This fires updated_post_meta, which the Restrict Content
+		// cache class listens for; nothing extra required here.
+		$post_settings->save( $merged );
+
+		// Return the post-save state, using the get ability so the shape
+		// exactly matches kit/post-settings-get.
+		$get_ability = new ConvertKit_MCP_Ability_Post_Settings_Get();
+		return $get_ability->execute_callback( array( 'post_id' => $post_id ) );
+
+	}
+
+}

--- a/includes/mcp/abilities/post-settings/class-convertkit-mcp-ability-post-settings.php
+++ b/includes/mcp/abilities/post-settings/class-convertkit-mcp-ability-post-settings.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Kit MCP Ability: Post Settings base class.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Base class for abilities that read or update the per-Post Kit settings
+ * (form, landing_page, tag, restrict_content) stored in the
+ * `_wp_convertkit_post_meta` post meta key.
+ *
+ * Each subclass represents a single verb (get / update). Produces ability
+ * names of the form `kit/post-settings-<operation>`.
+ *
+ * @package ConvertKit
+ * @author  ConvertKit
+ */
+abstract class ConvertKit_MCP_Ability_Post_Settings extends ConvertKit_MCP_Ability {
+
+	/**
+	 * Returns the operation suffix used in the ability name (e.g. 'get',
+	 * 'update').
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	abstract protected function get_operation();
+
+	/**
+	 * Returns the ability name.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_name() {
+
+		return 'kit/post-settings-' . $this->get_operation();
+
+	}
+
+	/**
+	 * Only permit an ability to be executed if the current user can edit
+	 * the given post.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @param   array $input   Ability input.
+	 * @return  bool|WP_Error
+	 */
+	public function permission_callback( $input ) {
+
+		// Get Post ID.
+		$post_id = isset( $input['post_id'] ) ? absint( $input['post_id'] ) : 0;
+
+		// Bail if no Post ID is provided.
+		if ( ! $post_id ) {
+			return new WP_Error(
+				'convertkit_mcp_missing_post_id',
+				__( 'A post_id is required.', 'convertkit' )
+			);
+		}
+
+		// Bail if the current user does not have permission to edit the post.
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return new WP_Error(
+				'convertkit_mcp_cannot_edit_post',
+				__( 'You do not have permission to edit this post.', 'convertkit' )
+			);
+		}
+
+		return true;
+
+	}
+
+	/**
+	 * Returns the JSON Schema properties that describe the four Kit post
+	 * settings, shared by both the input and output schemas.
+	 *
+	 * Values are stored by the Plugin as strings (matching what the metabox
+	 * submits), so the schemas expose them as strings with format constraints.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  array
+	 */
+	protected function get_settings_schema_properties() {
+
+		return array(
+			'form'             => array(
+				'type'        => 'string',
+				'description' => __( 'Form to display for the Post. `-1` = use the Plugin Default Form for this Post Type; `0` = display no form; any other positive integer is a specific Kit Form ID.', 'convertkit' ),
+				'pattern'     => '^(-1|0|[1-9][0-9]*)$',
+			),
+			'landing_page'     => array(
+				'type'        => 'string',
+				'description' => __( 'Kit Landing Page ID to display instead of the Post content. Empty string for none.', 'convertkit' ),
+				'pattern'     => '^([0-9]+)?$',
+			),
+			'tag'              => array(
+				'type'        => 'string',
+				'description' => __( 'Kit Tag ID to apply when the Post is viewed by a Kit subscriber. Empty string for none.', 'convertkit' ),
+				'pattern'     => '^([0-9]+)?$',
+			),
+			'restrict_content' => array(
+				'type'        => 'string',
+				'description' => __( 'Restrict Post content to Kit subscribers. Empty string for no restriction, or one of `form_<id>`, `tag_<id>`, `product_<id>` to require subscription to that resource.', 'convertkit' ),
+				'pattern'     => '^$|^(form|tag|product)_[1-9][0-9]*$',
+			),
+		);
+
+	}
+
+	/**
+	 * Returns the JSON Schema for the ability's output.
+	 *
+	 * The output shape is the same for get and update: the four settings
+	 * plus the post_id, so a caller can chain update -> confirm without a
+	 * follow-up get.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  array
+	 */
+	public function get_output_schema() {
+
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'post_id', 'form', 'landing_page', 'tag', 'restrict_content' ),
+			'properties' => array_merge(
+				array(
+					'post_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'The Post/Page/Custom Post Type ID.', 'convertkit' ),
+					),
+				),
+				$this->get_settings_schema_properties()
+			),
+		);
+
+	}
+
+}

--- a/includes/mcp/class-convertkit-mcp.php
+++ b/includes/mcp/class-convertkit-mcp.php
@@ -66,7 +66,7 @@ class ConvertKit_MCP {
 	 */
 	public static function get_server_url() {
 
-		return rest_url( self::SERVER_NAMESPACE . '/' . self::SERVER_ROUTE . '/mcp' );
+		return rest_url( self::SERVER_NAMESPACE . '/' . self::SERVER_ROUTE );
 
 	}
 
@@ -92,6 +92,12 @@ class ConvertKit_MCP {
 		// These are owned by the Plugin (not by any single feature),
 		// so they're added here rather than via a per-class register_abilities().
 		add_filter( 'convertkit_abilities', array( $this, 'register_settings_abilities' ) );
+
+		// Register the per-Post Kit settings get / update abilities. These
+		// operate on the `_wp_convertkit_post_meta` post meta (form,
+		// landing_page, tag, restrict_content) rather than any Plugin-wide
+		// settings group.
+		add_filter( 'convertkit_abilities', array( $this, 'register_post_settings_abilities' ) );
 
 		// Register the MCP server.
 		add_action( 'mcp_adapter_init', array( $this, 'register_mcp_server' ) );
@@ -125,6 +131,25 @@ class ConvertKit_MCP {
 			$abilities[ $get->get_name() ]    = $get;
 			$abilities[ $update->get_name() ] = $update;
 		}
+
+		return $abilities;
+
+	}
+
+	/**
+	 * Appends the per-Post Kit settings abilities to the convertkit_abilities
+	 * filter, so they are registered with the Abilities API and exposed via
+	 * the MCP server.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @param   array $abilities   Abilities to register.
+	 * @return  array
+	 */
+	public function register_post_settings_abilities( $abilities ) {
+
+		$abilities['kit/post-settings-get']    = new ConvertKit_MCP_Ability_Post_Settings_Get();
+		$abilities['kit/post-settings-update'] = new ConvertKit_MCP_Ability_Post_Settings_Update();
 
 		return $abilities;
 

--- a/includes/mcp/class-convertkit-mcp.php
+++ b/includes/mcp/class-convertkit-mcp.php
@@ -99,6 +99,11 @@ class ConvertKit_MCP {
 		// settings group.
 		add_filter( 'convertkit_abilities', array( $this, 'register_post_settings_abilities' ) );
 
+		// Register the per-Category Kit settings get / update abilities.
+		// These operate on the `_wp_convertkit_term_meta` term meta (form,
+		// form_position) for the WordPress `category` taxonomy.
+		add_filter( 'convertkit_abilities', array( $this, 'register_category_settings_abilities' ) );
+
 		// Register the MCP server.
 		add_action( 'mcp_adapter_init', array( $this, 'register_mcp_server' ) );
 
@@ -150,6 +155,25 @@ class ConvertKit_MCP {
 
 		$abilities['kit/post-settings-get']    = new ConvertKit_MCP_Ability_Post_Settings_Get();
 		$abilities['kit/post-settings-update'] = new ConvertKit_MCP_Ability_Post_Settings_Update();
+
+		return $abilities;
+
+	}
+
+	/**
+	 * Appends the per-Category Kit settings abilities to the convertkit_abilities
+	 * filter, so they are registered with the Abilities API and exposed via
+	 * the MCP server.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @param   array $abilities   Abilities to register.
+	 * @return  array
+	 */
+	public function register_category_settings_abilities( $abilities ) {
+
+		$abilities['kit/category-settings-get']    = new ConvertKit_MCP_Ability_Category_Settings_Get();
+		$abilities['kit/category-settings-update'] = new ConvertKit_MCP_Ability_Category_Settings_Update();
 
 		return $abilities;
 

--- a/tests/Integration/MCPCategorySettingsGetTest.php
+++ b/tests/Integration/MCPCategorySettingsGetTest.php
@@ -1,0 +1,237 @@
+<?php
+
+namespace Tests;
+
+use lucatume\WPBrowser\TestCase\WPTestCase;
+
+/**
+ * Tests for the Kit MCP category settings get ability:
+ *
+ * - kit/category-settings-get  (ConvertKit_MCP_Ability_Category_Settings_Get)
+ *
+ * @since   3.4.0
+ */
+class MCPCategorySettingsGetTest extends WPTestCase
+{
+	/**
+	 * The testing implementation.
+	 *
+	 * @var \IntegrationTester
+	 */
+	protected $tester;
+
+	/**
+	 * The ability name.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     string
+	 */
+	private const ABILITY_NAME = 'kit/category-settings-get';
+
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		activate_plugins('convertkit/wp-convertkit.php');
+	}
+
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function tearDown(): void
+	{
+		wp_set_current_user(0);
+		deactivate_plugins('convertkit/wp-convertkit.php');
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that the ability registers via the convertkit_abilities filter
+	 * with the expected name and class.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testAbilityRegistered()
+	{
+		$abilities = convertkit_get_abilities();
+
+		$this->assertArrayHasKey(self::ABILITY_NAME, $abilities);
+		$this->assertInstanceOf(\ConvertKit_MCP_Ability_Category_Settings_Get::class, $abilities[ self::ABILITY_NAME ]);
+	}
+
+	/**
+	 * Test that permission_callback() rejects an input with no term_id.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackRejectsMissingTermId()
+	{
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->permission_callback([]);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+		$this->assertSame('convertkit_mcp_missing_term_id', $result->get_error_code());
+	}
+
+	/**
+	 * Test that permission_callback() rejects a user who cannot edit the
+	 * given category (Subscriber role has no manage_categories cap).
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackDeniesWithoutEditTermCapability()
+	{
+		$term_id = $this->createCategoryAsAdmin();
+
+		// Switch to a subscriber.
+		$subscriber_id = static::factory()->user->create([ 'role' => 'subscriber' ]);
+		wp_set_current_user($subscriber_id);
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->permission_callback([ 'term_id' => $term_id ]);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+		$this->assertSame('convertkit_mcp_cannot_edit_term', $result->get_error_code());
+	}
+
+	/**
+	 * Test that get returns the default settings when the Category has no
+	 * Kit term meta stored.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testGetReturnsDefaultsWhenNoMetaExists()
+	{
+		$term_id = $this->createCategoryAsAdmin();
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback([ 'term_id' => $term_id ]);
+
+		$this->assertIsArray($result);
+		$this->assertSame($term_id, $result['term_id']);
+		$this->assertSame(0, $result['form']);
+		$this->assertSame('', $result['form_position']);
+	}
+
+	/**
+	 * Test that get returns stored Kit settings for a Category that has
+	 * term meta saved.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testGetReturnsStoredSettings()
+	{
+		$term_id = $this->createCategoryAsAdmin();
+
+		update_term_meta(
+			$term_id,
+			'_wp_convertkit_term_meta',
+			[
+				'form'          => 123,
+				'form_position' => 'before',
+			]
+		);
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback([ 'term_id' => $term_id ]);
+
+		$this->assertSame($term_id, $result['term_id']);
+		$this->assertSame(123, $result['form']);
+		$this->assertSame('before', $result['form_position']);
+	}
+
+	/**
+	 * Test that get returns `form_position = after` correctly (round-trips
+	 * both non-empty enum values, not just `before`).
+	 *
+	 * @since   3.4.0
+	 */
+	public function testGetReturnsFormPositionAfter()
+	{
+		$term_id = $this->createCategoryAsAdmin();
+
+		update_term_meta(
+			$term_id,
+			'_wp_convertkit_term_meta',
+			[
+				'form'          => -1,
+				'form_position' => 'after',
+			]
+		);
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback([ 'term_id' => $term_id ]);
+
+		$this->assertSame(-1, $result['form']);
+		$this->assertSame('after', $result['form_position']);
+	}
+
+	/**
+	 * Test that get returns a WP_Error when the term is not in the
+	 * `category` taxonomy (e.g. it's a `post_tag`).
+	 *
+	 * @since   3.4.0
+	 */
+	public function testGetReturnsErrorForNonCategoryTerm()
+	{
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		$tag_id = static::factory()->term->create([ 'taxonomy' => 'post_tag' ]);
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback([ 'term_id' => $tag_id ]);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+		$this->assertSame('convertkit_mcp_term_wrong_taxonomy', $result->get_error_code());
+	}
+
+	/**
+	 * Test that get returns a WP_Error when the given term_id does not exist.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testGetReturnsErrorForNonExistentTerm()
+	{
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback([ 'term_id' => 999999 ]);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+		$this->assertSame('convertkit_mcp_term_not_found', $result->get_error_code());
+	}
+
+	/**
+	 * Helper: creates an administrator user, switches to them, and returns
+	 * a new Category term ID.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  int
+	 */
+	private function createCategoryAsAdmin()
+	{
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		return static::factory()->term->create([ 'taxonomy' => 'category' ]);
+	}
+}

--- a/tests/Integration/MCPCategorySettingsUpdateTest.php
+++ b/tests/Integration/MCPCategorySettingsUpdateTest.php
@@ -1,0 +1,308 @@
+<?php
+
+namespace Tests;
+
+use lucatume\WPBrowser\TestCase\WPTestCase;
+
+/**
+ * Tests for the Kit MCP category settings update ability:
+ *
+ * - kit/category-settings-update  (ConvertKit_MCP_Ability_Category_Settings_Update)
+ *
+ * @since   3.4.0
+ */
+class MCPCategorySettingsUpdateTest extends WPTestCase
+{
+	/**
+	 * The testing implementation.
+	 *
+	 * @var \IntegrationTester
+	 */
+	protected $tester;
+
+	/**
+	 * The ability name.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     string
+	 */
+	private const ABILITY_NAME = 'kit/category-settings-update';
+
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		activate_plugins('convertkit/wp-convertkit.php');
+	}
+
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function tearDown(): void
+	{
+		wp_set_current_user(0);
+		deactivate_plugins('convertkit/wp-convertkit.php');
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that the ability registers via the convertkit_abilities filter
+	 * with the expected name and class.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testAbilityRegistered()
+	{
+		$abilities = convertkit_get_abilities();
+
+		$this->assertArrayHasKey(self::ABILITY_NAME, $abilities);
+		$this->assertInstanceOf(\ConvertKit_MCP_Ability_Category_Settings_Update::class, $abilities[ self::ABILITY_NAME ]);
+	}
+
+	/**
+	 * Test that update writes both settings and returns the post-save state.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateWritesBothSettings()
+	{
+		$term_id = $this->createCategoryAsAdmin();
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback(
+			[
+				'term_id'       => $term_id,
+				'form'          => 123,
+				'form_position' => 'before',
+			]
+		);
+
+		$this->assertIsArray($result);
+		$this->assertSame($term_id, $result['term_id']);
+		$this->assertSame(123, $result['form']);
+		$this->assertSame('before', $result['form_position']);
+
+		// Confirm persisted to the DB.
+		$stored = get_term_meta($term_id, '_wp_convertkit_term_meta', true);
+		$this->assertSame(123, $stored['form']);
+		$this->assertSame('before', $stored['form_position']);
+	}
+
+	/**
+	 * Test that a partial update writes only the provided key and preserves
+	 * the other stored setting. Verifies ConvertKit_Term::save()'s internal
+	 * merge behaviour is honoured.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdatePartialUpdatePreservesOtherKey()
+	{
+		$term_id = $this->createCategoryAsAdmin();
+
+		// Seed existing settings.
+		update_term_meta(
+			$term_id,
+			'_wp_convertkit_term_meta',
+			[
+				'form'          => 111,
+				'form_position' => 'after',
+			]
+		);
+
+		$abilities = convertkit_get_abilities();
+
+		// Update only the form.
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback(
+			[
+				'term_id' => $term_id,
+				'form'    => 999,
+			]
+		);
+
+		$this->assertSame(999, $result['form']);
+		$this->assertSame('after', $result['form_position']);
+	}
+
+	/**
+	 * Test that update rejects unknown keys in the input.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateRejectsUnknownKeys()
+	{
+		$term_id = $this->createCategoryAsAdmin();
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback(
+			[
+				'term_id'     => $term_id,
+				'form'        => 123,
+				'not_a_field' => 'garbage',
+			]
+		);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+		$this->assertSame('convertkit_mcp_category_settings_unknown_keys', $result->get_error_code());
+	}
+
+	/**
+	 * Test that update rejects a form_position value outside the enum
+	 * (must be '', 'before' or 'after').
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateRejectsInvalidFormPosition()
+	{
+		$term_id = $this->createCategoryAsAdmin();
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback(
+			[
+				'term_id'       => $term_id,
+				'form_position' => 'sideways',
+			]
+		);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+	}
+
+	/**
+	 * Test that update rejects a form value below the schema minimum
+	 * (schema allows -1 and up).
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateRejectsInvalidFormValue()
+	{
+		$term_id = $this->createCategoryAsAdmin();
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback(
+			[
+				'term_id' => $term_id,
+				'form'    => -99,
+			]
+		);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+	}
+
+	/**
+	 * Test that update rejects a call with only term_id and no settings.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateRejectsWhenNoSettingsProvided()
+	{
+		$term_id = $this->createCategoryAsAdmin();
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback([ 'term_id' => $term_id ]);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+		$this->assertSame('convertkit_mcp_category_settings_no_input', $result->get_error_code());
+	}
+
+	/**
+	 * Test that update rejects a term that isn't in the `category` taxonomy.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateRejectsNonCategoryTerm()
+	{
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		$tag_id = static::factory()->term->create([ 'taxonomy' => 'post_tag' ]);
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback(
+			[
+				'term_id' => $tag_id,
+				'form'    => 123,
+			]
+		);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+		$this->assertSame('convertkit_mcp_term_wrong_taxonomy', $result->get_error_code());
+	}
+
+	/**
+	 * Test that update returns a WP_Error when the given term_id does not exist.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateReturnsErrorForNonExistentTerm()
+	{
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback(
+			[
+				'term_id' => 999999,
+				'form'    => 123,
+			]
+		);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+		$this->assertSame('convertkit_mcp_term_not_found', $result->get_error_code());
+	}
+
+	/**
+	 * Test that update -> get round-trip returns the updated values.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateThenGetRoundTrip()
+	{
+		$term_id = $this->createCategoryAsAdmin();
+
+		$abilities = convertkit_get_abilities();
+
+		$abilities[ self::ABILITY_NAME ]->execute_callback(
+			[
+				'term_id'       => $term_id,
+				'form'          => 555,
+				'form_position' => 'after',
+			]
+		);
+
+		$get_result = $abilities['kit/category-settings-get']->execute_callback([ 'term_id' => $term_id ]);
+
+		$this->assertSame(555, $get_result['form']);
+		$this->assertSame('after', $get_result['form_position']);
+	}
+
+	/**
+	 * Helper: creates an administrator user, switches to them, and returns
+	 * a new Category term ID.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  int
+	 */
+	private function createCategoryAsAdmin()
+	{
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		return static::factory()->term->create([ 'taxonomy' => 'category' ]);
+	}
+}

--- a/tests/Integration/MCPPostSettingsGetTest.php
+++ b/tests/Integration/MCPPostSettingsGetTest.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace Tests;
+
+use lucatume\WPBrowser\TestCase\WPTestCase;
+
+/**
+ * Tests for the Kit MCP post settings get ability:
+ *
+ * - kit/post-settings-get   (ConvertKit_MCP_Ability_Post_Settings_Get)
+ *
+ * @since   3.4.0
+ */
+class MCPPostSettingsGetTest extends WPTestCase
+{
+	/**
+	 * The testing implementation.
+	 *
+	 * @var \IntegrationTester
+	 */
+	protected $tester;
+
+	/**
+	 * The ability name.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     string
+	 */
+	private const ABILITY_NAME = 'kit/post-settings-get';
+
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		activate_plugins('convertkit/wp-convertkit.php');
+	}
+
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function tearDown(): void
+	{
+		wp_set_current_user(0);
+		deactivate_plugins('convertkit/wp-convertkit.php');
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that the ability registers via the convertkit_abilities filter
+	 * with the expected name and class.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testAbilityRegistered()
+	{
+		$abilities = convertkit_get_abilities();
+
+		$this->assertArrayHasKey(self::ABILITY_NAME, $abilities);
+		$this->assertInstanceOf(\ConvertKit_MCP_Ability_Post_Settings_Get::class, $abilities[ self::ABILITY_NAME ]);
+	}
+
+	/**
+	 * Test that permission_callback() rejects an input with no post_id.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackRejectsMissingPostId()
+	{
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->permission_callback([]);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+		$this->assertSame('convertkit_mcp_missing_post_id', $result->get_error_code());
+	}
+
+	/**
+	 * Test that permission_callback() rejects a user who cannot edit the given post.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackDeniesWithoutEditPostCapability()
+	{
+		// Create a Post by an admin.
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		$post_id  = static::factory()->post->create([ 'post_author' => $admin_id ]);
+
+		// Switch to a subscriber.
+		$subscriber_id = static::factory()->user->create([ 'role' => 'subscriber' ]);
+		wp_set_current_user($subscriber_id);
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->permission_callback([ 'post_id' => $post_id ]);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+		$this->assertSame('convertkit_mcp_cannot_edit_post', $result->get_error_code());
+	}
+
+	/**
+	 * Test that get returns the default settings when the Post has no
+	 * Kit post meta stored.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testGetReturnsDefaultsWhenNoMetaExists()
+	{
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		$post_id = static::factory()->post->create();
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback([ 'post_id' => $post_id ]);
+
+		$this->assertIsArray($result);
+		$this->assertSame($post_id, $result['post_id']);
+		$this->assertSame('-1', $result['form']);
+		$this->assertSame('', $result['landing_page']);
+		$this->assertSame('', $result['tag']);
+		$this->assertSame('', $result['restrict_content']);
+	}
+
+	/**
+	 * Test that get returns the stored Kit settings for a Post that has
+	 * post meta saved.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testGetReturnsStoredSettings()
+	{
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		$post_id = static::factory()->post->create();
+
+		update_post_meta(
+			$post_id,
+			'_wp_convertkit_post_meta',
+			[
+				'form'             => '123',
+				'landing_page'     => '456',
+				'tag'              => '789',
+				'restrict_content' => 'product_101',
+			]
+		);
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback([ 'post_id' => $post_id ]);
+
+		$this->assertSame($post_id, $result['post_id']);
+		$this->assertSame('123', $result['form']);
+		$this->assertSame('456', $result['landing_page']);
+		$this->assertSame('789', $result['tag']);
+		$this->assertSame('product_101', $result['restrict_content']);
+	}
+
+	/**
+	 * Test that get returns settings for a Page (not just Posts) — confirms
+	 * the ability isn't coupled to any single post type.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testGetWorksForPages()
+	{
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		$page_id = static::factory()->post->create([ 'post_type' => 'page' ]);
+
+		update_post_meta(
+			$page_id,
+			'_wp_convertkit_post_meta',
+			[
+				'form'             => '0',
+				'landing_page'     => '999',
+				'tag'              => '',
+				'restrict_content' => '',
+			]
+		);
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback([ 'post_id' => $page_id ]);
+
+		$this->assertSame('0', $result['form']);
+		$this->assertSame('999', $result['landing_page']);
+	}
+
+	/**
+	 * Test that get returns a WP_Error when the given post_id does not exist.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testGetReturnsErrorForNonExistentPost()
+	{
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback([ 'post_id' => 999999 ]);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+		$this->assertSame('convertkit_mcp_post_not_found', $result->get_error_code());
+	}
+}

--- a/tests/Integration/MCPPostSettingsUpdateTest.php
+++ b/tests/Integration/MCPPostSettingsUpdateTest.php
@@ -1,0 +1,368 @@
+<?php
+
+namespace Tests;
+
+use lucatume\WPBrowser\TestCase\WPTestCase;
+
+/**
+ * Tests for the Kit MCP post settings update ability:
+ *
+ * - kit/post-settings-update  (ConvertKit_MCP_Ability_Post_Settings_Update)
+ *
+ * @since   3.4.0
+ */
+class MCPPostSettingsUpdateTest extends WPTestCase
+{
+	/**
+	 * The testing implementation.
+	 *
+	 * @var \IntegrationTester
+	 */
+	protected $tester;
+
+	/**
+	 * The ability name.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     string
+	 */
+	private const ABILITY_NAME = 'kit/post-settings-update';
+
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		activate_plugins('convertkit/wp-convertkit.php');
+
+		delete_option(\ConvertKit_Restrict_Content_Cache::OPTION_NAME);
+	}
+
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function tearDown(): void
+	{
+		wp_set_current_user(0);
+		deactivate_plugins('convertkit/wp-convertkit.php');
+
+		delete_option(\ConvertKit_Restrict_Content_Cache::OPTION_NAME);
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that the ability registers via the convertkit_abilities filter
+	 * with the expected name and class.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testAbilityRegistered()
+	{
+		$abilities = convertkit_get_abilities();
+
+		$this->assertArrayHasKey(self::ABILITY_NAME, $abilities);
+		$this->assertInstanceOf(\ConvertKit_MCP_Ability_Post_Settings_Update::class, $abilities[ self::ABILITY_NAME ]);
+	}
+
+	/**
+	 * Test that update writes all four settings and returns the post-save state.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateWritesAllFourSettings()
+	{
+		$post_id = $this->createPostAsAdmin();
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback(
+			[
+				'post_id'          => $post_id,
+				'form'             => '123',
+				'landing_page'     => '456',
+				'tag'              => '789',
+				'restrict_content' => 'product_101',
+			]
+		);
+
+		$this->assertIsArray($result);
+		$this->assertSame($post_id, $result['post_id']);
+		$this->assertSame('123', $result['form']);
+		$this->assertSame('456', $result['landing_page']);
+		$this->assertSame('789', $result['tag']);
+		$this->assertSame('product_101', $result['restrict_content']);
+
+		// Confirm persisted to the DB.
+		$stored = get_post_meta($post_id, '_wp_convertkit_post_meta', true);
+		$this->assertSame('123', $stored['form']);
+		$this->assertSame('456', $stored['landing_page']);
+		$this->assertSame('789', $stored['tag']);
+		$this->assertSame('product_101', $stored['restrict_content']);
+	}
+
+	/**
+	 * Test that a partial update writes only the provided keys and preserves
+	 * the other stored settings.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdatePartialUpdatePreservesOtherKeys()
+	{
+		$post_id = $this->createPostAsAdmin();
+
+		// Seed existing settings.
+		update_post_meta(
+			$post_id,
+			'_wp_convertkit_post_meta',
+			[
+				'form'             => '111',
+				'landing_page'     => '222',
+				'tag'              => '333',
+				'restrict_content' => 'form_444',
+			]
+		);
+
+		$abilities = convertkit_get_abilities();
+
+		// Update only the form.
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback(
+			[
+				'post_id' => $post_id,
+				'form'    => '999',
+			]
+		);
+
+		$this->assertSame('999', $result['form']);
+		$this->assertSame('222', $result['landing_page']);
+		$this->assertSame('333', $result['tag']);
+		$this->assertSame('form_444', $result['restrict_content']);
+	}
+
+	/**
+	 * Test that update rejects unknown keys in the input.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateRejectsUnknownKeys()
+	{
+		$post_id = $this->createPostAsAdmin();
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback(
+			[
+				'post_id'     => $post_id,
+				'form'        => '123',
+				'not_a_field' => 'garbage',
+			]
+		);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+		$this->assertSame('convertkit_mcp_post_settings_unknown_keys', $result->get_error_code());
+	}
+
+	/**
+	 * Test that update rejects a malformed form value (e.g. `abc`).
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateRejectsInvalidFormValue()
+	{
+		$post_id = $this->createPostAsAdmin();
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback(
+			[
+				'post_id' => $post_id,
+				'form'    => 'abc',
+			]
+		);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+	}
+
+	/**
+	 * Test that update rejects a malformed restrict_content prefix
+	 * (must be form_, tag_ or product_).
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateRejectsInvalidRestrictContentFormat()
+	{
+		$post_id = $this->createPostAsAdmin();
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback(
+			[
+				'post_id'          => $post_id,
+				'restrict_content' => 'sequence_123',
+			]
+		);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+	}
+
+	/**
+	 * Test that update rejects a call with only post_id and no settings.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateRejectsWhenNoSettingsProvided()
+	{
+		$post_id = $this->createPostAsAdmin();
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback([ 'post_id' => $post_id ]);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+		$this->assertSame('convertkit_mcp_post_settings_no_input', $result->get_error_code());
+	}
+
+	/**
+	 * Test that update returns a WP_Error when the given post_id does not exist.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateReturnsErrorForNonExistentPost()
+	{
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback(
+			[
+				'post_id' => 999999,
+				'form'    => '123',
+			]
+		);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+		$this->assertSame('convertkit_mcp_post_not_found', $result->get_error_code());
+	}
+
+	/**
+	 * Test that update -> get round-trip returns the updated values.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateThenGetRoundTrip()
+	{
+		$post_id = $this->createPostAsAdmin();
+
+		$abilities = convertkit_get_abilities();
+
+		$abilities[ self::ABILITY_NAME ]->execute_callback(
+			[
+				'post_id' => $post_id,
+				'form'    => '555',
+				'tag'     => '666',
+			]
+		);
+
+		$get_result = $abilities['kit/post-settings-get']->execute_callback([ 'post_id' => $post_id ]);
+
+		$this->assertSame('555', $get_result['form']);
+		$this->assertSame('666', $get_result['tag']);
+	}
+
+	/**
+	 * Test that setting restrict_content on a published Post populates
+	 * the Restrict Content cache option. Proves integration with the
+	 * ConvertKit_Restrict_Content_Cache class.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateRestrictContentPopulatesCache()
+	{
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		$post_id = static::factory()->post->create(
+			[
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			]
+		);
+
+		$abilities = convertkit_get_abilities();
+
+		$abilities[ self::ABILITY_NAME ]->execute_callback(
+			[
+				'post_id'          => $post_id,
+				'restrict_content' => 'product_101',
+			]
+		);
+
+		$cache = get_option(\ConvertKit_Restrict_Content_Cache::OPTION_NAME);
+
+		$this->assertIsArray($cache);
+		$this->assertArrayHasKey($post_id, $cache);
+	}
+
+	/**
+	 * Test that clearing restrict_content removes the Post from the
+	 * Restrict Content cache option.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateClearingRestrictContentRemovesFromCache()
+	{
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		$post_id = static::factory()->post->create(
+			[
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			]
+		);
+
+		$abilities = convertkit_get_abilities();
+
+		// Enable.
+		$abilities[ self::ABILITY_NAME ]->execute_callback(
+			[
+				'post_id'          => $post_id,
+				'restrict_content' => 'tag_123',
+			]
+		);
+		$this->assertArrayHasKey($post_id, get_option(\ConvertKit_Restrict_Content_Cache::OPTION_NAME));
+
+		// Clear.
+		$abilities[ self::ABILITY_NAME ]->execute_callback(
+			[
+				'post_id'          => $post_id,
+				'restrict_content' => '',
+			]
+		);
+		$this->assertArrayNotHasKey($post_id, get_option(\ConvertKit_Restrict_Content_Cache::OPTION_NAME));
+	}
+
+	/**
+	 * Helper: creates an administrator user, switches to them, and returns
+	 * a new Post ID.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  int
+	 */
+	private function createPostAsAdmin()
+	{
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		return static::factory()->post->create();
+	}
+}

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -119,6 +119,9 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/resources/class-c
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/settings/class-convertkit-mcp-ability-settings.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/settings/class-convertkit-mcp-ability-settings-get.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/settings/class-convertkit-mcp-ability-settings-update.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/post-settings/class-convertkit-mcp-ability-post-settings.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/post-settings/class-convertkit-mcp-ability-post-settings-get.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/post-settings/class-convertkit-mcp-ability-post-settings-update.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/plugin-sidebars/class-convertkit-plugin-sidebar.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/plugin-sidebars/class-convertkit-plugin-sidebar-post-settings.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/pre-publish-actions/class-convertkit-pre-publish-action.php';

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -122,6 +122,9 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/settings/class-co
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/post-settings/class-convertkit-mcp-ability-post-settings.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/post-settings/class-convertkit-mcp-ability-post-settings-get.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/post-settings/class-convertkit-mcp-ability-post-settings-update.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/category-settings/class-convertkit-mcp-ability-category-settings.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/category-settings/class-convertkit-mcp-ability-category-settings-get.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/category-settings/class-convertkit-mcp-ability-category-settings-update.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/plugin-sidebars/class-convertkit-plugin-sidebar.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/plugin-sidebars/class-convertkit-plugin-sidebar-post-settings.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/pre-publish-actions/class-convertkit-pre-publish-action.php';


### PR DESCRIPTION
## Summary

Registers get and update abilities (MCP tools) for the per-Post Kit settings (Form, Landing Page, Tag, Member Content / Restrict Content) stored in the `_wp_convertkit_post_meta` post meta, so an MCP client can fetch and update these settings for any Post, Page or Custom Post Type. Partial updates are supported; the Restrict Content cache stays in sync automatically via the existing `updated_post_meta` hook.

Ability | Description | Required input | Output
-- | -- | -- | --
kit/post-settings-get | Returns the current Kit settings (form, landing_page, tag, restrict_content) for the given Post, Page or Custom Post Type. | { post_id } | { post_id, form, landing_page, tag, restrict_content }
kit/post-settings-update | Updates one or more Kit settings for the given Post, Page or Custom Post Type. Only the settings provided in the input are updated; other settings are preserved. Unknown keys are rejected. | { post_id } _plus a partial object of any subset of_: form, landing_page, tag, restrict_content | _same shape as kit/post-settings-get (post-save state)_

## Testing
- `MCPPostSettingsGetTest`: Tests that the MCP tool is registered, permissions are honored (`edit_post` capability required), defaults are returned when no post meta exists, stored values are returned when set, non-existent post IDs are rejected, and the tool works across post types (Post, Page).
- `MCPPostSettingsUpdateTest`: Tests that the MCP tool is registered, full and partial updates persist correctly, unknown keys and malformed `form` / `restrict_content` values are rejected, empty input is rejected, non-existent post IDs are rejected, the update → get round-trip returns the updated values, and setting or clearing `restrict_content` correctly populates or removes the Post from the Restrict Content cache.

## Checklist
* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)