### PR TITLE
Custom Content Shortcode: Support Signed Subscriber IDs

### DIFF
--- a/includes/blocks/class-convertkit-block-content.php
+++ b/includes/blocks/class-convertkit-block-content.php
@@ -254,15 +254,40 @@ class ConvertKit_Block_Content extends ConvertKit_Block {
 		);
 
 		// Get the subscriber's tags, to see if they subscribed to this tag.
-		$tags = $api->get_subscriber_tags( $subscriber_id );
+		if ( is_numeric( $subscriber_id ) ) {
+			$tags = $api->get_subscriber_tags( $subscriber_id );
 
-		// Bail if an error occurred.
-		if ( is_wp_error( $tags ) ) {
-			if ( $settings->debug_enabled() ) {
-				return '<!-- Kit Custom Content: ' . $tags->get_error_message() . ' -->';
+			// Bail if an error occurred.
+			if ( is_wp_error( $tags ) ) {
+				if ( $settings->debug_enabled() ) {
+					return '<!-- Kit Custom Content: ' . $tags->get_error_message() . ' -->';
+				}
+
+				return '';
+			}
+		} else {
+			// Subscriber ID is a signed subscriber ID.
+			// Get tags that the subscriber has access to via the profile() method.
+			$result = $api->profile( $subscriber_id );
+
+			// If an error occurred, the subscriber ID is invalid.
+			if ( is_wp_error( $result ) ) {
+				if ( $settings->debug_enabled() ) {
+					return '<!-- Kit Custom Content: ' . $result->get_error_message() . ' -->';
+				}
+
+				return '';
 			}
 
-			return '';
+			// Build tags array.
+			$tags = array(
+				'tags' => array(),
+			);
+			foreach ( $result['tags'] as $tag_id ) {
+				$tags['tags'][] = array(
+					'id' => $tag_id,
+				);
+			}
 		}
 
 		// Bail if the subscriber has no tags.

--- a/tests/EndToEnd/tags/PageShortcodeCustomContentCest.php
+++ b/tests/EndToEnd/tags/PageShortcodeCustomContentCest.php
@@ -112,7 +112,7 @@ class PageShortcodeCustomContentCest
 		// Confirm that the Custom Content is not yet displayed.
 		$I->dontSee('KitCustomContent');
 
-		// Reload the page, this time with an invalid subscriber ID .
+		// Reload the page, this time with an invalid subscriber ID.
 		$I->amOnPage('/kit-custom-content-shortcode-valid-tag-param-and-invalid-subscriber-id?ck_subscriber_id=1');
 
 		// Check that no PHP warnings or notices were output.
@@ -149,8 +149,91 @@ class PageShortcodeCustomContentCest
 		// Confirm that the Custom Content is not yet displayed.
 		$I->dontSee('KitCustomContent');
 
-		// Reload the page, this time with a subscriber ID who is already subscribed to the tag.
-		$I->amOnPage('/kit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id?ck_subscriber_id=' . $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']);
+		// Set cookie with an invalid signed subscriber ID.
+		$I->setRestrictContentCookie($I, 'invalid-signed-subscriber-id');
+
+		// Reload the page, this time with an invalid signed subscriber ID.
+		$I->amOnPage('/kit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Custom Content is not yet displayed.
+		$I->dontSee('KitCustomContent');
+	}
+
+	/**
+	 * Test the [convertkit_content] shortcode works when a valid Tag ID is specified,
+	 * and an invalid signed subscriber ID is used who is subscribed to the tag.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testCustomContentShortcodeWithValidTagParameterAndInvalidSignedSubscriberID(EndToEndTester $I)
+	{
+		// Create Page with Shortcode.
+		$I->havePageInDatabase(
+			[
+				'post_name'    => 'kit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id',
+				'post_content' => '[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]KitCustomContent[/convertkit_content]',
+			]
+		);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/kit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Custom Content is not yet displayed.
+		$I->dontSee('KitCustomContent');
+
+		// Set cookie with signed subscriber ID.
+		$I->setRestrictContentCookie($I, $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID']);
+
+		// Reload the page.
+		$I->amOnPage('/kit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Custom Content is now displayed.
+		$I->see('KitCustomContent');
+	}
+
+	/**
+	 * Test the [convertkit_content] shortcode works when a valid Tag ID is specified,
+	 * and a valid signed subscriber ID is used who is subscribed to the tag.
+	 *
+	 * @since   3.4.0
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testCustomContentShortcodeWithValidTagParameterAndValidSignedSubscriberID(EndToEndTester $I)
+	{
+		// Create Page with Shortcode.
+		$I->havePageInDatabase(
+			[
+				'post_name'    => 'kit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id',
+				'post_content' => '[convertkit_content tag="' . $_ENV['CONVERTKIT_API_TAG_ID'] . '"]KitCustomContent[/convertkit_content]',
+			]
+		);
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/kit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm that the Custom Content is not yet displayed.
+		$I->dontSee('KitCustomContent');
+
+		// Set cookie with signed subscriber ID.
+		$I->setRestrictContentCookie($I, $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID']);
+
+		// Reload the page.
+		$I->amOnPage('/kit-custom-content-shortcode-valid-tag-param-and-valid-subscriber-id');
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://linear.app/kit/issue/WP-91/wp-p3-convertkit-content-shortcode-throws-fatal-typeerror-for) by calling the `profiles` method to determine which tags the subscriber has access to when a signed subscriber ID is used.

## Testing

- `testCustomContentShortcodeWithValidTagParameterAndInvalidSignedSubscriberID`: Test the [convertkit_content] shortcode works when a valid Tag ID is specified and an invalid signed subscriber ID is used who is subscribed to the tag.
- `testCustomContentShortcodeWithValidTagParameterAndValidSignedSubscriberID`: Test the [convertkit_content] shortcode works when a valid Tag ID is specified, and a valid signed subscriber ID is used who is subscribed to the tag.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)