### PR TITLE
Fix Forminator Quiz Tests

### DIFF
--- a/tests/EndToEnd/integrations/other/ForminatorCest.php
+++ b/tests/EndToEnd/integrations/other/ForminatorCest.php
@@ -706,7 +706,7 @@ class ForminatorCest
 	private function _createForminatorQuiz(EndToEndTester $I)
 	{
 		// Create Form for Leads.
-		// Forminator 1.55+ requires the lead form's post_status to be 'leads' (not 'publish');
+		// Forminator 1.55+ requires the lead form's post_status to be 'leads' (not 'publish').
 		$formLeadsID = $I->havePostInDatabase(
 			[
 				'post_name'   => 'forminator-form-leads',

--- a/tests/EndToEnd/integrations/other/ForminatorCest.php
+++ b/tests/EndToEnd/integrations/other/ForminatorCest.php
@@ -706,12 +706,13 @@ class ForminatorCest
 	private function _createForminatorQuiz(EndToEndTester $I)
 	{
 		// Create Form for Leads.
+		// Forminator 1.55+ requires the lead form's post_status to be 'leads' (not 'publish');
 		$formLeadsID = $I->havePostInDatabase(
 			[
 				'post_name'   => 'forminator-form-leads',
 				'post_title'  => 'Forminator Form Leads',
 				'post_type'   => 'forminator_forms',
-				'post_status' => 'publish',
+				'post_status' => 'leads',
 				'meta_input'  => [
 					'forminator_form_meta' => [
 						'fields'   => [


### PR DESCRIPTION
## Summary

Fixes Forminator Quiz tests, due to a change in the `post_status` for lead forms within Forminator since 1.55.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)