### PR TITLE
Settings: Post: Defaults: Use `0` instead of blank string

### DIFF
--- a/includes/class-convertkit-post.php
+++ b/includes/class-convertkit-post.php
@@ -314,9 +314,9 @@ class ConvertKit_Post {
 
 		$defaults = array(
 			'form'             => '-1', // -1: Plugin Default Form, 0: No Form, 1+: Specific Form ID on ConvertKit.
-			'landing_page'     => '',
-			'tag'              => '',
-			'restrict_content' => '',
+			'landing_page'     => '0',  // 0: None, 1+: Specific Landing Page ID.
+			'tag'              => '0',  // 0: None, 1+: Specific Tag ID.
+			'restrict_content' => '0',  // 0: None, form_<id> / tag_<id> / product_<id>: restrict to that resource.
 		);
 
 		/**


### PR DESCRIPTION
## Summary

This mirrors how settings are saved when adding/editing a Page, Post or CPT in WordPress and setting Landing Page, Add a Tag and/or Member Content functionality to ‘None’ / ‘Don’t restrict’, which would store these settings as 0, not a blank string.

Required for the Abilities API / MCP schema, so we consistently use '0' when setting 'None' values on a Post's settings.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)