### PR TITLE
Form Builder: Check for Access Token

### DIFF
--- a/includes/blocks/class-convertkit-block-form-builder.php
+++ b/includes/blocks/class-convertkit-block-form-builder.php
@@ -401,8 +401,18 @@ class ConvertKit_Block_Form_Builder extends ConvertKit_Block {
 				),
 			),
 
+			// Help descriptions, displayed when no Access Token / resources exist and this block/shortcode is added.
+			'no_access_token'         => array(
+				'notice'           => __( 'Not connected to Kit.', 'convertkit' ),
+				'link'             => convertkit_get_setup_wizard_plugin_link(),
+				'link_text'        => __( 'Click here to connect your Kit account.', 'convertkit' ),
+				'instruction_text' => __( 'Connect your Kit account at Settings > Kit, and then refresh this page to configure this block.', 'convertkit' ),
+			),
+
 			'has_access_token'        => $settings->has_access_and_refresh_token(),
-			'has_resources'           => $convertkit_forms->exist(),
+
+			// This block works without resources, so we don't need to check if resources exist.
+			'has_resources'           => true,
 		);
 
 	}

--- a/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormBuilderCest.php
+++ b/tests/EndToEnd/forms/blocks-shortcodes/PageBlockFormBuilderCest.php
@@ -24,6 +24,40 @@ class PageBlockFormBuilderCest
 	}
 
 	/**
+	 * Test the Form Builder block displays a message with a link that opens
+	 * a popup window with the Plugin's Setup Wizard, when the Plugin has
+	 * Not connected to Kit.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testFormBuilderBlockWhenNoCredentials(EndToEndTester $I)
+	{
+		// Add a Page using the Gutenberg editor.
+		$I->addGutenbergPage(
+			$I,
+			title: 'Kit: Page: Form Builder: Block: No Credentials'
+		);
+
+		// Add block to Page.
+		$I->addGutenbergBlock(
+			$I,
+			blockName: 'Kit Form Builder',
+			blockProgrammaticName: 'convertkit-form-builder'
+		);
+
+		// Test that the popup window works.
+		$I->testBlockNoCredentialsPopupWindow(
+			$I,
+			blockName: 'convertkit-form-builder'
+		);
+
+		// Save page to avoid a browser alert when _passed() runs to deactivate the Plugin.
+		$I->publishGutenbergPage($I);
+	}
+
+	/**
 	 * Test the Form Builder block's conditional fields work.
 	 *
 	 * @since   3.0.6


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://linear.app/kit/issue/WP-89/wp-p3-kit-form-builder-block-this-block-has-encountered-an-error-and) by showing the user they need to connect their Kit account before using the Form Builder block, in the same way the Plugin shows this across other blocks (Form, Product, Broadcasts etc).

## Testing

- `testFormBuilderBlockWhenNoCredentials`: Test that the expected message displays instead of a JS error, and connecting results in the block working correctly.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)