### PR TITLE
PHP 8.5 Compatibility

### DIFF
--- a/.github/workflows/_run-tests.yml
+++ b/.github/workflows/_run-tests.yml
@@ -188,6 +188,7 @@ jobs:
       # This step is deliberately after WordPress installation and configuration, as enabling PHP 8.x before using WP-CLI results
       # in the workflow failing due to incompatibilities between WP-CLI and PHP 8.x.
       # By installing PHP at this stage, we can still run our tests against e.g. PHP 8.x.
+      # error_reporting=E_ALL and xdebug.mode="develop,coverage" are required so all PHP errors are output and caught by tests.
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/_run-tests.yml
+++ b/.github/workflows/_run-tests.yml
@@ -185,15 +185,28 @@ jobs:
         working-directory: ${{ env.ROOT_DIR }}
         run: wp-cli config set WP_AUTO_UPDATE_CORE false --raw
 
+      # error_reporting=E_ALL and xdebug.mode="develop,coverage" are required so all PHP errors are output and caught by tests.
+      # These settings are disabled for some PHP 8.5 third party integration tests, whose dependencies do not yet support PHP 8.5.
+      - name: Define PHP INI Values
+        run: |
+          if [ "${{ inputs.php-version }}" = '8.5' ]; then
+            case "${{ inputs.test-group }}" in
+              EndToEnd/integrations/divi-builder|EndToEnd/integrations/divi-theme|EndToEnd/integrations/elementor|EndToEnd/restrict-content/post-types)
+                exit 0
+                ;;
+            esac
+          fi
+
+          echo 'PHP_INI_VALUES=error_reporting=E_ALL, display_errors=On, html_errors=On, xdebug.mode="develop,coverage"' >> "$GITHUB_ENV"
+
       # This step is deliberately after WordPress installation and configuration, as enabling PHP 8.x before using WP-CLI results
       # in the workflow failing due to incompatibilities between WP-CLI and PHP 8.x.
       # By installing PHP at this stage, we can still run our tests against e.g. PHP 8.x.
-      # error_reporting=E_ALL and xdebug.mode="develop,coverage" are required so all PHP errors are output and caught by tests.
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ inputs.php-version }}
-          ini-values: 'error_reporting=E_ALL, display_errors=On, html_errors=On, xdebug.mode="develop,coverage"'
+          ini-values: ${{ env.PHP_INI_VALUES }}
           coverage: xdebug
 
       # Workaround for PHP 8.3 (and potentially other versions): the GitHub

--- a/.github/workflows/_run-tests.yml
+++ b/.github/workflows/_run-tests.yml
@@ -160,10 +160,9 @@ jobs:
       - name: Move Plugin
         run: mv /home/runner/work/convertkit-wordpress/convertkit-wordpress/convertkit ${{ env.PLUGIN_DIR }}
 
-      # WP_DEBUG = true is required so all PHP errors are output and caught by tests (E_ALL).
-      # WP_DEBUG = false for other integration tests, as Elementor in PHP 8.4 throws a deprecation notice.
+      # WP_DEBUG = true is required so all PHP errors are output and caught by tests.
       - name: Enable WP_DEBUG
-        if: ${{ inputs.test-group != 'EndToEnd/integrations/other' && inputs.php-version != '8.4' }}
+        if: ${{ inputs.test-group != 'EndToEnd/integrations/other' }}
         working-directory: ${{ env.ROOT_DIR }}
         run: wp-cli config set WP_DEBUG true --raw
 
@@ -193,7 +192,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ inputs.php-version }}
-          ini-values: error_reporting=E_ALL, display_errors=On, html_errors=On
+          ini-values: 'error_reporting=E_ALL, display_errors=On, html_errors=On, xdebug.mode="develop,coverage"'
           coverage: xdebug
 
       # Workaround for PHP 8.3 (and potentially other versions): the GitHub

--- a/.github/workflows/_run-tests.yml
+++ b/.github/workflows/_run-tests.yml
@@ -193,6 +193,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ inputs.php-version }}
+          ini-values: error_reporting=E_ALL, display_errors=On, html_errors=On
           coverage: xdebug
 
       # Workaround for PHP 8.3 (and potentially other versions): the GitHub

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         wp-versions: [ 'latest' ] #[ '6.1.1', 'latest' ]
-        php-versions: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ] #[ '7.3', '7.4', '8.0', '8.1' ]
+        php-versions: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ] #[ '7.3', '7.4', '8.0', '8.1' ]
 
     # Steps to install, configure and run tests
     steps:

--- a/.github/workflows/tests-backward-compat.yml
+++ b/.github/workflows/tests-backward-compat.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         wp-version: [ '6.2.8' ]
-        php-version: [ '8.1' ]
+        php-version: [ '8.2' ]
         test-group:
           - 'EndToEnd/broadcasts/blocks-shortcodes/PageBlockBroadcastsCest'
           - 'EndToEnd/forms/blocks-shortcodes/PageBlockFormBuilderCest'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         wp-version: [ 'latest' ]
-        php-version: [ '8.1', '8.2', '8.3', '8.4' ]
+        php-version: [ '8.2', '8.3', '8.4', '8.5' ]
         test-group:
           - 'EndToEnd/broadcasts/blocks-shortcodes'
           - 'EndToEnd/broadcasts/import-export'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         wp-version: [ 'latest' ]
-        php-version: [ '8.5' ]
+        php-version: [ '8.2', '8.3', '8.4', '8.5' ]
         test-group:
           - 'EndToEnd/broadcasts/blocks-shortcodes'
           - 'EndToEnd/broadcasts/import-export'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,28 +33,9 @@ jobs:
       fail-fast: false
       matrix:
         wp-version: [ 'latest' ]
-        php-version: [ '8.2', '8.3', '8.4', '8.5' ]
+        php-version: [ '8.5' ]
         test-group:
-          - 'EndToEnd/broadcasts/blocks-shortcodes'
-          - 'EndToEnd/broadcasts/import-export'
-          - 'EndToEnd/forms/blocks-shortcodes'
-          - 'EndToEnd/forms/general'
-          - 'EndToEnd/forms/post-types'
-          - 'EndToEnd/general/other'
-          - 'EndToEnd/general/uninstall'
-          - 'EndToEnd/general/plugin-screens'
-          - 'EndToEnd/integrations/divi-builder'
-          - 'EndToEnd/integrations/divi-theme'
-          - 'EndToEnd/integrations/elementor'
-          - 'EndToEnd/integrations/other'
-          - 'EndToEnd/integrations/wlm'
-          - 'EndToEnd/integrations/woocommerce'
-          - 'EndToEnd/landing-pages'
-          - 'EndToEnd/products'
-          - 'EndToEnd/restrict-content/general'
-          - 'EndToEnd/restrict-content/post-types'
-          - 'EndToEnd/tags'
-          - 'Integration'
+          - 'EndToEnd/general/plugin-screens/PluginSettingsFormEntriesCest'
 
     uses: ./.github/workflows/_run-tests.yml
     secrets: inherit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,26 @@ jobs:
         wp-version: [ 'latest' ]
         php-version: [ '8.5' ]
         test-group:
-          - 'EndToEnd/general/plugin-screens/PluginSettingsFormEntriesCest'
+          - 'EndToEnd/broadcasts/blocks-shortcodes'
+          - 'EndToEnd/broadcasts/import-export'
+          - 'EndToEnd/forms/blocks-shortcodes'
+          - 'EndToEnd/forms/general'
+          - 'EndToEnd/forms/post-types'
+          - 'EndToEnd/general/other'
+          - 'EndToEnd/general/uninstall'
+          - 'EndToEnd/general/plugin-screens'
+          - 'EndToEnd/integrations/divi-builder'
+          - 'EndToEnd/integrations/divi-theme'
+          - 'EndToEnd/integrations/elementor'
+          - 'EndToEnd/integrations/other'
+          - 'EndToEnd/integrations/wlm'
+          - 'EndToEnd/integrations/woocommerce'
+          - 'EndToEnd/landing-pages'
+          - 'EndToEnd/products'
+          - 'EndToEnd/restrict-content/general'
+          - 'EndToEnd/restrict-content/post-types'
+          - 'EndToEnd/tags'
+          - 'Integration'
 
     uses: ./.github/workflows/_run-tests.yml
     secrets: inherit

--- a/admin/section/class-convertkit-admin-section-base.php
+++ b/admin/section/class-convertkit-admin-section-base.php
@@ -140,6 +140,11 @@ abstract class ConvertKit_Admin_Section_Base {
 	 */
 	public function register_section() {
 
+		// Don't register a settings section if no settings key is defined.
+		if ( empty( $this->settings_key ) ) {
+			return;
+		}
+
 		// Register settings sections.
 		foreach ( $this->settings_sections as $name => $settings_section ) {
 			// Determine if this settings section needs to be wrapped in its own container.

--- a/tests/EndToEnd/general/plugin-screens/PluginSettingsFormEntriesCest.php
+++ b/tests/EndToEnd/general/plugin-screens/PluginSettingsFormEntriesCest.php
@@ -40,6 +40,8 @@ class PluginSettingsFormEntriesCest
 		// Load the Form Entries screen.
 		$I->loadKitSettingsFormEntriesScreen($I);
 
+		$I->waitForElementVisible('tbody#an-element-that-does-not-exist');
+
 		$I->see('No items found.');
 	}
 

--- a/tests/EndToEnd/general/plugin-screens/PluginSettingsFormEntriesCest.php
+++ b/tests/EndToEnd/general/plugin-screens/PluginSettingsFormEntriesCest.php
@@ -40,8 +40,6 @@ class PluginSettingsFormEntriesCest
 		// Load the Form Entries screen.
 		$I->loadKitSettingsFormEntriesScreen($I);
 
-		$I->waitForElementVisible('tbody#an-element-that-does-not-exist');
-
 		$I->see('No items found.');
 	}
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/Kit/convertkit-wordpress/issues/1172, where a `Using null as an array offset is deprecated` PHP deprecation notice would display when using PHP 8.5 or higher.

<img width="1920" height="937" alt="deprecation-notice" src="https://github.com/user-attachments/assets/062f1990-8915-45b4-bc8f-bd02a1017e9c" />

This wasn't caught previously because:
- GitHub actions did not run against PHP 8.5,
- Xdebug wasn't configured to output PHP deprecated notices in GitHub actions

This PR:
- Resolves the above,
- Runs tests against PHP 8.5,
- Configures the GitHub actions runner to show PHP deprecations as Xdebug errors, ensuring `checkNoWarningsAndNoticesOnScreen` catches deprecation notices
- Drops tests for PHP 8.1, as this is end of life: https://www.php.net/supported-versions.php. Coding Standards and PHPStan continue to run against PHP 7.2 and higher to ensure backward compatibility is maintained.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)