### PR TITLE
Abilities API: Post Settings: Fix Schema

### DIFF
--- a/includes/class-convertkit-settings.php
+++ b/includes/class-convertkit-settings.php
@@ -625,61 +625,109 @@ class ConvertKit_Settings {
 	 */
 	public function get_schema() {
 
+		$properties = array(
+			'non_inline_form'                    => array(
+				'type'        => 'array',
+				'items'       => array( 'type' => 'integer' ),
+				'description' => __( 'IDs of non-inline Forms to display site-wide.', 'convertkit' ),
+			),
+			'non_inline_form_honor_none_setting' => array(
+				'type'        => 'string',
+				'enum'        => array( '', 'on' ),
+				'description' => __( 'Whether the site-wide non-inline Form honors a per-Page / per-Post "None" Form setting.', 'convertkit' ),
+			),
+			'non_inline_form_limit_per_session'  => array(
+				'type'        => 'string',
+				'enum'        => array( '', 'on' ),
+				'description' => __( 'Whether to limit non-inline Form display to once per session.', 'convertkit' ),
+			),
+			'recaptcha_site_key'                 => array(
+				'type'        => 'string',
+				'description' => __( 'Google reCAPTCHA v3 site key.', 'convertkit' ),
+			),
+			'recaptcha_minimum_score'            => array(
+				'type'        => 'number',
+				'minimum'     => 0,
+				'maximum'     => 1,
+				'description' => __( 'Minimum Google reCAPTCHA v3 score (0.0 - 1.0) below which a request is treated as spam.', 'convertkit' ),
+			),
+			'debug'                              => array(
+				'type'        => 'string',
+				'enum'        => array( '', 'on' ),
+				'description' => __( 'Whether debug logging is enabled.', 'convertkit' ),
+			),
+			'no_scripts'                         => array(
+				'type'        => 'string',
+				'enum'        => array( '', 'on' ),
+				'description' => __( 'Whether the Plugin\'s frontend JavaScript is disabled.', 'convertkit' ),
+			),
+			'no_css'                             => array(
+				'type'        => 'string',
+				'enum'        => array( '', 'on' ),
+				'description' => __( 'Whether the Plugin\'s frontend CSS is disabled.', 'convertkit' ),
+			),
+			'no_add_new_button'                  => array(
+				'type'        => 'string',
+				'enum'        => array( '', 'on' ),
+				'description' => __( 'Whether the "Add New" button for Landing Pages / Member Content is hidden in the WordPress Admin.', 'convertkit' ),
+			),
+			'usage_tracking'                     => array(
+				'type'        => 'string',
+				'enum'        => array( '', 'on' ),
+				'description' => __( 'Whether anonymous usage tracking is enabled.', 'convertkit' ),
+			),
+		);
+
+		// Per-post-type Default Form settings, mirroring get_defaults().
+		foreach ( convertkit_get_supported_post_types() as $post_type ) {
+			$properties[ $post_type . '_form' ] = array(
+				'type'        => 'integer',
+				'minimum'     => -1,
+				'description' => sprintf(
+					/* translators: Post type slug. */
+					__( 'Default Form ID to display on %s. `-1` = Plugin Default; `0` = None; positive integer = specific Kit Form ID.', 'convertkit' ),
+					$post_type
+				),
+			);
+
+			$properties[ $post_type . '_form_position' ] = array(
+				'type'        => 'string',
+				'enum'        => array( 'before_content', 'after_content', 'before_after_content', 'after_element' ),
+				'description' => sprintf(
+					/* translators: Post type slug. */
+					__( 'Where the Default Form displays relative to the %s content.', 'convertkit' ),
+					$post_type
+				),
+			);
+
+			$properties[ $post_type . '_form_position_element' ] = array(
+				'type'        => 'string',
+				'enum'        => array( 'p', 'h2', 'h3', 'h4', 'h5', 'h6', 'img' ),
+				'description' => sprintf(
+					/* translators: 1: Post type slug, 2: Post type slug. */
+					__( 'HTML element after which to display the Default Form on %1$s. Only used when `%2$s_form_position` is `after_element`.', 'convertkit' ),
+					$post_type,
+					$post_type
+				),
+			);
+
+			$properties[ $post_type . '_form_position_element_index' ] = array(
+				'type'        => 'integer',
+				'minimum'     => 1,
+				'maximum'     => 999,
+				'description' => sprintf(
+					/* translators: 1: Post type slug, 2: Post type slug. */
+					__( 'Nth occurrence of the element after which to display the Default Form on %1$s. Only used when `%2$s_form_position` is `after_element`.', 'convertkit' ),
+					$post_type,
+					$post_type
+				),
+			);
+		}
+
 		return array(
 			'type'                 => 'object',
 			'additionalProperties' => false,
-			'properties'           => array(
-				'non_inline_form'                    => array(
-					'type'        => 'array',
-					'items'       => array( 'type' => 'integer' ),
-					'description' => __( 'IDs of non-inline Forms to display site-wide.', 'convertkit' ),
-				),
-				'non_inline_form_honor_none_setting' => array(
-					'type'        => 'string',
-					'enum'        => array( '', 'on' ),
-					'description' => __( 'Whether the site-wide non-inline Form honors a per-Page / per-Post "None" Form setting.', 'convertkit' ),
-				),
-				'non_inline_form_limit_per_session'  => array(
-					'type'        => 'string',
-					'enum'        => array( '', 'on' ),
-					'description' => __( 'Whether to limit non-inline Form display to once per session.', 'convertkit' ),
-				),
-				'recaptcha_site_key'                 => array(
-					'type'        => 'string',
-					'description' => __( 'Google reCAPTCHA v3 site key.', 'convertkit' ),
-				),
-				'recaptcha_minimum_score'            => array(
-					'type'        => 'number',
-					'minimum'     => 0,
-					'maximum'     => 1,
-					'description' => __( 'Minimum Google reCAPTCHA v3 score (0.0 - 1.0) below which a request is treated as spam.', 'convertkit' ),
-				),
-				'debug'                              => array(
-					'type'        => 'string',
-					'enum'        => array( '', 'on' ),
-					'description' => __( 'Whether debug logging is enabled.', 'convertkit' ),
-				),
-				'no_scripts'                         => array(
-					'type'        => 'string',
-					'enum'        => array( '', 'on' ),
-					'description' => __( 'Whether the Plugin\'s frontend JavaScript is disabled.', 'convertkit' ),
-				),
-				'no_css'                             => array(
-					'type'        => 'string',
-					'enum'        => array( '', 'on' ),
-					'description' => __( 'Whether the Plugin\'s frontend CSS is disabled.', 'convertkit' ),
-				),
-				'no_add_new_button'                  => array(
-					'type'        => 'string',
-					'enum'        => array( '', 'on' ),
-					'description' => __( 'Whether the "Add New" button for Landing Pages / Member Content is hidden in the WordPress Admin.', 'convertkit' ),
-				),
-				'usage_tracking'                     => array(
-					'type'        => 'string',
-					'enum'        => array( '', 'on' ),
-					'description' => __( 'Whether anonymous usage tracking is enabled.', 'convertkit' ),
-				),
-			),
+			'properties'           => $properties,
 		);
 
 	}

--- a/includes/mcp/abilities/post-settings/class-convertkit-mcp-ability-post-settings.php
+++ b/includes/mcp/abilities/post-settings/class-convertkit-mcp-ability-post-settings.php
@@ -97,18 +97,18 @@ abstract class ConvertKit_MCP_Ability_Post_Settings extends ConvertKit_MCP_Abili
 			),
 			'landing_page'     => array(
 				'type'        => 'string',
-				'description' => __( 'Kit Landing Page ID to display instead of the Post content. Empty string for none.', 'convertkit' ),
+				'description' => __( 'Kit Landing Page ID to display instead of the Post content. `0` or empty string for none.', 'convertkit' ),
 				'pattern'     => '^([0-9]+)?$',
 			),
 			'tag'              => array(
 				'type'        => 'string',
-				'description' => __( 'Kit Tag ID to apply when the Post is viewed by a Kit subscriber. Empty string for none.', 'convertkit' ),
+				'description' => __( 'Kit Tag ID to apply when the Post is viewed by a Kit subscriber. `0` or empty string for none.', 'convertkit' ),
 				'pattern'     => '^([0-9]+)?$',
 			),
 			'restrict_content' => array(
 				'type'        => 'string',
-				'description' => __( 'Restrict Post content to Kit subscribers. Empty string for no restriction, or one of `form_<id>`, `tag_<id>`, `product_<id>` to require subscription to that resource.', 'convertkit' ),
-				'pattern'     => '^$|^(form|tag|product)_[1-9][0-9]*$',
+				'description' => __( 'Restrict Post content to Kit subscribers. Empty string or `0` for no restriction, or one of `form_<id>`, `tag_<id>`, `product_<id>` to require subscription to that resource.', 'convertkit' ),
+				'pattern'     => '^$|^0$|^(form|tag|product)_[1-9][0-9]*$',
 			),
 		);
 

--- a/tests/Integration/MCPPostSettingsGetTest.php
+++ b/tests/Integration/MCPPostSettingsGetTest.php
@@ -126,9 +126,9 @@ class MCPPostSettingsGetTest extends WPTestCase
 		$this->assertIsArray($result);
 		$this->assertSame($post_id, $result['post_id']);
 		$this->assertSame('-1', $result['form']);
-		$this->assertSame('', $result['landing_page']);
-		$this->assertSame('', $result['tag']);
-		$this->assertSame('', $result['restrict_content']);
+		$this->assertSame('0', $result['landing_page']);
+		$this->assertSame('0', $result['tag']);
+		$this->assertSame('0', $result['restrict_content']);
 	}
 
 	/**

--- a/tests/Integration/MCPPostSettingsUpdateTest.php
+++ b/tests/Integration/MCPPostSettingsUpdateTest.php
@@ -191,6 +191,31 @@ class MCPPostSettingsUpdateTest extends WPTestCase
 	}
 
 	/**
+	 * Test that update accepts `0` for restrict_content as a synonym for
+	 * "no restriction". Matches what ConvertKit_Post::get_default_settings()
+	 * returns and what the metabox / Gutenberg sidebar submit for the "None"
+	 * option, so the get -> update round-trip works for defaulted posts.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateAcceptsZeroForRestrictContent()
+	{
+		$post_id = $this->createPostAsAdmin();
+
+		$abilities = convertkit_get_abilities();
+
+		$result = $abilities[ self::ABILITY_NAME ]->execute_callback(
+			[
+				'post_id'          => $post_id,
+				'restrict_content' => '0',
+			]
+		);
+
+		$this->assertIsArray($result);
+		$this->assertSame('0', $result['restrict_content']);
+	}
+
+	/**
 	 * Test that update rejects a malformed restrict_content prefix
 	 * (must be form_, tag_ or product_).
 	 *

--- a/tests/Integration/MCPSettingsGeneralTest.php
+++ b/tests/Integration/MCPSettingsGeneralTest.php
@@ -158,6 +158,342 @@ class MCPSettingsGeneralTest extends WPTestCase
 		$this->assertArrayHasKey('no_css', $result);
 		$this->assertArrayHasKey('no_add_new_button', $result);
 		$this->assertArrayHasKey('usage_tracking', $result);
+
+		// Confirm per-post-type Default Form settings are returned for
+		// each supported post type (page, post at minimum).
+		$this->assertArrayHasKey('page_form', $result);
+		$this->assertArrayHasKey('page_form_position', $result);
+		$this->assertArrayHasKey('page_form_position_element', $result);
+		$this->assertArrayHasKey('page_form_position_element_index', $result);
+		$this->assertArrayHasKey('post_form', $result);
+		$this->assertArrayHasKey('post_form_position', $result);
+		$this->assertArrayHasKey('post_form_position_element', $result);
+		$this->assertArrayHasKey('post_form_position_element_index', $result);
+
+		// Confirm per-post-type Default Form values round-trip correctly.
+		$this->assertEquals( (int) $_ENV['CONVERTKIT_API_FORM_ID'], $result['page_form']);
+		$this->assertEquals('before_content', $result['page_form_position']);
+		$this->assertEquals('h2', $result['page_form_position_element']);
+		$this->assertEquals(2, $result['page_form_position_element_index']);
+	}
+
+	/**
+	 * Test that kit/settings-general-get returns all per-post-type Default
+	 * Form keys for each supported post type, exercising the dynamic
+	 * schema generation.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testGetReturnsPerPostTypeDefaultFormKeys()
+	{
+		$this->populateSettings();
+
+		$abilities = convertkit_get_abilities();
+		$result    = $abilities['kit/settings-general-get']->execute_callback([]);
+
+		foreach ( convertkit_get_supported_post_types() as $post_type ) {
+			$this->assertArrayHasKey($post_type . '_form', $result);
+			$this->assertArrayHasKey($post_type . '_form_position', $result);
+			$this->assertArrayHasKey($post_type . '_form_position_element', $result);
+			$this->assertArrayHasKey($post_type . '_form_position_element_index', $result);
+			$this->assertIsInt($result[ $post_type . '_form' ]);
+			$this->assertIsString($result[ $post_type . '_form_position' ]);
+			$this->assertIsString($result[ $post_type . '_form_position_element' ]);
+			$this->assertIsInt($result[ $post_type . '_form_position_element_index' ]);
+		}
+	}
+
+	/**
+	 * Test that kit/settings-general-update accepts a positive integer
+	 * Form ID for a per-post-type Default Form setting.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdatePageFormAcceptsPositiveInteger()
+	{
+		$abilities = convertkit_get_abilities();
+		$result    = $abilities['kit/settings-general-update']->execute_callback(
+			[ 'page_form' => 123 ]
+		);
+
+		$this->assertIsArray($result);
+		$this->assertSame(123, $result['page_form']);
+	}
+
+	/**
+	 * Test that kit/settings-general-update accepts `-1` as the Plugin
+	 * Default sentinel value for a per-post-type Default Form setting.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdatePageFormAcceptsMinusOne()
+	{
+		$abilities = convertkit_get_abilities();
+		$result    = $abilities['kit/settings-general-update']->execute_callback(
+			[ 'page_form' => -1 ]
+		);
+
+		$this->assertSame(-1, $result['page_form']);
+	}
+
+	/**
+	 * Test that kit/settings-general-update accepts `0` as the "None"
+	 * value for a per-post-type Default Form setting.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdatePageFormAcceptsZero()
+	{
+		$abilities = convertkit_get_abilities();
+		$result    = $abilities['kit/settings-general-update']->execute_callback(
+			[ 'page_form' => 0 ]
+		);
+
+		$this->assertSame(0, $result['page_form']);
+	}
+
+	/**
+	 * Test that kit/settings-general-update rejects a Form value below the
+	 * schema minimum of `-1`.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdatePageFormRejectsBelowMinimum()
+	{
+		$abilities = convertkit_get_abilities();
+		$result    = $abilities['kit/settings-general-update']->execute_callback(
+			[ 'page_form' => -99 ]
+		);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+	}
+
+	/**
+	 * Test that kit/settings-general-update accepts every value in the
+	 * `<post_type>_form_position` enum.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdatePageFormPositionAcceptsEnumValues()
+	{
+		$abilities = convertkit_get_abilities();
+
+		foreach ( [ 'before_content', 'after_content', 'before_after_content', 'after_element' ] as $position ) {
+			$result = $abilities['kit/settings-general-update']->execute_callback(
+				[ 'page_form_position' => $position ]
+			);
+
+			$this->assertIsArray($result, "Expected `$position` to be accepted.");
+			$this->assertSame($position, $result['page_form_position']);
+		}
+	}
+
+	/**
+	 * Test that kit/settings-general-update rejects a
+	 * `<post_type>_form_position` value outside the enum.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdatePageFormPositionRejectsUnknownValue()
+	{
+		$abilities = convertkit_get_abilities();
+		$result    = $abilities['kit/settings-general-update']->execute_callback(
+			[ 'page_form_position' => 'middle' ]
+		);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+	}
+
+	/**
+	 * Test that kit/settings-general-update accepts every value in the
+	 * `<post_type>_form_position_element` enum.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdatePageFormPositionElementAcceptsEnumValues()
+	{
+		$abilities = convertkit_get_abilities();
+
+		foreach ( [ 'p', 'h2', 'h3', 'h4', 'h5', 'h6', 'img' ] as $element ) {
+			$result = $abilities['kit/settings-general-update']->execute_callback(
+				[ 'page_form_position_element' => $element ]
+			);
+
+			$this->assertIsArray($result, "Expected `$element` to be accepted.");
+			$this->assertSame($element, $result['page_form_position_element']);
+		}
+	}
+
+	/**
+	 * Test that kit/settings-general-update rejects `h1` for
+	 * `<post_type>_form_position_element`. h1 is deliberately excluded
+	 * from the enum because it's the post title.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdatePageFormPositionElementRejectsH1()
+	{
+		$abilities = convertkit_get_abilities();
+		$result    = $abilities['kit/settings-general-update']->execute_callback(
+			[ 'page_form_position_element' => 'h1' ]
+		);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
+	}
+
+	/**
+	 * Test the acceptable range for
+	 * `<post_type>_form_position_element_index` (1..999 inclusive).
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdatePageFormPositionElementIndexRange()
+	{
+		$abilities = convertkit_get_abilities();
+
+		// Boundary values are accepted.
+		foreach ( [ 1, 999 ] as $index ) {
+			$result = $abilities['kit/settings-general-update']->execute_callback(
+				[ 'page_form_position_element_index' => $index ]
+			);
+			$this->assertIsArray($result, "Expected index `$index` to be accepted.");
+			$this->assertSame($index, $result['page_form_position_element_index']);
+		}
+
+		// Out-of-range values are rejected.
+		foreach ( [ 0, 1000, -1 ] as $index ) {
+			$result = $abilities['kit/settings-general-update']->execute_callback(
+				[ 'page_form_position_element_index' => $index ]
+			);
+			$this->assertInstanceOf(\WP_Error::class, $result, "Expected index `$index` to be rejected.");
+		}
+	}
+
+	/**
+	 * Test that a partial update to `page_form` preserves other settings
+	 * — including other per-post-type keys and unrelated settings.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdatePartialPageFormPreservesOtherSettings()
+	{
+		// Seed a full settings state.
+		$this->populateSettings();
+
+		$abilities = convertkit_get_abilities();
+
+		// Update only page_form.
+		$result = $abilities['kit/settings-general-update']->execute_callback(
+			[ 'page_form' => 999 ]
+		);
+
+		$this->assertSame(999, $result['page_form']);
+
+		// Confirm unrelated settings are unchanged.
+		$this->assertEquals('on', $result['debug']);
+
+		// Confirm the other page_form_* keys are unchanged.
+		$this->assertEquals('before_content', $result['page_form_position']);
+		$this->assertEquals('h2', $result['page_form_position_element']);
+		$this->assertEquals(2, $result['page_form_position_element_index']);
+
+		// Confirm the post_form_* keys are unchanged.
+		$this->assertEquals( (int) $_ENV['CONVERTKIT_API_FORM_ID'], $result['post_form']);
+	}
+
+	/**
+	 * Test that update -> get round-trip returns the updated per-post-type
+	 * Default Form value.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdatePageFormRoundTrip()
+	{
+		$abilities = convertkit_get_abilities();
+
+		$abilities['kit/settings-general-update']->execute_callback(
+			[ 'page_form' => 555 ]
+		);
+
+		$get_result = $abilities['kit/settings-general-get']->execute_callback([]);
+
+		$this->assertSame(555, $get_result['page_form']);
+	}
+
+	/**
+	 * Test that a custom post type added via the
+	 * `convertkit_supported_post_types` filter is dynamically added to
+	 * the schema, and that get/update work against its keys.
+	 *
+	 * This proves the schema iterates the filter's supported post types
+	 * at request time rather than using a hardcoded list.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testGetIncludesCustomPostTypeRegisteredViaFilter()
+	{
+		// Register the CPT with WordPress first so the filter's output
+		// is meaningful (get_post_type_object() succeeds downstream).
+		register_post_type(
+			'kit_test_cpt',
+			[
+				'public' => true,
+				'label'  => 'Kit Test CPT',
+			]
+		);
+
+		// Append the CPT to the supported post types.
+		$filter = function ( $post_types ) {
+			$post_types[] = 'kit_test_cpt';
+			return $post_types;
+		};
+		add_filter('convertkit_supported_post_types', $filter);
+
+		try {
+			$abilities = convertkit_get_abilities();
+
+			// Get should include the CPT's four Default Form keys.
+			$get_result = $abilities['kit/settings-general-get']->execute_callback([]);
+			$this->assertArrayHasKey('kit_test_cpt_form', $get_result);
+			$this->assertArrayHasKey('kit_test_cpt_form_position', $get_result);
+			$this->assertArrayHasKey('kit_test_cpt_form_position_element', $get_result);
+			$this->assertArrayHasKey('kit_test_cpt_form_position_element_index', $get_result);
+
+			// Update should accept them.
+			$update_result = $abilities['kit/settings-general-update']->execute_callback(
+				[
+					'kit_test_cpt_form'                  => 777,
+					'kit_test_cpt_form_position'         => 'after_content',
+					'kit_test_cpt_form_position_element' => 'h3',
+					'kit_test_cpt_form_position_element_index' => 5,
+				]
+			);
+			$this->assertIsArray($update_result);
+			$this->assertSame(777, $update_result['kit_test_cpt_form']);
+			$this->assertSame('after_content', $update_result['kit_test_cpt_form_position']);
+			$this->assertSame('h3', $update_result['kit_test_cpt_form_position_element']);
+			$this->assertSame(5, $update_result['kit_test_cpt_form_position_element_index']);
+		} finally {
+			remove_filter('convertkit_supported_post_types', $filter);
+			unregister_post_type('kit_test_cpt');
+		}
+	}
+
+	/**
+	 * Test that kit/settings-general-update rejects a key that looks
+	 * post-type-shaped but is not a supported post type — proving
+	 * `additionalProperties: false` is enforced against the dynamic schema.
+	 *
+	 * @since   3.4.0
+	 */
+	public function testUpdateRejectsUnsupportedPostTypeFormKey()
+	{
+		$abilities = convertkit_get_abilities();
+		$result    = $abilities['kit/settings-general-update']->execute_callback(
+			[ 'unsupportedcpt_form' => 123 ]
+		);
+
+		$this->assertInstanceOf(\WP_Error::class, $result);
 	}
 
 	/**
@@ -256,10 +592,16 @@ class MCPSettingsGeneralTest extends WPTestCase
 				'no_css'                             => '',
 				'no_add_new_button'                  => '',
 				'usage_tracking'                     => '',
-				'post_form'                          => $_ENV['CONVERTKIT_API_FORM_ID'],
-				'page_form'                          => $_ENV['CONVERTKIT_API_FORM_ID'],
-				'article_form'                       => $_ENV['CONVERTKIT_API_FORM_ID'],
-				'product_form'                       => $_ENV['CONVERTKIT_API_FORM_ID'],
+				'post_form'                          => (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+				'post_form_position'                 => 'after_content',
+				'post_form_position_element'         => 'p',
+				'post_form_position_element_index'   => 1,
+				'page_form'                          => (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+				'page_form_position'                 => 'before_content',
+				'page_form_position_element'         => 'h2',
+				'page_form_position_element_index'   => 2,
+				'article_form'                       => (int) $_ENV['CONVERTKIT_API_FORM_ID'],
+				'product_form'                       => (int) $_ENV['CONVERTKIT_API_FORM_ID'],
 				'non_inline_form'                    => array(),
 				'non_inline_form_honor_none_setting' => '',
 				'recaptcha_site_key'                 => '',


### PR DESCRIPTION
## Summary

Allows the Member Content setting to be zero, in line with the changes made to https://github.com/Kit/convertkit-wordpress/pull/1145. Fixes the error `Ability "kit/post-settings-get" has invalid output. Reason: output[restrict_content] does not match pattern ^$|^(form|tag|product)_[1-9][0-9]*$`

## Testing

- `testUpdateAcceptsZeroForRestrictContent`: Confirms that Member Content accepts zero as a value.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)