### PR TITLE
Tests: Resources: Cache Custom Fields

### DIFF
--- a/admin/section/class-convertkit-admin-section-general.php
+++ b/admin/section/class-convertkit-admin-section-general.php
@@ -695,8 +695,19 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 			return;
 		}
 
-		// Also refresh Landing Pages, Tags and Posts. Whilst not displayed in the Plugin Settings, this ensures up to date
+		// Also refresh other resources. Whilst not displayed in the Plugin Settings, this ensures up to date
 		// lists are stored for when editing e.g. Pages.
+
+		// Refresh Custom Fields.
+		$custom_fields = new ConvertKit_Resource_Custom_Fields( 'settings' );
+		$result        = $custom_fields->refresh();
+
+		// Bail if an error occured.
+		if ( is_wp_error( $result ) ) {
+			return;
+		}
+
+		// Refresh Landing Pages.
 		$landing_pages = new ConvertKit_Resource_Landing_Pages( 'settings' );
 		$result        = $landing_pages->refresh();
 
@@ -705,6 +716,7 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 			return;
 		}
 
+		// Refresh Posts.
 		remove_all_actions( 'convertkit_resource_refreshed_posts' );
 		$posts  = new ConvertKit_Resource_Posts( 'settings' );
 		$result = $posts->refresh();
@@ -714,6 +726,7 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 			return;
 		}
 
+		// Refresh Products.
 		$products = new ConvertKit_Resource_Products( 'settings' );
 		$result   = $products->refresh();
 
@@ -722,6 +735,7 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 			return;
 		}
 
+		// Refresh Sequences.
 		$sequences = new ConvertKit_Resource_Sequences( 'settings' );
 		$result    = $sequences->refresh();
 
@@ -730,6 +744,7 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 			return;
 		}
 
+		// Refresh Tags.
 		$tags   = new ConvertKit_Resource_Tags( 'settings' );
 		$result = $tags->refresh();
 

--- a/tests/Support/Helper/KitPlugin.php
+++ b/tests/Support/Helper/KitPlugin.php
@@ -512,7 +512,6 @@ class KitPlugin extends \Codeception\Module
 		);
 
 		// Define Custom Fields.
-		// Define Custom Fields.
 		$I->haveOptionInDatabase(
 			'convertkit_custom_fields',
 			[
@@ -524,32 +523,32 @@ class KitPlugin extends \Codeception\Module
 				],
 				276295  => [
 					'id'    => 276295,
-					'name'  => 'Payment Method',
-					'key'   => 'ck_field_276295_payment_method',
+					'name'  => 'ck_field_276295_payment_method',
+					'key'   => 'payment_method',
 					'label' => 'Payment Method',
 				],
 				276273  => [
 					'id'    => 276273,
-					'name'  => 'Billing Address',
-					'key'   => 'ck_field_276273_billing_address',
+					'name'  => 'ck_field_276273_billing_address',
+					'key'   => 'billing_address',
 					'label' => 'Billing Address',
 				],
 				276272  => [
 					'id'    => 276272,
-					'name'  => 'Shipping Address',
-					'key'   => 'ck_field_276272_shipping_address',
+					'name'  => 'ck_field_276272_shipping_address',
+					'key'   => 'shipping_address',
 					'label' => 'Shipping Address',
 				],
 				276271  => [
 					'id'    => 276271,
-					'name'  => 'Phone Number',
-					'key'   => 'ck_field_276271_phone_number',
+					'name'  => 'ck_field_276271_phone_number',
+					'key'   => 'phone_number',
 					'label' => 'Phone Number',
 				],
 				264073  => [
 					'id'    => 264073,
-					'name'  => 'Last Name',
-					'key'   => 'ck_field_264073_last_name',
+					'name'  => 'ck_field_264073_last_name',
+					'key'   => 'last_name',
 					'label' => 'Last Name',
 				],
 				258240  => [

--- a/tests/Support/Helper/KitPlugin.php
+++ b/tests/Support/Helper/KitPlugin.php
@@ -511,12 +511,63 @@ class KitPlugin extends \Codeception\Module
 			]
 		);
 
+		// Define Custom Fields.
+		// Define Custom Fields.
+		$I->haveOptionInDatabase(
+			'convertkit_custom_fields',
+			[
+				1075083 => [
+					'id'    => 1075083,
+					'name'  => 'ck_field_1075083_url',
+					'key'   => 'url',
+					'label' => 'URL',
+				],
+				276295  => [
+					'id'    => 276295,
+					'name'  => 'Payment Method',
+					'key'   => 'ck_field_276295_payment_method',
+					'label' => 'Payment Method',
+				],
+				276273  => [
+					'id'    => 276273,
+					'name'  => 'Billing Address',
+					'key'   => 'ck_field_276273_billing_address',
+					'label' => 'Billing Address',
+				],
+				276272  => [
+					'id'    => 276272,
+					'name'  => 'Shipping Address',
+					'key'   => 'ck_field_276272_shipping_address',
+					'label' => 'Shipping Address',
+				],
+				276271  => [
+					'id'    => 276271,
+					'name'  => 'Phone Number',
+					'key'   => 'ck_field_276271_phone_number',
+					'label' => 'Phone Number',
+				],
+				264073  => [
+					'id'    => 264073,
+					'name'  => 'Last Name',
+					'key'   => 'ck_field_264073_last_name',
+					'label' => 'Last Name',
+				],
+				258240  => [
+					'id'    => 258240,
+					'name'  => 'ck_field_258240_notes',
+					'key'   => 'notes',
+					'label' => 'Notes',
+				],
+			]
+		);
+
 		// Define last queried to now for all resources, so they're not automatically immediately refreshed by the Plugin's logic.
 		$I->haveOptionInDatabase( 'convertkit_forms_last_queried', strtotime( 'now' ) );
 		$I->haveOptionInDatabase( 'convertkit_landing_pages_last_queried', strtotime( 'now' ) );
 		$I->haveOptionInDatabase( 'convertkit_posts_last_queried', strtotime( 'now' ) );
 		$I->haveOptionInDatabase( 'convertkit_products_last_queried', strtotime( 'now' ) );
 		$I->haveOptionInDatabase( 'convertkit_tags_last_queried', strtotime( 'now' ) );
+		$I->haveOptionInDatabase( 'convertkit_custom_fields_last_queried', strtotime( 'now' ) );
 	}
 
 	/**
@@ -560,12 +611,19 @@ class KitPlugin extends \Codeception\Module
 			[]
 		);
 
+		// Define Custom Fields.
+		$I->haveOptionInDatabase(
+			'convertkit_custom_fields',
+			[]
+		);
+
 		// Define last queried to now for all resources, so they're not automatically immediately refreshed by the Plugin's logic.
 		$I->haveOptionInDatabase( 'convertkit_forms_last_queried', strtotime( 'now' ) );
 		$I->haveOptionInDatabase( 'convertkit_landing_pages_last_queried', strtotime( 'now' ) );
 		$I->haveOptionInDatabase( 'convertkit_posts_last_queried', strtotime( 'now' ) );
 		$I->haveOptionInDatabase( 'convertkit_products_last_queried', strtotime( 'now' ) );
 		$I->haveOptionInDatabase( 'convertkit_tags_last_queried', strtotime( 'now' ) );
+		$I->haveOptionInDatabase( 'convertkit_custom_fields_last_queried', strtotime( 'now' ) );
 	}
 
 	/**
@@ -596,6 +654,8 @@ class KitPlugin extends \Codeception\Module
 		$I->dontHaveOptionInDatabase('convertkit_products_last_queried');
 		$I->dontHaveOptionInDatabase('convertkit_tags');
 		$I->dontHaveOptionInDatabase('convertkit_tags_last_queried');
+		$I->dontHaveOptionInDatabase('convertkit_custom_fields');
+		$I->dontHaveOptionInDatabase('convertkit_custom_fields_last_queried');
 
 		// Persistent notices.
 		$I->dontHaveOptionInDatabase('convertkit-admin-notices');


### PR DESCRIPTION
## Summary

Improves test performance when working with Custom Fields by adding them to the resource cache, as tests already do for other resources (such as Forms, Tags, Products etc).

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)