### PR TITLE
Improve Permission Checks

### DIFF
--- a/admin/class-convertkit-admin-bulk-edit.php
+++ b/admin/class-convertkit-admin-bulk-edit.php
@@ -111,6 +111,13 @@ class ConvertKit_Admin_Bulk_Edit {
 
 		// Iterate through each Post, updating its settings.
 		foreach ( $post_ids as $post_id ) {
+			// Skip Posts the current user cannot edit.
+			// The post type's edit_posts capability checked above does not grant
+			// permission to edit every Post of that type.
+			if ( ! current_user_can( 'edit_post', $post_id ) ) {
+				continue;
+			}
+
 			WP_ConvertKit()->get_class( 'admin_post' )->save_post_settings( $post_id, wp_unslash( $_REQUEST['wp-convertkit'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		}
 

--- a/admin/class-convertkit-admin-cache-plugins.php
+++ b/admin/class-convertkit-admin-cache-plugins.php
@@ -54,6 +54,11 @@ class ConvertKit_Admin_Cache_Plugins {
 	 */
 	public function maybe_configure_cache_plugins() {
 
+		// Only allow Administrators to update third party Plugin settings.
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
 		// If no Pages, Posts or CPTs are configured to use Restrict Content, don't
 		// configure any caching plugins.
 		if ( ! WP_ConvertKit()->get_class( 'admin_restrict_content' )->restrict_content_enabled() ) {

--- a/admin/class-convertkit-admin-category.php
+++ b/admin/class-convertkit-admin-category.php
@@ -181,6 +181,11 @@ class ConvertKit_Admin_Category {
 	 */
 	public function save_category_fields( $term_id ) {
 
+		// Bail if the current user cannot edit this Category.
+		if ( ! current_user_can( 'edit_term', $term_id ) ) {
+			return;
+		}
+
 		// Bail if no nonce field exists.
 		if ( ! isset( $_POST['wp-convertkit-save-meta-nonce'] ) ) {
 			return;

--- a/admin/class-convertkit-admin-landing-page.php
+++ b/admin/class-convertkit-admin-landing-page.php
@@ -54,6 +54,11 @@ class ConvertKit_Admin_Landing_Page {
 			return $buttons;
 		}
 
+		// Don't show the button if the user cannot create and publish Pages.
+		if ( ! convertkit_user_can_create_published_post_type( $post_type ) ) {
+			return $buttons;
+		}
+
 		// Register button.
 		$buttons['convertkit_landing_page_setup'] = array(
 			'url'   => add_query_arg(

--- a/admin/class-convertkit-admin-post.php
+++ b/admin/class-convertkit-admin-post.php
@@ -267,11 +267,6 @@ class ConvertKit_Admin_Post {
 			return;
 		}
 
-		// Bail if the current user cannot edit this Post.
-		if ( ! current_user_can( 'edit_post', $post_id ) ) {
-			return;
-		}
-
 		// Bail if no nonce field exists.
 		if ( ! isset( $_POST['wp-convertkit-save-meta-nonce'] ) ) {
 			return;
@@ -284,6 +279,11 @@ class ConvertKit_Admin_Post {
 
 		// Bail if no ConvertKit settings were posted.
 		if ( ! isset( $_POST['wp-convertkit'] ) ) {
+			return;
+		}
+
+		// Bail if the current user cannot edit this Post.
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
 			return;
 		}
 

--- a/admin/class-convertkit-admin-post.php
+++ b/admin/class-convertkit-admin-post.php
@@ -267,6 +267,11 @@ class ConvertKit_Admin_Post {
 			return;
 		}
 
+		// Bail if the current user cannot edit this Post.
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return;
+		}
+
 		// Bail if no nonce field exists.
 		if ( ! isset( $_POST['wp-convertkit-save-meta-nonce'] ) ) {
 			return;

--- a/admin/class-convertkit-admin-restrict-content.php
+++ b/admin/class-convertkit-admin-restrict-content.php
@@ -251,6 +251,11 @@ class ConvertKit_Admin_Restrict_Content {
 			return $buttons;
 		}
 
+		// Don't show the button if the user cannot create and publish this Post Type.
+		if ( ! convertkit_user_can_create_published_post_type( $post_type ) ) {
+			return $buttons;
+		}
+
 		// Register button.
 		$buttons['convertkit_restrict_content_setup'] = array(
 			'url'   => add_query_arg(

--- a/admin/class-convertkit-admin-setup-wizard.php
+++ b/admin/class-convertkit-admin-setup-wizard.php
@@ -507,4 +507,29 @@ class ConvertKit_Admin_Setup_Wizard {
 
 	}
 
+	/**
+	 * Sets the Post Type from the request, ensuring it is supported by the Plugin.
+	 *
+	 * @since   3.3.9
+	 */
+	protected function set_post_type() {
+
+		$this->post_type = ( filter_has_var( INPUT_GET, 'ck_post_type' ) ? filter_input( INPUT_GET, 'ck_post_type', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) : 'page' );
+
+		if ( ! in_array( $this->post_type, convertkit_get_supported_post_types(), true ) ) {
+			wp_die(
+				sprintf(
+					/* translators: Post Type */
+					esc_html__( 'The post type `%s` is not supported for Member Content.', 'convertkit' ),
+					esc_html( $this->post_type )
+				),
+				esc_html__( 'WordPress Error', 'convertkit' ),
+				array(
+					'back_link' => true,
+				)
+			);
+		}
+
+	}
+
 }

--- a/admin/class-convertkit-admin-setup-wizard.php
+++ b/admin/class-convertkit-admin-setup-wizard.php
@@ -38,6 +38,15 @@ class ConvertKit_Admin_Setup_Wizard {
 	public $error = false;
 
 	/**
+	 * Holds the Post Type to generate.
+	 *
+	 * @since   3.3.9
+	 *
+	 * @var     string
+	 */
+	public $post_type = 'page';
+
+	/**
 	 * The required user capability to access the setup wizard.
 	 *
 	 * @since   1.9.8.4

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-landing-page.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-landing-page.php
@@ -287,29 +287,4 @@ class ConvertKit_Admin_Setup_Wizard_Landing_Page extends ConvertKit_Admin_Setup_
 
 	}
 
-	/**
-	 * Sets the Post Type from the request, ensuring it is supported by the Plugin.
-	 *
-	 * @since   3.3.9
-	 */
-	private function set_post_type() {
-
-		$this->post_type = ( filter_has_var( INPUT_GET, 'ck_post_type' ) ? filter_input( INPUT_GET, 'ck_post_type', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) : 'page' );
-
-		if ( ! in_array( $this->post_type, convertkit_get_supported_post_types(), true ) ) {
-			wp_die(
-				sprintf(
-					/* translators: Post Type */
-					esc_html__( 'The post type `%s` is not supported for Member Content.', 'convertkit' ),
-					esc_html( $this->post_type )
-				),
-				esc_html__( 'WordPress Error', 'convertkit' ),
-				array(
-					'back_link' => true,
-				)
-			);
-		}
-
-	}
-
 }

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-landing-page.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-landing-page.php
@@ -128,6 +128,13 @@ class ConvertKit_Admin_Setup_Wizard_Landing_Page extends ConvertKit_Admin_Setup_
 	 */
 	public function process_form( $step ) {
 
+		// Set and authorize the Post Type before processing data.
+		$this->set_post_type();
+		if ( ! convertkit_user_can_create_published_post_type( $this->post_type ) ) {
+			$this->error = __( 'You are not allowed to create and publish this type of content.', 'convertkit' );
+			return;
+		}
+
 		// Run security checks.
 		if ( ! isset( $_REQUEST['_wpnonce'] ) ) {
 			return;
@@ -181,26 +188,10 @@ class ConvertKit_Admin_Setup_Wizard_Landing_Page extends ConvertKit_Admin_Setup_
 			wp_die( esc_html__( 'Connect your Kit account in the Kit Plugin\'s settings to get started', 'convertkit' ) );
 		}
 
-		// Get Post Type.
-		if ( filter_has_var( INPUT_GET, 'ck_post_type' ) ) {
-			$this->post_type = filter_input( INPUT_GET, 'ck_post_type', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
-		} else {
-			$this->post_type = 'page';
-		}
-
-		// Bail if the Post Type isn't supported.
-		if ( ! in_array( $this->post_type, convertkit_get_supported_post_types(), true ) ) {
-			wp_die(
-				sprintf(
-					/* translators: Post Type */
-					esc_html__( 'The post type `%s` is not supported for Member Content.', 'convertkit' ),
-					esc_html( $this->post_type )
-				),
-				esc_html__( 'WordPress Error', 'convertkit' ),
-				array(
-					'back_link' => true,
-				)
-			);
+		// Set and authorize the Post Type.
+		$this->set_post_type();
+		if ( ! convertkit_user_can_create_published_post_type( $this->post_type ) ) {
+			wp_die( esc_html__( 'Sorry, you are not allowed to create and publish this type of content.', 'convertkit' ) );
 		}
 
 		// Define Exit URL to take the user back to the WP_List_Table for the Post Type they were viewing.
@@ -293,6 +284,31 @@ class ConvertKit_Admin_Setup_Wizard_Landing_Page extends ConvertKit_Admin_Setup_
 
 		// Return.
 		return $page_id;
+
+	}
+
+	/**
+	 * Sets the Post Type from the request, ensuring it is supported by the Plugin.
+	 *
+	 * @since   3.3.9
+	 */
+	private function set_post_type() {
+
+		$this->post_type = ( filter_has_var( INPUT_GET, 'ck_post_type' ) ? filter_input( INPUT_GET, 'ck_post_type', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) : 'page' );
+
+		if ( ! in_array( $this->post_type, convertkit_get_supported_post_types(), true ) ) {
+			wp_die(
+				sprintf(
+					/* translators: Post Type */
+					esc_html__( 'The post type `%s` is not supported for Member Content.', 'convertkit' ),
+					esc_html( $this->post_type )
+				),
+				esc_html__( 'WordPress Error', 'convertkit' ),
+				array(
+					'back_link' => true,
+				)
+			);
+		}
 
 	}
 

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-landing-page.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-landing-page.php
@@ -15,15 +15,6 @@
 class ConvertKit_Admin_Setup_Wizard_Landing_Page extends ConvertKit_Admin_Setup_Wizard {
 
 	/**
-	 * Holds the Post Type to generate.
-	 *
-	 * @since   2.5.5
-	 *
-	 * @var     string
-	 */
-	public $post_type = 'page';
-
-	/**
 	 * Holds the ConvertKit Products resource class.
 	 *
 	 * @since   2.5.5

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-plugin.php
@@ -72,7 +72,7 @@ class ConvertKit_Admin_Setup_Wizard_Plugin extends ConvertKit_Admin_Setup_Wizard
 	 *
 	 * @var     string
 	 */
-	public $required_capability = 'edit_posts';
+	public $required_capability = 'manage_options';
 
 	/**
 	 * The programmatic name for this wizard.

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php
@@ -584,31 +584,6 @@ class ConvertKit_Admin_Setup_Wizard_Restrict_Content extends ConvertKit_Admin_Se
 	}
 
 	/**
-	 * Sets the Post Type from the request, ensuring it is supported by the Plugin.
-	 *
-	 * @since   3.3.9
-	 */
-	private function set_post_type() {
-
-		$this->post_type = ( filter_has_var( INPUT_GET, 'ck_post_type' ) ? filter_input( INPUT_GET, 'ck_post_type', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) : 'page' );
-
-		if ( ! in_array( $this->post_type, convertkit_get_supported_post_types(), true ) ) {
-			wp_die(
-				sprintf(
-					/* translators: Post Type */
-					esc_html__( 'The post type `%s` is not supported for Member Content.', 'convertkit' ),
-					esc_html( $this->post_type )
-				),
-				esc_html__( 'WordPress Error', 'convertkit' ),
-				array(
-					'back_link' => true,
-				)
-			);
-		}
-
-	}
-
-	/**
 	 * Returns a paragraph for the given text, depending on if the Classic Editor or Block Editor is used.
 	 *
 	 * @since   2.1.0

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php
@@ -185,6 +185,13 @@ class ConvertKit_Admin_Setup_Wizard_Restrict_Content extends ConvertKit_Admin_Se
 	 */
 	public function process_form( $step ) {
 
+		// Set and authorize the Post Type before processing data.
+		$this->set_post_type();
+		if ( ! convertkit_user_can_create_published_post_type( $this->post_type ) ) {
+			$this->error = __( 'You are not allowed to create and publish this type of content.', 'convertkit' );
+			return;
+		}
+
 		// Run security checks.
 		if ( ! isset( $_REQUEST['_wpnonce'] ) ) {
 			return;
@@ -256,26 +263,10 @@ class ConvertKit_Admin_Setup_Wizard_Restrict_Content extends ConvertKit_Admin_Se
 			wp_die( esc_html__( 'Connect your ConvertKit account in the ConvertKit Plugin\'s settings to get started', 'convertkit' ) );
 		}
 
-		// Get the Post Type.
-		if ( filter_has_var( INPUT_GET, 'ck_post_type' ) ) {
-			$this->post_type = filter_input( INPUT_GET, 'ck_post_type', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
-		} else {
-			$this->post_type = 'page';
-		}
-
-		// Bail if the Post Type isn't supported.
-		if ( ! in_array( $this->post_type, convertkit_get_supported_post_types(), true ) ) {
-			wp_die(
-				sprintf(
-					/* translators: Post Type */
-					esc_html__( 'The post type `%s` is not supported for Member Content.', 'convertkit' ),
-					esc_html( $this->post_type )
-				),
-				esc_html__( 'WordPress Error', 'convertkit' ),
-				array(
-					'back_link' => true,
-				)
-			);
+		// Set and authorize the Post Type.
+		$this->set_post_type();
+		if ( ! convertkit_user_can_create_published_post_type( $this->post_type ) ) {
+			wp_die( esc_html__( 'Sorry, you are not allowed to create and publish this type of content.', 'convertkit' ) );
 		}
 
 		// Define Exit URL to take the user back to the WP_List_Table for the Post Type they were viewing.
@@ -589,6 +580,31 @@ class ConvertKit_Admin_Setup_Wizard_Restrict_Content extends ConvertKit_Admin_Se
 
 		// Return.
 		return $page_id;
+
+	}
+
+	/**
+	 * Sets the Post Type from the request, ensuring it is supported by the Plugin.
+	 *
+	 * @since   3.3.9
+	 */
+	private function set_post_type() {
+
+		$this->post_type = ( filter_has_var( INPUT_GET, 'ck_post_type' ) ? filter_input( INPUT_GET, 'ck_post_type', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) : 'page' );
+
+		if ( ! in_array( $this->post_type, convertkit_get_supported_post_types(), true ) ) {
+			wp_die(
+				sprintf(
+					/* translators: Post Type */
+					esc_html__( 'The post type `%s` is not supported for Member Content.', 'convertkit' ),
+					esc_html( $this->post_type )
+				),
+				esc_html__( 'WordPress Error', 'convertkit' ),
+				array(
+					'back_link' => true,
+				)
+			);
+		}
 
 	}
 

--- a/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php
+++ b/admin/setup-wizard/class-convertkit-admin-setup-wizard-restrict-content.php
@@ -15,15 +15,6 @@
 class ConvertKit_Admin_Setup_Wizard_Restrict_Content extends ConvertKit_Admin_Setup_Wizard {
 
 	/**
-	 * Holds the Post Type to generate Members Content for.
-	 *
-	 * @since   2.1.0
-	 *
-	 * @var     string
-	 */
-	public $post_type = 'page';
-
-	/**
 	 * Holds the type of Member's Content to generate (course|download).
 	 *
 	 * @since   2.1.0

--- a/includes/class-convertkit-broadcasts-exporter.php
+++ b/includes/class-convertkit-broadcasts-exporter.php
@@ -109,6 +109,11 @@ class ConvertKit_Broadcasts_Exporter {
 			return;
 		}
 
+		// Bail if the current user cannot edit the Post being exported.
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			wp_die( esc_html__( 'Sorry, you are not allowed to export this Post.', 'convertkit' ) );
+		}
+
 		// Export Post to a draft ConvertKit Broadcast.
 		$result = $this->export_post_to_broadcast( $post_id );
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -148,6 +148,26 @@ function convertkit_get_supported_post_types() {
 }
 
 /**
+ * Determines whether the current user can create and publish the given Post Type.
+ *
+ * @since   3.3.9
+ *
+ * @param   string $post_type    Post Type.
+ * @return  bool                User can create and publish Post Type.
+ */
+function convertkit_user_can_create_published_post_type( $post_type ) {
+
+	$post_type_object = get_post_type_object( $post_type );
+
+	if ( ! $post_type_object ) {
+		return false;
+	}
+
+	return current_user_can( $post_type_object->cap->create_posts ) && current_user_can( $post_type_object->cap->publish_posts );
+
+}
+
+/**
  * Helper method to get supported Post Types for Restricted Content (Member's Content)
  *
  * @since   2.1.0

--- a/includes/pre-publish-actions/class-convertkit-pre-publish-action.php
+++ b/includes/pre-publish-actions/class-convertkit-pre-publish-action.php
@@ -201,6 +201,11 @@ class ConvertKit_Pre_Publish_Action {
 			return;
 		}
 
+		// Bail if the current user cannot edit this Post.
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return;
+		}
+
 		// Bail if no nonce field exists.
 		if ( ! isset( $_POST['wp-convertkit-pre-publish-actions-nonce'] ) ) {
 			return;

--- a/includes/pre-publish-actions/class-convertkit-pre-publish-action.php
+++ b/includes/pre-publish-actions/class-convertkit-pre-publish-action.php
@@ -201,11 +201,6 @@ class ConvertKit_Pre_Publish_Action {
 			return;
 		}
 
-		// Bail if the current user cannot edit this Post.
-		if ( ! current_user_can( 'edit_post', $post_id ) ) {
-			return;
-		}
-
 		// Bail if no nonce field exists.
 		if ( ! isset( $_POST['wp-convertkit-pre-publish-actions-nonce'] ) ) {
 			return;
@@ -213,6 +208,11 @@ class ConvertKit_Pre_Publish_Action {
 
 		// Bail if the nonce verification fails.
 		if ( ! wp_verify_nonce( sanitize_key( wp_unslash( $_POST['wp-convertkit-pre-publish-actions-nonce'] ) ), 'wp-convertkit-pre-publish-actions' ) ) {
+			return;
+		}
+
+		// Bail if the current user cannot edit this Post.
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
 			return;
 		}
 

--- a/tests/EndToEnd/forms/post-types/BulkQuickEditFormCest.php
+++ b/tests/EndToEnd/forms/post-types/BulkQuickEditFormCest.php
@@ -182,6 +182,71 @@ class BulkQuickEditFormCest
 	}
 
 	/**
+	 * Test that Bulk Edit does not save Kit settings for a Post the current user cannot edit.
+	 *
+	 * @since   3.3.9
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testBulkEditDoesNotSaveSettingsForPostUserCannotEdit(EndToEndTester $I)
+	{
+		// Create an Author and a Post that they own.
+		$authorID = $I->haveUserInDatabase('convertkit_bulk_edit_author', 'author');
+		$postID   = $I->havePostInDatabase(
+			[
+				'post_author' => $authorID,
+				'post_type'   => 'post',
+				'post_title'  => 'Kit: Bulk Edit: Author Post',
+			]
+		);
+
+		// Create a Post owned by the Administrator.
+		$administratorID = $I->grabUserIdFromDatabase($_ENV['WORDPRESS_ADMIN_USER']);
+		$otherPostID     = $I->havePostInDatabase(
+			[
+				'post_author' => $administratorID,
+				'post_type'   => 'post',
+				'post_title'  => 'Kit: Bulk Edit: Administrator Post',
+			]
+		);
+
+		// Login as the Author.
+		$I->logOut();
+		$I->loginAs('convertkit_bulk_edit_author', 'convertkit_bulk_edit_author');
+
+		// Open Bulk Edit for the Author's Post.
+		$I->openBulkEdit($I, 'post', [ $postID ]);
+
+		// Add an Administrator-owned Post ID to the submitted request.
+		$I->executeJS(
+			'
+				var postID = document.createElement("input");
+				postID.setAttribute("type", "hidden");
+				postID.setAttribute("name", "post[]");
+				postID.setAttribute("value", "' . $otherPostID . '");
+				document.querySelector("#bulk-edit").appendChild(postID);
+			'
+		);
+
+		// Set a Kit Form and save the Bulk Edit request.
+		$I->selectOption('#convertkit-bulk-edit #wp-convertkit-bulk-edit-form', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->click('#bulk_edit');
+		$I->waitForElementVisible('div.updated');
+
+		// Confirm no settings were saved against the Administrator-owned Post.
+		$I->dontSeePostMetaInDatabase(
+			[
+				'post_id'  => $otherPostID,
+				'meta_key' => '_wp_convertkit_post_meta',
+			]
+		);
+
+		// Login as the Administrator so the test suite can deactivate the Plugin.
+		$I->logOut();
+		$I->doLoginAsAdmin($I);
+	}
+
+	/**
 	 * Test that the defined form displays when chosen via
 	 * WordPress' Bulk Edit functionality.
 	 *

--- a/tests/EndToEnd/landing-pages/PageLandingPageSetupWizardCest.php
+++ b/tests/EndToEnd/landing-pages/PageLandingPageSetupWizardCest.php
@@ -85,6 +85,53 @@ class PageLandingPageSetupWizardCest
 	}
 
 	/**
+	 * Test that the Add New Landing Page and Member Content buttons do not display when the user
+	 * cannot publish Pages.
+	 *
+	 * @since   3.3.9
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testAddNewContentButtonsNotDisplayedWhenUserCannotPublishPages(EndToEndTester $I)
+	{
+		// Setup Plugin.
+		$I->setupKitPlugin($I);
+
+		// Create an Editor who cannot publish Pages.
+		$userID = $I->haveUserInDatabase('convertkit_pages_contributor', 'editor');
+		$I->dontHaveUserMetaInDatabase(
+			[
+				'user_id'  => $userID,
+				'meta_key' => $I->grabTablePrefix() . 'capabilities',
+			]
+		);
+		$I->haveUserMetaInDatabase(
+			$userID,
+			$I->grabTablePrefix() . 'capabilities',
+			serialize(
+				[
+					'editor'        => true,
+					'publish_pages' => false,
+				]
+			)
+		);
+
+		// Login as the user who cannot publish Pages.
+		$I->logOut();
+		$I->loginAs('convertkit_pages_contributor', 'convertkit_pages_contributor');
+
+		// Navigate to Pages.
+		$I->amOnAdminPage('edit.php?post_type=page');
+
+		// Confirm no content creation buttons are displayed.
+		$I->dontSeeElementInDOM('span.convertkit-action.page-title-action');
+
+		// Login as the Administrator so the test suite can deactivate the Plugin.
+		$I->logOut();
+		$I->doLoginAsAdmin($I);
+	}
+
+	/**
 	 * Test that the Dashboard submenu item for this wizard does not display when a
 	 * third party Admin Menu editor type Plugin is installed and active.
 	 *

--- a/tests/Integration/PermissionsTest.php
+++ b/tests/Integration/PermissionsTest.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace Tests;
+
+use lucatume\WPBrowser\TestCase\WPTestCase;
+
+/**
+ * Tests for Plugin permission checks.
+ *
+ * @since   3.3.9
+ */
+class PermissionsTest extends WPTestCase
+{
+	/**
+	 * The testing implementation.
+	 *
+	 * @var \IntegrationTester
+	 */
+	protected $tester;
+
+	/**
+	 * Holds the ConvertKit Settings class.
+	 *
+	 * @since   3.3.9
+	 *
+	 * @var     \ConvertKit_Settings
+	 */
+	private $settings;
+
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since   3.3.9
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		// Activate Plugin, to include the Plugin's constants in tests.
+		activate_plugins( 'convertkit/wp-convertkit.php' );
+
+		// Store credentials in Plugin settings.
+		$this->settings = new \ConvertKit_Settings();
+		$this->settings->save(
+			array(
+				'access_token'  => $_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
+				'refresh_token' => $_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN'],
+				'token_expires' => ( time() + 10000 ),
+			)
+		);
+	}
+
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since   3.3.9
+	 */
+	public function tearDown(): void
+	{
+		// Delete credentials from Plugin settings.
+		$this->settings->delete_credentials();
+
+		// Reset request data used by admin request handlers.
+		$_POST    = array();
+		$_REQUEST = array();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that users must be able to create and publish the requested Post Type.
+	 *
+	 * @since   3.3.9
+	 */
+	public function testUserCanCreatePublishedPostType()
+	{
+		// Administrators and Editors can create and publish Pages.
+		$this->actAs( 'administrator' );
+		$this->assertTrue( convertkit_user_can_create_published_post_type( 'page' ) );
+
+		$this->actAs( 'editor' );
+		$this->assertTrue( convertkit_user_can_create_published_post_type( 'page' ) );
+
+		// Authors can create and publish Posts, but not Pages.
+		$this->actAs( 'author' );
+		$this->assertTrue( convertkit_user_can_create_published_post_type( 'post' ) );
+		$this->assertFalse( convertkit_user_can_create_published_post_type( 'page' ) );
+
+		// Contributors cannot publish Posts.
+		$this->actAs( 'contributor' );
+		$this->assertFalse( convertkit_user_can_create_published_post_type( 'post' ) );
+
+		// Unknown Post Types cannot be created.
+		$this->assertFalse( convertkit_user_can_create_published_post_type( 'convertkit_unknown' ) );
+	}
+
+	/**
+	 * Test that users unable to publish Pages are not offered content creation buttons.
+	 *
+	 * @since   3.3.9
+	 */
+	public function testListTableButtonsNotRegisteredWhenUserCannotPublishPages()
+	{
+		// Create and become an Author, who cannot create or publish Pages.
+		$this->actAs( 'author' );
+
+		// Confirm no content creation buttons are registered.
+		$landing_page = new \ConvertKit_Admin_Landing_Page();
+		$this->assertSame( array(), $landing_page->register_add_new_button( array(), 'page' ) );
+
+		$restrict_content = new \ConvertKit_Admin_Restrict_Content();
+		$this->assertSame( array(), $restrict_content->register_add_new_button( array(), 'page' ) );
+	}
+
+	/**
+	 * Test that only Administrators can access the Plugin setup wizard.
+	 *
+	 * @since   3.3.9
+	 */
+	public function testPluginSetupWizardRequiresManageOptionsCapability()
+	{
+		$wizard = new \ConvertKit_Admin_Setup_Wizard_Plugin();
+
+		// Editors cannot access the Plugin setup wizard.
+		$this->actAs( 'editor' );
+		$this->assertFalse( $wizard->user_has_access() );
+
+		// Administrators can access the Plugin setup wizard.
+		$this->actAs( 'administrator' );
+		$this->assertTrue( $wizard->user_has_access() );
+	}
+
+	/**
+	 * Test that Post settings cannot be saved for a Post the user cannot edit.
+	 *
+	 * @since   3.3.9
+	 */
+	public function testPostSettingsNotSavedWhenUserCannotEditPost()
+	{
+		// Create a Post owned by an Administrator.
+		$administrator_id = static::factory()->user->create( array( 'role' => 'administrator' ) );
+		$post_id          = static::factory()->post->create(
+			array(
+				'post_author' => $administrator_id,
+			)
+		);
+
+		// Become an Author, who cannot edit another user's Post.
+		$this->actAs( 'author' );
+		$_POST = array(
+			'wp-convertkit-save-meta-nonce' => wp_create_nonce( 'wp-convertkit-save-meta' ),
+			'wp-convertkit'                 => array(
+				'form' => '123',
+			),
+		);
+
+		// Attempt to save the Post's settings.
+		( new \ConvertKit_Admin_Post() )->save_post_meta( $post_id );
+
+		// Confirm no settings were saved.
+		$this->assertSame( '', get_post_meta( $post_id, '_wp_convertkit_post_meta', true ) );
+	}
+
+	/**
+	 * Test that Category settings cannot be saved when the user cannot edit the Category.
+	 *
+	 * @since   3.3.9
+	 */
+	public function testCategorySettingsNotSavedWhenUserCannotEditCategory()
+	{
+		// Create a Category.
+		$term = static::factory()->term->create_and_get(
+			array(
+				'taxonomy' => 'category',
+			)
+		);
+
+		// Become an Author, who cannot manage Categories.
+		$this->actAs( 'author' );
+		$_POST = array(
+			'wp-convertkit-save-meta-nonce' => wp_create_nonce( 'wp-convertkit-save-meta' ),
+			'wp-convertkit'                 => array(
+				'form' => '123',
+			),
+		);
+
+		// Attempt to save the Category's settings.
+		( new \ConvertKit_Admin_Category() )->save_category_fields( $term->term_id );
+
+		// Confirm no settings were saved.
+		$this->assertSame( '', get_term_meta( $term->term_id, '_wp_convertkit_term_meta', true ) );
+	}
+
+	/**
+	 * Test that exporting a Post to a Broadcast stops when the user cannot edit the Post.
+	 *
+	 * @since   3.3.9
+	 */
+	public function testBroadcastExportStopsWhenUserCannotEditPost()
+	{
+		// Enable Broadcast exports.
+		$broadcasts_settings = new \ConvertKit_Settings_Broadcasts();
+		$broadcasts_settings->save( array( 'enabled_export' => 'on' ) );
+
+		// Create a Post owned by an Administrator.
+		$administrator_id = static::factory()->user->create( array( 'role' => 'administrator' ) );
+		$post_id          = static::factory()->post->create(
+			array(
+				'post_author' => $administrator_id,
+			)
+		);
+
+		// Become an Author, who cannot edit the Administrator's Post.
+		$this->actAs( 'author' );
+		$_REQUEST = array(
+			'nonce'              => wp_create_nonce( 'action-convertkit-broadcast-export' ),
+			'convertkit-action' => 'broadcast-export',
+			'id'                 => $post_id,
+		);
+
+		// Confirm the export stops before a Broadcast can be created.
+		$this->expectException( \WPDieException::class );
+		$this->expectExceptionMessage( 'Sorry, you are not allowed to export this Post.' );
+		( new \ConvertKit_Broadcasts_Exporter() )->run_row_action();
+	}
+
+	/**
+	 * Creates a User with the given role and makes them the current User.
+	 *
+	 * @since   3.3.9
+	 *
+	 * @param   string $role   User role.
+	 */
+	private function actAs( $role )
+	{
+		$user_id = static::factory()->user->create( array( 'role' => $role ) );
+		wp_set_current_user( $user_id );
+	}
+}

--- a/tests/Integration/PermissionsTest.php
+++ b/tests/Integration/PermissionsTest.php
@@ -213,9 +213,9 @@ class PermissionsTest extends WPTestCase
 		// Become an Author, who cannot edit the Administrator's Post.
 		$this->actAs( 'author' );
 		$_REQUEST = array(
-			'nonce'              => wp_create_nonce( 'action-convertkit-broadcast-export' ),
+			'nonce'             => wp_create_nonce( 'action-convertkit-broadcast-export' ),
 			'convertkit-action' => 'broadcast-export',
-			'id'                 => $post_id,
+			'id'                => $post_id,
 		);
 
 		// Confirm the export stops before a Broadcast can be created.


### PR DESCRIPTION
## Summary

Adds object-level authorization checks for Kit admin actions that write data or create external resources.

- Restricts the Plugin Setup Wizard to users with `manage_options`.
- Requires users of the Landing Page and Member Content wizards to be able to create and publish the selected Post Type.
- Hides the Landing Page and Member Content buttons when the current user lacks those capabilities.
- Prevents Bulk Edit, post settings, category settings, pre-publish actions, and Broadcast export from acting on content the current user cannot edit.
- Restricts automatic third-party cache-plugin configuration to Administrators.

Some checks are additional e.g. `current_user_can( 'edit_term', $term_id )` within `save_category_fields`, which WordPress will already run some security checks again.

## Testing

Added integration coverage for:

- Post Type create/publish capability checks.
- Plugin Setup Wizard `manage_options` access requirement.
- Landing Page and Member Content button registration for unauthorized users.
- Unauthorized post and category settings saves.
- Unauthorized Broadcast export requests.

Added end-to-end coverage for:

- Hiding Landing Page and Member Content buttons for a user who can edit Pages but cannot publish them.
- Preventing a malicious Bulk Edit request from saving Kit metadata against another user’s Post.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)