### PR TITLE
Abilities API: Update `wordpress/mcp-adapter` to `0.6.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "GPLv3",
     "require": {
         "convertkit/convertkit-wordpress-libraries": "2.1.7",
-        "wordpress/mcp-adapter": "^0.5.0"
+        "wordpress/mcp-adapter": "^0.6.1"
     },
     "require-dev": {
         "php-webdriver/webdriver": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -97,7 +97,8 @@
     },
     "config": {
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "automattic/jetpack-autoloader": true
         }
     },
     "repositories": [

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -261,11 +261,6 @@ class WP_ConvertKit {
 			}
 		}
 
-		// Sanity check MCP Adapter is loaded.
-		if ( ! class_exists( 'WP\\MCP\\Core\\McpAdapter' ) ) {
-			return;
-		}
-
 		// Bootstrap the MCP Adapter, per WordPress/mcp-adapter's recommended
 		// integration pattern.
 		// @see https://github.com/WordPress/mcp-adapter#using-mcp-adapter-in-your-plugin.

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -245,15 +245,23 @@ class WP_ConvertKit {
 			return;
 		}
 
-		// Bail if the WordPress MCP Adapter autoloader is missing.
-		if ( ! file_exists( CONVERTKIT_PLUGIN_PATH . '/vendor/autoload.php' ) ) {
-			return;
+		// Load MCP Adapter if another Plugin hasn't already loaded it.
+		if ( ! class_exists( 'WP\\MCP\\Core\\McpAdapter' ) ) {
+			// Bail if the WordPress MCP Adapter autoloader is missing.
+			if ( ! file_exists( CONVERTKIT_PLUGIN_PATH . '/vendor/autoload.php' ) ) {
+				return;
+			}
+
+			// Load MCP Adapter.
+			require_once CONVERTKIT_PLUGIN_PATH . '/vendor/autoload.php';
+
+			// Bail if the MCP Adapter class doesn't exist - something went wrong with the autoloader.
+			if ( ! class_exists( 'WP\\MCP\\Core\\McpAdapter' ) ) {
+				return;
+			}
 		}
 
-		// Load MCP Adapter.
-		require_once CONVERTKIT_PLUGIN_PATH . '/vendor/autoload.php';
-
-		// Bail if the MCP Adapter class doesn't exist - something went wrong with the autoloader.
+		// Sanity check MCP Adapter is loaded.
 		if ( ! class_exists( 'WP\\MCP\\Core\\McpAdapter' ) ) {
 			return;
 		}

--- a/includes/class-wp-convertkit.php
+++ b/includes/class-wp-convertkit.php
@@ -256,7 +256,7 @@ class WP_ConvertKit {
 			require_once CONVERTKIT_PLUGIN_PATH . '/vendor/autoload.php';
 
 			// Bail if the MCP Adapter class doesn't exist - something went wrong with the autoloader.
-			if ( ! class_exists( 'WP\\MCP\\Core\\McpAdapter' ) ) {
+			if ( ! class_exists( 'WP\\MCP\\Core\\McpAdapter' ) ) { // @phpstan-ignore-line
 				return;
 			}
 		}


### PR DESCRIPTION
## Summary

Updates the WordPress MCP Adapter to the latest version, 0.6.1:
https://github.com/WordPress/mcp-adapter/releases/tag/v0.6.1

Improves loading the MCP Adapter if another Plugin has/hasn't initialised it.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)