### PR TITLE
Settings: Legacy Forms: Add Warning Notice

### DIFF
--- a/admin/class-convertkit-admin-legacy-resource-notice.php
+++ b/admin/class-convertkit-admin-legacy-resource-notice.php
@@ -217,6 +217,49 @@ class ConvertKit_Admin_Legacy_Resource_Notice {
 	}
 
 	/**
+	 * Returns an array of warning strings for the Plugin's General Settings,
+	 * when one or more Default Form settings reference Legacy Forms.
+	 *
+	 * @since   3.3.9
+	 *
+	 * @param   array $settings   Plugin settings array.
+	 * @return  array
+	 */
+	public function get_legacy_warnings_for_plugin_settings( $settings ) {
+
+		// Get Forms resource.
+		$forms = new ConvertKit_Resource_Forms();
+
+		// Initialize warnings array.
+		$warnings = array();
+
+		// Check each supported Post Type's Default Form setting.
+		foreach ( convertkit_get_supported_post_types() as $supported_post_type ) {
+			// Get Post Type object.
+			$post_type = get_post_type_object( $supported_post_type );
+			if ( ! $post_type ) {
+				continue;
+			}
+
+			// Get Default Form setting.
+			$setting_key = $supported_post_type . '_form';
+			if ( empty( $settings[ $setting_key ] ) || ! $forms->is_legacy( $settings[ $setting_key ] ) ) {
+				continue;
+			}
+
+			$warnings[] = sprintf(
+				/* translators: 1: Post Type name, plural; 2: Form name */
+				__( 'Default Form (%1$s): %2$s', 'convertkit' ),
+				$post_type->label,
+				$this->get_form_display_name( $settings[ $setting_key ], $forms )
+			);
+		}
+
+		return $warnings;
+
+	}
+
+	/**
 	 * Resolves the form ID to a human-readable "Form Name" string, falling
 	 * back to "a Legacy Form" when the resource isn't cached.
 	 *

--- a/admin/section/class-convertkit-admin-section-general.php
+++ b/admin/section/class-convertkit-admin-section-general.php
@@ -78,6 +78,7 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 		if ( $this->on_settings_screen( $this->name ) ) {
 			add_filter( 'convertkit_settings_base_register_notices', array( $this, 'register_notices' ) );
 			add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_notices' ) );
+			add_action( 'convertkit_settings_base_render_before', array( $this, 'maybe_output_legacy_form_notice' ) );
 		}
 
 		// Enqueue scripts and CSS.
@@ -107,6 +108,41 @@ class ConvertKit_Admin_Section_General extends ConvertKit_Admin_Section_Base {
 				'oauth2_success' => __( 'Successfully authorized with Kit.', 'convertkit' ),
 			)
 		);
+
+	}
+
+	/**
+	 * Outputs a non-dismissible warning when one or more Default Form settings
+	 * reference Legacy Forms.
+	 *
+	 * @since   3.3.9
+	 */
+	public function maybe_output_legacy_form_notice() {
+
+		// Get warnings.
+		$warnings = WP_ConvertKit()->get_class( 'admin_legacy_resource_notice' )->get_legacy_warnings_for_plugin_settings( $this->settings->get() );
+
+		// Bail if no warnings are found.
+		if ( empty( $warnings ) ) {
+			return;
+		}
+
+		// Output warnings.
+		?>
+		<div id="convertkit-legacy-settings-warning" class="notice notice-warning">
+			<p>
+				<strong><?php esc_html_e( 'Kit', 'convertkit' ); ?>:</strong>
+				<?php esc_html_e( 'Your Default Form settings reference Legacy Forms. They still work, but should be migrated:', 'convertkit' ); ?>
+			</p>
+			<ul>
+				<?php
+				foreach ( $warnings as $warning ) {
+					echo '<li>' . esc_html( $warning ) . '</li>';
+				}
+				?>
+			</ul>
+		</div>
+		<?php
 
 	}
 

--- a/tests/EndToEnd/general/other/LegacyFormDropdownCest.php
+++ b/tests/EndToEnd/general/other/LegacyFormDropdownCest.php
@@ -98,6 +98,36 @@ class LegacyFormDropdownCest
 	}
 
 	/**
+	 * Test that a warning is displayed on Settings > Kit > General when one or
+	 * more Default Form settings reference a Legacy Form.
+	 *
+	 * @since   3.3.9
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testWarningDisplayedForLegacyDefaultFormsSetting(EndToEndTester $I)
+	{
+		// Setup Plugin with a legacy form pre-assigned as the Default Form for
+		// both Pages and Posts, as would be the case for an upgraded install.
+		$I->setupKitPlugin(
+			$I,
+			[
+				'page_form' => (string) $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
+				'post_form' => (string) $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
+			]
+		);
+		$I->setupKitPluginResources($I);
+
+		// Go to the Plugin's Settings Screen.
+		$I->loadKitSettingsGeneralScreen($I);
+
+		// Confirm the warning identifies each affected Default Form setting.
+		$I->seeElementInDOM('#convertkit-legacy-settings-warning');
+		$I->see('Default Form (Pages): ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'], '#convertkit-legacy-settings-warning');
+		$I->see('Default Form (Posts): ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'], '#convertkit-legacy-settings-warning');
+	}
+
+	/**
 	 * Test that a previously-saved legacy Form ID assigned to a Category
 	 * term continues to render as the selected option in the term edit
 	 * screen's Form dropdown, even though legacy forms are no longer offered

--- a/tests/EndToEnd/general/other/LegacyFormDropdownCest.php
+++ b/tests/EndToEnd/general/other/LegacyFormDropdownCest.php
@@ -125,6 +125,22 @@ class LegacyFormDropdownCest
 		$I->seeElementInDOM('#convertkit-legacy-settings-warning');
 		$I->see('Default Form (Pages): ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'], '#convertkit-legacy-settings-warning');
 		$I->see('Default Form (Posts): ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'], '#convertkit-legacy-settings-warning');
+
+		// Replace the Legacy Forms with a current Kit Form and save the settings.
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-_wp_convertkit_settings_page_form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
+		$I->fillSelect2Field(
+			$I,
+			container: '#select2-_wp_convertkit_settings_post_form-container',
+			value: $_ENV['CONVERTKIT_API_FORM_NAME']
+		);
+		$I->click('Save Changes');
+
+		// Confirm the warning is no longer displayed.
+		$I->waitForElementNotVisible('#convertkit-legacy-settings-warning');
 	}
 
 	/**

--- a/tests/Integration/AdminLegacyResourceNoticeTest.php
+++ b/tests/Integration/AdminLegacyResourceNoticeTest.php
@@ -98,6 +98,42 @@ class AdminLegacyResourceNoticeTest extends WPTestCase
 	}
 
 	/**
+	 * Test that a legacy Default Form setting produces a warning containing
+	 * the Post Type label and Form name.
+	 *
+	 * @since   3.3.9
+	 */
+	public function testWarningForLegacyPluginDefaultForm()
+	{
+		$warnings = $this->notice->get_legacy_warnings_for_plugin_settings(
+			[
+				'page_form' => $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
+			]
+		);
+
+		$this->assertCount(1, $warnings);
+		$this->assertStringContainsString('Default Form (Pages):', $warnings[0]);
+		$this->assertStringContainsString($_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'], $warnings[0]);
+	}
+
+	/**
+	 * Test that current and empty Default Form settings do not produce warnings.
+	 *
+	 * @since   3.3.7
+	 */
+	public function testNoWarningForCurrentOrEmptyPluginDefaultForms()
+	{
+		$warnings = $this->notice->get_legacy_warnings_for_plugin_settings(
+			[
+				'page_form' => $_ENV['CONVERTKIT_API_FORM_ID'],
+				'post_form' => 0,
+			]
+		);
+
+		$this->assertSame([], $warnings);
+	}
+
+	/**
 	 * Test that a legacy landing page assignment (by numeric ID) produces
 	 * a landing-page-scoped warning containing the landing page's name.
 	 *

--- a/tests/Integration/AdminLegacyResourceNoticeTest.php
+++ b/tests/Integration/AdminLegacyResourceNoticeTest.php
@@ -117,11 +117,11 @@ class AdminLegacyResourceNoticeTest extends WPTestCase
 	}
 
 	/**
-	 * Test that current and empty Default Form settings do not produce warnings.
+	 * Test that Plugin settings with no Legacy Forms do not produce warnings.
 	 *
 	 * @since   3.3.7
 	 */
-	public function testNoWarningForCurrentOrEmptyPluginDefaultForms()
+	public function testNoWarningForPluginSettingsWithoutLegacyForms()
 	{
 		$warnings = $this->notice->get_legacy_warnings_for_plugin_settings(
 			[


### PR DESCRIPTION
## Summary

Adds a non-dismissible yellow warning notice at Settings > Kit when a Post Type reference a legacy form.

<img width="890" height="597" alt="Screenshot 2026-08-10 at 12 24 43" src="https://github.com/user-attachments/assets/2ac29f18-6f17-4b31-94c7-6b5b7774802f" />

## Testing

- `testWarningDisplayedForLegacyDefaultFormsSetting`: Test a warning is displayed at `Settings > Kit` when a post type specifies a legacy form
- `testWarningForLegacyPluginDefaultForm`: Integration test to confirm `get_legacy_warnings_for_plugin_settings` returns a warning when a legacy form is specified in the Plugni settings.
- `testNoWarningForPluginSettingsWithoutLegacyForms`: Integration test to confirm `get_legacy_warnings_for_plugin_settings` returns no warnings when no legacy form is specified in the Plugin settings.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)