### PR TITLE
Abilities API: Category Settings

### DIFF
--- a/includes/mcp/abilities/category-settings/class-convertkit-mcp-ability-category-settings-get.php
+++ b/includes/mcp/abilities/category-settings/class-convertkit-mcp-ability-category-settings-get.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Kit MCP Ability: Get Category Settings.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Ability that returns the current Kit settings for a Category.
+ *
+ * Produces an ability named `kit/category-settings-get`.
+ *
+ * @package ConvertKit
+ * @author  ConvertKit
+ */
+class ConvertKit_MCP_Ability_Category_Settings_Get extends ConvertKit_MCP_Ability_Category_Settings {
+
+	/**
+	 * Sets whether the ability is readonly.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     bool
+	 */
+	private $readonly = true; // @phpstan-ignore-line
+
+	/**
+	 * Sets whether the ability is idempotent.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     bool
+	 */
+	private $idempotent = true; // @phpstan-ignore-line
+
+	/**
+	 * Returns the operation suffix used in the ability name.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	protected function get_operation() {
+
+		return 'get';
+
+	}
+
+	/**
+	 * Returns the ability's human-readable label.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_label() {
+
+		return __( 'Get Kit Category Settings', 'convertkit' );
+
+	}
+
+	/**
+	 * Returns the ability's human-readable description.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_description() {
+
+		return __( 'Returns the current Kit settings (form, form_position) for the given Category (WordPress `category` taxonomy term).', 'convertkit' );
+
+	}
+
+	/**
+	 * Returns the ability's input JSON Schema.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  array
+	 */
+	public function get_input_schema() {
+
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'term_id' ),
+			'properties' => array(
+				'term_id' => array(
+					'type'        => 'integer',
+					'description' => __( 'The Category (term) ID to read Kit settings for.', 'convertkit' ),
+					'minimum'     => 1,
+				),
+			),
+		);
+
+	}
+
+	/**
+	 * Executes the ability.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @param   array $input   Ability input.
+	 * @return  array|WP_Error
+	 */
+	public function execute_callback( $input ) {
+
+		$term_id = isset( $input['term_id'] ) ? absint( $input['term_id'] ) : 0;
+
+		// Bail if the term does not exist or is not a Category.
+		$valid = $this->validate_term( $term_id );
+		if ( is_wp_error( $valid ) ) {
+			return $valid;
+		}
+
+		// Load the Category's settings.
+		$term_settings = new ConvertKit_Term( $term_id );
+		$settings      = $term_settings->get();
+
+		// Cast `form` to int and `form_position` to string so the output
+		// exactly matches the declared schema, regardless of how the value
+		// was stored (defaults may be '' for form, but the schema wants int).
+		$form          = isset( $settings['form'] ) && $settings['form'] !== '' ? (int) $settings['form'] : 0;
+		$form_position = isset( $settings['form_position'] ) ? (string) $settings['form_position'] : '';
+
+		return array(
+			'term_id'       => $term_id,
+			'form'          => $form,
+			'form_position' => $form_position,
+		);
+
+	}
+
+}

--- a/includes/mcp/abilities/category-settings/class-convertkit-mcp-ability-category-settings-update.php
+++ b/includes/mcp/abilities/category-settings/class-convertkit-mcp-ability-category-settings-update.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Kit MCP Ability: Update Category Settings.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Ability that updates one or more Kit settings for a Category.
+ *
+ * Produces an ability named `kit/category-settings-update`.
+ *
+ * @package ConvertKit
+ * @author  ConvertKit
+ */
+class ConvertKit_MCP_Ability_Category_Settings_Update extends ConvertKit_MCP_Ability_Category_Settings {
+
+	/**
+	 * Sets whether the ability is idempotent.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     bool
+	 */
+	private $idempotent = true; // @phpstan-ignore-line
+
+	/**
+	 * Returns the operation suffix used in the ability name.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	protected function get_operation() {
+
+		return 'update';
+
+	}
+
+	/**
+	 * Returns the ability's human-readable label.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_label() {
+
+		return __( 'Update Kit Category Settings', 'convertkit' );
+
+	}
+
+	/**
+	 * Returns the ability's human-readable description.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_description() {
+
+		return __( 'Updates one or more Kit settings (form, form_position) for the given Category (WordPress `category` taxonomy term). Only the settings provided in the input are updated; other settings are preserved.', 'convertkit' );
+
+	}
+
+	/**
+	 * Returns the ability's input JSON Schema.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  array
+	 */
+	public function get_input_schema() {
+
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'term_id' ),
+			'properties' => array_merge(
+				array(
+					'term_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'The Category (term) ID to update Kit settings for.', 'convertkit' ),
+						'minimum'     => 1,
+					),
+				),
+				$this->get_settings_schema_properties()
+			),
+		);
+
+	}
+
+	/**
+	 * Executes the ability.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @param   array $input   Ability input.
+	 * @return  array|WP_Error
+	 */
+	public function execute_callback( $input ) {
+
+		$term_id = isset( $input['term_id'] ) ? absint( $input['term_id'] ) : 0;
+
+		// Bail if the term does not exist or is not a Category.
+		$valid = $this->validate_term( $term_id );
+		if ( is_wp_error( $valid ) ) {
+			return $valid;
+		}
+
+		// Reject unknown keys.
+		$properties   = $this->get_settings_schema_properties();
+		$allowed_keys = array_merge( array( 'term_id' ), array_keys( $properties ) );
+		$unknown_keys = array_diff( array_keys( $input ), $allowed_keys );
+		if ( ! empty( $unknown_keys ) ) {
+			return new WP_Error(
+				'convertkit_mcp_category_settings_unknown_keys',
+				sprintf(
+					/* translators: %s: Comma-separated list of unknown keys. */
+					__( 'The following settings keys are not recognised: %s.', 'convertkit' ),
+					implode( ', ', $unknown_keys )
+				)
+			);
+		}
+
+		// Validate each provided setting against its declared schema.
+		$validated = array();
+		foreach ( $properties as $key => $property_schema ) {
+			if ( ! array_key_exists( $key, $input ) ) {
+				continue;
+			}
+
+			$valid = rest_validate_value_from_schema( $input[ $key ], $property_schema, $key );
+
+			// Bail if the value is invalid.
+			if ( is_wp_error( $valid ) ) {
+				return $valid;
+			}
+
+			$validated[ $key ] = rest_sanitize_value_from_schema( $input[ $key ], $property_schema, $key );
+		}
+
+		// Bail if no settings were provided.
+		if ( empty( $validated ) ) {
+			return new WP_Error(
+				'convertkit_mcp_category_settings_no_input',
+				__( 'At least one setting (form or form_position) must be provided.', 'convertkit' )
+			);
+		}
+
+		// Save. ConvertKit_Term::save() merges the provided values into the
+		// term's existing settings internally, so this is a partial update.
+		$term_settings = new ConvertKit_Term( $term_id );
+		$term_settings->save( $validated );
+
+		// Return the post-save state, using the get ability so the shape
+		// exactly matches kit/category-settings-get.
+		$get_ability = new ConvertKit_MCP_Ability_Category_Settings_Get();
+		return $get_ability->execute_callback( array( 'term_id' => $term_id ) );
+
+	}
+
+}

--- a/includes/mcp/abilities/category-settings/class-convertkit-mcp-ability-category-settings.php
+++ b/includes/mcp/abilities/category-settings/class-convertkit-mcp-ability-category-settings.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Kit MCP Ability: Category Settings base class.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Base class for abilities that read or update the per-Category Kit settings
+ * (form, form_position) stored in the `_wp_convertkit_term_meta` term meta key.
+ *
+ * Each subclass represents a single verb (get / update). Produces ability
+ * names of the form `kit/category-settings-<operation>`.
+ *
+ * Scope is limited to the `category` taxonomy, matching the admin UI
+ * (ConvertKit_Admin_Category) and the frontend read path
+ * (ConvertKit_Output::get_term_form_position()).
+ *
+ * @package ConvertKit
+ * @author  ConvertKit
+ */
+abstract class ConvertKit_MCP_Ability_Category_Settings extends ConvertKit_MCP_Ability {
+
+	/**
+	 * The taxonomy this ability operates on.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     string
+	 */
+	const TAXONOMY = 'category';
+
+	/**
+	 * Returns the operation suffix used in the ability name (e.g. 'get',
+	 * 'update').
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	abstract protected function get_operation();
+
+	/**
+	 * Returns the ability name.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  string
+	 */
+	public function get_name() {
+
+		return 'kit/category-settings-' . $this->get_operation();
+
+	}
+
+	/**
+	 * Only permit an ability to be executed if the current user can edit
+	 * the given category term.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @param   array $input   Ability input.
+	 * @return  bool|WP_Error
+	 */
+	public function permission_callback( $input ) {
+
+		// Get Term ID.
+		$term_id = isset( $input['term_id'] ) ? absint( $input['term_id'] ) : 0;
+
+		// Bail if no Term ID is provided.
+		if ( ! $term_id ) {
+			return new WP_Error(
+				'convertkit_mcp_missing_term_id',
+				__( 'A term_id is required.', 'convertkit' )
+			);
+		}
+
+		// Bail if the current user cannot edit this term.
+		if ( ! current_user_can( 'edit_term', $term_id ) ) {
+			return new WP_Error(
+				'convertkit_mcp_cannot_edit_term',
+				__( 'You do not have permission to edit this category.', 'convertkit' )
+			);
+		}
+
+		return true;
+
+	}
+
+	/**
+	 * Validates that the given term exists and is in the `category` taxonomy.
+	 *
+	 * Returned as a shared helper for both verb subclasses' execute_callback.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @param   int $term_id    Term ID.
+	 * @return  true|WP_Error
+	 */
+	protected function validate_term( $term_id ) {
+
+		$term = get_term( $term_id );
+
+		// Bail if the term does not exist.
+		if ( ! $term || is_wp_error( $term ) ) {
+			return new WP_Error(
+				'convertkit_mcp_term_not_found',
+				sprintf(
+					/* translators: %d: Term ID. */
+					__( 'Term %d does not exist.', 'convertkit' ),
+					$term_id
+				)
+			);
+		}
+
+		// Bail if the term is not in the `category` taxonomy.
+		if ( $term->taxonomy !== self::TAXONOMY ) {
+			return new WP_Error(
+				'convertkit_mcp_term_wrong_taxonomy',
+				sprintf(
+					/* translators: 1: Term ID, 2: Actual taxonomy, 3: Expected taxonomy. */
+					__( 'Term %1$d is in the "%2$s" taxonomy; this ability only supports the "%3$s" taxonomy.', 'convertkit' ),
+					$term_id,
+					$term->taxonomy,
+					self::TAXONOMY
+				)
+			);
+		}
+
+		return true;
+
+	}
+
+	/**
+	 * Returns the JSON Schema properties that describe the two Kit category
+	 * settings, shared by both the input and output schemas.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  array
+	 */
+	protected function get_settings_schema_properties() {
+
+		return array(
+			'form'          => array(
+				'type'        => 'integer',
+				'description' => __( 'Form to display for Posts assigned to this Category. `-1` = use the Plugin Default Form; `0` = display no form; any other positive integer is a specific Kit Form ID.', 'convertkit' ),
+				'minimum'     => -1,
+			),
+			'form_position' => array(
+				'type'        => 'string',
+				'description' => __( 'Where the Form displays on the Category archive page. Empty string uses the Plugin default position; `before` displays it before the post list; `after` displays it after.', 'convertkit' ),
+				'enum'        => array( '', 'before', 'after' ),
+			),
+		);
+
+	}
+
+	/**
+	 * Returns the JSON Schema for the ability's output.
+	 *
+	 * Shared by get and update so a caller can chain update -> confirm.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  array
+	 */
+	public function get_output_schema() {
+
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'term_id', 'form', 'form_position' ),
+			'properties' => array_merge(
+				array(
+					'term_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'The Category (term) ID.', 'convertkit' ),
+					),
+				),
+				$this->get_settings_schema_properties()
+			),
+		);
+
+	}
+
+}

--- a/includes/mcp/class-convertkit-mcp.php
+++ b/includes/mcp/class-convertkit-mcp.php
@@ -99,6 +99,11 @@ class ConvertKit_MCP {
 		// settings group.
 		add_filter( 'convertkit_abilities', array( $this, 'register_post_settings_abilities' ) );
 
+		// Register the per-Category Kit settings get / update abilities.
+		// These operate on the `_wp_convertkit_term_meta` term meta (form,
+		// form_position) for the WordPress `category` taxonomy.
+		add_filter( 'convertkit_abilities', array( $this, 'register_category_settings_abilities' ) );
+
 		// Register the MCP server.
 		add_action( 'mcp_adapter_init', array( $this, 'register_mcp_server' ) );
 
@@ -150,6 +155,25 @@ class ConvertKit_MCP {
 
 		$abilities['kit/post-settings-get']    = new ConvertKit_MCP_Ability_Post_Settings_Get();
 		$abilities['kit/post-settings-update'] = new ConvertKit_MCP_Ability_Post_Settings_Update();
+
+		return $abilities;
+
+	}
+
+	/**
+	 * Appends the per-Category Kit settings abilities to the convertkit_abilities
+	 * filter, so they are registered with the Abilities API and exposed via
+	 * the MCP server.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @param   array $abilities   Abilities to register.
+	 * @return  array
+	 */
+	public function register_category_settings_abilities( $abilities ) {
+
+		$abilities['kit/category-settings-get']    = new ConvertKit_MCP_Ability_Category_Settings_Get();
+		$abilities['kit/category-settings-update'] = new ConvertKit_MCP_Ability_Category_Settings_Update();
 
 		return $abilities;
 

--- a/tests/Integration/MCPCategorySettingsGetTest.php
+++ b/tests/Integration/MCPCategorySettingsGetTest.php
@@ -1,0 +1,237 @@
+<?php
+
+namespace Tests;
+
+use lucatume\WPBrowser\TestCase\WPTestCase;
+
+/**
+ * Tests for the Kit MCP category settings get ability:
+ *
+ * - kit/category-settings-get  (ConvertKit_MCP_Ability_Category_Settings_Get)
+ *
+ * @since   3.4.0
+ */
+class MCPCategorySettingsGetTest extends WPTestCase
+{
+	/**
+	 * The testing implementation.
+	 *
+	 * @var \IntegrationTester
+	 */
+	protected $tester;
+
+	/**
+	 * The ability name.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     string
+	 */
+	private const ABILITY_NAME = 'kit/category-settings-get';
+
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		activate_plugins('convertkit/wp-convertkit.php');
+	}
+
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function tearDown(): void
+	{
+		wp_set_current_user(0);
+		deactivate_plugins('convertkit/wp-convertkit.php');
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that the ability registers via the convertkit_abilities filter
+	 * with the expected name and class.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testAbilityRegistered()
+	{
+		$abilities = convertkit_get_abilities();
+
+		$this->assertArrayHasKey(self::ABILITY_NAME, $abilities);
+		$this->assertInstanceOf(\ConvertKit_MCP_Ability_Category_Settings_Get::class, $abilities[ self::ABILITY_NAME ]);
+	}
+
+	/**
+	 * Test that permission_callback() rejects an input with no term_id.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackRejectsMissingTermId()
+	{
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->permission_callback([]);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+		$this->assertSame('convertkit_mcp_missing_term_id', $result->get_error_code());
+	}
+
+	/**
+	 * Test that permission_callback() rejects a user who cannot edit the
+	 * given category (Subscriber role has no manage_categories cap).
+	 *
+	 * @since   3.4.0
+	 */
+	public function testPermissionCallbackDeniesWithoutEditTermCapability()
+	{
+		$term_id = $this->createCategoryAsAdmin();
+
+		// Switch to a subscriber.
+		$subscriber_id = static::factory()->user->create([ 'role' => 'subscriber' ]);
+		wp_set_current_user($subscriber_id);
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->permission_callback([ 'term_id' => $term_id ]);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+		$this->assertSame('convertkit_mcp_cannot_edit_term', $result->get_error_code());
+	}
+
+	/**
+	 * Test that get returns the default settings when the Category has no
+	 * Kit term meta stored.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testGetReturnsDefaultsWhenNoMetaExists()
+	{
+		$term_id = $this->createCategoryAsAdmin();
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback([ 'term_id' => $term_id ]);
+
+		$this->assertIsArray($result);
+		$this->assertSame($term_id, $result['term_id']);
+		$this->assertSame(0, $result['form']);
+		$this->assertSame('', $result['form_position']);
+	}
+
+	/**
+	 * Test that get returns stored Kit settings for a Category that has
+	 * term meta saved.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testGetReturnsStoredSettings()
+	{
+		$term_id = $this->createCategoryAsAdmin();
+
+		update_term_meta(
+			$term_id,
+			'_wp_convertkit_term_meta',
+			[
+				'form'          => 123,
+				'form_position' => 'before',
+			]
+		);
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback([ 'term_id' => $term_id ]);
+
+		$this->assertSame($term_id, $result['term_id']);
+		$this->assertSame(123, $result['form']);
+		$this->assertSame('before', $result['form_position']);
+	}
+
+	/**
+	 * Test that get returns `form_position = after` correctly (round-trips
+	 * both non-empty enum values, not just `before`).
+	 *
+	 * @since   3.4.0
+	 */
+	public function testGetReturnsFormPositionAfter()
+	{
+		$term_id = $this->createCategoryAsAdmin();
+
+		update_term_meta(
+			$term_id,
+			'_wp_convertkit_term_meta',
+			[
+				'form'          => -1,
+				'form_position' => 'after',
+			]
+		);
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback([ 'term_id' => $term_id ]);
+
+		$this->assertSame(-1, $result['form']);
+		$this->assertSame('after', $result['form_position']);
+	}
+
+	/**
+	 * Test that get returns a WP_Error when the term is not in the
+	 * `category` taxonomy (e.g. it's a `post_tag`).
+	 *
+	 * @since   3.4.0
+	 */
+	public function testGetReturnsErrorForNonCategoryTerm()
+	{
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		$tag_id = static::factory()->term->create([ 'taxonomy' => 'post_tag' ]);
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback([ 'term_id' => $tag_id ]);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+		$this->assertSame('convertkit_mcp_term_wrong_taxonomy', $result->get_error_code());
+	}
+
+	/**
+	 * Test that get returns a WP_Error when the given term_id does not exist.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testGetReturnsErrorForNonExistentTerm()
+	{
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback([ 'term_id' => 999999 ]);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+		$this->assertSame('convertkit_mcp_term_not_found', $result->get_error_code());
+	}
+
+	/**
+	 * Helper: creates an administrator user, switches to them, and returns
+	 * a new Category term ID.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  int
+	 */
+	private function createCategoryAsAdmin()
+	{
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		return static::factory()->term->create([ 'taxonomy' => 'category' ]);
+	}
+}

--- a/tests/Integration/MCPCategorySettingsUpdateTest.php
+++ b/tests/Integration/MCPCategorySettingsUpdateTest.php
@@ -1,0 +1,308 @@
+<?php
+
+namespace Tests;
+
+use lucatume\WPBrowser\TestCase\WPTestCase;
+
+/**
+ * Tests for the Kit MCP category settings update ability:
+ *
+ * - kit/category-settings-update  (ConvertKit_MCP_Ability_Category_Settings_Update)
+ *
+ * @since   3.4.0
+ */
+class MCPCategorySettingsUpdateTest extends WPTestCase
+{
+	/**
+	 * The testing implementation.
+	 *
+	 * @var \IntegrationTester
+	 */
+	protected $tester;
+
+	/**
+	 * The ability name.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @var     string
+	 */
+	private const ABILITY_NAME = 'kit/category-settings-update';
+
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		activate_plugins('convertkit/wp-convertkit.php');
+	}
+
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since   3.4.0
+	 */
+	public function tearDown(): void
+	{
+		wp_set_current_user(0);
+		deactivate_plugins('convertkit/wp-convertkit.php');
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that the ability registers via the convertkit_abilities filter
+	 * with the expected name and class.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testAbilityRegistered()
+	{
+		$abilities = convertkit_get_abilities();
+
+		$this->assertArrayHasKey(self::ABILITY_NAME, $abilities);
+		$this->assertInstanceOf(\ConvertKit_MCP_Ability_Category_Settings_Update::class, $abilities[ self::ABILITY_NAME ]);
+	}
+
+	/**
+	 * Test that update writes both settings and returns the post-save state.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateWritesBothSettings()
+	{
+		$term_id = $this->createCategoryAsAdmin();
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback(
+			[
+				'term_id'       => $term_id,
+				'form'          => 123,
+				'form_position' => 'before',
+			]
+		);
+
+		$this->assertIsArray($result);
+		$this->assertSame($term_id, $result['term_id']);
+		$this->assertSame(123, $result['form']);
+		$this->assertSame('before', $result['form_position']);
+
+		// Confirm persisted to the DB.
+		$stored = get_term_meta($term_id, '_wp_convertkit_term_meta', true);
+		$this->assertSame(123, $stored['form']);
+		$this->assertSame('before', $stored['form_position']);
+	}
+
+	/**
+	 * Test that a partial update writes only the provided key and preserves
+	 * the other stored setting. Verifies ConvertKit_Term::save()'s internal
+	 * merge behaviour is honoured.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdatePartialUpdatePreservesOtherKey()
+	{
+		$term_id = $this->createCategoryAsAdmin();
+
+		// Seed existing settings.
+		update_term_meta(
+			$term_id,
+			'_wp_convertkit_term_meta',
+			[
+				'form'          => 111,
+				'form_position' => 'after',
+			]
+		);
+
+		$abilities = convertkit_get_abilities();
+
+		// Update only the form.
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback(
+			[
+				'term_id' => $term_id,
+				'form'    => 999,
+			]
+		);
+
+		$this->assertSame(999, $result['form']);
+		$this->assertSame('after', $result['form_position']);
+	}
+
+	/**
+	 * Test that update rejects unknown keys in the input.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateRejectsUnknownKeys()
+	{
+		$term_id = $this->createCategoryAsAdmin();
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback(
+			[
+				'term_id'     => $term_id,
+				'form'        => 123,
+				'not_a_field' => 'garbage',
+			]
+		);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+		$this->assertSame('convertkit_mcp_category_settings_unknown_keys', $result->get_error_code());
+	}
+
+	/**
+	 * Test that update rejects a form_position value outside the enum
+	 * (must be '', 'before' or 'after').
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateRejectsInvalidFormPosition()
+	{
+		$term_id = $this->createCategoryAsAdmin();
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback(
+			[
+				'term_id'       => $term_id,
+				'form_position' => 'sideways',
+			]
+		);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+	}
+
+	/**
+	 * Test that update rejects a form value below the schema minimum
+	 * (schema allows -1 and up).
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateRejectsInvalidFormValue()
+	{
+		$term_id = $this->createCategoryAsAdmin();
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback(
+			[
+				'term_id' => $term_id,
+				'form'    => -99,
+			]
+		);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+	}
+
+	/**
+	 * Test that update rejects a call with only term_id and no settings.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateRejectsWhenNoSettingsProvided()
+	{
+		$term_id = $this->createCategoryAsAdmin();
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback([ 'term_id' => $term_id ]);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+		$this->assertSame('convertkit_mcp_category_settings_no_input', $result->get_error_code());
+	}
+
+	/**
+	 * Test that update rejects a term that isn't in the `category` taxonomy.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateRejectsNonCategoryTerm()
+	{
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		$tag_id = static::factory()->term->create([ 'taxonomy' => 'post_tag' ]);
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback(
+			[
+				'term_id' => $tag_id,
+				'form'    => 123,
+			]
+		);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+		$this->assertSame('convertkit_mcp_term_wrong_taxonomy', $result->get_error_code());
+	}
+
+	/**
+	 * Test that update returns a WP_Error when the given term_id does not exist.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateReturnsErrorForNonExistentTerm()
+	{
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback(
+			[
+				'term_id' => 999999,
+				'form'    => 123,
+			]
+		);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+		$this->assertSame('convertkit_mcp_term_not_found', $result->get_error_code());
+	}
+
+	/**
+	 * Test that update -> get round-trip returns the updated values.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateThenGetRoundTrip()
+	{
+		$term_id = $this->createCategoryAsAdmin();
+
+		$abilities = convertkit_get_abilities();
+
+		$abilities[ self::ABILITY_NAME ]->execute_callback(
+			[
+				'term_id'       => $term_id,
+				'form'          => 555,
+				'form_position' => 'after',
+			]
+		);
+
+		$get_result = $abilities['kit/category-settings-get']->execute_callback([ 'term_id' => $term_id ]);
+
+		$this->assertSame(555, $get_result['form']);
+		$this->assertSame('after', $get_result['form_position']);
+	}
+
+	/**
+	 * Helper: creates an administrator user, switches to them, and returns
+	 * a new Category term ID.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @return  int
+	 */
+	private function createCategoryAsAdmin()
+	{
+		$admin_id = static::factory()->user->create([ 'role' => 'administrator' ]);
+		wp_set_current_user($admin_id);
+
+		return static::factory()->term->create([ 'taxonomy' => 'category' ]);
+	}
+}

--- a/wp-convertkit.php
+++ b/wp-convertkit.php
@@ -122,6 +122,9 @@ require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/settings/class-co
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/post-settings/class-convertkit-mcp-ability-post-settings.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/post-settings/class-convertkit-mcp-ability-post-settings-get.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/post-settings/class-convertkit-mcp-ability-post-settings-update.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/category-settings/class-convertkit-mcp-ability-category-settings.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/category-settings/class-convertkit-mcp-ability-category-settings-get.php';
+require_once CONVERTKIT_PLUGIN_PATH . '/includes/mcp/abilities/category-settings/class-convertkit-mcp-ability-category-settings-update.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/plugin-sidebars/class-convertkit-plugin-sidebar.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/plugin-sidebars/class-convertkit-plugin-sidebar-post-settings.php';
 require_once CONVERTKIT_PLUGIN_PATH . '/includes/pre-publish-actions/class-convertkit-pre-publish-action.php';


### PR DESCRIPTION
## Summary

Registers get and update abilities (MCP tools) for the per-Category Kit settings (Form, Form Position) stored in the `_wp_convertkit_term_meta` term meta, so an MCP client can fetch and update these settings for any WordPress Category. Scope is deliberately limited to the `category` taxonomy — matching the plugin's admin UI (`ConvertKit_Admin_Category`) and frontend read path (`ConvertKit_Output::get_term_form_position()`) — and non-category terms are rejected with a specific error. Partial updates are supported via `ConvertKit_Term::save()`'s existing internal merge.

Ability | Description | Required input | Output
-- | -- | -- | --
kit/category-settings-get | Returns the current Kit settings (form, form_position) for the given Category (WordPress `category` taxonomy term). | { term_id } | { term_id, form, form_position }
kit/category-settings-update | Updates one or more Kit settings for the given Category. Only the settings provided in the input are updated; other settings are preserved. Unknown keys are rejected. | { term_id } _plus a partial object of any subset of_: form, form_position | _same shape as kit/category-settings-get (post-save state)_

## Testing
- `MCPCategorySettingsGetTest`: Tests that the MCP tool is registered, permissions are honored (`edit_term` capability required), defaults are returned when no term meta exists, stored values are returned when set, both `form_position` enum values (`before` and `after`) round-trip correctly, non-`category` terms (e.g. `post_tag`) are rejected with a specific error, and non-existent term IDs are rejected.
- `MCPCategorySettingsUpdateTest`: Tests that the MCP tool is registered, full and partial updates persist correctly (partial-update behaviour relies on `ConvertKit_Term::save()`'s internal merge), unknown keys are rejected, `form_position` values outside the enum are rejected, out-of-range `form` values are rejected, empty input is rejected, non-`category` terms are rejected, non-existent term IDs are rejected, and the update → get round-trip returns the updated values.

## Checklist
* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)