### PR TITLE
Run `composer update` before tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,10 +54,12 @@
         "fix-js-coding-standards": "npm run fix:js",
         "php-static-analysis": "vendor/bin/phpstan analyse --memory-limit=1250M",
         "test": [
+            "@composer update --no-interaction",
             "vendor/bin/codecept build @no_additional_args",
             "vendor/bin/codecept run EndToEnd @additional_args --fail-fast"
         ],
         "test-integration": [
+            "@composer update --no-interaction",
             "vendor/bin/codecept build @no_additional_args",
             "vendor/bin/codecept run Integration @additional_args --fail-fast"
         ]


### PR DESCRIPTION
## Summary

When running tests using `composer test` or `composer test-integration`, automatically calls `composer update` to ensure any required packages are included, particularly when switching between branches that include different packages, such as the Abilities API / MCP work.

GitHub actions [directly call `composer update`](https://github.com/Kit/convertkit-wordpress/blob/main/.github/workflows/_run-tests.yml#L301-L303) before [calling `vendor/bin/codecept`](https://github.com/Kit/convertkit-wordpress/blob/main/.github/workflows/_run-tests.yml#L367-L369), so this doesn't result in a double composer update run on actions.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)